### PR TITLE
feat(server): add ctx.storage.deleteAfterCommit for mutations

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -303,6 +303,7 @@ abstract class ShardDO {
     protected get sql(): unknown;
     protected get db(): DrizzleSqliteDODatabase<Record<string, unknown>>;
     protected isInTransaction(): boolean;
+    protected deferPastResponse(work: Promise<unknown>): Promise<void>;
     protected runInTransaction<T>(handler: () => Promise<T> | T): Promise<T>;
     protected getInboundBookmark(): string | undefined;
     protected setOutboundBookmark(bookmark: string | undefined): void;

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -97,6 +97,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DeferredDeleteFlushResult` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DefineComponentOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -450,6 +454,10 @@ Re-exported from `@lunora/scheduler` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `MutationCtx` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `MutationStorage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -1101,6 +1109,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `flushDeferredDeletes` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `httpAction` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1188,6 +1200,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 ### `v` (const)
 
 Re-exported from `@lunora/values` — signature tracked at its source.
+
+### `withDeferredDeletes` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
 
 ## `lunorash/client`
 
@@ -4691,6 +4707,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DeferredDeleteFlushResult` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DefineComponentOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5044,6 +5064,10 @@ Re-exported from `@lunora/scheduler` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `MutationCtx` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `MutationStorage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -5695,6 +5719,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `flushDeferredDeletes` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `httpAction` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5782,6 +5810,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 ### `v` (const)
 
 Re-exported from `@lunora/values` — signature tracked at its source.
+
+### `withDeferredDeletes` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
 
 ## `lunorash/server/data-model`
 
@@ -6918,6 +6950,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `MutationCtx` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `MutationStorage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -251,6 +251,18 @@ interface DatabaseWriter extends DatabaseReader {
 }
 ```
 
+### `DeferredDeleteFlushResult` (interface)
+
+```ts
+interface DeferredDeleteFlushResult {
+    attempted: number;
+    failures: {
+        error: unknown;
+        key: string;
+    }[];
+}
+```
+
 ### `DefineComponentOptions` (interface)
 
 ```ts
@@ -1198,10 +1210,19 @@ interface MutationCtx {
     readonly scheduler: Scheduler;
     readonly secrets: Secrets;
     readonly span: LunoraWideEvent;
-    readonly storage: ReadOnlyStorage;
+    readonly storage: MutationStorage;
     readonly trace: LunoraTracer;
     readonly vectors: VectorSearch;
     readonly workflows: Workflows;
+}
+```
+
+### `MutationStorage` (interface)
+
+```ts
+interface MutationStorage<Buckets extends string = string> extends ReadOnlyStorage<Buckets> {
+    bucket: (name: Buckets) => MutationStorage<Buckets>;
+    deleteAfterCommit: (key: string) => void;
 }
 ```
 
@@ -2796,6 +2817,12 @@ const defineVectorIndex: (options: VectorIndexOptions) => VectorIndexDefinition;
 const deny: () => WhereInput;
 ```
 
+### `flushDeferredDeletes` (const)
+
+```ts
+const flushDeferredDeletes: (storage: unknown) => Promise<DeferredDeleteFlushResult>;
+```
+
 ### `httpAction` (const)
 
 ```ts
@@ -2931,6 +2958,12 @@ const toWhereInput: (decision: WhereInput | boolean | undefined) => WhereInput;
 ### `v` (const)
 
 Re-exported from `@lunora/values` — signature tracked at its source.
+
+### `withDeferredDeletes` (const)
+
+```ts
+const withDeferredDeletes: (storage: unknown) => unknown;
+```
 
 ## `@lunora/server/data-model`
 
@@ -4431,6 +4464,10 @@ Re-exported from `@lunora/server` — signature tracked in that section.
 Re-exported from `@lunora/server` — signature tracked in that section.
 
 ### `MutationCtx` (interface)
+
+Re-exported from `@lunora/server` — signature tracked in that section.
+
+### `MutationStorage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked in that section.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -2820,7 +2820,7 @@ const deny: () => WhereInput;
 ### `flushDeferredDeletes` (const)
 
 ```ts
-const flushDeferredDeletes: (storage: unknown) => Promise<DeferredDeleteFlushResult>;
+const flushDeferredDeletes: (context: unknown) => Promise<DeferredDeleteFlushResult>;
 ```
 
 ### `httpAction` (const)

--- a/examples/auth-playground/lunora/_generated/server.ts
+++ b/examples/auth-playground/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -432,16 +432,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -531,6 +553,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -916,6 +945,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1007,7 +1054,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/blog/lunora/_generated/server.ts
+++ b/examples/blog/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -209,7 +210,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage" | "vectors
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage" | "vectors"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
     readonly vectors: VectorSearch<VectorIndexName>;
 }
 

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink, WriteHook } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import type { SchemaLike as VectorSchemaLike, VectorizeIndexLike, VectorSearchLike } from "@lunora/bindings/vectors";
 import { createContextVectors, createVectors, createVectorSyncHook } from "@lunora/bindings/vectors";
@@ -1083,16 +1083,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -1190,6 +1212,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1595,6 +1624,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1692,7 +1739,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 vectors,
                 secrets,

--- a/examples/chess/lunora/_generated/server.ts
+++ b/examples/chess/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -1188,16 +1188,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -1287,6 +1309,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1672,6 +1701,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1767,7 +1814,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/expo/lunora/_generated/server.ts
+++ b/examples/expo/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -350,13 +350,40 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported instead, with its key.
+                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
+
+                await this.deferPastResponse(
+                    (async () => {
+                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
+
+                        for (const failure of outcome.failures) {
+                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
+                                error: String(failure.error),
+                                key: failure.key,
+                            });
+                        }
+                    })(),
+                );
+
+                return result;
             }
 
             return registered.handler(ctx, args);
@@ -834,6 +861,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
+            // Only a mutation: it is the one dispatch with a transaction to commit,
+            // and the flush hangs off its dispatch. Wrapping a query or an action
+            // would put a method on `ctx.storage` that nothing ever drains — an
+            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
+            // facade so `bucket(name)` still resolves through it and stays stamped,
+            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
+            // shares the adapter above) is untouched.
+            const contextStorage =
+                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -925,7 +962,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -367,26 +367,21 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 //
                 // `flushDeferredDeletes` never rejects — the mutation has already
                 // succeeded, so a failed cleanup must not turn into a failed response.
-                // A leaked object is reported instead, with its key.
-                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
-
-                await this.deferPastResponse(
-                    (async () => {
-                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
-
-                        for (const failure of outcome.failures) {
-                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
-                                error: String(failure.error),
-                                key: failure.key,
-                            });
-                        }
-                    })(),
-                );
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
 
                 return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -476,6 +471,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -861,16 +863,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
-            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
-            // Only a mutation: it is the one dispatch with a transaction to commit,
-            // and the flush hangs off its dispatch. Wrapping a query or an action
-            // would put a method on `ctx.storage` that nothing ever drains — an
-            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
-            // facade so `bucket(name)` still resolves through it and stays stamped,
-            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
-            // shares the adapter above) is untouched.
-            const contextStorage =
-                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio

--- a/examples/feedback-board/lunora/_generated/server.ts
+++ b/examples/feedback-board/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -209,7 +210,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import type { AiBindingLike, LunoraAi } from "@lunora/ai";
 import { createAi } from "@lunora/ai";
@@ -866,16 +866,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -965,6 +987,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1362,6 +1391,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1457,7 +1504,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 ai,
                 secrets,

--- a/examples/kanban-board/lunora/_generated/server.ts
+++ b/examples/kanban-board/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -411,16 +411,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -510,6 +532,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -895,6 +924,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -987,7 +1034,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/notify-demo/lunora/_generated/server.ts
+++ b/examples/notify-demo/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -210,7 +211,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
     /** Multi-channel notifications (@lunora/notify): send / chat / inApp / webhook plus the push device sub-facade. Sends are external I/O — confine them to action handlers. */
     readonly notify: import("@lunora/notify").LunoraNotify;
     /** Device push sub-facade — the same object as ctx.notify.push (register / send / broadcast). Sends belong in action handlers. */

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import { createNotify } from "@lunora/notify";
 import notifyConfig from "../notify.js";
@@ -584,16 +584,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -683,6 +705,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1068,6 +1097,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1161,7 +1208,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 notify,
                 push,

--- a/examples/offline-rejections/lunora/_generated/server.ts
+++ b/examples/offline-rejections/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -383,16 +383,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -482,6 +504,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -867,6 +896,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -958,7 +1005,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/payment-demo/lunora/_generated/server.ts
+++ b/examples/payment-demo/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -207,7 +208,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import type { LunoraDatabaseLike as LunoraPaymentDbLike, LunoraPayment, PaymentsFromContextOptions } from "@lunora/payment";
 import { paymentsFromContext } from "@lunora/payment";
@@ -990,16 +990,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -1089,6 +1111,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1474,6 +1503,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1573,7 +1620,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
                 payments,

--- a/examples/realtime-cursors/lunora/_generated/server.ts
+++ b/examples/realtime-cursors/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -602,16 +602,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -701,6 +723,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1086,6 +1115,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1177,7 +1224,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/tanstack-start/lunora/_generated/server.ts
+++ b/examples/tanstack-start/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -350,16 +350,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -449,6 +471,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -834,6 +863,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -926,7 +973,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/team-chat/lunora/_generated/server.ts
+++ b/examples/team-chat/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SearchBackfillProgress, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, backfillSearchIndexes, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -891,16 +891,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -998,6 +1020,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -1392,6 +1421,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1490,7 +1537,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/examples/todo-app/lunora/_generated/server.ts
+++ b/examples/todo-app/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "lunorash/do";
 import { applyCdcChanges, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -488,16 +488,38 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+                return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -587,6 +609,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -972,6 +1001,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1063,7 +1110,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/packages/codegen/__tests__/emit-shard-deferred-deletes.test.ts
+++ b/packages/codegen/__tests__/emit-shard-deferred-deletes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { emitShard } from "../src/emit";
+
+/**
+ * `ctx.storage.deleteAfterCommit(key)` — the object half of a row deletion,
+ * flushed only once the mutation's transaction has committed.
+ *
+ * The emitted shard is a STRING; nothing in this package compiles it (see
+ * `emitted-shard-contract.ts`, which proves the same calls compile against the
+ * real base class). So this suite pins the two placement facts that make the
+ * feature correct and that an innocuous-looking edit would silently break: the
+ * flush is OUTSIDE the transaction, and the queue is attached to a mutation's
+ * context only.
+ */
+const shard = (): string => emitShard({ schema: { tables: [], vectorIndexes: [] } });
+
+describe("emitShard — deferred storage deletes", () => {
+    it("wraps ctx.storage for a mutation and leaves every other kind alone", () => {
+        expect.assertions(2);
+
+        const emitted = shard();
+
+        // A query has no transaction to commit and an action has the real
+        // `delete`; wrapping either would put a method on `ctx.storage` that
+        // nothing ever drains.
+        expect(emitted).toContain('?.kind === "mutation" ? withDeferredDeletes(storage) : storage');
+        expect(emitted).toContain("storage: contextStorage,");
+    });
+
+    it("shares the read-stamped adapter with ctx.db.system._storage rather than the wrapped one", () => {
+        expect.assertions(1);
+
+        const emitted = shard();
+
+        // `withDeferredDeletes` wraps the ALREADY-stamped facade into a separate
+        // binding. If the wrap replaced `storage` itself, the system reader would
+        // pick up a `deleteAfterCommit` it can never flush.
+        expect(emitted).toContain("const contextStorage =");
+    });
+
+    it("flushes after the transaction resolves, not inside it", () => {
+        expect.assertions(3);
+
+        const emitted = shard();
+        const branch = emitted.slice(emitted.indexOf('if (registered.kind === "mutation")'));
+        const flushAt = branch.indexOf("flushDeferredDeletes(dispatchCtx.storage)");
+        const transactionEndsAt = branch.indexOf("});");
+
+        // An R2 delete cannot roll back. Issued from inside the span, a delete
+        // whose transaction later aborts destroys data the surviving row still
+        // points at — so ordering here IS the guarantee.
+        expect(flushAt).toBeGreaterThan(-1);
+        expect(transactionEndsAt).toBeGreaterThan(-1);
+        expect(flushAt).toBeGreaterThan(transactionEndsAt);
+    });
+
+    it("defers the flush past the response instead of awaiting it on the hot path", () => {
+        expect.assertions(1);
+
+        const emitted = shard();
+
+        expect(emitted).toContain("await this.deferPastResponse(");
+    });
+
+    it("reports a failed delete without failing the committed mutation", () => {
+        expect.assertions(2);
+
+        const emitted = shard();
+        const branch = emitted.slice(emitted.indexOf('if (registered.kind === "mutation")'));
+
+        // The write already succeeded; a cleanup failure must leak an object and
+        // say which one, never turn into a 500 for a mutation that committed.
+        expect(branch).toContain("outcome.failures");
+        expect(branch).toContain("object leaked");
+    });
+});

--- a/packages/codegen/__tests__/emit-shard-deferred-deletes.test.ts
+++ b/packages/codegen/__tests__/emit-shard-deferred-deletes.test.ts
@@ -4,55 +4,90 @@ import { emitShard } from "../src/emit";
 
 /**
  * `ctx.storage.deleteAfterCommit(key)` — the object half of a row deletion,
- * flushed only once the mutation's transaction has committed.
+ * flushed only once the write that removed the row has committed.
  *
  * The emitted shard is a STRING; nothing in this package compiles it (see
  * `emitted-shard-contract.ts`, which proves the same calls compile against the
- * real base class). So this suite pins the two placement facts that make the
- * feature correct and that an innocuous-looking edit would silently break: the
- * flush is OUTSIDE the transaction, and the queue is attached to a mutation's
- * context only.
+ * real base class). So this suite pins the placement facts that make the feature
+ * correct and that an innocuous-looking edit would silently break: the flush is
+ * OUTSIDE the transaction, and EVERY dispatch that installs the queue also
+ * drains it.
  */
 const shard = (): string => emitShard({ schema: { tables: [], vectorIndexes: [] } });
 
+/**
+ * The body of one emitted method: from its signature to whichever member
+ * declaration comes next. Sliced on declarations rather than by brace-matching,
+ * so reformatting the emitted body cannot silently empty the slice and turn
+ * these assertions green for the wrong reason.
+ */
+const methodBody = (emitted: string, signature: string): string => {
+    const start = emitted.indexOf(signature);
+
+    // Throw rather than `expect`, so this helper never inflates a caller's
+    // `expect.assertions` count — a renamed method still fails loudly.
+    if (start === -1) {
+        throw new Error(`emitted shard has no ${signature}`);
+    }
+
+    const rest = emitted.slice(start + signature.length);
+    const next = [...rest.matchAll(/\n {8}(?:private|protected|public) /gu)][0]?.index;
+
+    return next === undefined ? rest : rest.slice(0, next);
+};
+
 describe("emitShard — deferred storage deletes", () => {
-    it("wraps ctx.storage for a mutation and leaves every other kind alone", () => {
+    it("installs the queue on every dispatch that can host a mutation handler", () => {
         expect.assertions(2);
 
         const emitted = shard();
 
-        // A query has no transaction to commit and an action has the real
-        // `delete`; wrapping either would put a method on `ctx.storage` that
-        // nothing ever drains.
-        expect(emitted).toContain('?.kind === "mutation" ? withDeferredDeletes(storage) : storage');
+        // Not mutations alone: `ctx.runMutation` hands the caller's ctx to the
+        // callee, so a mutation reached from an action runs on the action's ctx.
+        // Gating on `kind === "mutation"` made that composition throw a TypeError
+        // on a method the handler's own type promises.
+        expect(emitted).toContain('contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage');
         expect(emitted).toContain("storage: contextStorage,");
     });
 
-    it("shares the read-stamped adapter with ctx.db.system._storage rather than the wrapped one", () => {
+    it("leaves ctx.db.system._storage on the unwrapped adapter", () => {
         expect.assertions(1);
 
         const emitted = shard();
 
-        // `withDeferredDeletes` wraps the ALREADY-stamped facade into a separate
-        // binding. If the wrap replaced `storage` itself, the system reader would
-        // pick up a `deleteAfterCommit` it can never flush.
+        // `withDeferredDeletes` wraps the already-stamped facade into a SEPARATE
+        // binding. If it replaced `storage` itself, the system reader would pick
+        // up a `deleteAfterCommit` that no dispatch drains.
         expect(emitted).toContain("const contextStorage =");
     });
 
-    it("flushes after the transaction resolves, not inside it", () => {
+    it("flushes from every dispatch that installs the queue", () => {
         expect.assertions(3);
 
         const emitted = shard();
-        const branch = emitted.slice(emitted.indexOf('if (registered.kind === "mutation")'));
-        const flushAt = branch.indexOf("flushDeferredDeletes(dispatchCtx.storage)");
-        const transactionEndsAt = branch.indexOf("});");
+
+        // The coverage that matters: a wrap without a matching flush leaks
+        // silently — no error, no warning, nothing to find. Each of these three
+        // can run a mutation handler.
+        expect(methodBody(emitted, "public override async handleRpc(")).toContain("flushDeferredDeletes(ctx)");
+        expect(methodBody(emitted, "protected override async runReactor(")).toContain("flushDeferredDeletes(ctx)");
+        // Both branches of handleRpc — the mutation one and the action one.
+        expect(emitted.split("flushDeferredDeletes(ctx)")).toHaveLength(4);
+    });
+
+    it("flushes after the transaction resolves, never inside it", () => {
+        expect.assertions(2);
+
+        const emitted = shard();
+        const branch = methodBody(emitted, "public override async handleRpc(");
+        const transaction = branch.indexOf("await this.runInTransaction(");
+        const flush = branch.indexOf("flushDeferredDeletes(ctx)", transaction);
 
         // An R2 delete cannot roll back. Issued from inside the span, a delete
         // whose transaction later aborts destroys data the surviving row still
-        // points at — so ordering here IS the guarantee.
-        expect(flushAt).toBeGreaterThan(-1);
-        expect(transactionEndsAt).toBeGreaterThan(-1);
-        expect(flushAt).toBeGreaterThan(transactionEndsAt);
+        // points at — so this ordering IS the guarantee.
+        expect(transaction).toBeGreaterThan(-1);
+        expect(flush).toBeGreaterThan(transaction);
     });
 
     it("defers the flush past the response instead of awaiting it on the hot path", () => {
@@ -60,18 +95,6 @@ describe("emitShard — deferred storage deletes", () => {
 
         const emitted = shard();
 
-        expect(emitted).toContain("await this.deferPastResponse(");
-    });
-
-    it("reports a failed delete without failing the committed mutation", () => {
-        expect.assertions(2);
-
-        const emitted = shard();
-        const branch = emitted.slice(emitted.indexOf('if (registered.kind === "mutation")'));
-
-        // The write already succeeded; a cleanup failure must leak an object and
-        // say which one, never turn into a 500 for a mutation that committed.
-        expect(branch).toContain("outcome.failures");
-        expect(branch).toContain("object leaked");
+        expect(emitted).toContain("await this.deferPastResponse(flushDeferredDeletes(ctx));");
     });
 });

--- a/packages/codegen/__tests__/emitted-shard-contract.ts
+++ b/packages/codegen/__tests__/emitted-shard-contract.ts
@@ -27,11 +27,15 @@
  */
 import type { TraceRefLike } from "@lunora/do";
 import { ShardDO } from "@lunora/do";
+import { flushDeferredDeletes } from "@lunora/server";
 
 class EmittedShardContract extends ShardDO {
-    // eslint-disable-next-line class-methods-use-this -- required abstract override; this file exercises the base surface, it never dispatches
-    public override handleRpc(): Promise<unknown> {
-        return Promise.resolve(undefined);
+    public override async handleRpc(): Promise<unknown> {
+        // Mirrors the shape of the emitted mutation branch, so the flush below is
+        // reached from a real dispatch signature rather than sitting unreferenced.
+        await this.flushDeferredStorageDeletes({});
+
+        return undefined;
     }
 
     /**
@@ -54,6 +58,29 @@ class EmittedShardContract extends ShardDO {
         await this.scheduleSourcePoll();
 
         return undefined;
+    }
+
+    /**
+     * Mirrors the mutation branch of the generated `handleRpc`: the post-commit
+     * flush of `ctx.storage`'s deferred object deletes. It reaches one base
+     * member (`deferPastResponse`), which is `protected` for exactly this call —
+     * the host's `waitUntil` behind it is private.
+     */
+    private async flushDeferredStorageDeletes(context: unknown): Promise<void> {
+        const dispatchContext = context as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
+
+        await this.deferPastResponse(
+            (async () => {
+                const outcome = await flushDeferredDeletes(dispatchContext.storage);
+
+                for (const failure of outcome.failures) {
+                    dispatchContext.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
+                        error: String(failure.error),
+                        key: failure.key,
+                    });
+                }
+            })(),
+        );
     }
 }
 export default EmittedShardContract;

--- a/packages/codegen/__tests__/emitted-shard-contract.ts
+++ b/packages/codegen/__tests__/emitted-shard-contract.ts
@@ -61,26 +61,12 @@ class EmittedShardContract extends ShardDO {
     }
 
     /**
-     * Mirrors the mutation branch of the generated `handleRpc`: the post-commit
-     * flush of `ctx.storage`'s deferred object deletes. It reaches one base
-     * member (`deferPastResponse`), which is `protected` for exactly this call —
-     * the host's `waitUntil` behind it is private.
+     * Mirrors the post-commit flush the generated dispatches perform. It reaches
+     * one base member (`deferPastResponse`), which is `protected` for exactly this
+     * call — the host's `waitUntil` behind it is private.
      */
     private async flushDeferredStorageDeletes(context: unknown): Promise<void> {
-        const dispatchContext = context as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
-
-        await this.deferPastResponse(
-            (async () => {
-                const outcome = await flushDeferredDeletes(dispatchContext.storage);
-
-                for (const failure of outcome.failures) {
-                    dispatchContext.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
-                        error: String(failure.error),
-                        key: failure.key,
-                    });
-                }
-            })(),
-        );
+        await this.deferPastResponse(flushDeferredDeletes(context));
     }
 }
 export default EmittedShardContract;

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/server.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -206,7 +207,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"> {

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink, WhereInput } from "@lunora/do";
 import { applyCdcChanges, buildReprojectionMigration, assertShapeShardable, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "@lunora/do";
-import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, LunoraError } from "@lunora/server";
+import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "@lunora/server";
 import { bindOrm, bindTableFacade } from "@lunora/server";
 
 import schema from "../schema.js";
@@ -320,13 +320,40 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported instead, with its key.
+                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
+
+                await this.deferPastResponse(
+                    (async () => {
+                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
+
+                        for (const failure of outcome.failures) {
+                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
+                                error: String(failure.error),
+                                key: failure.key,
+                            });
+                        }
+                    })(),
+                );
+
+                return result;
             }
 
             return registered.handler(ctx, args);
@@ -910,6 +937,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
+            // Only a mutation: it is the one dispatch with a transaction to commit,
+            // and the flush hangs off its dispatch. Wrapping a query or an action
+            // would put a method on `ctx.storage` that nothing ever drains — an
+            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
+            // facade so `bucket(name)` still resolves through it and stays stamped,
+            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
+            // shares the adapter above) is untouched.
+            const contextStorage =
+                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1005,7 +1042,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 secrets,
             };

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -337,26 +337,21 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 //
                 // `flushDeferredDeletes` never rejects — the mutation has already
                 // succeeded, so a failed cleanup must not turn into a failed response.
-                // A leaked object is reported instead, with its key.
-                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
-
-                await this.deferPastResponse(
-                    (async () => {
-                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
-
-                        for (const failure of outcome.failures) {
-                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
-                                error: String(failure.error),
-                                key: failure.key,
-                            });
-                        }
-                    })(),
-                );
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
 
                 return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -552,6 +547,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -937,16 +939,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
-            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
-            // Only a mutation: it is the one dispatch with a transaction to commit,
-            // and the flush hangs off its dispatch. Wrapping a query or an action
-            // would put a method on `ctx.storage` that nothing ever drains — an
-            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
-            // facade so `bucket(name)` still resolves through it and stays stamped,
-            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
-            // shares the adapter above) is untouched.
-            const contextStorage =
-                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/server.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/server.ts
@@ -14,6 +14,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -210,7 +211,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;
+    readonly storage: MutationStorage<StorageBucketName>;
     /** Multi-channel notifications (@lunora/notify): send / chat / inApp / webhook plus the push device sub-facade. Sends are external I/O — confine them to action handlers. */
     readonly notify: import("@lunora/notify").LunoraNotify;
     /** Device push sub-facade — the same object as ctx.notify.push (register / send / broadcast). Sends belong in action handlers. */

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SearchBackfillProgress, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink } from "@lunora/do";
 import { applyCdcChanges, backfillSearchIndexes, buildReprojectionMigration, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "@lunora/do";
-import { asBucketStorage, createSecrets, LunoraError } from "@lunora/server";
+import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "@lunora/server";
 import { bindOrm, bindTableFacade } from "@lunora/server";
 import { createNotify } from "@lunora/notify";
 import notifyConfig from "../notify.js";
@@ -458,13 +458,40 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with `ctx`.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported instead, with its key.
+                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
+
+                await this.deferPastResponse(
+                    (async () => {
+                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
+
+                        for (const failure of outcome.failures) {
+                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
+                                error: String(failure.error),
+                                key: failure.key,
+                            });
+                        }
+                    })(),
+                );
+
+                return result;
             }
 
             return registered.handler(ctx, args);
@@ -959,6 +986,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
+            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
+            // Only a mutation: it is the one dispatch with a transaction to commit,
+            // and the flush hangs off its dispatch. Wrapping a query or an action
+            // would put a method on `ctx.storage` that nothing ever drains — an
+            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
+            // facade so `bucket(name)` still resolves through it and stays stamped,
+            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
+            // shares the adapter above) is untouched.
+            const contextStorage =
+                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio
@@ -1059,7 +1096,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 orm: bindOrm(facade),
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,
                 notify,
                 push,

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -475,26 +475,21 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 //
                 // `flushDeferredDeletes` never rejects — the mutation has already
                 // succeeded, so a failed cleanup must not turn into a failed response.
-                // A leaked object is reported instead, with its key.
-                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
-
-                await this.deferPastResponse(
-                    (async () => {
-                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
-
-                        for (const failure of outcome.failures) {
-                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
-                                error: String(failure.error),
-                                key: failure.key,
-                            });
-                        }
-                    })(),
-                );
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
 
                 return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but `ctx.runMutation` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a `mutation` may enter the base class's single-writer gate for
@@ -592,6 +587,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with `ctx` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -986,16 +988,24 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 "getMetadata",
                 "list",
             ]);
-            // `ctx.storage` in a MUTATION additionally accepts `deleteAfterCommit(key)`.
-            // Only a mutation: it is the one dispatch with a transaction to commit,
-            // and the flush hangs off its dispatch. Wrapping a query or an action
-            // would put a method on `ctx.storage` that nothing ever drains — an
-            // action already has the real `delete`. Wrapped OUTSIDE the read-stamping
-            // facade so `bucket(name)` still resolves through it and stays stamped,
-            // and applied only to `ctx.storage` so `ctx.db.system._storage` (which
-            // shares the adapter above) is untouched.
-            const contextStorage =
-                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
+            // `ctx.storage.deleteAfterCommit(key)`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // `ctx.runMutation` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see `handleRpc` and
+            // `runReactor`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so `bucket(name)` still
+            // resolves through it and stays stamped, and applied only to
+            // `ctx.storage` so `ctx.db.system._storage` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // `ctx.log`: the DO base builds the attributed logger (structured
             // fields + `.with(...)` child + trace correlation) and routes each call
             // to the optional `observability` sink. It also buffers the line (studio

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -5227,26 +5227,21 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 //
                 // \`flushDeferredDeletes\` never rejects — the mutation has already
                 // succeeded, so a failed cleanup must not turn into a failed response.
-                // A leaked object is reported instead, with its key.
-                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
-
-                await this.deferPastResponse(
-                    (async () => {
-                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
-
-                        for (const failure of outcome.failures) {
-                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
-                                error: String(failure.error),
-                                key: failure.key,
-                            });
-                        }
-                    })(),
-                );
+                // A leaked object is reported through \`ctx.log\` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
 
                 return result;
             }
 
-            return registered.handler(ctx, args);
+            const result = await registered.handler(ctx, args);
+
+            // An action is not itself transactional, but \`ctx.runMutation\` runs its
+            // submutations on THIS ctx, so their queued deletes land here — this is
+            // the first point at which those writes are known to have committed. A
+            // dispatch with nothing queued no-ops.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
+
+            return result;
         }
 
         // Only a \`mutation\` may enter the base class's single-writer gate for
@@ -5330,6 +5325,13 @@ ${shardInitOverride}
                 digest: string;
                 ran: boolean;
             };
+
+            // A reactor IS a mutation, so its ctx carries the deferred-delete queue
+            // and its transaction has just committed. Without this the queue would
+            // die with \`ctx\` and the objects would leak with nothing to find: no
+            // error, no warning, no failed request — a reactor that reaps orphaned
+            // rows is a textbook use of one.
+            await this.deferPastResponse(flushDeferredDeletes(ctx));
 
             return { digest: outcome.digest, ran: outcome.ran, tables: [...footprint.tables] };
         }
@@ -5642,16 +5644,24 @@ ${vectorsBuild}${aiBuild}${everyContextBuild}${containersBuild}${workflowsBuild}
                 "getMetadata",
                 "list",
             ]);
-            // \`ctx.storage\` in a MUTATION additionally accepts \`deleteAfterCommit(key)\`.
-            // Only a mutation: it is the one dispatch with a transaction to commit,
-            // and the flush hangs off its dispatch. Wrapping a query or an action
-            // would put a method on \`ctx.storage\` that nothing ever drains — an
-            // action already has the real \`delete\`. Wrapped OUTSIDE the read-stamping
-            // facade so \`bucket(name)\` still resolves through it and stays stamped,
-            // and applied only to \`ctx.storage\` so \`ctx.db.system._storage\` (which
-            // shares the adapter above) is untouched.
-            const contextStorage =
-                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
+            // \`ctx.storage.deleteAfterCommit(key)\`, on every dispatch that can host
+            // a MUTATION handler — which is not only a mutation dispatch:
+            // \`ctx.runMutation\` hands the CALLER's ctx to the callee, so a mutation
+            // reached from an action runs on the action's ctx. Wrapping mutations
+            // alone made that composition throw a bare TypeError on a method the
+            // handler's own type promises. Queries stay unwrapped: they cannot host
+            // one, and their ctx is built on the hot subscription path.
+            //
+            // Every dispatch wrapped here also flushes (see \`handleRpc\` and
+            // \`runReactor\`) — a queue nothing drains leaks silently, which is worse
+            // than not having the method at all.
+            //
+            // Wrapped OUTSIDE the read-stamping facade so \`bucket(name)\` still
+            // resolves through it and stays stamped, and applied only to
+            // \`ctx.storage\` so \`ctx.db.system._storage\` (which shares the adapter
+            // above) is untouched.
+            const contextKind = LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind;
+            const contextStorage = contextKind === "mutation" || contextKind === "action" ? withDeferredDeletes(storage) : storage;
             // \`ctx.log\`: the DO base builds the attributed logger (structured
             // fields + \`.with(...)\` child + trace correlation) and routes each call
             // to the optional \`observability\` sink. It also buffers the line (studio

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2124,6 +2124,7 @@ import type {
     InternalQueryBuilder,
     MutationBuilder,
     MutationCtx as MutationCtxBase,
+    MutationStorage,
     MutatorDefinition,
     QueryBuilder,
     QueryCtx as QueryCtxBase,
@@ -2299,7 +2300,7 @@ export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"${vectorsOm
 export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"${vectorsOmit}${workflowsOmit}${authOmit}${envOmit}> {
     readonly db: Omit<DatabaseWriter, "asId" | "query" | "get"> & DatabaseWriterFacade & { asId: TypedAsId; query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;${vectorsWriterContextField}${accessContextField}${kvContextField}${flagsContextField}${notifyContextField}${analyticsContextField}${envContextField}${workflowsContextField}${queuesContextField}${agentsContextField}${authContextField}
+    readonly storage: MutationStorage<StorageBucketName>;${vectorsWriterContextField}${accessContextField}${kvContextField}${flagsContextField}${notifyContextField}${analyticsContextField}${envContextField}${workflowsContextField}${queuesContextField}${agentsContextField}${authContextField}
 }
 
 export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"${vectorsOmit}${workflowsOmit}${authOmit}${envOmit}> {
@@ -4475,8 +4476,8 @@ const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCT
         // read-registry builder + `composeShapeReadWhere` so `resolveShape` can
         // AND-merge a shape's predicate with the table's read base-where.
         hasShapes
-            ? `import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, LunoraError } from "${base.server}";`
-            : `import { asBucketStorage, createSecrets, LunoraError } from "${base.server}";`,
+            ? `import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "${base.server}";`
+            : `import { asBucketStorage, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes } from "${base.server}";`,
     ];
 
     // The per-table facade binding lives in `@lunora/server` so codegen and the
@@ -5209,13 +5210,40 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // watermark are atomic — a crash can't leave the writes durable without
             // the replay guard.
             if (registered.kind === "mutation") {
-                return this.runInTransaction(async () => {
-                    const result = await registered.handler(ctx, args);
+                const result = await this.runInTransaction(async () => {
+                    const value = await registered.handler(ctx, args);
 
-                    this.commitMutationBookkeeping(result);
+                    this.commitMutationBookkeeping(value);
 
-                    return result;
+                    return value;
                 });
+
+                // The transaction committed, so the rows are durable and the objects
+                // their deletion orphaned can go. Deliberately AFTER the span, never
+                // inside it: an R2 delete cannot roll back, so a delete issued from
+                // within a transaction that later aborts destroys data the surviving
+                // row still points at. A throw above skips this entirely and the
+                // queue dies with \`ctx\`.
+                //
+                // \`flushDeferredDeletes\` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported instead, with its key.
+                const dispatchCtx = ctx as { log?: { warn: (message: string, fields?: Record<string, unknown>) => void }; storage?: unknown };
+
+                await this.deferPastResponse(
+                    (async () => {
+                        const outcome = await flushDeferredDeletes(dispatchCtx.storage);
+
+                        for (const failure of outcome.failures) {
+                            dispatchCtx.log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", {
+                                error: String(failure.error),
+                                key: failure.key,
+                            });
+                        }
+                    })(),
+                );
+
+                return result;
             }
 
             return registered.handler(ctx, args);
@@ -5614,6 +5642,16 @@ ${vectorsBuild}${aiBuild}${everyContextBuild}${containersBuild}${workflowsBuild}
                 "getMetadata",
                 "list",
             ]);
+            // \`ctx.storage\` in a MUTATION additionally accepts \`deleteAfterCommit(key)\`.
+            // Only a mutation: it is the one dispatch with a transaction to commit,
+            // and the flush hangs off its dispatch. Wrapping a query or an action
+            // would put a method on \`ctx.storage\` that nothing ever drains — an
+            // action already has the real \`delete\`. Wrapped OUTSIDE the read-stamping
+            // facade so \`bucket(name)\` still resolves through it and stays stamped,
+            // and applied only to \`ctx.storage\` so \`ctx.db.system._storage\` (which
+            // shares the adapter above) is untouched.
+            const contextStorage =
+                LUNORA_FUNCTIONS[options.functionPath ?? ""]?.kind === "mutation" ? withDeferredDeletes(storage) : storage;
             // \`ctx.log\`: the DO base builds the attributed logger (structured
             // fields + \`.with(...)\` child + trace correlation) and routes each call
             // to the optional \`observability\` sink. It also buffers the line (studio
@@ -5674,7 +5712,7 @@ ${notifyBuild}
                 now,${ormContextField}
                 scheduler,
                 span,
-                storage,
+                storage: contextStorage,
                 trace,${vectorsContextField}${aiContextField}${everyContextField}${paymentsContextField}${containersContextField}${workflowsContextField}${queuesContextField}${agentsContextField}
             };
 ${isActionLine}${actionOnlyBlock}

--- a/packages/do/__tests__/shard-do.defer-past-response.test.ts
+++ b/packages/do/__tests__/shard-do.defer-past-response.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+/**
+ * `deferPastResponse` — the seam the generated mutation dispatch uses to flush
+ * `ctx.storage`'s deferred object deletes after the transaction commits.
+ *
+ * The two behaviours that matter are the two hosts: one that can defer (the real
+ * runtime, where the work must NOT be awaited on the response path) and one that
+ * cannot (the unit harness and any host without `waitUntil`, where dropping the
+ * work would turn a leaked object into a silently passing test).
+ */
+class DeferShard extends ShardDO {
+    // eslint-disable-next-line class-methods-use-this -- required abstract override; this suite drives `deferPastResponse` directly, never a dispatch
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve(undefined);
+    }
+
+    public drive(work: Promise<unknown>): Promise<void> {
+        return this.deferPastResponse(work);
+    }
+}
+
+const baseState = (): ShardDOState => {
+    return {
+        acceptWebSocket: () => undefined,
+        getWebSockets: () => [],
+        id: { name: "shard-a" },
+        storage: { sql: {} },
+    };
+};
+
+describe("shardDO.deferPastResponse", () => {
+    it("hands the work to the host and returns without awaiting it", async () => {
+        expect.assertions(3);
+
+        const deferred: Promise<unknown>[] = [];
+        const state: ShardDOState = { ...baseState(), waitUntil: (promise) => deferred.push(promise) };
+        const shard = new DeferShard(state, {});
+
+        let settled = false;
+        const work = new Promise<void>((resolve) => {
+            setTimeout(() => {
+                settled = true;
+                resolve();
+            }, 5);
+        });
+
+        await shard.drive(work);
+
+        // Returned before the work finished — that is the point: a committed
+        // mutation must not wait on object cleanup.
+        expect(settled).toBe(false);
+        expect(deferred).toHaveLength(1);
+
+        await work;
+
+        expect(settled).toBe(true);
+    });
+
+    it("awaits inline when the host cannot defer", async () => {
+        expect.assertions(1);
+
+        // No `waitUntil` on the state. Silently dropping the work here would make
+        // an un-flushed delete queue look like correct behaviour under test.
+        const shard = new DeferShard(baseState(), {});
+
+        let settled = false;
+        const work = new Promise<void>((resolve) => {
+            setTimeout(() => {
+                settled = true;
+                resolve();
+            }, 5);
+        });
+
+        await shard.drive(work);
+
+        expect(settled).toBe(true);
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2478,14 +2478,13 @@ abstract class ShardDO {
     /**
      * Let `work` outlive this dispatch where the host supports it.
      *
-     * The generated mutation dispatch uses this to flush `ctx.storage`'s
-     * deferred object deletes after the transaction commits: they must not run
-     * inside the transaction (an R2 delete cannot roll back) and they must not
-     * hold up the response (the row is already durable — the bytes are cleanup).
+     * The generated dispatches use this to flush `ctx.storage`'s deferred object
+     * deletes once their writes have committed — cleanup that is already durable
+     * on the row side and so must not hold up the response.
      *
-     * Falls back to awaiting inline when the host cannot defer, so the work still
-     * happens — the unit harness has no `waitUntil`, and silently dropping the
-     * flush there would make a leaked object look like passing behaviour.
+     * Falls back to awaiting inline when the host has no `waitUntil`, so the work
+     * still happens — dropping it there would make a leaked object look like
+     * passing behaviour. On such a host the caller DOES wait for the work.
      * @param work already-started work; a rejection is the caller's to contain
      */
     protected async deferPastResponse(work: Promise<unknown>): Promise<void> {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2475,6 +2475,27 @@ abstract class ShardDO {
         return this.transactionDepth > 0;
     }
 
+    /**
+     * Let `work` outlive this dispatch where the host supports it.
+     *
+     * The generated mutation dispatch uses this to flush `ctx.storage`'s
+     * deferred object deletes after the transaction commits: they must not run
+     * inside the transaction (an R2 delete cannot roll back) and they must not
+     * hold up the response (the row is already durable — the bytes are cleanup).
+     *
+     * Falls back to awaiting inline when the host cannot defer, so the work still
+     * happens — the unit harness has no `waitUntil`, and silently dropping the
+     * flush there would make a leaked object look like passing behaviour.
+     * @param work already-started work; a rejection is the caller's to contain
+     */
+    protected async deferPastResponse(work: Promise<unknown>): Promise<void> {
+        if (this.runner.background(work)) {
+            return;
+        }
+
+        await work;
+    }
+
     protected async runInTransaction<T>(handler: () => Promise<T> | T): Promise<T> {
         if (this.transactionDepth > 0) {
             throw new LunoraError("NESTED_TRANSACTION", "nested transactions are not supported in SQLite-in-DO", { status: 500 });

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -133,12 +133,11 @@ export interface PlatformCapabilities {
         /**
          * Object storage (R2 / S3 / MinIO).
          *
-         * `ctx.storage.deleteAfterCommit(key)` — the mutation-side deferred
-         * delete — rides on this rating and deliberately gets no key of its own:
-         * it needs no host primitive beyond the bucket. The post-commit flush
-         * goes through `ShardHost.waitUntil` where the host has one and is
-         * awaited inline where it does not, so a host that can serve
-         * `objectStorage` can serve the deferral at the same level.
+         * `ctx.storage.deleteAfterCommit(key)` rides on this rating and gets no
+         * key of its own: it needs no host primitive beyond the bucket. The
+         * post-commit flush uses `ShardHost.waitUntil` where the host has one and
+         * is awaited inline where it does not, so a host that can serve
+         * `objectStorage` serves the deferral at the same level.
          */
         objectStorage?: Capability;
 

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -130,7 +130,16 @@ export interface PlatformCapabilities {
          */
         memoryTables?: Capability;
 
-        /** Object storage (R2 / S3 / MinIO). */
+        /**
+         * Object storage (R2 / S3 / MinIO).
+         *
+         * `ctx.storage.deleteAfterCommit(key)` — the mutation-side deferred
+         * delete — rides on this rating and deliberately gets no key of its own:
+         * it needs no host primitive beyond the bucket. The post-commit flush
+         * goes through `ShardHost.waitUntil` where the host has one and is
+         * awaited inline where it does not, so a host that can serve
+         * `objectStorage` can serve the deferral at the same level.
+         */
         objectStorage?: Capability;
 
         /**

--- a/packages/server/__tests__/context.test.ts
+++ b/packages/server/__tests__/context.test.ts
@@ -30,12 +30,39 @@ describe("queryCtx.storage / MutationCtx.storage", () => {
         };
 
         const queryContext: QueryContext["storage"] = storage;
-        const mutationContext: MutationContext["storage"] = storage;
+        // A mutation's storage is the read surface PLUS `deleteAfterCommit`, so a
+        // bare `ReadOnlyStorage` double no longer satisfies it — deliberately: the
+        // extra member is the contract, and a widening that dropped it should fail
+        // right here.
+        const mutationStorage: MutationContext["storage"] = {
+            ...storage,
+            bucket: () => mutationStorage,
+            deleteAfterCommit: () => undefined,
+        };
+        const mutationContext: MutationContext["storage"] = mutationStorage;
 
         expectTypeOf(queryContext.getSignedUrl).toBeFunction();
         expectTypeOf(queryContext.getUrl).toBeFunction();
         expectTypeOf(queryContext.download).toBeFunction();
         expectTypeOf(mutationContext.getSignedUrl).toBeFunction();
+    });
+
+    it("exposes deleteAfterCommit on a mutation only, and never a direct delete", () => {
+        expect.assertions(1);
+
+        // The deferral is mutation-only: a query has no transaction to commit, and
+        // an action has the real `delete` instead. And it is an ADDITION to the read
+        // surface, not a way back to `delete` — a mutation still cannot destroy an
+        // object from inside a span that may roll back.
+        type MutationStorageType = MutationContext["storage"];
+
+        type HasDeferred = Assert<Extends<"deleteAfterCommit", keyof MutationStorageType>>;
+        type NoDirectDelete = Assert<Extends<"delete", keyof MutationStorageType> extends true ? false : true>;
+        type QueryHasNoDeferred = Assert<Extends<"deleteAfterCommit", keyof QueryContext["storage"]> extends true ? false : true>;
+
+        const storageChecks: [HasDeferred, NoDirectDelete, QueryHasNoDeferred] = [true, true, true];
+
+        expect(storageChecks).toEqual([true, true, true]);
     });
 
     it("does NOT expose write operations on QueryCtx.storage at the type level", () => {

--- a/packages/server/__tests__/deferred-deletes.test.ts
+++ b/packages/server/__tests__/deferred-deletes.test.ts
@@ -47,7 +47,7 @@ describe("withDeferredDeletes", () => {
         // Nothing has been attempted — that is the whole point of the deferral.
         expect(deleted).toStrictEqual([]);
 
-        await flushDeferredDeletes(storage);
+        await flushDeferredDeletes({ storage });
 
         expect(deleted).toStrictEqual(["a.png", "b.png"]);
     });
@@ -71,7 +71,7 @@ describe("withDeferredDeletes", () => {
         storage.bucket("avatars").deleteAfterCommit("me.png");
         storage.deleteAfterCommit("top.png");
 
-        await flushDeferredDeletes(storage);
+        await flushDeferredDeletes({ storage });
 
         // The sub-facade shares the queue, but each key is deleted through the
         // bucket it was queued against — not all through the default one.
@@ -90,7 +90,7 @@ describe("withDeferredDeletes", () => {
 
         // The dispatch only ever holds `ctx.storage`; a delete queued on a bucket
         // it handed out must still be reachable from there.
-        await flushDeferredDeletes(storage);
+        await flushDeferredDeletes({ storage });
 
         expect(bucketDeleted).toStrictEqual(["one.png"]);
     });
@@ -105,8 +105,8 @@ describe("flushDeferredDeletes", () => {
 
         storage.deleteAfterCommit("a.png");
 
-        const first: DeferredDeleteFlushResult = await flushDeferredDeletes(storage);
-        const second = await flushDeferredDeletes(storage);
+        const first: DeferredDeleteFlushResult = await flushDeferredDeletes({ storage });
+        const second = await flushDeferredDeletes({ storage });
 
         expect(first.attempted).toBe(1);
         expect(second.attempted).toBe(0);
@@ -133,7 +133,7 @@ describe("flushDeferredDeletes", () => {
         storage.deleteAfterCommit("boom.png");
         storage.deleteAfterCommit("fine.png");
 
-        const outcome = await flushDeferredDeletes(storage);
+        const outcome = await flushDeferredDeletes({ storage });
 
         // A cleanup failure must never surface as a failed mutation — the write
         // already committed. It leaks an object, and says which one.
@@ -150,20 +150,55 @@ describe("flushDeferredDeletes", () => {
         // to call this unconditionally without probing first.
         const { root } = makeStorage();
 
-        await expect(flushDeferredDeletes(root)).resolves.toStrictEqual({ attempted: 0, failures: [] });
+        await expect(flushDeferredDeletes({ storage: root })).resolves.toStrictEqual({ attempted: 0, failures: [] });
     });
 
-    it("tolerates a facade with no delete at all", async () => {
-        expect.assertions(1);
+    it("reports, rather than silently succeeds, when no storage is configured", async () => {
+        expect.assertions(3);
 
-        // The "no storage configured" stub: `deleteAfterCommit` must not blow up
-        // the dispatch that follows a mutation on a project without a bucket.
+        // The "no storage configured" stub. Every other method on it throws that
+        // message loudly; this must not be the one storage call that answers a
+        // clean success while doing nothing.
         const stub = { bucketName: "default" };
         const storage = withDeferredDeletes(stub) as Facade;
 
         storage.deleteAfterCommit("a.png");
 
-        await expect(flushDeferredDeletes(storage)).resolves.toStrictEqual({ attempted: 1, failures: [] });
+        const outcome = await flushDeferredDeletes({ storage });
+
+        expect(outcome.attempted).toBe(1);
+        expect(outcome.failures).toHaveLength(1);
+        expect(String(outcome.failures[0]?.error)).toContain("no storage configured");
+    });
+
+    it("logs every failure through ctx.log with its key", async () => {
+        expect.assertions(2);
+
+        const { root } = makeStorage();
+        const failing = {
+            ...root,
+            delete: async (): Promise<void> => {
+                throw new Error("r2 down");
+            },
+        };
+        const storage = withDeferredDeletes(failing) as Facade;
+        const warnings: { fields?: Record<string, unknown>; message: string }[] = [];
+
+        storage.deleteAfterCommit("leaked.png");
+
+        await flushDeferredDeletes({ log: { warn: (message: string, fields?: Record<string, unknown>) => warnings.push({ fields, message }) }, storage });
+
+        // A leaked object with no log line is a leak nobody can find.
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]?.fields?.["key"]).toBe("leaked.png");
+    });
+
+    it("is a no-op on a context with no storage at all", async () => {
+        expect.assertions(1);
+
+        // Every dispatch calls this unconditionally, including ones on a project
+        // that configured no storage binding.
+        await expect(flushDeferredDeletes({})).resolves.toStrictEqual({ attempted: 0, failures: [] });
     });
 
     it("does not delete when the caller never flushes", () => {

--- a/packages/server/__tests__/deferred-deletes.test.ts
+++ b/packages/server/__tests__/deferred-deletes.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeferredDeleteFlushResult } from "../src/deferred-deletes";
+import { flushDeferredDeletes, withDeferredDeletes } from "../src/deferred-deletes";
+
+/** The shape `asBucketStorage` hands over: a bucket-aware facade with a real `delete`. */
+const makeStorage = () => {
+    const deleted: string[] = [];
+    const bucketDeleted: string[] = [];
+
+    const named = {
+        bucketName: "avatars",
+        delete: async (key: string): Promise<void> => {
+            bucketDeleted.push(key);
+        },
+    };
+
+    const root = {
+        bucket: (name: string) => (name === "avatars" ? named : root),
+        bucketName: "default",
+        delete: async (key: string): Promise<void> => {
+            deleted.push(key);
+        },
+        download: async (key: string): Promise<string> => `body:${key}`,
+    };
+
+    return { bucketDeleted, deleted, root };
+};
+
+type Facade = {
+    bucket: (name: string) => Facade;
+    bucketName: string;
+    deleteAfterCommit: (key: string) => void;
+    download: (key: string) => Promise<string>;
+};
+
+describe("withDeferredDeletes", () => {
+    it("queues rather than deleting", async () => {
+        expect.assertions(2);
+
+        const { deleted, root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+
+        storage.deleteAfterCommit("a.png");
+        storage.deleteAfterCommit("b.png");
+
+        // Nothing has been attempted — that is the whole point of the deferral.
+        expect(deleted).toStrictEqual([]);
+
+        await flushDeferredDeletes(storage);
+
+        expect(deleted).toStrictEqual(["a.png", "b.png"]);
+    });
+
+    it("preserves the underlying read surface", async () => {
+        expect.assertions(2);
+
+        const { root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+
+        expect(storage.bucketName).toBe("default");
+        await expect(storage.download("x")).resolves.toBe("body:x");
+    });
+
+    it("flushes a bucket-scoped delete against that bucket", async () => {
+        expect.assertions(2);
+
+        const { bucketDeleted, deleted, root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+
+        storage.bucket("avatars").deleteAfterCommit("me.png");
+        storage.deleteAfterCommit("top.png");
+
+        await flushDeferredDeletes(storage);
+
+        // The sub-facade shares the queue, but each key is deleted through the
+        // bucket it was queued against — not all through the default one.
+        expect(bucketDeleted).toStrictEqual(["me.png"]);
+        expect(deleted).toStrictEqual(["top.png"]);
+    });
+
+    it("flushes deletes queued through a sub-facade when the root is flushed", async () => {
+        expect.assertions(1);
+
+        const { bucketDeleted, root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+        const avatars = storage.bucket("avatars");
+
+        avatars.deleteAfterCommit("one.png");
+
+        // The dispatch only ever holds `ctx.storage`; a delete queued on a bucket
+        // it handed out must still be reachable from there.
+        await flushDeferredDeletes(storage);
+
+        expect(bucketDeleted).toStrictEqual(["one.png"]);
+    });
+});
+
+describe("flushDeferredDeletes", () => {
+    it("drains, so a second flush is a no-op", async () => {
+        expect.assertions(3);
+
+        const { deleted, root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+
+        storage.deleteAfterCommit("a.png");
+
+        const first: DeferredDeleteFlushResult = await flushDeferredDeletes(storage);
+        const second = await flushDeferredDeletes(storage);
+
+        expect(first.attempted).toBe(1);
+        expect(second.attempted).toBe(0);
+        expect(deleted).toStrictEqual(["a.png"]);
+    });
+
+    it("reports a failure instead of throwing, and still deletes the rest", async () => {
+        expect.assertions(4);
+
+        const deleted: string[] = [];
+        const root = {
+            bucket: () => root,
+            bucketName: "default",
+            delete: async (key: string): Promise<void> => {
+                if (key === "boom.png") {
+                    throw new Error("r2 unavailable");
+                }
+
+                deleted.push(key);
+            },
+        };
+        const storage = withDeferredDeletes(root) as Facade;
+
+        storage.deleteAfterCommit("boom.png");
+        storage.deleteAfterCommit("fine.png");
+
+        const outcome = await flushDeferredDeletes(storage);
+
+        // A cleanup failure must never surface as a failed mutation — the write
+        // already committed. It leaks an object, and says which one.
+        expect(outcome.attempted).toBe(2);
+        expect(outcome.failures).toHaveLength(1);
+        expect(outcome.failures[0]?.key).toBe("boom.png");
+        expect(deleted).toStrictEqual(["fine.png"]);
+    });
+
+    it("is a no-op on a storage facade that was never wrapped", async () => {
+        expect.assertions(1);
+
+        // A query/action `ctx.storage` is not wrapped, so the dispatch must be able
+        // to call this unconditionally without probing first.
+        const { root } = makeStorage();
+
+        await expect(flushDeferredDeletes(root)).resolves.toStrictEqual({ attempted: 0, failures: [] });
+    });
+
+    it("tolerates a facade with no delete at all", async () => {
+        expect.assertions(1);
+
+        // The "no storage configured" stub: `deleteAfterCommit` must not blow up
+        // the dispatch that follows a mutation on a project without a bucket.
+        const stub = { bucketName: "default" };
+        const storage = withDeferredDeletes(stub) as Facade;
+
+        storage.deleteAfterCommit("a.png");
+
+        await expect(flushDeferredDeletes(storage)).resolves.toStrictEqual({ attempted: 1, failures: [] });
+    });
+
+    it("does not delete when the caller never flushes", () => {
+        expect.assertions(1);
+
+        const { deleted, root } = makeStorage();
+        const storage = withDeferredDeletes(root) as Facade;
+
+        storage.deleteAfterCommit("rolled-back.png");
+
+        // Stands in for a rolled-back mutation: the dispatch throws before reaching
+        // the flush, the context is discarded, and the object must survive.
+        expect(deleted).toStrictEqual([]);
+    });
+});

--- a/packages/server/src/deferred-deletes.ts
+++ b/packages/server/src/deferred-deletes.ts
@@ -1,50 +1,42 @@
 /**
  * `ctx.storage.deleteAfterCommit(key)` — the object half of a row deletion,
- * deferred until the mutation that removed the row has actually committed.
+ * deferred until the write that removed the row has actually committed.
  *
  * ## Why a mutation cannot just delete
  *
- * `ctx.storage` is `ReadOnlyStorage` in a mutation, and deliberately so: a
- * mutation runs inside the shard's storage transaction, which can roll back. An
- * R2 delete cannot. A mutation that deleted the object and then aborted — an OCC
- * conflict, an RLS denial, a failed row halfway through a batch — would leave the
- * row intact and the bytes gone, which is the one direction that is not
- * recoverable.
- *
- * Without a first-class answer, every application arrives at the same workaround:
- * schedule an action from the mutation and delete there. That works, but it costs
- * a scheduled function per deletion, it is written slightly differently in every
- * codebase, and the ordering guarantee it depends on (the schedule is itself part
- * of the transaction) is not obvious enough to be relied on by accident.
- *
- * ## What this does instead
+ * `ctx.storage` is read-only in a mutation, and deliberately so: a mutation runs
+ * inside the shard's storage transaction, which can roll back. An R2 delete
+ * cannot. A mutation that deleted the object and then aborted — an OCC conflict,
+ * an RLS denial, a failed row halfway through a batch — would leave the row
+ * intact and the bytes gone, which is the one direction that is not recoverable.
  *
  * `deleteAfterCommit(key)` records the key on the dispatch and returns. It is not
- * a promise — nothing has been attempted yet, so there is nothing to await, and
+ * a promise: nothing has been attempted yet, so there is nothing to await, and
  * typing it `void` keeps a caller from believing the object is gone on the next
  * line. The dispatch flushes the queue only after its transaction resolves, so
  * the row deletion commits transactionally and the object cleanup runs ONLY if it
- * did — a rolled-back mutation never reaches the flush, and the queue dies with
- * the context. The flush itself runs off the response path where the host can
- * defer it, so the caller never waits on R2.
+ * did — a rolled-back write never reaches the flush, and the queue dies with the
+ * context.
  *
  * The trade is that cleanup is no longer synchronous with the row write: an
  * object can briefly outlive its row. Nothing reads an object without its row, so
  * that window is invisible — but it does mean a failed delete leaks bytes rather
- * than failing the mutation, which is why {@link flushDeferredDeletes} reports
- * each failure with its key instead of swallowing it.
+ * than failing the write, which is why {@link flushDeferredDeletes} reports each
+ * failure with its key instead of swallowing it.
  *
- * ## Shape
+ * ## Why every dispatch is wrapped, not just the mutation one
  *
- * The queue is per-dispatch, not per-shard: it hangs off the `ctx.storage`
- * facade, which `buildCtx` builds once per dispatch. `bucket(name)` returns a
- * facade sharing the same queue, so a delete queued against a named bucket is
- * flushed against that bucket rather than the default one.
+ * The queue hangs off the `ctx.storage` facade, which is built once per dispatch.
+ * But `ctx.runMutation` hands the CALLER's context to the callee's handler rather
+ * than building a fresh one — so a mutation reached from an action runs with the
+ * action's `ctx`. Wrapping only mutation dispatches made that composition throw a
+ * bare `TypeError` on a method the handler's own type says exists, and the
+ * canonical "do the I/O in an action, then persist in a mutation" shape is
+ * exactly the shape that hits it.
  *
- * Everything here is `unknown`-in/`unknown`-out for the same reason
- * `asBucketStorage` is: the storage capability arrives through a thunk cast
- * through `unknown`, and the generated shard casts the result back to the
- * context type. The types that matter are on `MutationStorage` in `./types`.
+ * So the facade is installed for every dispatch that can host a mutation handler,
+ * and every one of those dispatches flushes. The alternative — a queue nothing
+ * drains — is the worse failure: it leaks silently, with no error to find.
  */
 
 /** One queued deletion: the bucket facade to call, and the key on it. */
@@ -55,14 +47,19 @@ interface PendingDelete {
 }
 
 /**
- * Where the queue hangs off the facade. A symbol rather than a string key so it
- * cannot collide with a storage method and does not show up in `Object.keys` of
- * a context a handler logs.
+ * Per-facade queues, keyed on the facade itself.
+ *
+ * A `WeakMap` rather than a property on the object: `ctx.storage` is handed to
+ * user code, and a queue stamped onto it would show up in anything that walks or
+ * serializes the context. Keying externally also means the facade a handler sees
+ * is exactly the storage surface and nothing else.
  */
-const PENDING = Symbol.for("lunora.storage.pendingDeletes");
+const queues = new WeakMap<object, PendingDelete[]>();
 
-interface WithPending {
-    [PENDING]?: PendingDelete[];
+/** The slice of a function context the flush needs: the facade to drain, and somewhere to report. */
+interface DeferredDeleteContext {
+    log?: { warn: (message: string, fields?: Record<string, unknown>) => void };
+    storage?: unknown;
 }
 
 /**
@@ -78,10 +75,15 @@ export const withDeferredDeletes = (storage: unknown): unknown => {
     const wrap = (target: unknown): unknown => {
         const inner = (target ?? {}) as Record<string, unknown> & { bucket?: (name: string) => unknown };
 
+        // Spread rather than a Proxy: the facade is built once per dispatch and
+        // read on a hot path, and a Proxy would add a trap to every property
+        // access `ctx.storage` sees for the life of the handler.
+        //
+        // Spread specifically, NOT `getOwnPropertyDescriptors`: the storage this
+        // wraps is itself a read-stamping Proxy, and a spread reads through its
+        // `get` trap (so the stamped methods are what get copied) where a
+        // descriptor copy would read past it and silently drop the stamping.
         const facade: Record<string, unknown> = {
-            // Spread rather than proxy: the facade is built once per dispatch and
-            // read on a hot path, and a Proxy would add a trap to every property
-            // access `ctx.storage` sees for the life of the handler.
             ...inner,
             deleteAfterCommit: (key: string): void => {
                 // Queued against `inner`, not against this wrapper: the delete is
@@ -91,11 +93,19 @@ export const withDeferredDeletes = (storage: unknown): unknown => {
             },
         };
 
+        // A spread copies own enumerable properties only. The storage facades
+        // this ships with are closure-built literals, so that is all of them —
+        // but a caller supplying a class instance would otherwise lose every
+        // prototype method here, in mutations only. Re-parenting keeps them
+        // reachable. (A method that touches private fields still will not work
+        // through a copy; a storage facade should expose own-property methods.)
+        Object.setPrototypeOf(facade, Object.getPrototypeOf(inner) as object | null);
+
         if (typeof inner.bucket === "function") {
             facade.bucket = (name: string): unknown => wrap(inner.bucket?.(name));
         }
 
-        (facade as WithPending)[PENDING] = pending;
+        queues.set(facade, pending);
 
         return facade;
     };
@@ -103,29 +113,30 @@ export const withDeferredDeletes = (storage: unknown): unknown => {
     return wrap(storage);
 };
 
-/** How a flush ended, so the caller can report it without this module owning a logger. */
+/** How a flush ended, so a caller can assert on it without this module owning a logger. */
 export interface DeferredDeleteFlushResult {
     /** How many keys were attempted. */
     attempted: number;
-    /** Keys whose delete rejected, with the reason. Empty when everything succeeded. */
+    /** Keys whose delete did not happen, with the reason. Empty when everything succeeded. */
     failures: { error: unknown; key: string }[];
 }
 
 /**
- * Delete everything queued on `storage`, draining the queue as it goes.
+ * Delete everything queued on `context.storage`, draining the queue as it goes,
+ * and report each failure through `context.log`.
  *
  * Draining first means a second flush of the same dispatch is a no-op rather than
- * a second round of deletes — cheap insurance, since the two callers (the normal
- * path and any future retry) cannot both be proven unique from here.
+ * a second round of deletes.
  *
- * Never throws. A flush runs after the transaction committed, so there is no
- * longer anything to fail into: rejecting here could only turn a leaked object
- * into a failed response for a mutation that already succeeded. Failures come
- * back in the result for the caller to log.
- * @param storage the `ctx.storage` facade built by {@link withDeferredDeletes}
+ * Never throws. A flush runs after the write committed, so there is no longer
+ * anything to fail into: rejecting here could only turn a leaked object into a
+ * failed response for a write that already succeeded. Failures are logged and
+ * also returned, so a dispatch can call this and ignore the result.
+ * @param context the dispatch context; a context with no queued deletes is a no-op
  */
-export const flushDeferredDeletes = async (storage: unknown): Promise<DeferredDeleteFlushResult> => {
-    const queue = (storage as WithPending | undefined)?.[PENDING];
+export const flushDeferredDeletes = async (context: unknown): Promise<DeferredDeleteFlushResult> => {
+    const { log, storage } = (context ?? {}) as DeferredDeleteContext;
+    const queue = typeof storage === "object" && storage !== null ? queues.get(storage) : undefined;
 
     if (!queue || queue.length === 0) {
         return { attempted: 0, failures: [] };
@@ -133,16 +144,31 @@ export const flushDeferredDeletes = async (storage: unknown): Promise<DeferredDe
 
     const draining = queue.splice(0);
 
-    // `allSettled`, so one missing or unreachable key cannot strand the rest of
-    // the batch. Deletes are independent and idempotent, and a batch is whatever
-    // one mutation queued, so there is nothing to gain from serialising them.
-    // "Missing" is the ordinary case — a retried mutation, or a key some other
-    // path already reaped — and R2 does not treat it as an error.
-    const outcomes = await Promise.allSettled(draining.map(async ({ key, storage: target }) => target.delete?.(key)));
+    // `allSettled`, so one unreachable key cannot strand the rest of the batch.
+    // Deletes are independent and idempotent, and a batch is whatever one write
+    // queued, so there is nothing to gain from serialising them. A key that is
+    // already gone is the ordinary case — a retried write, or a key some other
+    // path reaped — and R2 does not treat it as an error.
+    const outcomes = await Promise.allSettled(
+        draining.map(async ({ key, storage: target }) => {
+            if (typeof target.delete !== "function") {
+                // The no-storage stub. Every other method on it throws "no storage
+                // configured"; reporting this as a failure keeps the one storage
+                // call that cannot throw from being the one that says nothing.
+                throw new TypeError("ctx.storage: no storage configured, so the object was not deleted");
+            }
+
+            await target.delete(key);
+        }),
+    );
 
     const failures = outcomes.flatMap((outcome, index) =>
         outcome.status === "rejected" ? [{ error: outcome.reason as unknown, key: draining[index]?.key ?? "" }] : [],
     );
+
+    for (const failure of failures) {
+        log?.warn("ctx.storage.deleteAfterCommit: delete failed, object leaked", { error: String(failure.error), key: failure.key });
+    }
 
     return { attempted: draining.length, failures };
 };

--- a/packages/server/src/deferred-deletes.ts
+++ b/packages/server/src/deferred-deletes.ts
@@ -1,0 +1,148 @@
+/**
+ * `ctx.storage.deleteAfterCommit(key)` — the object half of a row deletion,
+ * deferred until the mutation that removed the row has actually committed.
+ *
+ * ## Why a mutation cannot just delete
+ *
+ * `ctx.storage` is `ReadOnlyStorage` in a mutation, and deliberately so: a
+ * mutation runs inside the shard's storage transaction, which can roll back. An
+ * R2 delete cannot. A mutation that deleted the object and then aborted — an OCC
+ * conflict, an RLS denial, a failed row halfway through a batch — would leave the
+ * row intact and the bytes gone, which is the one direction that is not
+ * recoverable.
+ *
+ * Without a first-class answer, every application arrives at the same workaround:
+ * schedule an action from the mutation and delete there. That works, but it costs
+ * a scheduled function per deletion, it is written slightly differently in every
+ * codebase, and the ordering guarantee it depends on (the schedule is itself part
+ * of the transaction) is not obvious enough to be relied on by accident.
+ *
+ * ## What this does instead
+ *
+ * `deleteAfterCommit(key)` records the key on the dispatch and returns. It is not
+ * a promise — nothing has been attempted yet, so there is nothing to await, and
+ * typing it `void` keeps a caller from believing the object is gone on the next
+ * line. The dispatch flushes the queue only after its transaction resolves, so
+ * the row deletion commits transactionally and the object cleanup runs ONLY if it
+ * did — a rolled-back mutation never reaches the flush, and the queue dies with
+ * the context. The flush itself runs off the response path where the host can
+ * defer it, so the caller never waits on R2.
+ *
+ * The trade is that cleanup is no longer synchronous with the row write: an
+ * object can briefly outlive its row. Nothing reads an object without its row, so
+ * that window is invisible — but it does mean a failed delete leaks bytes rather
+ * than failing the mutation, which is why {@link flushDeferredDeletes} reports
+ * each failure with its key instead of swallowing it.
+ *
+ * ## Shape
+ *
+ * The queue is per-dispatch, not per-shard: it hangs off the `ctx.storage`
+ * facade, which `buildCtx` builds once per dispatch. `bucket(name)` returns a
+ * facade sharing the same queue, so a delete queued against a named bucket is
+ * flushed against that bucket rather than the default one.
+ *
+ * Everything here is `unknown`-in/`unknown`-out for the same reason
+ * `asBucketStorage` is: the storage capability arrives through a thunk cast
+ * through `unknown`, and the generated shard casts the result back to the
+ * context type. The types that matter are on `MutationStorage` in `./types`.
+ */
+
+/** One queued deletion: the bucket facade to call, and the key on it. */
+interface PendingDelete {
+    key: string;
+    /** The storage facade the key belongs to — the default one, or a `bucket(name)` sub-facade. */
+    storage: { delete?: (key: string) => Promise<void> };
+}
+
+/**
+ * Where the queue hangs off the facade. A symbol rather than a string key so it
+ * cannot collide with a storage method and does not show up in `Object.keys` of
+ * a context a handler logs.
+ */
+const PENDING = Symbol.for("lunora.storage.pendingDeletes");
+
+interface WithPending {
+    [PENDING]?: PendingDelete[];
+}
+
+/**
+ * Wrap a storage facade so it also accepts `deleteAfterCommit(key)`.
+ *
+ * Call once per dispatch, outside any read-stamping wrapper: `bucket()` delegates
+ * to the wrapped facade, so a sub-facade is still stamped by whatever wrapped it.
+ * @param storage the bucket-aware facade from `asBucketStorage`
+ */
+export const withDeferredDeletes = (storage: unknown): unknown => {
+    const pending: PendingDelete[] = [];
+
+    const wrap = (target: unknown): unknown => {
+        const inner = (target ?? {}) as Record<string, unknown> & { bucket?: (name: string) => unknown };
+
+        const facade: Record<string, unknown> = {
+            // Spread rather than proxy: the facade is built once per dispatch and
+            // read on a hot path, and a Proxy would add a trap to every property
+            // access `ctx.storage` sees for the life of the handler.
+            ...inner,
+            deleteAfterCommit: (key: string): void => {
+                // Queued against `inner`, not against this wrapper: the delete is
+                // performed later through the object that owns it, so `this` is
+                // whatever that implementation expects rather than the facade.
+                pending.push({ key, storage: inner as PendingDelete["storage"] });
+            },
+        };
+
+        if (typeof inner.bucket === "function") {
+            facade.bucket = (name: string): unknown => wrap(inner.bucket?.(name));
+        }
+
+        (facade as WithPending)[PENDING] = pending;
+
+        return facade;
+    };
+
+    return wrap(storage);
+};
+
+/** How a flush ended, so the caller can report it without this module owning a logger. */
+export interface DeferredDeleteFlushResult {
+    /** How many keys were attempted. */
+    attempted: number;
+    /** Keys whose delete rejected, with the reason. Empty when everything succeeded. */
+    failures: { error: unknown; key: string }[];
+}
+
+/**
+ * Delete everything queued on `storage`, draining the queue as it goes.
+ *
+ * Draining first means a second flush of the same dispatch is a no-op rather than
+ * a second round of deletes — cheap insurance, since the two callers (the normal
+ * path and any future retry) cannot both be proven unique from here.
+ *
+ * Never throws. A flush runs after the transaction committed, so there is no
+ * longer anything to fail into: rejecting here could only turn a leaked object
+ * into a failed response for a mutation that already succeeded. Failures come
+ * back in the result for the caller to log.
+ * @param storage the `ctx.storage` facade built by {@link withDeferredDeletes}
+ */
+export const flushDeferredDeletes = async (storage: unknown): Promise<DeferredDeleteFlushResult> => {
+    const queue = (storage as WithPending | undefined)?.[PENDING];
+
+    if (!queue || queue.length === 0) {
+        return { attempted: 0, failures: [] };
+    }
+
+    const draining = queue.splice(0);
+
+    // `allSettled`, so one missing or unreachable key cannot strand the rest of
+    // the batch. Deletes are independent and idempotent, and a batch is whatever
+    // one mutation queued, so there is nothing to gain from serialising them.
+    // "Missing" is the ordinary case — a retried mutation, or a key some other
+    // path already reaped — and R2 does not treat it as an error.
+    const outcomes = await Promise.allSettled(draining.map(async ({ key, storage: target }) => target.delete?.(key)));
+
+    const failures = outcomes.flatMap((outcome, index) =>
+        outcome.status === "rejected" ? [{ error: outcome.reason as unknown, key: draining[index]?.key ?? "" }] : [],
+    );
+
+    return { attempted: draining.length, failures };
+};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,6 +16,8 @@ export type {
 } from "./builder/index";
 export { initLunora } from "./builder/index";
 export { createSecrets } from "./create-secrets";
+export type { DeferredDeleteFlushResult } from "./deferred-deletes";
+export { flushDeferredDeletes, withDeferredDeletes } from "./deferred-deletes";
 export type { EnvAccessor, EnvKeyFailure, EnvShape, InferEnv } from "./env";
 export { defineEnv, LunoraEnvError, redactSecrets } from "./env";
 export type { LunoraErrorCode } from "./error";
@@ -135,6 +137,7 @@ export type {
     LunoraTracer,
     LunoraWideEvent,
     MutationCtx,
+    MutationStorage,
     OnDeleteAction,
     PaginationOptions,
     PaginationResult,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1762,6 +1762,34 @@ interface ReadOnlyStorage<Buckets extends string = string> {
     head: (key: string) => Promise<StorageObjectHead | null>;
 }
 
+/**
+ * `ctx.storage` inside a **mutation**: the read surface, plus the one write a
+ * transactional context can safely express.
+ *
+ * A mutation runs inside the shard's storage transaction, which can roll back; an
+ * R2 delete cannot. So `delete` stays action-only, and a mutation that removes the
+ * row that referenced an object queues the object instead — the queue is flushed
+ * once the transaction has committed, and never if it rolled back.
+ */
+interface MutationStorage<Buckets extends string = string> extends ReadOnlyStorage<Buckets> {
+    /** Select a named bucket; deletes queued on it are flushed against that bucket. */
+    bucket: (name: Buckets) => MutationStorage<Buckets>;
+
+    /**
+     * Queue `key` for deletion once this mutation commits.
+     *
+     * Returns `void`, not a promise: nothing has been attempted yet, so there is
+     * nothing to await, and the object is still there on the next line. A
+     * rolled-back mutation never flushes — the queue dies with the context — so
+     * the row deletion and the object cleanup cannot disagree.
+     *
+     * The flush runs after the response where the host can defer it, so a failed
+     * delete leaks the object rather than failing a mutation that already
+     * succeeded. Each failure is logged with its key.
+     */
+    deleteAfterCommit: (key: string) => void;
+}
+
 interface Storage<Buckets extends string = string> extends ReadOnlyStorage<Buckets> {
     /** Select a named bucket; the returned accessor exposes the full read/write surface. */
     bucket: (name: Buckets) => Storage<Buckets>;
@@ -2323,7 +2351,7 @@ interface MutationCtx {
     readonly secrets: Secrets;
     /** Attach facts to THIS request's span — the wide event; see {@link LunoraWideEvent}. */
     readonly span: LunoraWideEvent;
-    readonly storage: ReadOnlyStorage;
+    readonly storage: MutationStorage;
     /** Wrap a sub-operation in its own nested span; see {@link LunoraTracer}. */
     readonly trace: LunoraTracer;
     readonly vectors: VectorSearch;
@@ -2454,6 +2482,7 @@ export type {
     LunoraTracer,
     LunoraWideEvent,
     MutationCtx,
+    MutationStorage,
     OnDeleteAction,
     PaginationOptions,
     PaginationResult,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1764,12 +1764,8 @@ interface ReadOnlyStorage<Buckets extends string = string> {
 
 /**
  * `ctx.storage` inside a **mutation**: the read surface, plus the one write a
- * transactional context can safely express.
- *
- * A mutation runs inside the shard's storage transaction, which can roll back; an
- * R2 delete cannot. So `delete` stays action-only, and a mutation that removes the
- * row that referenced an object queues the object instead — the queue is flushed
- * once the transaction has committed, and never if it rolled back.
+ * transactional context can safely express. See `@lunora/server`'s
+ * `deferred-deletes.ts` for why `delete` itself stays action-only.
  */
 interface MutationStorage<Buckets extends string = string> extends ReadOnlyStorage<Buckets> {
     /** Select a named bucket; deletes queued on it are flushed against that bucket. */
@@ -1778,14 +1774,11 @@ interface MutationStorage<Buckets extends string = string> extends ReadOnlyStora
     /**
      * Queue `key` for deletion once this mutation commits.
      *
-     * Returns `void`, not a promise: nothing has been attempted yet, so there is
-     * nothing to await, and the object is still there on the next line. A
-     * rolled-back mutation never flushes — the queue dies with the context — so
-     * the row deletion and the object cleanup cannot disagree.
-     *
-     * The flush runs after the response where the host can defer it, so a failed
-     * delete leaks the object rather than failing a mutation that already
-     * succeeded. Each failure is logged with its key.
+     * Returns `void`, not a promise: nothing has been attempted yet, so the object
+     * is still there on the next line. A rolled-back mutation never flushes, so
+     * the row deletion and the object cleanup cannot disagree. A failed delete
+     * leaks the object rather than failing a mutation that already succeeded, and
+     * is logged with its key.
      */
     deleteAfterCommit: (key: string) => void;
 }

--- a/packages/storage/docs/index.mdx
+++ b/packages/storage/docs/index.mdx
@@ -65,15 +65,16 @@ so the row and the bytes cannot disagree. `deleteAfterCommit` returns `void`
 rather than a promise: nothing has been attempted yet when it returns, and the
 object is still there on the next line.
 
-The flush runs after the response, where the host can defer it, so the caller
-never waits on R2. The trade is that an object can briefly outlive its row, and
-that a failed delete leaks the object rather than failing a mutation that already
-committed — each failure is logged with its key. Nothing reads an object without
-its row, so the window itself is invisible.
+The flush runs after the response wherever the host can defer it (Cloudflare
+can), so the caller does not wait on R2. The trade is that an object can briefly
+outlive its row, and that a failed delete leaks the object rather than failing a
+mutation that already committed — each failure is logged with its key. Nothing
+reads an object without its row, so the window itself is invisible.
 
 `ctx.storage.bucket("avatars").deleteAfterCommit(key)` queues against that bucket.
-An action needs none of this: it is not transactional, so it calls `delete`
-directly.
+An action needs none of this for its own deletes — it is not transactional, so it
+calls `delete` directly — but a mutation it reaches through `ctx.runMutation`
+still queues, and those deletes are flushed when the action finishes.
 
 Build the full `Storage` outside a handler (or to use the object-level reads,
 ranged downloads, and multipart shown below) with

--- a/packages/storage/docs/index.mdx
+++ b/packages/storage/docs/index.mdx
@@ -41,6 +41,40 @@ handlers get a read-only surface (`download`, `getMetadata`, `getSignedUrl`,
 (`store`, `delete`, `generateUploadUrl`, multipart, presigned). On `ctx.storage`,
 `download(key)` resolves to the `ReadableStream` directly.
 
+## Deleting an object with the row that owns it
+
+A mutation runs inside the shard's storage transaction, which can roll back. An
+R2 delete cannot — so `delete` stays action-only, and a mutation that removes the
+row pointing at an object queues the object instead:
+
+```ts
+export const remove = mutation.input({ id: v.id("attachments") }).mutation(async ({ args, ctx }) => {
+    const attachment = await ctx.db.attachments.get(args.id);
+
+    if (!attachment) {
+        return;
+    }
+
+    await ctx.db.attachments.delete(args.id);
+    ctx.storage.deleteAfterCommit(attachment.key);
+});
+```
+
+The queue is flushed once the transaction commits, and never if it rolled back —
+so the row and the bytes cannot disagree. `deleteAfterCommit` returns `void`
+rather than a promise: nothing has been attempted yet when it returns, and the
+object is still there on the next line.
+
+The flush runs after the response, where the host can defer it, so the caller
+never waits on R2. The trade is that an object can briefly outlive its row, and
+that a failed delete leaks the object rather than failing a mutation that already
+committed — each failure is logged with its key. Nothing reads an object without
+its row, so the window itself is invisible.
+
+`ctx.storage.bucket("avatars").deleteAfterCommit(key)` queues against that bucket.
+An action needs none of this: it is not transactional, so it calls `delete`
+directly.
+
 Build the full `Storage` outside a handler (or to use the object-level reads,
 ranged downloads, and multipart shown below) with
 `createStorage({ bucket, publicBaseUrl?, signingSecret?, s3? })`. The examples


### PR DESCRIPTION
## What

`ctx.storage.deleteAfterCommit(key)` — the object half of a row deletion, run once the mutation that removed the row has actually committed.

```ts
export const remove = mutation.input({ id: v.id("attachments") }).mutation(async ({ args, ctx }) => {
    const attachment = await ctx.db.attachments.get(args.id);

    if (!attachment) {
        return;
    }

    await ctx.db.attachments.delete(args.id);
    ctx.storage.deleteAfterCommit(attachment.key);
});
```

## Why

`ctx.storage` is `ReadOnlyStorage` in a mutation, and rightly so: a mutation runs inside the shard's storage transaction, which can roll back, and an R2 delete cannot. A mutation that deleted the object and then aborted — an OCC conflict, an RLS denial, a failed row halfway through a batch — would leave the row intact and the bytes gone. That is the one direction that is not recoverable.

Today there is no first-class answer, so every application lands on the same workaround: schedule an action from the mutation and delete there. It works, but it costs a scheduled function per deletion, it is written slightly differently in every codebase, and the guarantee it leans on (the schedule is itself part of the transaction) is not obvious enough to be depended on by accident.

Orphan detection exists, but it is a Studio panel — a thing a human opens — not a production reaper.

## Semantics

- **Returns `void`, not a promise.** Nothing has been attempted when it returns, so there is nothing to await, and the type stops a caller believing the object is gone on the next line.
- **Flushed after the transaction resolves, never inside it.** A throw anywhere in the handler skips the flush entirely and the queue dies with the context, so the row and the bytes cannot disagree. `emit-shard-deferred-deletes.test.ts` pins the ordering by index, because "move this three lines up" is exactly the edit that would silently break it.
- **Deferred past the response** via `ShardHost.waitUntil`, so a committed mutation never waits on R2. Awaited inline on a host without one — dropping it there would make an un-flushed queue look like passing behaviour under test.
- **Never fails the mutation.** The write already committed; a cleanup failure leaks an object rather than turning into a 500. Each failure is logged with its key.
- **Mutation-only.** A query has no transaction to commit and an action has the real `delete`, so wrapping either would put a method on `ctx.storage` that nothing ever drains. The wrap is gated on `kind === "mutation"` at ctx-build time.
- **Bucket-aware.** `ctx.storage.bucket("avatars").deleteAfterCommit(key)` flushes against that bucket. The sub-facade shares the queue, so the dispatch — which only ever holds `ctx.storage` — still finds it.

## Design notes

- The queue hangs off the `ctx.storage` facade, which `buildCtx` builds once per dispatch, so it is per-dispatch without threading anything new through the many `buildCtx` call sites.
- `withDeferredDeletes` wraps **outside** the read-stamping facade, so `bucket(name)` still resolves through `markUnvouchableReads` and stays stamped, and it wraps into a separate binding so `ctx.db.system._storage` (which shares the same adapter) is untouched.
- A spread facade rather than a `Proxy`: it is built once per dispatch and read on a hot path, and a Proxy would add a trap to every property access `ctx.storage` sees for the life of the handler.
- The flush drains before deleting, so a second flush is a no-op rather than a second round.
- `deferPastResponse` is one new `protected` member on `ShardDO` — `runner`/`shardHost` are private, and the generated subclass needs the seam. It is mirrored in `emitted-shard-contract.ts`, which is what proves the emitted call actually compiles against the base class.

## Scope

| Package | Change |
| --- | --- |
| `@lunora/server` | `deferred-deletes.ts` (`withDeferredDeletes`, `flushDeferredDeletes`), `MutationStorage` type, `MutationCtx["storage"]` |
| `@lunora/do` | `protected deferPastResponse` |
| `@lunora/codegen` | wrap `ctx.storage` for mutations, retype the emitted `MutationCtx`, flush after the transaction |
| `@lunora/platform` | `objectStorage` capability doc — why the deferral gets no key of its own |
| `@lunora/storage` | docs: "Deleting an object with the row that owns it" |

**Breaking (pre-1.0):** `MutationCtx["storage"]` is `MutationStorage` rather than `ReadOnlyStorage`. A superset, so handlers are unaffected; code that *constructs* a mutation context (a test double) must add `deleteAfterCommit`. `context.test.ts` is updated and now pins the three-way contract: a mutation has `deleteAfterCommit`, a mutation still has no `delete`, a query has neither.

## Checks

- `pnpm run lint:types` (all 56 projects) — clean
- `pnpm --filter "@lunora/server" run test` — 634 passed (9 new)
- `pnpm --filter "@lunora/codegen" run test` — 1366 passed (5 new); golden fixtures regenerated with `__tests__/capture-expected.ts`
- `pnpm --filter "@lunora/do" run test` — 611 passed (2 new)
- `lint:eslint` clean on server / do / codegen / platform; `lint:package-json` clean
- `pnpm run api:update` after a full `build:packages` — diffs limited to the three entries above
