### PR TITLE
feat(server): add defineActionCache for memoising actions

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -9,7 +9,31 @@ here is a public-API change and must be reviewed as one (SemVer applies).
 
 ## `lunorash`
 
+### `ACTION_CACHE_DEFAULT_TTL_MS` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ACTION_CACHE_TABLE` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `ActionBuilder` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheComponent` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheContext` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheDatabase` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheFunctions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -106,6 +130,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DeferredDeleteFlushResult` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DefineActionCacheOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -993,6 +1021,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `actionCacheExtension` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `allowAll` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1021,6 +1053,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `cacheKeyFor` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `clampLimit` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1044,6 +1080,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 ### `cronJobs` (const)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
+
+### `defineActionCache` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `defineAggregateIndex` (const)
 
@@ -4655,7 +4695,31 @@ Re-exported from `@lunora/runtime` — signature tracked at its source.
 
 ## `lunorash/server`
 
+### `ACTION_CACHE_DEFAULT_TTL_MS` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ACTION_CACHE_TABLE` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `ActionBuilder` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheComponent` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheContext` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheDatabase` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ActionCacheFunctions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -4752,6 +4816,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DeferredDeleteFlushResult` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DefineActionCacheOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -5639,6 +5707,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `actionCacheExtension` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `allowAll` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5667,6 +5739,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `cacheKeyFor` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `clampLimit` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5690,6 +5766,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 ### `cronJobs` (const)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
+
+### `defineActionCache` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `defineAggregateIndex` (const)
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -9,6 +9,18 @@ here is a public-API change and must be reviewed as one (SemVer applies).
 
 ## `@lunora/server`
 
+### `ACTION_CACHE_DEFAULT_TTL_MS` (const)
+
+```ts
+const DEFAULT_ACTION_CACHE_TTL_MS: number;
+```
+
+### `ACTION_CACHE_TABLE` (const)
+
+```ts
+const ACTION_CACHE_TABLE: "actionCache_entries";
+```
+
 ### `ActionBuilder` (interface)
 
 ```ts
@@ -31,6 +43,53 @@ interface ActionBuilder<Context, Args extends ArgsValidator, Output = undefined>
     output: <V extends Validator>(validator: V) => ActionBuilder<Context, Args, Infer<V>>;
     use: <ContextOut>(middleware: Middleware<Context, ContextOut>) => ActionBuilder<ContextOut, Args, Output>;
     x402: (config: X402ProcedureConfig) => ActionBuilder<Context, Args, Output>;
+}
+```
+
+### `ActionCacheComponent` (type)
+
+```ts
+type ActionCacheComponent = {
+    functions: ActionCacheFunctions;
+    invalidate: (context: ActionCacheContext, name: string, args: unknown) => Promise<void>;
+    invalidateAll: (context: ActionCacheContext, name: string) => Promise<{
+        complete: boolean;
+        deleted: number;
+    }>;
+    wrap: <T>(context: ActionCacheContext, name: string, args: unknown, compute: () => Promise<T>) => Promise<T>;
+} & Component<{
+    [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable>;
+}>;
+```
+
+### `ActionCacheContext` (interface)
+
+```ts
+interface ActionCacheContext {
+    db: ActionCacheDatabase;
+}
+```
+
+### `ActionCacheDatabase` (interface)
+
+```ts
+interface ActionCacheDatabase {
+    delete: <T extends string>(id: Id<T>) => Promise<void>;
+    insert: (table: string, document: Record<string, unknown>) => Promise<unknown>;
+    patch: <T extends string>(id: Id<T>, patch: Record<string, unknown>) => Promise<void>;
+    query: (table: string) => ActionCacheQuery;
+}
+```
+
+### `ActionCacheFunctions` (interface)
+
+```ts
+interface ActionCacheFunctions {
+    purgeExpired: RegisteredMutation<{
+        limit: ReturnType<typeof v.optional>;
+    }, {
+        deleted: number;
+    }>;
 }
 ```
 
@@ -272,6 +331,15 @@ interface DeferredDeleteFlushResult {
         error: unknown;
         key: string;
     }[];
+}
+```
+
+### `DefineActionCacheOptions` (interface)
+
+```ts
+interface DefineActionCacheOptions {
+    maxValueBytes?: number;
+    ttlMs?: number;
 }
 ```
 
@@ -2666,6 +2734,14 @@ interface Workflows {
 }
 ```
 
+### `actionCacheExtension` (const)
+
+```ts
+const actionCacheExtension: SchemaExtension<{
+    [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable>;
+}>;
+```
+
 ### `allowAll` (const)
 
 ```ts
@@ -2708,6 +2784,12 @@ const buildMaskRegistry: (functions: Iterable<unknown>) => MaskRegistry;
 const buildRlsReadRegistry: (functions: Iterable<unknown>) => RlsReadRegistry;
 ```
 
+### `cacheKeyFor` (const)
+
+```ts
+const cacheKeyFor: (name: string, argumentsKey: string) => Promise<string>;
+```
+
 ### `clampLimit` (const)
 
 ```ts
@@ -2741,6 +2823,12 @@ const createSecrets: (env: Record<string, unknown>) => Secrets;
 ### `cronJobs` (const)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
+
+### `defineActionCache` (const)
+
+```ts
+const defineActionCache: (options?: DefineActionCacheOptions) => ActionCacheComponent;
+```
 
 ### `defineAggregateIndex` (const)
 

--- a/packages/server/__tests__/action-cache.test.ts
+++ b/packages/server/__tests__/action-cache.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionCacheContext } from "../src/action-cache";
+import { ACTION_CACHE_TABLE, cacheKeyFor, defineActionCache } from "../src/action-cache";
+
+/**
+ * Minimal in-memory `db` matching the slice the action cache uses:
+ * `query(table).withIndex(...).order(...).first()/take()`, `insert`, `patch`,
+ * `delete`. Index arguments are emulated by full-scan + the same `eq` logic,
+ * faithful for the handful of rows under test; ordered reads sort by
+ * `expiresAt`, which is the only index the cache reads in order.
+ */
+interface Eq {
+    field: string;
+    value: unknown;
+}
+
+/** Emulate one index read: the table filter plus the `q.eq(...)` predicates the cache builds. */
+const matchRows = (rows: Map<string, Record<string, unknown>>, table: string, eqs: Eq[]): Record<string, unknown>[] =>
+    [...rows.values()].filter((row) => (row["__table"] as string) === table && eqs.every((eq) => row[eq.field] === eq.value));
+
+/** `byExpiresAt` is the only index the cache reads in order, so emulate that order. */
+const byExpiresAt = (rows: Record<string, unknown>[], direction: "asc" | "desc"): Record<string, unknown>[] =>
+    rows.toSorted((a, b) =>
+        direction === "asc" ? (a["expiresAt"] as number) - (b["expiresAt"] as number) : (b["expiresAt"] as number) - (a["expiresAt"] as number),
+    );
+
+const createMemoryDb = () => {
+    const rows = new Map<string, Record<string, unknown>>();
+    let nextId = 1;
+
+    const makeReader = (table: string) => {
+        const eqs: Eq[] = [];
+        let direction: "asc" | "desc" | undefined;
+
+        const resolved = (): Record<string, unknown>[] => {
+            const matched = matchRows(rows, table, eqs);
+
+            return direction === undefined ? matched : byExpiresAt(matched, direction);
+        };
+
+        const reader = {
+            first: async () => resolved()[0] ?? null,
+            order(requested: "asc" | "desc") {
+                direction = requested;
+
+                return reader;
+            },
+            take: async (limit: number) => resolved().slice(0, limit),
+            withIndex(_name: string, range?: (q: unknown) => unknown) {
+                const builder = {
+                    eq(field: string, value: unknown) {
+                        eqs.push({ field, value });
+
+                        return builder;
+                    },
+                };
+
+                range?.(builder);
+
+                return reader;
+            },
+        };
+
+        return reader;
+    };
+
+    return {
+        delete: async (id: string) => {
+            rows.delete(id);
+        },
+        insert: async (table: string, document: Record<string, unknown>) => {
+            const id = `${table}|${String(nextId)}`;
+
+            nextId += 1;
+            rows.set(id, { ...document, __table: table, _creationTime: Date.now(), _id: id });
+
+            return id;
+        },
+        patch: async (id: string, patch: Record<string, unknown>) => {
+            const existing = rows.get(id);
+
+            if (existing) {
+                rows.set(id, { ...existing, ...patch });
+            }
+        },
+        query: (table: string) => makeReader(table),
+        rows,
+    };
+};
+
+type MemoryDb = ReturnType<typeof createMemoryDb>;
+
+const contextFor = (db: MemoryDb): ActionCacheContext => ({ db }) as unknown as ActionCacheContext;
+
+const entries = (db: MemoryDb): Record<string, unknown>[] => [...db.rows.values()].filter((row) => row["__table"] === ACTION_CACHE_TABLE);
+
+describe("cacheKeyFor", () => {
+    it("is stable for the same inputs and differs across names", async () => {
+        expect.assertions(2);
+
+        await expect(cacheKeyFor("a", "{}")).resolves.toBe(await cacheKeyFor("a", "{}"));
+        await expect(cacheKeyFor("a", "{}")).resolves.not.toBe(await cacheKeyFor("b", "{}"));
+    });
+
+    it("separates the name from the args so a shifted boundary cannot collide", async () => {
+        expect.assertions(1);
+
+        // Without a separator, ("ab", "c") and ("a", "bc") hash the same bytes —
+        // one action could then serve another's cached answer.
+        await expect(cacheKeyFor("ab", "c")).resolves.not.toBe(await cacheKeyFor("a", "bc"));
+    });
+});
+
+describe("defineActionCache — wrap", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("runs the function on a miss and serves the stored value on a hit", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<{ score: number }>>(async () => {
+            return { score: 1 };
+        });
+
+        vi.setSystemTime(1000);
+
+        await expect(cache.wrap(contextFor(db), "embed", { text: "hi" }, fn)).resolves.toStrictEqual({ score: 1 });
+        await expect(cache.wrap(contextFor(db), "embed", { text: "hi" }, fn)).resolves.toStrictEqual({ score: 1 });
+
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("keys on the arguments, so a different call is a separate entry", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<number>>(async () => 1);
+
+        vi.setSystemTime(1000);
+
+        await cache.wrap(contextFor(db), "embed", { text: "a" }, fn);
+        await cache.wrap(contextFor(db), "embed", { text: "b" }, fn);
+
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect(entries(db)).toHaveLength(2);
+    });
+
+    it("treats an entry past its TTL as a miss and refreshes it in place", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<number>>(async () => 1);
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "embed", {}, fn);
+
+        vi.setSystemTime(1000 + 10_001);
+        await cache.wrap(contextFor(db), "embed", {}, fn);
+
+        expect(fn).toHaveBeenCalledTimes(2);
+        // Refreshed, not duplicated: the stale row is patched rather than joined
+        // by a second row under the same key.
+        expect(entries(db)).toHaveLength(1);
+        expect(entries(db)[0]?.["expiresAt"]).toBe(1000 + 10_001 + 10_000);
+    });
+
+    it("round-trips an undefined result rather than re-running forever", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<undefined>>(async () => undefined);
+
+        vi.setSystemTime(1000);
+
+        // `JSON.stringify(undefined)` is not a string, so a bare value could not
+        // be stored at all and every call would miss.
+        await expect(cache.wrap(contextFor(db), "maybe", {}, fn)).resolves.toBeUndefined();
+
+        await cache.wrap(contextFor(db), "maybe", {}, fn);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns an oversized result without storing it", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ maxValueBytes: 32, ttlMs: 10_000 });
+        const big = "x".repeat(200);
+        const fn = vi.fn<() => Promise<string>>(async () => big);
+
+        vi.setSystemTime(1000);
+
+        // A cache must not fail a successful action just because its answer was
+        // large — the caller still gets the value, it is simply not kept.
+        await expect(cache.wrap(contextFor(db), "big", {}, fn)).resolves.toBe(big);
+        expect(entries(db)).toHaveLength(0);
+
+        await cache.wrap(contextFor(db), "big", {}, fn);
+
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("drops a stale entry whose fresh answer is too large to keep", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ maxValueBytes: 64, ttlMs: 10_000 });
+        let payload = "small";
+        const fn = vi.fn<() => Promise<string>>(async () => payload);
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "grow", {}, fn);
+
+        expect(entries(db)).toHaveLength(1);
+
+        payload = "x".repeat(500);
+        vi.setSystemTime(1000 + 10_001);
+        await cache.wrap(contextFor(db), "grow", {}, fn);
+
+        // Keeping the row would serve the old value until it expired, while the
+        // new one was silently uncached.
+        expect(entries(db)).toHaveLength(0);
+    });
+
+    it("reaps expired rows opportunistically on a miss", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "a", {}, async () => 1);
+        await cache.wrap(contextFor(db), "b", {}, async () => 2);
+
+        expect(entries(db)).toHaveLength(2);
+
+        // Both entries are now expired; a miss on a third key pays for the sweep.
+        vi.setSystemTime(1000 + 10_001);
+        await cache.wrap(contextFor(db), "c", {}, async () => 3);
+
+        expect(entries(db)).toHaveLength(1);
+    });
+});
+
+describe("defineActionCache — invalidation", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("invalidate drops exactly the matching entry", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "embed", { text: "a" }, async () => 1);
+        await cache.wrap(contextFor(db), "embed", { text: "b" }, async () => 2);
+
+        await cache.invalidate(contextFor(db), "embed", { text: "a" });
+
+        expect(entries(db)).toHaveLength(1);
+        expect(entries(db)[0]?.["name"]).toBe("embed");
+    });
+
+    it("invalidate on an absent entry resolves without throwing", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        await expect(cache.invalidate(contextFor(db), "embed", { text: "nope" })).resolves.toBeUndefined();
+    });
+
+    it("invalidateAll drops every entry under one name and leaves the others", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "embed", { text: "a" }, async () => 1);
+        await cache.wrap(contextFor(db), "embed", { text: "b" }, async () => 2);
+        await cache.wrap(contextFor(db), "other", {}, async () => 3);
+
+        const deleted = await cache.invalidateAll(contextFor(db), "embed");
+
+        expect(deleted).toBe(2);
+        expect(entries(db)).toHaveLength(1);
+        expect(entries(db)[0]?.["name"]).toBe("other");
+    });
+});
+
+describe("defineActionCache — purgeExpired", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("deletes only the expired entries and reports the count", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "old", {}, async () => 1);
+
+        // Far enough ahead that the first entry has expired and the second has not.
+        vi.setSystemTime(1000 + 9000);
+        await cache.wrap(contextFor(db), "fresh", {}, async () => 2);
+
+        vi.setSystemTime(1000 + 10_500);
+        const result = await cache.functions.purgeExpired.handler({ db }, {});
+
+        expect(result.deleted).toBe(1);
+        expect(entries(db)).toHaveLength(1);
+        expect(entries(db)[0]?.["name"]).toBe("fresh");
+    });
+});

--- a/packages/server/__tests__/action-cache.test.ts
+++ b/packages/server/__tests__/action-cache.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ActionCacheContext } from "../src/action-cache";
 import { ACTION_CACHE_TABLE, cacheKeyFor, defineActionCache } from "../src/action-cache";
+import { LunoraError } from "../src/error";
 
 /**
  * Minimal in-memory `db` matching the slice the action cache uses:
@@ -459,5 +460,50 @@ describe("defineActionCache — purgeExpired limits", () => {
         // `take()` has no ceiling of its own, so an unbounded limit is an
         // unbounded index scan inside a mutation.
         expect(Math.max(...reads)).toBeLessThanOrEqual(4096);
+    });
+});
+
+describe("defineActionCache — concurrent writers", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("returns the computed value when another writer won the key", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        // The unique index doing its job: two callers missed at once, both ran
+        // compute, and this one lost the insert race. The work already succeeded
+        // and was paid for — losing the race must not turn into a failed action.
+        db.insert = async () => {
+            throw new LunoraError("CONFLICT", "unique index breach");
+        };
+
+        vi.setSystemTime(1000);
+
+        await expect(cache.wrap(contextFor(db), "embed", {}, async () => "computed")).resolves.toBe("computed");
+    });
+
+    it("still propagates an unexpected database error", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        // Degrading silently to "uncached forever" is how a schema or permission
+        // problem would stay hidden.
+        db.insert = async () => {
+            throw new LunoraError("FORBIDDEN", "denied by policy");
+        };
+
+        vi.setSystemTime(1000);
+
+        await expect(cache.wrap(contextFor(db), "embed", {}, async () => "computed")).rejects.toThrow("denied by policy");
     });
 });

--- a/packages/server/__tests__/action-cache.test.ts
+++ b/packages/server/__tests__/action-cache.test.ts
@@ -299,9 +299,9 @@ describe("defineActionCache — invalidation", () => {
         await cache.wrap(contextFor(db), "embed", { text: "b" }, async () => 2);
         await cache.wrap(contextFor(db), "other", {}, async () => 3);
 
-        const deleted = await cache.invalidateAll(contextFor(db), "embed");
+        const outcome = await cache.invalidateAll(contextFor(db), "embed");
 
-        expect(deleted).toBe(2);
+        expect(outcome).toStrictEqual({ complete: true, deleted: 2 });
         expect(entries(db)).toHaveLength(1);
         expect(entries(db)[0]?.["name"]).toBe("other");
     });
@@ -335,5 +335,129 @@ describe("defineActionCache — purgeExpired", () => {
         expect(result.deleted).toBe(1);
         expect(entries(db)).toHaveLength(1);
         expect(entries(db)[0]?.["name"]).toBe("fresh");
+    });
+});
+
+describe("defineActionCache — key derivation", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("keys structurally, so argument order is not a cache miss", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<number>>(async () => 1);
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "embed", { a: 1, b: 2 }, fn);
+        await cache.wrap(contextFor(db), "embed", { b: 2, a: 1 }, fn);
+
+        // Under raw JSON.stringify these are two entries and the caller pays
+        // twice, with nothing to indicate why.
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("keys distinct byte payloads distinctly", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+        const fn = vi.fn<() => Promise<number>>(async () => 1);
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "embed", { blob: new Uint8Array([1, 2, 3]).buffer }, fn);
+        await cache.wrap(contextFor(db), "embed", { blob: new Uint8Array([9, 9, 9]).buffer }, fn);
+
+        // `JSON.stringify` renders every ArrayBuffer as `{}` — which is not a miss,
+        // it is a COLLISION: the second caller would be served the first's result.
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect(entries(db)).toHaveLength(2);
+    });
+
+    it("round-trips a bigint result instead of throwing after the work is done", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+
+        // Raw JSON.stringify throws on a bigint — after `compute` has already run
+        // and been paid for.
+        await expect(cache.wrap(contextFor(db), "count", {}, async () => 9_007_199_254_740_993n)).resolves.toBe(9_007_199_254_740_993n);
+        await expect(cache.wrap(contextFor(db), "count", {}, async () => 0n)).resolves.toBe(9_007_199_254_740_993n);
+    });
+});
+
+describe("defineActionCache — ttl", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("measures the TTL from after compute, not before it", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await cache.wrap(contextFor(db), "slow", {}, async () => {
+            // A slow upstream call: the clock moves while it runs.
+            vi.setSystemTime(6000);
+
+            return 1;
+        });
+
+        // Measured from the start, the entry would already be half-expired.
+        expect(entries(db)[0]?.["expiresAt"]).toBe(16_000);
+    });
+});
+
+describe("defineActionCache — purgeExpired limits", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("clamps a caller-supplied limit", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const cache = defineActionCache({ ttlMs: 1000 });
+        const reads: number[] = [];
+        const inner = db.query;
+
+        db.query = (table: string) => {
+            const reader = inner(table);
+            const take = reader.take.bind(reader);
+
+            reader.take = async (limit: number) => {
+                reads.push(limit);
+
+                return take(limit);
+            };
+
+            return reader;
+        };
+
+        vi.setSystemTime(1000);
+        await cache.functions.purgeExpired.handler({ db }, { limit: 1e9 });
+
+        // `take()` has no ceiling of its own, so an unbounded limit is an
+        // unbounded index scan inside a mutation.
+        expect(Math.max(...reads)).toBeLessThanOrEqual(4096);
     });
 });

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -372,6 +372,54 @@ pre-write row does not discard a small post-write one.
     needs a policy — deny client access outright, since `listForDocument` is internal and meant to be wrapped by a procedure of your own.
 </Callout>
 
+## `defineActionCache(options)` — memoising an action
+
+The section above caches a _response_ at the HTTP edge. This caches the _result_
+of an action inside the app — the model call, the third-party fetch, the
+embedding — keyed by its arguments, with a TTL:
+
+```ts
+// lunora/cache.ts
+import { defineActionCache } from "@lunora/server";
+
+export const cache = defineActionCache({ ttlMs: 60 * 60 * 1000 });
+
+// lunora/schema.ts — merges in as `actionCache_entries`
+export const schema = defineSchema({ ... }).extend(cache.extension);
+
+// Re-export so codegen registers it; schedule it from a cron for bulk cleanup.
+export const { purgeExpired } = cache.functions;
+```
+
+```ts
+export const embed = action
+    .input({ text: v.string() })
+    .action(async ({ args, ctx }) => cache.wrap(ctx, "embed", args, async () => callEmbeddingModel(args.text)));
+```
+
+`wrap(ctx, name, args, fn)` returns the stored value on a hit and runs `fn` on a
+miss. The key is a SHA-256 of `name` and `JSON.stringify(args)` — call sites pass
+whole model requests, which are far too large to index directly — so two calls
+agree only if their arguments serialize identically, key order included. Pass the
+handler's own `args` rather than rebuilding one.
+
+`invalidate(ctx, name, args)` drops one entry; `invalidateAll(ctx, name)` drops
+every entry under a name.
+
+Expiry is lazy: a read past the TTL reports a miss and the row is overwritten by
+the same call. Each miss also reaps a few expired rows, so an app with steady
+traffic stays bounded on its own; `purgeExpired` is for reclaiming entries whose
+names went quiet.
+
+Two things it deliberately does not do. There is **no single-flight** — two
+callers that miss at the same instant both run `fn` — because preventing that
+needs a lock held across an arbitrarily long external call, whose own failure
+mode (a crashed holder wedging the key) is worse than a duplicate cold start.
+And the stored value is **JSON**, so a `Date` comes back as a string: cache what
+you would send over the wire. A result over `maxValueBytes` (512 KB by default)
+is returned to the caller but not stored, so a large answer costs a cache miss
+rather than a failed action.
+
 ## Subpaths
 
 - `@lunora/server/rls/testing`: `expectPolicy(policies)`, an in-process RLS

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -398,27 +398,35 @@ export const embed = action
 ```
 
 `wrap(ctx, name, args, fn)` returns the stored value on a hit and runs `fn` on a
-miss. The key is a SHA-256 of `name` and `JSON.stringify(args)` — call sites pass
-whole model requests, which are far too large to index directly — so two calls
-agree only if their arguments serialize identically, key order included. Pass the
-handler's own `args` rather than rebuilding one.
+miss. The key is a SHA-256 of `name` and the args encoded through the wire codec
+with sorted keys — call sites pass whole model requests, which are far too large
+to index directly. Because the encoding is structural, `{ a, b }` and `{ b, a }`
+are one entry, and `bigint` / `Date` / bytes arguments key distinctly instead of
+collapsing together.
 
-`invalidate(ctx, name, args)` drops one entry; `invalidateAll(ctx, name)` drops
-every entry under a name.
+`invalidate(ctx, name, args)` drops one entry. `invalidateAll(ctx, name)` drops
+every entry under a name and returns `{ deleted, complete }` — call it again while
+`complete` is `false`.
 
 Expiry is lazy: a read past the TTL reports a miss and the row is overwritten by
 the same call. Each miss also reaps a few expired rows, so an app with steady
 traffic stays bounded on its own; `purgeExpired` is for reclaiming entries whose
 names went quiet.
 
-Two things it deliberately does not do. There is **no single-flight** — two
-callers that miss at the same instant both run `fn` — because preventing that
-needs a lock held across an arbitrarily long external call, whose own failure
-mode (a crashed holder wedging the key) is worse than a duplicate cold start.
-And the stored value is **JSON**, so a `Date` comes back as a string: cache what
-you would send over the wire. A result over `maxValueBytes` (512 KB by default)
-is returned to the caller but not stored, so a large answer costs a cache miss
-rather than a failed action.
+One thing it deliberately does not do: there is **no single-flight**. Two callers
+that miss at the same instant both run `fn`; the unique index on the key means one
+result is stored rather than two rows appearing. Preventing the duplicate work
+needs a lock held across an arbitrarily long external call, whose own failure mode
+— a crashed holder wedging the key — is worse than a cold start being paid twice.
+
+A result over `maxValueBytes` (512 KB by default) is returned to the caller but
+not stored, so a large answer costs a cache miss rather than a failed action.
+
+<Callout type="warn">
+    `wrap` reads and writes through the app's own `ctx.db`, so on an `.rls("required")` schema the merged `actionCache_entries` table needs a policy like any
+    other. Declare one that denies client access outright — entries are keyed by a digest and carry no ownership column, so there is nothing for a row policy to
+    scope to.
+</Callout>
 
 ## Subpaths
 

--- a/packages/server/src/action-cache.ts
+++ b/packages/server/src/action-cache.ts
@@ -50,6 +50,7 @@
  * Cache what you would send over the wire, because that is exactly what this is.
  */
 
+import { isLunoraError } from "@lunora/errors";
 import type { Id } from "@lunora/values";
 import { v } from "@lunora/values";
 
@@ -302,6 +303,40 @@ const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheC
             .withIndex("byKey", (q) => q.eq("key", key))
             .first();
 
+    /**
+     * Codes a concurrent writer can legitimately produce on the store step.
+     *
+     * `CONFLICT` is the unique index on `key` doing its job: two callers missed at
+     * the same instant, both ran `compute`, and the loser's insert lost the race.
+     * `NOT_FOUND` is the refresh equivalent — the row this call read was removed
+     * (an `invalidate`, a reap) before the patch landed.
+     */
+    const CONCURRENT_WRITE_CODES = new Set(["CONFLICT", "NOT_FOUND", "NOT_UNIQUE"]);
+
+    /**
+     * Store the entry, tolerating a concurrent writer.
+     *
+     * A cache write must never fail the call it is caching: `compute` has already
+     * run and been paid for, and the value in hand is correct whether or not this
+     * process is the one that got to store it. So an expected concurrent-write
+     * failure is swallowed — the winner's entry is equivalent — and anything else
+     * propagates, because a schema or permission error here is a real problem and
+     * silently degrading to "uncached forever" is how it would stay hidden.
+     */
+    const store = async (context: ActionCacheContext, existing: Record<string, unknown> | null, entry: Record<string, unknown>): Promise<void> => {
+        try {
+            await (existing
+                ? context.db.patch(existing["_id"] as Id<string>, { expiresAt: entry["expiresAt"], value: entry["value"] })
+                : context.db.insert(ACTION_CACHE_TABLE, entry));
+        } catch (error: unknown) {
+            if (isLunoraError(error) && CONCURRENT_WRITE_CODES.has(error.code)) {
+                return;
+            }
+
+            throw error;
+        }
+    };
+
     const wrap = async <T>(context: ActionCacheContext, name: string, args: unknown, compute: () => Promise<T>): Promise<T> => {
         const argumentsJson = serializeArgs(args);
         const key = await cacheKeyFor(name, argumentsJson);
@@ -332,9 +367,7 @@ const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheC
 
         // Oversized results are returned, never stored — see `maxValueBytes`.
         if (new TextEncoder().encode(serialized).length <= maxValueBytes) {
-            await (existing
-                ? context.db.patch(existing["_id"] as Id<string>, { expiresAt, value: serialized })
-                : context.db.insert(ACTION_CACHE_TABLE, { expiresAt, key, name, value: serialized }));
+            await store(context, existing, { expiresAt, key, name, value: serialized });
         } else if (existing) {
             // A stale row for a key whose fresh answer is too big to keep would
             // otherwise stay readable until it expires, serving the old value
@@ -361,36 +394,46 @@ const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheC
         await Promise.all(rows.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
     };
 
-    const invalidateAll = async (context: ActionCacheContext, name: string): Promise<{ complete: boolean; deleted: number }> => {
-        let deleted = 0;
-
-        // Page rather than one unbounded read: a name that accumulated many
-        // argument variants should not have to fit in a single read. Each round
-        // deletes what the previous read returned, so the loop makes progress and
-        // terminates; `MAX_INVALIDATE_ROUNDS` is a liveness bound against a reader
-        // that stops advancing, not a cap on how much may be deleted.
-        for (let round = 0; round < MAX_INVALIDATE_ROUNDS; round += 1) {
-            // eslint-disable-next-line no-await-in-loop -- each round deletes the page the previous one read; the reads are inherently sequential
-            const page = await context.db
-                .query(ACTION_CACHE_TABLE)
-                .withIndex("byName", (q) => q.eq("name", name))
-                .take(INVALIDATE_PAGE);
-
-            if (page.length === 0) {
-                return { complete: true, deleted };
-            }
-
-            // eslint-disable-next-line no-await-in-loop -- see above
-            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
-            deleted += page.length;
+    /**
+     * Delete one page of `name`'s entries, then recur.
+     *
+     * Recursive rather than a `for` loop with an `await` in it: the rounds are
+     * inherently sequential (each deletes what the previous read returned), and
+     * expressing that as recursion says so without silencing `no-await-in-loop`.
+     * Depth is bounded by `MAX_INVALIDATE_ROUNDS`.
+     */
+    const deleteNamedPage = async (
+        context: ActionCacheContext,
+        name: string,
+        deleted: number,
+        round: number,
+    ): Promise<{ complete: boolean; deleted: number }> => {
+        if (round >= MAX_INVALIDATE_ROUNDS) {
+            // Hit the liveness bound with rows still matching. Reported rather
+            // than returned as a plain count, because "dropped every entry" and
+            // "dropped the first few thousand" must not look the same to a caller
+            // that asked for the former.
+            return { complete: false, deleted };
         }
 
-        // Hit the liveness bound with rows still matching. Reported rather than
-        // returned as a plain count, because "dropped every entry" and "dropped
-        // 4096 of them" must not look the same to a caller that asked for the
-        // former.
-        return { complete: false, deleted };
+        const page = await context.db
+            .query(ACTION_CACHE_TABLE)
+            .withIndex("byName", (q) => q.eq("name", name))
+            .take(INVALIDATE_PAGE);
+
+        if (page.length === 0) {
+            return { complete: true, deleted };
+        }
+
+        await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
+
+        return deleteNamedPage(context, name, deleted + page.length, round + 1);
     };
+
+    const invalidateAll = async (context: ActionCacheContext, name: string): Promise<{ complete: boolean; deleted: number }> =>
+        // Paged rather than one unbounded read: a name that accumulated many
+        // argument variants should not have to fit in a single read.
+        deleteNamedPage(context, name, 0, 0);
 
     const purgeExpired = internalMutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
         const now = Date.now();

--- a/packages/server/src/action-cache.ts
+++ b/packages/server/src/action-cache.ts
@@ -36,20 +36,25 @@
  *
  * # What it does not do
  *
- * **No single-flight.** Two callers that miss at the same instant both run `compute`,
- * and the second write wins. Preventing that needs a lock held across an
- * arbitrarily long external call, which is a different feature with a different
- * failure mode (a crashed holder wedges the key). For the case this targets —
- * repeated identical requests spread over time — the duplicate is a cold-start
- * cost, not a steady-state one.
+ * **No single-flight.** Two callers that miss at the same instant both run
+ * `compute`; the unique index on `key` means the loser's insert conflicts rather
+ * than leaving a second row, so one result is stored and the work was done twice.
+ * Preventing that needs a lock held across an arbitrarily long external call,
+ * which is a different feature with a worse failure mode (a crashed holder wedges
+ * the key). For the case this targets — repeated identical requests spread over
+ * time — the duplicate is a cold-start cost, not a steady-state one.
  *
- * **The stored value is JSON.** Whatever `compute` returns is round-tripped through
- * `JSON.stringify`/`JSON.parse`, so a `Date` comes back as a string and a `Map`
- * comes back as `{}`. Cache what you would send over the wire.
+ * **The stored value goes through the wire codec**, the same encoding an RPC
+ * response uses — so `bigint`, `Date`, `Map`, `Set` and bytes round-trip as
+ * themselves. A value the wire refuses (a class instance, a cyclic graph) throws.
+ * Cache what you would send over the wire, because that is exactly what this is.
  */
 
+import type { Id } from "@lunora/values";
 import { v } from "@lunora/values";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
+import { stableWireKey } from "../../../shared/wire-key";
 import { initLunora } from "./builder/index";
 import type { Component, SchemaExtension } from "./plugin";
 import { defineComponent, defineSchemaExtension } from "./plugin";
@@ -69,14 +74,21 @@ const DEFAULT_ACTION_CACHE_TTL_MS: number = 60 * 60 * 1000;
 const DEFAULT_MAX_VALUE_BYTES = 512 * 1024;
 
 /**
- * Rows each miss inspects for reaping, and the page size `purgeExpired` deletes
- * in. Small on the write path on purpose: the reap rides a request that is
- * already paying for an external call, so it must stay O(1).
+ * Rows each miss inspects for reaping. Small on the write path on purpose: the
+ * reap rides a request that is already paying for an external call, so it must
+ * stay O(1).
  */
 const REAP_BATCH = 8;
 
-/** Pages `purgeExpired` will walk before yielding, so a stuck read cannot spin forever. */
-const MAX_PURGE_ROUNDS = 64;
+/** Rows `invalidate`/`invalidateAll` read per round. */
+const INVALIDATE_PAGE = 64;
+
+/** Rounds `invalidateAll` will walk, so a reader that stops advancing cannot spin forever. */
+const MAX_INVALIDATE_ROUNDS = 64;
+
+/** Default rows `purgeExpired` deletes in one call, and the ceiling on a caller-supplied `limit`. */
+const PURGE_DEFAULT_LIMIT = 256;
+const PURGE_MAX_LIMIT = 4096;
 
 /** The bare extension key and table name. Prefixing makes the merged table `actionCache_entries`. */
 const ACTION_CACHE_KEY = "actionCache";
@@ -117,9 +129,9 @@ interface ActionCacheQuery {
  * directly.
  */
 interface ActionCacheDatabase {
-    delete: (id: never) => Promise<void>;
+    delete: <T extends string>(id: Id<T>) => Promise<void>;
     insert: (table: string, document: Record<string, unknown>) => Promise<unknown>;
-    patch: (id: never, patch: Record<string, unknown>) => Promise<void>;
+    patch: <T extends string>(id: Id<T>, patch: Record<string, unknown>) => Promise<void>;
     query: (table: string) => ActionCacheQuery;
 }
 
@@ -153,10 +165,35 @@ interface ActionCacheFunctions {
      * this; schedule it on a cron to reclaim entries whose names went quiet.
      *
      * Returns `{ deleted }`; compare it against `limit` to decide whether to run
-     * again rather than assuming one pass drained the table.
+     * again rather than assuming one pass drained the table. A caller-supplied
+     * `limit` is clamped — `take()` has no ceiling of its own.
      */
     purgeExpired: RegisteredMutation<{ limit: ReturnType<typeof v.optional> }, { deleted: number }>;
 }
+
+/**
+ * Serialize the arguments for hashing.
+ *
+ * `stableWireKey` rather than `JSON.stringify`, for two reasons that are both
+ * correctness rather than taste.
+ *
+ * It **sorts keys**, so `{ a, b }` and `{ b, a }` are one cache entry. Raw
+ * `JSON.stringify` makes them two, and the extra miss is invisible — you just pay
+ * twice.
+ *
+ * It encodes through the **wire codec**, so a `bigint` / `Date` / bytes argument
+ * gets a distinct tagged token. `JSON.stringify` throws on `bigint` and renders
+ * an `ArrayBuffer` as `{}` — and `{}` for every distinct byte payload under one
+ * name is a key COLLISION, i.e. one caller served another caller's cached result.
+ * `v.bytes()` and `v.bigint()` are first-class argument types, so that is
+ * reachable from ordinary code.
+ *
+ * A value the wire itself refuses (a class instance, a cyclic graph) throws
+ * here, before `compute` runs — such a value can never be a stable key, and
+ * failing at the boundary beats hashing something that isn't one.
+ * @param args the handler's arguments
+ */
+const serializeArgs = (args: unknown): string => (args === undefined ? "" : stableWireKey(args));
 
 /**
  * SHA-256 of `name` and the serialized args, hex.
@@ -166,19 +203,10 @@ interface ActionCacheFunctions {
  * would run into column-size limits; a digest is fixed-width and indexes cleanly.
  * The NUL separator keeps `("ab", "c")` and `("a", "bc")` from colliding.
  * @param name the logical cache namespace (usually the action's name)
- * @param argumentsJson the arguments, already serialized
+ * @param argumentsKey the arguments, already serialized by {@link serializeArgs}
  */
-
-/**
- * Serialize the arguments for hashing. `undefined` becomes the empty string
- * rather than going through `JSON.stringify` (which returns `undefined`, not a
- * string), so a no-argument call still has a stable key.
- * @param args the handler's arguments
- */
-const serializeArgs = (args: unknown): string => (args === undefined ? "" : JSON.stringify(args));
-
-const cacheKeyFor = async (name: string, argumentsJson: string): Promise<string> => {
-    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(`${name}\u0000${argumentsJson}`));
+const cacheKeyFor = async (name: string, argumentsKey: string): Promise<string> => {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(`${name}\u0000${argumentsKey}`));
 
     return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 };
@@ -193,15 +221,21 @@ type ActionCacheComponent = {
     /** Drop the entry for exactly this `name` + `args`. Resolves whether or not one existed. */
     invalidate: (context: ActionCacheContext, name: string, args: unknown) => Promise<void>;
 
-    /** Drop every entry under `name`, whatever its arguments. */
-    invalidateAll: (context: ActionCacheContext, name: string) => Promise<number>;
+    /**
+     * Drop every entry under `name`, whatever its arguments.
+     *
+     * `complete` is `false` when the paging bound was reached with rows still
+     * matching — call again. A plain count could not tell "dropped all of them"
+     * apart from "dropped the first few thousand".
+     */
+    invalidateAll: (context: ActionCacheContext, name: string) => Promise<{ complete: boolean; deleted: number }>;
 
     /**
      * Return the cached result for `name` + `args`, or run `compute` and cache it.
      *
-     * `args` is serialized with `JSON.stringify`, so two calls agree only if their
-     * arguments serialize identically — key order included. Pass the handler's
-     * own `args` object rather than rebuilding one.
+     * `args` is keyed through the wire codec with sorted keys, so two calls agree
+     * whenever their arguments are structurally equal — key order does not matter,
+     * and `bigint` / `Date` / bytes arguments key distinctly rather than colliding.
      */
     wrap: <T>(context: ActionCacheContext, name: string, args: unknown, compute: () => Promise<T>) => Promise<T>;
 } & Component<{ [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
@@ -220,8 +254,11 @@ const actionCacheExtension = defineSchemaExtension(ACTION_CACHE_KEY, {
             name: v.string(),
             value: v.string(),
         })
-            // Drives the hit/miss lookup and the invalidate-by-args delete.
-            .index("byKey", ["key"])
+            // Drives the hit/miss lookup and the invalidate-by-args delete. UNIQUE
+            // because one key IS one entry: `wrap` inserts on a miss, so two
+            // concurrent misses would otherwise leave two rows under one key, and
+            // `.first()` would then serve one while `invalidate` deleted the other.
+            .index("byKey", ["key"], { unique: true })
             // Drives `invalidateAll`.
             .index("byName", ["name"])
             // Drives the opportunistic reap and `purgeExpired`, both oldest-first.
@@ -230,8 +267,11 @@ const actionCacheExtension = defineSchemaExtension(ACTION_CACHE_KEY, {
 }) as unknown as SchemaExtension<{ [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
 
 // No generated server here, so bind the base context via the builder factory —
-// same as `definePresence`.
-const { mutation } = initLunora.dataModel().create();
+// same as `definePresence`. `internalMutation`, NOT `mutation`: `purgeExpired`
+// is a bulk delete, and a public one would let any anonymous caller empty the
+// cache table over `/rpc` — turning every subsequent request back into a paid
+// upstream call.
+const { internalMutation } = initLunora.dataModel().create();
 
 /**
  * Build an action-cache {@link Component} — schema extension, `purgeExpired`, and
@@ -253,7 +293,7 @@ const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheC
         const oldest = await context.db.query(ACTION_CACHE_TABLE).withIndex("byExpiresAt").order("asc").take(REAP_BATCH);
         const expired = oldest.filter((row) => (row["expiresAt"] as number) <= now);
 
-        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as never)));
+        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
     };
 
     const rowFor = async (context: ActionCacheContext, key: string): Promise<Record<string, unknown> | null> =>
@@ -273,76 +313,98 @@ const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheC
         // into a delete. The row is overwritten by this same call anyway.
         if (existing && (existing["expiresAt"] as number) > now) {
             // `{ v: value }` rather than the bare value, so a cached `undefined`
-            // round-trips: `JSON.stringify(undefined)` is `undefined` (not a
-            // string) and could not be stored at all, while `{}` parses back to
-            // the same absent `v`.
-            return (JSON.parse(existing["value"] as string) as { v: T }).v;
+            // round-trips: a bare `undefined` does not serialize to a string at
+            // all and could not be stored, while `{}` decodes back to the same
+            // absent `v`.
+            return (decodeWire(JSON.parse(existing["value"] as string)) as { v: T }).v;
         }
 
         const value = await compute();
-        const serialized = JSON.stringify({ v: value });
-        const expiresAt = now + ttlMs;
+        // Through the wire codec, for the same reason the key is: `compute` can
+        // legitimately return a `bigint`, a `Date`, or bytes, and raw
+        // `JSON.stringify` would throw on the first and quietly flatten the rest —
+        // after the caller has already paid for the call.
+        const serialized = JSON.stringify(encodeWire({ v: value }));
+        // Re-read the clock AFTER `compute`: a 30-second model call would
+        // otherwise produce an entry that is already 30 seconds into its own TTL.
+        const storedAt = Date.now();
+        const expiresAt = storedAt + ttlMs;
 
         // Oversized results are returned, never stored — see `maxValueBytes`.
         if (new TextEncoder().encode(serialized).length <= maxValueBytes) {
             await (existing
-                ? context.db.patch(existing["_id"] as never, { expiresAt, value: serialized })
+                ? context.db.patch(existing["_id"] as Id<string>, { expiresAt, value: serialized })
                 : context.db.insert(ACTION_CACHE_TABLE, { expiresAt, key, name, value: serialized }));
         } else if (existing) {
             // A stale row for a key whose fresh answer is too big to keep would
             // otherwise stay readable until it expires, serving the old value
             // while the new one is silently uncached.
-            await context.db.delete(existing["_id"] as never);
+            await context.db.delete(existing["_id"] as Id<string>);
         }
 
-        await reap(context, now);
+        await reap(context, storedAt);
 
         return value;
     };
 
     const invalidate = async (context: ActionCacheContext, name: string, args: unknown): Promise<void> => {
         const key = await cacheKeyFor(name, serializeArgs(args));
-        const existing = await rowFor(context, key);
+        const rows = await context.db
+            .query(ACTION_CACHE_TABLE)
+            .withIndex("byKey", (q) => q.eq("key", key))
+            .take(INVALIDATE_PAGE);
 
-        if (existing) {
-            await context.db.delete(existing["_id"] as never);
-        }
+        // Every row under the key, not just `.first()`. The unique index makes a
+        // duplicate unreachable in a healthy table — but an invalidation is
+        // usually triggered by a permission change or a data correction, and
+        // leaving a sibling row behind serves the value the caller just purged.
+        await Promise.all(rows.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
     };
 
-    const invalidateAll = async (context: ActionCacheContext, name: string): Promise<number> => {
+    const invalidateAll = async (context: ActionCacheContext, name: string): Promise<{ complete: boolean; deleted: number }> => {
         let deleted = 0;
 
-        // Bounded rounds rather than one unbounded read: a name that accumulated
-        // many argument variants should not have to fit in a single page.
-        for (let round = 0; round < MAX_PURGE_ROUNDS; round += 1) {
+        // Page rather than one unbounded read: a name that accumulated many
+        // argument variants should not have to fit in a single read. Each round
+        // deletes what the previous read returned, so the loop makes progress and
+        // terminates; `MAX_INVALIDATE_ROUNDS` is a liveness bound against a reader
+        // that stops advancing, not a cap on how much may be deleted.
+        for (let round = 0; round < MAX_INVALIDATE_ROUNDS; round += 1) {
             // eslint-disable-next-line no-await-in-loop -- each round deletes the page the previous one read; the reads are inherently sequential
             const page = await context.db
                 .query(ACTION_CACHE_TABLE)
                 .withIndex("byName", (q) => q.eq("name", name))
-                .take(REAP_BATCH * 8);
+                .take(INVALIDATE_PAGE);
 
             if (page.length === 0) {
-                return deleted;
+                return { complete: true, deleted };
             }
 
             // eslint-disable-next-line no-await-in-loop -- see above
-            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as never)));
+            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
             deleted += page.length;
         }
 
-        return deleted;
+        // Hit the liveness bound with rows still matching. Reported rather than
+        // returned as a plain count, because "dropped every entry" and "dropped
+        // 4096 of them" must not look the same to a caller that asked for the
+        // former.
+        return { complete: false, deleted };
     };
 
-    const purgeExpired = mutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
+    const purgeExpired = internalMutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
         const now = Date.now();
-        const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : REAP_BATCH * 32;
+        // Clamped, not just floored: `take()` has no ceiling of its own, so an
+        // unbounded `limit` is an unbounded index scan inside a mutation.
+        const limit =
+            args.limit !== undefined && Number.isFinite(args.limit) ? Math.min(PURGE_MAX_LIMIT, Math.max(1, Math.floor(args.limit))) : PURGE_DEFAULT_LIMIT;
 
         const oldest = await context.db.query(ACTION_CACHE_TABLE).withIndex("byExpiresAt").order("asc").take(limit);
         // The index is ordered by expiry, so the fresh rows are all at the
         // tail — filtering rather than breaking keeps this one pass.
         const expired = oldest.filter((row) => (row["expiresAt"] as number) <= now);
 
-        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as never)));
+        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
 
         return { deleted: expired.length };
     });

--- a/packages/server/src/action-cache.ts
+++ b/packages/server/src/action-cache.ts
@@ -1,0 +1,359 @@
+/**
+ * Action-result cache — memoise an expensive `action` by its arguments, with a
+ * TTL.
+ *
+ * An action is where the expensive, non-transactional work lives: a model call,
+ * a third-party fetch, an embedding. Those are routinely deterministic in their
+ * arguments and routinely paid for per call, so the same arguments arriving twice
+ * is money and latency spent on an answer already known. Nothing in the framework
+ * memoised that, so every app grew its own table and its own key derivation.
+ *
+ * This ships it on primitives that already exist — the schema-extension /
+ * component system for the table, `ctx.db` for the reads and writes — so it is a
+ * preset rather than a new subsystem, in the same shape as `definePresence`.
+ *
+ * # Wiring
+ *
+ * ```ts
+ * // lunora/cache.ts
+ * import { defineActionCache } from "@lunora/server";
+ *
+ * export const cache = defineActionCache({ ttlMs: 60 * 60 * 1000 });
+ *
+ * // lunora/schema.ts — merges in as `actionCache_entries`
+ * export const schema = defineSchema({ ... }).extend(cache.extension);
+ *
+ * // Re-export so codegen registers it (schedule it from a cron for bulk cleanup):
+ * export const { purgeExpired } = cache.functions;
+ * ```
+ *
+ * Then, in the action:
+ *
+ * ```ts
+ * export const embed = action.input({ text: v.string() }).action(async ({ args, ctx }) =>
+ *     cache.wrap(ctx, "embed", args, async () => callEmbeddingModel(args.text)));
+ * ```
+ *
+ * # What it does not do
+ *
+ * **No single-flight.** Two callers that miss at the same instant both run `compute`,
+ * and the second write wins. Preventing that needs a lock held across an
+ * arbitrarily long external call, which is a different feature with a different
+ * failure mode (a crashed holder wedges the key). For the case this targets —
+ * repeated identical requests spread over time — the duplicate is a cold-start
+ * cost, not a steady-state one.
+ *
+ * **The stored value is JSON.** Whatever `compute` returns is round-tripped through
+ * `JSON.stringify`/`JSON.parse`, so a `Date` comes back as a string and a `Map`
+ * comes back as `{}`. Cache what you would send over the wire.
+ */
+
+import { v } from "@lunora/values";
+
+import { initLunora } from "./builder/index";
+import type { Component, SchemaExtension } from "./plugin";
+import { defineComponent, defineSchemaExtension } from "./plugin";
+import { defineTable } from "./schema";
+import type { RegisteredMutation } from "./types";
+
+/** Default lifetime of a cached entry: one hour. */
+const DEFAULT_ACTION_CACHE_TTL_MS: number = 60 * 60 * 1000;
+
+/**
+ * Default cap on a serialized entry (bytes). An over-limit result is returned to
+ * the caller but not stored — the point of a cache is to be faster, and failing a
+ * successful action because its answer was large would trade a cost saving for an
+ * outage. 512 KB clears any ordinary API payload while keeping one entry well
+ * inside a shard row.
+ */
+const DEFAULT_MAX_VALUE_BYTES = 512 * 1024;
+
+/**
+ * Rows each miss inspects for reaping, and the page size `purgeExpired` deletes
+ * in. Small on the write path on purpose: the reap rides a request that is
+ * already paying for an external call, so it must stay O(1).
+ */
+const REAP_BATCH = 8;
+
+/** Pages `purgeExpired` will walk before yielding, so a stuck read cannot spin forever. */
+const MAX_PURGE_ROUNDS = 64;
+
+/** The bare extension key and table name. Prefixing makes the merged table `actionCache_entries`. */
+const ACTION_CACHE_KEY = "actionCache";
+const ACTION_CACHE_BARE_TABLE = "entries";
+
+/**
+ * The prefixed table name the extension produces at merge time. The handlers and
+ * helpers read/write this name directly so they always agree with the merged
+ * schema.
+ */
+const ACTION_CACHE_TABLE: "actionCache_entries" = `${ACTION_CACHE_KEY}_${ACTION_CACHE_BARE_TABLE}`;
+
+/**
+ * The slice of an index-range builder this preset uses. Mirrors `IndexRangeBuilder`
+ * field-for-field so the real `ctx.db` query builder is assignable — the generated
+ * `ctx.db.query` is typed per table, and a helper holding a runtime string needs
+ * the wide overload.
+ */
+interface ActionCacheIndexRange {
+    eq: (field: string, value: unknown) => ActionCacheIndexRange;
+    gt: (field: string, value: unknown) => ActionCacheIndexRange;
+    gte: (field: string, value: unknown) => ActionCacheIndexRange;
+    lt: (field: string, value: unknown) => ActionCacheIndexRange;
+    lte: (field: string, value: unknown) => ActionCacheIndexRange;
+}
+
+/** The slice of a `ctx.db` table query this preset relies on. */
+interface ActionCacheQuery {
+    first: () => Promise<Record<string, unknown> | null>;
+    order: (direction: "asc" | "desc") => ActionCacheQuery;
+    take: (limit: number) => Promise<Record<string, unknown>[]>;
+    withIndex: (indexName: string, range?: (q: ActionCacheIndexRange) => ActionCacheIndexRange) => ActionCacheQuery;
+}
+
+/**
+ * The slice of the ORM writer (`ctx.db` on an action or mutation) the helpers
+ * need. The real `DatabaseWriter` is structurally assignable, so pass `ctx.db`
+ * directly.
+ */
+interface ActionCacheDatabase {
+    delete: (id: never) => Promise<void>;
+    insert: (table: string, document: Record<string, unknown>) => Promise<unknown>;
+    patch: (id: never, patch: Record<string, unknown>) => Promise<void>;
+    query: (table: string) => ActionCacheQuery;
+}
+
+/** The slice of a function context the helpers need — just its writer. */
+interface ActionCacheContext {
+    db: ActionCacheDatabase;
+}
+
+/** Options for {@link defineActionCache}. */
+interface DefineActionCacheOptions {
+    /**
+     * Cap on the serialized size (bytes) of one cached value. A larger result is
+     * returned but not stored. Defaults to 512 KB; a non-finite value falls back
+     * to the default.
+     */
+    maxValueBytes?: number;
+
+    /**
+     * How long (ms) an entry stays fresh. A read past it reports a miss.
+     * Defaults to one hour.
+     */
+    ttlMs?: number;
+}
+
+/** The registered functions an action-cache component ships. */
+interface ActionCacheFunctions {
+    /**
+     * Internal mutation that hard-deletes expired entries, oldest first, and
+     * reports how many it removed. Every miss already reaps a few rows
+     * opportunistically, so an app with steady traffic stays bounded without
+     * this; schedule it on a cron to reclaim entries whose names went quiet.
+     *
+     * Returns `{ deleted }`; compare it against `limit` to decide whether to run
+     * again rather than assuming one pass drained the table.
+     */
+    purgeExpired: RegisteredMutation<{ limit: ReturnType<typeof v.optional> }, { deleted: number }>;
+}
+
+/**
+ * SHA-256 of `name` and the serialized args, hex.
+ *
+ * Hashed rather than stored: call sites routinely pass an entire model request,
+ * which is tens of kilobytes. As an indexed column that would be wasteful and
+ * would run into column-size limits; a digest is fixed-width and indexes cleanly.
+ * The NUL separator keeps `("ab", "c")` and `("a", "bc")` from colliding.
+ * @param name the logical cache namespace (usually the action's name)
+ * @param argumentsJson the arguments, already serialized
+ */
+
+/**
+ * Serialize the arguments for hashing. `undefined` becomes the empty string
+ * rather than going through `JSON.stringify` (which returns `undefined`, not a
+ * string), so a no-argument call still has a stable key.
+ * @param args the handler's arguments
+ */
+const serializeArgs = (args: unknown): string => (args === undefined ? "" : JSON.stringify(args));
+
+const cacheKeyFor = async (name: string, argumentsJson: string): Promise<string> => {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(`${name}\u0000${argumentsJson}`));
+
+    return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+/**
+ * The component shape {@link defineActionCache} returns: the extension, the
+ * registered functions, and the helpers an action calls directly.
+ */
+type ActionCacheComponent = {
+    functions: ActionCacheFunctions;
+
+    /** Drop the entry for exactly this `name` + `args`. Resolves whether or not one existed. */
+    invalidate: (context: ActionCacheContext, name: string, args: unknown) => Promise<void>;
+
+    /** Drop every entry under `name`, whatever its arguments. */
+    invalidateAll: (context: ActionCacheContext, name: string) => Promise<number>;
+
+    /**
+     * Return the cached result for `name` + `args`, or run `compute` and cache it.
+     *
+     * `args` is serialized with `JSON.stringify`, so two calls agree only if their
+     * arguments serialize identically — key order included. Pass the handler's
+     * own `args` object rather than rebuilding one.
+     */
+    wrap: <T>(context: ActionCacheContext, name: string, args: unknown, compute: () => Promise<T>) => Promise<T>;
+} & Component<{ [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
+
+/**
+ * The action-cache schema extension: one `entries` table, auto-namespaced to
+ * `actionCache_entries` at merge time.
+ */
+// Explicit type on this exported const (isolatedDeclarations can't infer it from
+// the generic call), matching `presenceExtension`.
+const actionCacheExtension = defineSchemaExtension(ACTION_CACHE_KEY, {
+    tables: {
+        [ACTION_CACHE_BARE_TABLE]: defineTable({
+            expiresAt: v.number(),
+            key: v.string(),
+            name: v.string(),
+            value: v.string(),
+        })
+            // Drives the hit/miss lookup and the invalidate-by-args delete.
+            .index("byKey", ["key"])
+            // Drives `invalidateAll`.
+            .index("byName", ["name"])
+            // Drives the opportunistic reap and `purgeExpired`, both oldest-first.
+            .index("byExpiresAt", ["expiresAt"]),
+    },
+}) as unknown as SchemaExtension<{ [ACTION_CACHE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
+
+// No generated server here, so bind the base context via the builder factory —
+// same as `definePresence`.
+const { mutation } = initLunora.dataModel().create();
+
+/**
+ * Build an action-cache {@link Component} — schema extension, `purgeExpired`, and
+ * the `wrap` / `invalidate` / `invalidateAll` helpers — wired to one TTL.
+ * @param options cache configuration (TTL, value-size cap).
+ * @returns a component bundling the extension, the functions, and the helpers.
+ */
+const defineActionCache = (options: DefineActionCacheOptions = {}): ActionCacheComponent => {
+    // `Number.isFinite` first: a `NaN`/`Infinity` option would otherwise flow
+    // through unchanged and land in the row as an expiry nothing can compare.
+    const ttlMs = options.ttlMs !== undefined && Number.isFinite(options.ttlMs) ? Math.max(1, Math.floor(options.ttlMs)) : DEFAULT_ACTION_CACHE_TTL_MS;
+    const maxValueBytes =
+        options.maxValueBytes !== undefined && Number.isFinite(options.maxValueBytes)
+            ? Math.max(1, Math.floor(options.maxValueBytes))
+            : DEFAULT_MAX_VALUE_BYTES;
+
+    /** Delete up to `REAP_BATCH` already-expired rows. Rides a path already paying for an external call. */
+    const reap = async (context: ActionCacheContext, now: number): Promise<void> => {
+        const oldest = await context.db.query(ACTION_CACHE_TABLE).withIndex("byExpiresAt").order("asc").take(REAP_BATCH);
+        const expired = oldest.filter((row) => (row["expiresAt"] as number) <= now);
+
+        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as never)));
+    };
+
+    const rowFor = async (context: ActionCacheContext, key: string): Promise<Record<string, unknown> | null> =>
+        context.db
+            .query(ACTION_CACHE_TABLE)
+            .withIndex("byKey", (q) => q.eq("key", key))
+            .first();
+
+    const wrap = async <T>(context: ActionCacheContext, name: string, args: unknown, compute: () => Promise<T>): Promise<T> => {
+        const argumentsJson = serializeArgs(args);
+        const key = await cacheKeyFor(name, argumentsJson);
+        const now = Date.now();
+        const existing = await rowFor(context, key);
+
+        // Expiry is lazy: a read past `expiresAt` reports a miss and leaves the
+        // row for the reap below to take, rather than turning every stale read
+        // into a delete. The row is overwritten by this same call anyway.
+        if (existing && (existing["expiresAt"] as number) > now) {
+            // `{ v: value }` rather than the bare value, so a cached `undefined`
+            // round-trips: `JSON.stringify(undefined)` is `undefined` (not a
+            // string) and could not be stored at all, while `{}` parses back to
+            // the same absent `v`.
+            return (JSON.parse(existing["value"] as string) as { v: T }).v;
+        }
+
+        const value = await compute();
+        const serialized = JSON.stringify({ v: value });
+        const expiresAt = now + ttlMs;
+
+        // Oversized results are returned, never stored — see `maxValueBytes`.
+        if (new TextEncoder().encode(serialized).length <= maxValueBytes) {
+            await (existing
+                ? context.db.patch(existing["_id"] as never, { expiresAt, value: serialized })
+                : context.db.insert(ACTION_CACHE_TABLE, { expiresAt, key, name, value: serialized }));
+        } else if (existing) {
+            // A stale row for a key whose fresh answer is too big to keep would
+            // otherwise stay readable until it expires, serving the old value
+            // while the new one is silently uncached.
+            await context.db.delete(existing["_id"] as never);
+        }
+
+        await reap(context, now);
+
+        return value;
+    };
+
+    const invalidate = async (context: ActionCacheContext, name: string, args: unknown): Promise<void> => {
+        const key = await cacheKeyFor(name, serializeArgs(args));
+        const existing = await rowFor(context, key);
+
+        if (existing) {
+            await context.db.delete(existing["_id"] as never);
+        }
+    };
+
+    const invalidateAll = async (context: ActionCacheContext, name: string): Promise<number> => {
+        let deleted = 0;
+
+        // Bounded rounds rather than one unbounded read: a name that accumulated
+        // many argument variants should not have to fit in a single page.
+        for (let round = 0; round < MAX_PURGE_ROUNDS; round += 1) {
+            // eslint-disable-next-line no-await-in-loop -- each round deletes the page the previous one read; the reads are inherently sequential
+            const page = await context.db
+                .query(ACTION_CACHE_TABLE)
+                .withIndex("byName", (q) => q.eq("name", name))
+                .take(REAP_BATCH * 8);
+
+            if (page.length === 0) {
+                return deleted;
+            }
+
+            // eslint-disable-next-line no-await-in-loop -- see above
+            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as never)));
+            deleted += page.length;
+        }
+
+        return deleted;
+    };
+
+    const purgeExpired = mutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
+        const now = Date.now();
+        const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : REAP_BATCH * 32;
+
+        const oldest = await context.db.query(ACTION_CACHE_TABLE).withIndex("byExpiresAt").order("asc").take(limit);
+        // The index is ordered by expiry, so the fresh rows are all at the
+        // tail — filtering rather than breaking keeps this one pass.
+        const expired = oldest.filter((row) => (row["expiresAt"] as number) <= now);
+
+        await Promise.all(expired.map(async (row) => context.db.delete(row["_id"] as never)));
+
+        return { deleted: expired.length };
+    });
+
+    const component = defineComponent(ACTION_CACHE_KEY, {
+        extension: actionCacheExtension,
+        functions: { purgeExpired },
+    }) as ActionCacheComponent;
+
+    return { ...component, invalidate, invalidateAll, wrap };
+};
+
+export type { ActionCacheComponent, ActionCacheContext, ActionCacheDatabase, ActionCacheFunctions, DefineActionCacheOptions };
+export { DEFAULT_ACTION_CACHE_TTL_MS as ACTION_CACHE_DEFAULT_TTL_MS, ACTION_CACHE_TABLE, actionCacheExtension, cacheKeyFor, defineActionCache };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,3 +1,5 @@
+export type { ActionCacheComponent, ActionCacheContext, ActionCacheDatabase, ActionCacheFunctions, DefineActionCacheOptions } from "./action-cache";
+export { ACTION_CACHE_DEFAULT_TTL_MS, ACTION_CACHE_TABLE, actionCacheExtension, cacheKeyFor, defineActionCache } from "./action-cache";
 export { default as asBucketStorage } from "./as-bucket-storage";
 export type {
     ActionBuilder,


### PR DESCRIPTION
## What

`defineActionCache(options)` — memoise an expensive action by its arguments, with a TTL. A preset in the shape of `definePresence`: schema extension for the table, `ctx.db` for the reads and writes, no new package and no DO-level support.

```ts
// lunora/cache.ts
export const cache = defineActionCache({ ttlMs: 60 * 60 * 1000 });

// lunora/schema.ts — merges in as `actionCache_entries`
export const schema = defineSchema({ ... }).extend(cache.extension);
export const { purgeExpired } = cache.functions;
```

```ts
export const embed = action.input({ text: v.string() }).action(async ({ args, ctx }) =>
    cache.wrap(ctx, "embed", args, async () => callEmbeddingModel(args.text)));
```

`wrap` / `invalidate` / `invalidateAll` are plain helpers taking the caller's `ctx`, so there is no extra RPC hop; `purgeExpired` is the one registered function.

## Why

An action is where the expensive, non-transactional work lives — a model call, a third-party fetch, an embedding — and it is routinely deterministic in its arguments and paid for per call. The same arguments arriving twice is money and latency spent on an answer already known.

Nothing in the framework memoises that, so an app grows its own table and its own key derivation. The key derivation is the part worth centralising: call sites pass whole model requests, so the key has to be a digest rather than the arguments, and the digest needs a separator or `("ab", "c")` and `("a", "bc")` hash the same bytes and one action serves another's cached answer. That is a silent wrong-answer bug, and it is exactly the kind of thing each app gets to rediscover.

`ctx.cache` is unrelated — that is HTTP-cache purge at the edge. This caches a *result* inside the app.

## Semantics

- **Key** = SHA-256 of `name` + `` + `JSON.stringify(args)`, hex. Two calls agree only if their arguments serialize identically, key order included, so pass the handler's own `args` rather than rebuilding one.
- **Lazy expiry.** A read past `expiresAt` is a miss and the row is *patched*, not duplicated — the entry refreshes in place under the same key.
- **Self-cleaning.** Each miss reaps a few expired rows (the same opportunistic-reap idea `definePresence` uses on its heartbeat), so a steady workload stays bounded without scheduling anything. `purgeExpired` is for reclaiming entries whose names went quiet; it reports `deleted` so a cron can decide whether to run again rather than assuming one pass drained the table.
- **`undefined` round-trips.** The value is stored as `{ v: value }`, because `JSON.stringify(undefined)` is not a string — a bare value could not be stored at all and every call would miss forever.
- **Oversized results are returned, not stored.** Over `maxValueBytes` (512 KB default) the caller still gets the value; a cache must not fail a successful action because its answer was large. If a stale row exists for that key it is *deleted* rather than left behind, or it would keep serving the old value while the new one was silently uncached.

## What it deliberately does not do

- **No single-flight.** Two callers that miss at the same instant both run `compute` and the second write wins. Preventing that needs a lock held across an arbitrarily long external call, whose own failure mode — a crashed holder wedging the key — is worse than a duplicate cold start for the case this targets.
- **The stored value is JSON**, so a `Date` comes back as a string and a `Map` comes back as `{}`. Cache what you would send over the wire. Both are documented on the export, not just here.

## Scope

Additive. No existing export changes shape.

- `packages/server/src/action-cache.ts` — the preset
- `packages/server/src/index.ts` — exports
- `packages/server/__tests__/action-cache.test.ts` — 13 tests over an in-memory `ctx.db` double (same harness style as `presence.test.ts`): hit/miss, arg-keying, TTL refresh-in-place, `undefined` round-trip, oversize skip, stale-row drop on oversize, opportunistic reap, both invalidations, `purgeExpired`, and the key-separator collision
- `packages/server/docs/index.mdx` — new section, placed next to the REST-cache one and explicit about the difference
- `api-snapshots/{server,lunora}.api.md`

The `ctx` parameter is typed as a structural projection (`ActionCacheContext`/`ActionCacheDatabase`), the way `@lunora/ratelimit`'s `RateLimitDb` is, so a generated `ctx.db` — typed per table — is assignable while the helper holds a runtime table name.

## Checks

- `pnpm run lint:types` (all 56 projects) — clean
- `pnpm --filter "@lunora/server" run test` — 637 passed (13 new)
- `pnpm --filter "@lunora/server" run lint:eslint` — clean; `lint:package-json` clean
- `pnpm run api:update` after a full `build:packages`; diffs limited to the new exports

One note from the build: exported consts need explicit annotations under `--isolatedDeclarations`, which `lint:types` does not catch — only `build` does. Worth knowing for anything added to this package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable caching for action results, keyed consistently by actions and arguments.
  * Supports expiration, individual or full-cache invalidation, automatic cleanup, and bounded maintenance operations.
  * Oversized results are returned without being cached, while stale oversized entries are removed.
  * Added public APIs for configuring and using the action cache.
  * Full-cache invalidation now reports the number deleted and whether cleanup completed.

* **Documentation**
  * Expanded guidance on keying, supported value types, concurrency, invalidation behavior, and access policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->