### PR TITLE
feat(server): add defineDocumentHistory for row-version history

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -81,6 +81,14 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DOCUMENT_HISTORY_REDACTED_FIELDS` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DOCUMENT_HISTORY_TABLE` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -105,6 +113,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DefineDocumentHistoryOptions` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DefineIdentityOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -126,6 +138,18 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DefineStorageRuleInput` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryComponent` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryEntry` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryFunctions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -1029,6 +1053,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `defineDocumentHistory` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `defineEnv` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1106,6 +1134,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `deny` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `documentHistoryExtension` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -4695,6 +4727,14 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DOCUMENT_HISTORY_REDACTED_FIELDS` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DOCUMENT_HISTORY_TABLE` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -4719,6 +4759,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `DefineDocumentHistoryOptions` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DefineIdentityOptions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -4740,6 +4784,18 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DefineStorageRuleInput` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryComponent` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryEntry` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DocumentHistoryFunctions` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -5643,6 +5699,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `defineDocumentHistory` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `defineEnv` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5720,6 +5780,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `deny` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `documentHistoryExtension` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -172,6 +172,18 @@ const DEFAULT_LIMIT = 25;
 const DEFAULT_MAX_LIMIT = 100;
 ```
 
+### `DOCUMENT_HISTORY_REDACTED_FIELDS` (const)
+
+```ts
+const DEFAULT_REDACTED_FIELDS: ReadonlyArray<string>;
+```
+
+### `DOCUMENT_HISTORY_TABLE` (const)
+
+```ts
+const DOCUMENT_HISTORY_TABLE: "documentHistory_versions";
+```
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -271,6 +283,16 @@ interface DefineComponentOptions<TExtension extends Record<string, TableDefiniti
 }
 ```
 
+### `DefineDocumentHistoryOptions` (interface)
+
+```ts
+interface DefineDocumentHistoryOptions {
+    maxSnapshotBytes?: number;
+    redact?: ReadonlyArray<string>;
+    retentionMs?: number;
+}
+```
+
 ### `DefineIdentityOptions` (interface)
 
 ```ts
@@ -329,6 +351,48 @@ interface DefineStorageRuleInput<Context = unknown> {
     on: StorageOperation;
     prefix?: string;
     when: (context: StorageRuleContext<Context>) => StorageRuleDecision;
+}
+```
+
+### `DocumentHistoryComponent` (type)
+
+```ts
+type DocumentHistoryComponent = {
+    functions: DocumentHistoryFunctions;
+    record: (t: TriggerBuilder) => Record<string, TriggerDefinition>;
+} & Component<{
+    [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable>;
+}>;
+```
+
+### `DocumentHistoryEntry` (interface)
+
+```ts
+interface DocumentHistoryEntry {
+    doc?: Record<string, unknown>;
+    documentId: string;
+    op: "delete" | "insert" | "update";
+    previous?: Record<string, unknown>;
+    recordedAt: number;
+    tableName: string;
+    truncated?: boolean;
+}
+```
+
+### `DocumentHistoryFunctions` (interface)
+
+```ts
+interface DocumentHistoryFunctions {
+    listForDocument: RegisteredQuery<{
+        before: ReturnType<typeof v.optional>;
+        documentId: ReturnType<typeof v.string>;
+        limit: ReturnType<typeof v.optional>;
+    }, DocumentHistoryEntry[]>;
+    vacuum: RegisteredMutation<{
+        limit: ReturnType<typeof v.optional>;
+    }, {
+        deleted: number;
+    }>;
 }
 ```
 
@@ -2690,6 +2754,12 @@ const defineAggregateIndex: (name: string, options: AggregateIndexOptions) => Ag
 const defineComponent: <TExtension extends Record<string, TableDefinition>, TContextIn = unknown, TContextOut = TContextIn, F extends ComponentFunctions = ComponentFunctions>(key: string, options: DefineComponentOptions<TExtension, TContextIn, TContextOut, F>) => Component<TExtension, TContextIn, TContextOut, F>;
 ```
 
+### `defineDocumentHistory` (const)
+
+```ts
+const defineDocumentHistory: (options?: DefineDocumentHistoryOptions) => DocumentHistoryComponent;
+```
+
 ### `defineEnv` (const)
 
 ```ts
@@ -2815,6 +2885,14 @@ const defineVectorIndex: (options: VectorIndexOptions) => VectorIndexDefinition;
 
 ```ts
 const deny: () => WhereInput;
+```
+
+### `documentHistoryExtension` (const)
+
+```ts
+const documentHistoryExtension: SchemaExtension<{
+    [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable>;
+}>;
 ```
 
 ### `flushDeferredDeletes` (const)

--- a/packages/server/__tests__/document-history.test.ts
+++ b/packages/server/__tests__/document-history.test.ts
@@ -12,9 +12,9 @@ import type { TriggerBuilder, TriggerCtx, TriggerDefinition } from "../src/index
 type Predicate = (row: Record<string, unknown>) => boolean;
 
 const byRecordedAt = (rows: Record<string, unknown>[], direction: "asc" | "desc"): Record<string, unknown>[] =>
-    // Both index keys, in order — `[..., recordedAt, seq]`. Sorting on
-    // `recordedAt` alone would leave the double unable to express the ordering
-    // the real index gives, and the tie-break test would fail against correct code.
+    // The index keys, in order — `[..., recordedAt, seq]`. Sorting on `recordedAt`
+    // alone would leave the double unable to express the ordering the real index
+    // gives, and the tie-break tests would fail against correct code.
     rows.toSorted((a, b) => {
         const byTime = (a["recordedAt"] as number) - (b["recordedAt"] as number);
         const delta = byTime === 0 ? (a["seq"] as number) - (b["seq"] as number) : byTime;
@@ -67,6 +67,11 @@ const createRangeBuilder = (predicates: Predicate[]) => {
 const createMemoryDb = () => {
     const rows = new Map<string, Record<string, unknown>>();
     let nextId = 1;
+    // Stands in for `.commitOrdered()`: a per-shard integer allocated ONCE per
+    // mutation and strictly increasing in commit order. `commit()` opens the next
+    // one, so a test can express "these writes shared a mutation" and "this write
+    // came from a later one" — including across a simulated restart.
+    let commitSeq = 1;
 
     const makeReader = (table: string) => {
         const predicates: Predicate[] = [];
@@ -104,9 +109,13 @@ const createMemoryDb = () => {
             const id = `${table}|${String(nextId)}`;
 
             nextId += 1;
-            rows.set(id, { ...document, __table: table, _creationTime: Date.now(), _id: id });
+            rows.set(id, { ...document, __table: table, _commitSeq: commitSeq, _creationTime: Date.now(), _id: id });
 
             return id;
+        },
+        /** Open the next mutation, the way a fresh dispatch does. */
+        commit: () => {
+            commitSeq += 1;
         },
         query: (table: string) => makeReader(table),
         rows,
@@ -539,5 +548,52 @@ describe("defineDocumentHistory — snapshot fidelity", () => {
         const result = await history.functions.listForDocument.handler({ db }, { documentId: "thread_1" });
 
         expect(result[0]?.doc).toStrictEqual({ title: "c" });
+    });
+});
+
+describe("defineDocumentHistory — ordering across a restart", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("keeps commit order when the in-process counter has been reset", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+
+        // Two components over one table: the second stands in for the shard
+        // restarting, which resets the in-process `seq` to zero. The clock is
+        // pinned to the same instant throughout, so `recordedAt` cannot break the
+        // tie either — only the durable `_commitSeq` can.
+        const before = defineDocumentHistory();
+        const after = defineDocumentHistory();
+
+        vi.setSystemTime(1000);
+        await capture(before.record).handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "first" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "zero" },
+            table: "threads",
+        } as never);
+
+        db.commit();
+
+        await capture(after.record).handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "second" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "first" },
+            table: "threads",
+        } as never);
+
+        const result = await after.functions.listForDocument.handler({ db }, { documentId: "thread_1" });
+
+        expect(result[0]?.doc).toStrictEqual({ title: "second" });
+        expect(result[1]?.doc).toStrictEqual({ title: "first" });
     });
 });

--- a/packages/server/__tests__/document-history.test.ts
+++ b/packages/server/__tests__/document-history.test.ts
@@ -12,9 +12,15 @@ import type { TriggerBuilder, TriggerCtx, TriggerDefinition } from "../src/index
 type Predicate = (row: Record<string, unknown>) => boolean;
 
 const byRecordedAt = (rows: Record<string, unknown>[], direction: "asc" | "desc"): Record<string, unknown>[] =>
-    rows.toSorted((a, b) =>
-        direction === "asc" ? (a["recordedAt"] as number) - (b["recordedAt"] as number) : (b["recordedAt"] as number) - (a["recordedAt"] as number),
-    );
+    // Both index keys, in order — `[..., recordedAt, seq]`. Sorting on
+    // `recordedAt` alone would leave the double unable to express the ordering
+    // the real index gives, and the tie-break test would fail against correct code.
+    rows.toSorted((a, b) => {
+        const byTime = (a["recordedAt"] as number) - (b["recordedAt"] as number);
+        const delta = byTime === 0 ? (a["seq"] as number) - (b["seq"] as number) : byTime;
+
+        return direction === "asc" ? delta : -delta;
+    });
 
 /** Emulate one index read: the table filter plus the predicates the range built. */
 const matchRows = (rows: Map<string, Record<string, unknown>>, table: string, predicates: Predicate[]): Record<string, unknown>[] =>
@@ -154,7 +160,7 @@ describe("defineDocumentHistory — recording", () => {
         expect.assertions(2);
 
         const history = defineDocumentHistory();
-        const { definitions, handlers } = capture(history.record());
+        const { definitions, handlers } = capture(history.record);
 
         // A `before*` handler runs while the write can still be aborted, so an
         // entry written there could describe a write that never landed.
@@ -167,7 +173,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory();
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["insert"]?.(triggerContextFor(db), {
@@ -190,7 +196,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory();
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["update"]?.(triggerContextFor(db), {
@@ -212,7 +218,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory();
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["delete"]?.(triggerContextFor(db), {
@@ -233,7 +239,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory();
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["update"]?.(triggerContextFor(db), {
@@ -258,7 +264,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory({ redact: ["inviteToken"] });
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["insert"]?.(triggerContextFor(db), {
@@ -276,7 +282,7 @@ describe("defineDocumentHistory — recording", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory({ maxSnapshotBytes: 32 });
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["insert"]?.(triggerContextFor(db), {
@@ -305,7 +311,7 @@ describe("defineDocumentHistory — listForDocument", () => {
     });
 
     const seed = async (db: MemoryDb, history: ReturnType<typeof defineDocumentHistory>): Promise<void> => {
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["insert"]?.(triggerContextFor(db), { doc: { title: "a" }, id: "thread_1", op: "insert", table: "threads" } as never);
@@ -385,7 +391,7 @@ describe("defineDocumentHistory — vacuum", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory({ retentionMs: 10_000 });
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         await handlers["insert"]?.(triggerContextFor(db), { doc: {}, id: "old", op: "insert", table: "threads" } as never);
@@ -405,7 +411,7 @@ describe("defineDocumentHistory — vacuum", () => {
 
         const db = createMemoryDb();
         const history = defineDocumentHistory({ retentionMs: 1000 });
-        const { handlers } = capture(history.record());
+        const { handlers } = capture(history.record);
 
         vi.setSystemTime(1000);
         for (const id of ["a", "b", "c"]) {
@@ -418,5 +424,120 @@ describe("defineDocumentHistory — vacuum", () => {
 
         expect(result.deleted).toBe(2);
         expect(entries(db)).toHaveLength(1);
+    });
+});
+
+describe("defineDocumentHistory — snapshot fidelity", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("drops a nested credential, not only a top-level one", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record);
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), {
+            doc: { connections: [{ label: "gh", refreshToken: "nested-secret" }], oauth: { apiKey: "deep-secret" }, name: "n" },
+            id: "user_1",
+            op: "insert",
+            table: "users",
+        } as never);
+
+        const serialized = entries(db)[0]?.["doc"] as string;
+
+        // This table retains what it is given for months, so a credential one level
+        // down is the same problem as one at the root.
+        expect(serialized).not.toContain("deep-secret");
+        expect(serialized).not.toContain("nested-secret");
+    });
+
+    it("records a bigint column instead of aborting the write", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record);
+
+        vi.setSystemTime(1000);
+
+        // This runs in an AFTER-trigger: a throw here would roll back the write it
+        // is recording, so a `v.bigint()` column would break every insert, update
+        // and delete on any table with history attached.
+        await expect(
+            handlers["insert"]?.(triggerContextFor(db), {
+                doc: { total: 9_007_199_254_740_993n },
+                id: "invoice_1",
+                op: "insert",
+                table: "invoices",
+            } as never),
+        ).resolves.toBeUndefined();
+
+        const result = await history.functions.listForDocument.handler({ db }, { documentId: "invoice_1" });
+
+        expect(result[0]?.doc?.["total"]).toBe(9_007_199_254_740_993n);
+    });
+
+    it("caps doc and previous independently", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory({ maxSnapshotBytes: 128 });
+        const { handlers } = capture(history.record);
+
+        vi.setSystemTime(1000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "small" },
+            id: "doc_1",
+            op: "update",
+            previous: { blob: "x".repeat(500) },
+            table: "documents",
+        } as never);
+
+        const [entry] = entries(db);
+
+        // A large `previous` must not discard a small `doc` — usually the more
+        // useful half of the pair.
+        expect(entry?.["doc"]).toBeDefined();
+        expect(entry?.["previous"]).toBeUndefined();
+        expect(entry?.["truncated"]).toBe(true);
+    });
+
+    it("orders entries written in the same millisecond", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record);
+
+        // Workers do not advance the clock between I/O operations, so every entry
+        // from one mutation shares a `recordedAt`. Without a tie-breaker these come
+        // back in an arbitrary order and a point-in-time read picks at random.
+        vi.setSystemTime(1000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "b" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "a" },
+            table: "threads",
+        } as never);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "c" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "b" },
+            table: "threads",
+        } as never);
+
+        const result = await history.functions.listForDocument.handler({ db }, { documentId: "thread_1" });
+
+        expect(result[0]?.doc).toStrictEqual({ title: "c" });
     });
 });

--- a/packages/server/__tests__/document-history.test.ts
+++ b/packages/server/__tests__/document-history.test.ts
@@ -1,0 +1,422 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { defineDocumentHistory, DOCUMENT_HISTORY_TABLE } from "../src/document-history";
+import type { TriggerBuilder, TriggerCtx, TriggerDefinition } from "../src/index";
+
+/**
+ * Minimal in-memory `db` covering the slice this preset uses: `insert`,
+ * `delete`, and `query(table).withIndex(...).order(...).take(...)` where the
+ * index range builds `eq` / `lt` / `lte` predicates. Ordered reads sort by
+ * `recordedAt`, the only column either index orders on.
+ */
+type Predicate = (row: Record<string, unknown>) => boolean;
+
+const byRecordedAt = (rows: Record<string, unknown>[], direction: "asc" | "desc"): Record<string, unknown>[] =>
+    rows.toSorted((a, b) =>
+        direction === "asc" ? (a["recordedAt"] as number) - (b["recordedAt"] as number) : (b["recordedAt"] as number) - (a["recordedAt"] as number),
+    );
+
+/** Emulate one index read: the table filter plus the predicates the range built. */
+const matchRows = (rows: Map<string, Record<string, unknown>>, table: string, predicates: Predicate[]): Record<string, unknown>[] =>
+    [...rows.values()].filter((row) => (row["__table"] as string) === table && predicates.every((predicate) => predicate(row)));
+
+const equals =
+    (field: string, value: unknown): Predicate =>
+    (row) =>
+        row[field] === value;
+
+const lessThan =
+    (field: string, value: unknown): Predicate =>
+    (row) =>
+        (row[field] as number) < (value as number);
+
+const atMost =
+    (field: string, value: unknown): Predicate =>
+    (row) =>
+        (row[field] as number) <= (value as number);
+
+/** The `q` handed to `withIndex(name, (q) => …)`; only the three comparisons this preset uses. */
+const createRangeBuilder = (predicates: Predicate[]) => {
+    const builder = {
+        eq(field: string, value: unknown) {
+            predicates.push(equals(field, value));
+
+            return builder;
+        },
+        lt(field: string, value: unknown) {
+            predicates.push(lessThan(field, value));
+
+            return builder;
+        },
+        lte(field: string, value: unknown) {
+            predicates.push(atMost(field, value));
+
+            return builder;
+        },
+    };
+
+    return builder;
+};
+
+const createMemoryDb = () => {
+    const rows = new Map<string, Record<string, unknown>>();
+    let nextId = 1;
+
+    const makeReader = (table: string) => {
+        const predicates: Predicate[] = [];
+        let direction: "asc" | "desc" | undefined;
+
+        const resolved = (): Record<string, unknown>[] => {
+            const matched = matchRows(rows, table, predicates);
+
+            return direction === undefined ? matched : byRecordedAt(matched, direction);
+        };
+
+        const reader = {
+            first: async () => resolved()[0] ?? null,
+            order(requested: "asc" | "desc") {
+                direction = requested;
+
+                return reader;
+            },
+            take: async (limit: number) => resolved().slice(0, limit),
+            withIndex(_name: string, range?: (q: unknown) => unknown) {
+                range?.(createRangeBuilder(predicates));
+
+                return reader;
+            },
+        };
+
+        return reader;
+    };
+
+    return {
+        delete: async (id: string) => {
+            rows.delete(id);
+        },
+        insert: async (table: string, document: Record<string, unknown>) => {
+            const id = `${table}|${String(nextId)}`;
+
+            nextId += 1;
+            rows.set(id, { ...document, __table: table, _creationTime: Date.now(), _id: id });
+
+            return id;
+        },
+        query: (table: string) => makeReader(table),
+        rows,
+    };
+};
+
+type MemoryDb = ReturnType<typeof createMemoryDb>;
+
+const triggerContextFor = (db: MemoryDb): TriggerCtx => ({ db }) as unknown as TriggerCtx;
+
+const entries = (db: MemoryDb): Record<string, unknown>[] => [...db.rows.values()].filter((row) => row["__table"] === DOCUMENT_HISTORY_TABLE);
+
+/**
+ * Collect the trigger definitions the recorder builds, capturing each handler so
+ * a test can fire it the way the write path would.
+ */
+const capture = (build: (t: TriggerBuilder) => Record<string, TriggerDefinition>) => {
+    const handlers: Record<string, TriggerDefinition["handler"]> = {};
+    const bind =
+        (op: string) =>
+        (handler: TriggerDefinition["handler"]): TriggerDefinition => {
+            handlers[op] = handler;
+
+            return { handler, op, timing: "after" } as unknown as TriggerDefinition;
+        };
+
+    const builder = {
+        afterDelete: bind("delete"),
+        afterInsert: bind("insert"),
+        afterUpdate: bind("update"),
+        beforeDelete: bind("beforeDelete"),
+        beforeInsert: bind("beforeInsert"),
+        beforeUpdate: bind("beforeUpdate"),
+    } as unknown as TriggerBuilder;
+
+    const definitions = build(builder);
+
+    return { definitions, handlers };
+};
+
+describe("defineDocumentHistory — recording", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("binds all three after-triggers and no before-triggers", () => {
+        expect.assertions(2);
+
+        const history = defineDocumentHistory();
+        const { definitions, handlers } = capture(history.record());
+
+        // A `before*` handler runs while the write can still be aborted, so an
+        // entry written there could describe a write that never landed.
+        expect(Object.keys(handlers).toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["delete", "insert", "update"]);
+        expect(Object.keys(definitions)).toHaveLength(3);
+    });
+
+    it("records an insert with the new row and no previous", async () => {
+        expect.assertions(4);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), {
+            doc: { title: "a" },
+            id: "thread_1",
+            op: "insert",
+            table: "threads",
+        } as never);
+
+        const [entry] = entries(db);
+
+        expect(entry?.["op"]).toBe("insert");
+        expect(entry?.["documentId"]).toBe("thread_1");
+        expect(entry?.["recordedAt"]).toBe(1000);
+        expect(entry?.["previous"]).toBeUndefined();
+    });
+
+    it("records an update with both sides", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "b" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "a" },
+            table: "threads",
+        } as never);
+
+        const [entry] = entries(db);
+
+        expect(JSON.parse(entry?.["doc"] as string)).toStrictEqual({ title: "b" });
+        expect(JSON.parse(entry?.["previous"] as string)).toStrictEqual({ title: "a" });
+    });
+
+    it("records a delete with the pre-write row and no doc", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["delete"]?.(triggerContextFor(db), {
+            id: "thread_1",
+            op: "delete",
+            previous: { title: "a" },
+            table: "threads",
+        } as never);
+
+        const [entry] = entries(db);
+
+        expect(entry?.["doc"]).toBeUndefined();
+        expect(JSON.parse(entry?.["previous"] as string)).toStrictEqual({ title: "a" });
+    });
+
+    it("drops secret-shaped fields from both snapshots", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { email: "a@b.c", hashedPassword: "new-hash" },
+            id: "user_1",
+            op: "update",
+            previous: { email: "a@b.c", hashedPassword: "old-hash" },
+            table: "users",
+        } as never);
+
+        const [entry] = entries(db);
+        const serialized = `${entry?.["doc"] as string}${entry?.["previous"] as string}`;
+
+        // A stored credential outlives the rotation meant to retire it.
+        expect(serialized).not.toContain("new-hash");
+        expect(serialized).not.toContain("old-hash");
+        expect(JSON.parse(entry?.["doc"] as string)).toStrictEqual({ email: "a@b.c" });
+    });
+
+    it("drops the caller's extra redacted fields too", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory({ redact: ["inviteToken"] });
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), {
+            doc: { inviteToken: "tok", name: "n" },
+            id: "org_1",
+            op: "insert",
+            table: "orgs",
+        } as never);
+
+        expect(JSON.parse(entries(db)[0]?.["doc"] as string)).toStrictEqual({ name: "n" });
+    });
+
+    it("keeps the entry but drops the snapshot past the size cap", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory({ maxSnapshotBytes: 32 });
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), {
+            doc: { blob: "x".repeat(500) },
+            id: "doc_1",
+            op: "insert",
+            table: "documents",
+        } as never);
+
+        const [entry] = entries(db);
+
+        // "This row changed, at this time" is the part a trail cannot lose.
+        expect(entry?.["truncated"]).toBe(true);
+        expect(entry?.["doc"]).toBeUndefined();
+        expect(entry?.["recordedAt"]).toBe(1000);
+    });
+});
+
+describe("defineDocumentHistory — listForDocument", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const seed = async (db: MemoryDb, history: ReturnType<typeof defineDocumentHistory>): Promise<void> => {
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), { doc: { title: "a" }, id: "thread_1", op: "insert", table: "threads" } as never);
+        vi.setSystemTime(2000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "b" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "a" },
+            table: "threads",
+        } as never);
+        vi.setSystemTime(3000);
+        await handlers["update"]?.(triggerContextFor(db), {
+            doc: { title: "c" },
+            id: "thread_1",
+            op: "update",
+            previous: { title: "b" },
+            table: "threads",
+        } as never);
+        vi.setSystemTime(1500);
+        await handlers["insert"]?.(triggerContextFor(db), { doc: { title: "x" }, id: "thread_2", op: "insert", table: "threads" } as never);
+    };
+
+    it("returns one row's versions newest first", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+
+        await seed(db, history);
+
+        const result = await history.functions.listForDocument.handler({ db }, { documentId: "thread_1" });
+
+        expect(result.map((entry) => entry.recordedAt)).toStrictEqual([3000, 2000, 1000]);
+        expect(result[0]?.doc).toStrictEqual({ title: "c" });
+    });
+
+    it("bounds by `before`, so the first entry is the version as of that instant", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+
+        await seed(db, history);
+
+        const result = await history.functions.listForDocument.handler({ db }, { before: 2500, documentId: "thread_1" });
+
+        expect(result[0]?.recordedAt).toBe(2000);
+        expect(result[0]?.doc).toStrictEqual({ title: "b" });
+    });
+
+    it("does not leak another row's versions", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory();
+
+        await seed(db, history);
+
+        const result = await history.functions.listForDocument.handler({ db }, { documentId: "thread_1" });
+
+        expect(result.every((entry) => entry.documentId === "thread_1")).toBe(true);
+    });
+});
+
+describe("defineDocumentHistory — vacuum", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("deletes only entries past the retention window", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory({ retentionMs: 10_000 });
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        await handlers["insert"]?.(triggerContextFor(db), { doc: {}, id: "old", op: "insert", table: "threads" } as never);
+        vi.setSystemTime(9000);
+        await handlers["insert"]?.(triggerContextFor(db), { doc: {}, id: "fresh", op: "insert", table: "threads" } as never);
+
+        vi.setSystemTime(1000 + 10_500);
+        const result = await history.functions.vacuum.handler({ db }, {});
+
+        expect(result.deleted).toBe(1);
+        expect(entries(db)).toHaveLength(1);
+        expect(entries(db)[0]?.["documentId"]).toBe("fresh");
+    });
+
+    it("honours the limit so a caller can decide whether to run again", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const history = defineDocumentHistory({ retentionMs: 1000 });
+        const { handlers } = capture(history.record());
+
+        vi.setSystemTime(1000);
+        for (const id of ["a", "b", "c"]) {
+            // eslint-disable-next-line no-await-in-loop -- deterministic order matters for the assertion below
+            await handlers["insert"]?.(triggerContextFor(db), { doc: {}, id, op: "insert", table: "threads" } as never);
+        }
+
+        vi.setSystemTime(100_000);
+        const result = await history.functions.vacuum.handler({ db }, { limit: 2 });
+
+        expect(result.deleted).toBe(2);
+        expect(entries(db)).toHaveLength(1);
+    });
+});

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -329,7 +329,7 @@ them somewhere to go:
 export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });
 
 // lunora/schema.ts — attach to each table you want versioned
-const threads = defineTable({ ... }).triggers(history.record());
+const threads = defineTable({ ... }).triggers(history.record);
 
 export const schema = defineSchema({ threads }).extend(history.extension);
 export const { listForDocument, vacuum } = history.functions;
@@ -348,10 +348,12 @@ Three things worth knowing before you rely on it:
 not exist. An unattributed trail that called itself an audit log would be worse
 than none.
 
-**Snapshots are redacted.** Secret-shaped fields (`hashedPassword`, `apiKey`,
-`refreshToken`, …) are dropped before the entry is written — a stored credential
-outlives the rotation meant to retire it. `redact` extends the list; it matches
-on field name, which is the only signal a trigger has.
+**Snapshots are redacted, at every depth.** Secret-shaped fields
+(`hashedPassword`, `apiKey`, `refreshToken`, …) are dropped before the entry is
+written — a stored credential outlives the rotation meant to retire it — and the
+filter recurses, so a credential inside a `v.object(...)` column goes too.
+Matching is by exact field name, which is the only signal a trigger has, so use
+`redact` for anything spelled differently (`api_key`, `sessionToken`).
 
 **Reads are internal.** An entry is a full row snapshot, including columns the
 table's own RLS hides, so `listForDocument` is an internal query. Wrap it in a
@@ -359,7 +361,14 @@ procedure of your own with whatever authorization the surface needs.
 
 A snapshot over `maxSnapshotBytes` (64 KB default) is dropped and the entry is
 marked `truncated` — that a row changed, and when, is the part a trail cannot
-afford to lose.
+afford to lose. `doc` and `previous` are capped independently, so a large
+pre-write row does not discard a small post-write one.
+
+<Callout type="warn">
+    One blind spot: `insertManyUnsafe` skips triggers by design, so seed, migration, and admin-import writes leave no entry. Fine for an undo stack; if you are
+    using this for compliance, that gap has to be closed elsewhere. Note too that on an `.rls("required")` schema the merged `documentHistory_versions` table
+    needs a policy — deny client access outright, since `listForDocument` is internal and meant to be wrapped by a procedure of your own.
+</Callout>
 
 ## Subpaths
 

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -326,6 +326,8 @@ them somewhere to go:
 
 ```ts
 // lunora/history.ts
+import { defineDocumentHistory } from "@lunora/server";
+
 export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });
 
 // lunora/schema.ts — attach to each table you want versioned

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -318,6 +318,49 @@ response is never cached. `tag` is purgeable through the same
 `ctx.cache.purge({ tags: [...] })` surface `httpRoute(...).cacheTag()` uses, and
 the emitted OpenAPI documents the headers a caller will observe.
 
+## `defineDocumentHistory(options)` — row-version history
+
+`.triggers()` already fires on every write with the merged row and the pre-write
+row in hand, which is exactly the pair a version history needs. This preset gives
+them somewhere to go:
+
+```ts
+// lunora/history.ts
+export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });
+
+// lunora/schema.ts — attach to each table you want versioned
+const threads = defineTable({ ... }).triggers(history.record());
+
+export const schema = defineSchema({ threads }).extend(history.extension);
+export const { listForDocument, vacuum } = history.functions;
+```
+
+`listForDocument({ documentId, before?, limit? })` returns that row's versions
+newest first. With `before`, the first entry back is the last version at or
+before that instant — a point-in-time reconstruction in one read. `vacuum` drops
+entries past `retentionMs` and reports how many, so a cron can decide whether to
+run again.
+
+Three things worth knowing before you rely on it:
+
+**It records what changed, not who.** A trigger's context carries `db` and
+`scheduler` and no identity, so there is no actor to record and the field does
+not exist. An unattributed trail that called itself an audit log would be worse
+than none.
+
+**Snapshots are redacted.** Secret-shaped fields (`hashedPassword`, `apiKey`,
+`refreshToken`, …) are dropped before the entry is written — a stored credential
+outlives the rotation meant to retire it. `redact` extends the list; it matches
+on field name, which is the only signal a trigger has.
+
+**Reads are internal.** An entry is a full row snapshot, including columns the
+table's own RLS hides, so `listForDocument` is an internal query. Wrap it in a
+procedure of your own with whatever authorization the surface needs.
+
+A snapshot over `maxSnapshotBytes` (64 KB default) is dropped and the entry is
+marked `truncated` — that a row changed, and when, is the part a trail cannot
+afford to lose.
+
 ## Subpaths
 
 - `@lunora/server/rls/testing`: `expectPolicy(policies)`, an in-process RLS

--- a/packages/server/src/document-history.ts
+++ b/packages/server/src/document-history.ts
@@ -1,0 +1,335 @@
+/**
+ * Row-version history — an append-only record of what a table's rows looked
+ * like, written by the table's own triggers.
+ *
+ * `.triggers()` already fires on every insert/update/delete with the merged row
+ * and the pre-write row in hand, which is exactly the pair a version history
+ * needs. What was missing was somewhere to put them and the discipline about
+ * what not to put there, so an app that wanted an audit trail, an undo stack, or
+ * a GDPR "what did we hold about this person" export had to build all three.
+ *
+ * Like `definePresence` and `defineActionCache`, this is a preset over
+ * primitives that already exist — the schema-extension system for the table, the
+ * trigger builder for the write path — not a new subsystem.
+ *
+ * # Wiring
+ *
+ * ```ts
+ * // lunora/history.ts
+ * import { defineDocumentHistory } from "@lunora/server";
+ *
+ * export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });
+ *
+ * // lunora/schema.ts — attach to each table you want versioned
+ * const threads = defineTable({ ... }).triggers(history.record());
+ *
+ * export const schema = defineSchema({ threads }).extend(history.extension);
+ *
+ * // Re-export so codegen registers them (both internal — see below):
+ * export const { listForDocument, vacuum } = history.functions;
+ * ```
+ *
+ * # What it records, and what it cannot
+ *
+ * **Not who.** A trigger's context carries `db` and `scheduler` and no identity,
+ * so an entry says what changed, when, and by which operation — never by whom.
+ * Attributing a change needs the actor to reach the trigger, which is a change to
+ * `TriggerCtx`, not something this preset can paper over. Recording an
+ * unattributed trail and *calling* it an audit log would be worse than not having
+ * one, so the field simply does not exist.
+ *
+ * **Redacted by default.** The point of keeping a snapshot is that it is readable
+ * later, and a stored `hashedPassword` is a credential at rest — one that outlives
+ * the rotation that was supposed to retire it. Secret-shaped fields are dropped
+ * before the row is written; {@link DefineDocumentHistoryOptions.redact} extends
+ * the list.
+ *
+ * **Reads are internal.** An entry is a full row snapshot, including columns the
+ * table's own RLS would hide. `listForDocument` is registered as an internal
+ * query so it cannot be called from a client; wrap it in your own procedure with
+ * whatever authorization the surface needs.
+ */
+
+import { v } from "@lunora/values";
+
+import { initLunora } from "./builder/index";
+import type { Component, SchemaExtension } from "./plugin";
+import { defineComponent, defineSchemaExtension } from "./plugin";
+import { defineTable } from "./schema";
+import type { RegisteredMutation, RegisteredQuery, TriggerBuilder, TriggerCtx as TriggerContext, TriggerDefinition } from "./types";
+
+/** Default retention: 90 days. `vacuum` deletes entries older than this. */
+const DEFAULT_RETENTION_MS: number = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * Default cap on one serialized snapshot (bytes). Past it the entry is still
+ * written — that a row changed, and when, is the part an audit trail cannot
+ * afford to lose — but the snapshot itself is dropped and `truncated` is set. A
+ * history that silently skipped its largest rows would be worse than one that
+ * says so.
+ */
+const DEFAULT_MAX_SNAPSHOT_BYTES = 64 * 1024;
+
+/** Entries read/deleted per page. */
+const PAGE = 200;
+
+/** Pages `vacuum` will walk in one call, so a stuck read cannot spin forever. */
+const MAX_VACUUM_ROUNDS = 64;
+
+/**
+ * Fields never written into a snapshot, whatever table they appear on.
+ *
+ * Names rather than types, because that is the only signal available here: a
+ * trigger sees values, not the column metadata that would say "this one is a
+ * secret". Extend it per app rather than relying on this list being complete.
+ */
+const DEFAULT_REDACTED_FIELDS: ReadonlyArray<string> = [
+    "accessToken",
+    "apiKey",
+    "backupCodes",
+    "clientSecret",
+    "hashedPassword",
+    "password",
+    "privateKey",
+    "refreshToken",
+    "secret",
+    "totpSecret",
+];
+
+/** The bare extension key and table name. Prefixing makes the merged table `documentHistory_versions`. */
+const DOCUMENT_HISTORY_KEY = "documentHistory";
+const DOCUMENT_HISTORY_BARE_TABLE = "versions";
+
+/** The prefixed table name the extension produces at merge time. */
+const DOCUMENT_HISTORY_TABLE: "documentHistory_versions" = `${DOCUMENT_HISTORY_KEY}_${DOCUMENT_HISTORY_BARE_TABLE}`;
+
+/** One recorded version, as {@link DocumentHistoryFunctions.listForDocument} returns it. */
+interface DocumentHistoryEntry {
+    /** The row as it stood after the write, redacted. Absent for a delete, and when `truncated`. */
+    doc?: Record<string, unknown>;
+    /** The row this version belongs to. */
+    documentId: string;
+    /** Which write produced this version. */
+    op: "delete" | "insert" | "update";
+    /** The row as it stood before the write, redacted. Absent for an insert, and when `truncated`. */
+    previous?: Record<string, unknown>;
+    /** When the write happened (epoch ms). */
+    recordedAt: number;
+    /** The table the row lives in. */
+    tableName: string;
+    /** `true` when the snapshots were dropped for exceeding `maxSnapshotBytes`. */
+    truncated?: boolean;
+}
+
+/** Options for {@link defineDocumentHistory}. */
+interface DefineDocumentHistoryOptions {
+    /**
+     * Cap on one serialized snapshot (bytes). Past it the entry is written
+     * without its snapshots and marked `truncated`. Defaults to 64 KB.
+     */
+    maxSnapshotBytes?: number;
+
+    /**
+     * Extra field names to drop from every snapshot, on top of the built-in
+     * secret-shaped defaults.
+     */
+    redact?: ReadonlyArray<string>;
+
+    /**
+     * How long (ms) an entry is kept. `vacuum` deletes entries older than this.
+     * Defaults to 90 days.
+     */
+    retentionMs?: number;
+}
+
+/** The registered functions a document-history component ships. */
+interface DocumentHistoryFunctions {
+    /**
+     * **Internal** query: the recorded versions of one row, newest first.
+     *
+     * Internal because an entry is a full row snapshot, including columns the
+     * table's own RLS hides — wrap it in a procedure of your own that applies
+     * whatever authorization the surface needs.
+     *
+     * Pass `before` to read the history as of an instant: the first entry back is
+     * the last version at or before it, which is what a point-in-time
+     * reconstruction needs.
+     */
+    listForDocument: RegisteredQuery<
+        { before: ReturnType<typeof v.optional>; documentId: ReturnType<typeof v.string>; limit: ReturnType<typeof v.optional> },
+        DocumentHistoryEntry[]
+    >;
+
+    /**
+     * Internal mutation that deletes entries older than the retention window,
+     * oldest first, and reports how many it removed. Schedule it on a cron.
+     *
+     * Compare `deleted` against `limit` to decide whether to run again rather
+     * than assuming one pass drained the backlog.
+     */
+    vacuum: RegisteredMutation<{ limit: ReturnType<typeof v.optional> }, { deleted: number }>;
+}
+
+/** The component shape {@link defineDocumentHistory} returns. */
+type DocumentHistoryComponent = Component<{ [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable> }> & {
+    functions: DocumentHistoryFunctions;
+
+    /**
+     * The `.triggers(...)` argument that records this table's versions.
+     *
+     * `after*` on all three ops: a `before*` handler runs while the write can
+     * still be aborted, and a history entry for a write that never happened is a
+     * lie the reader has no way to detect.
+     */
+    record: () => (t: TriggerBuilder) => Record<string, TriggerDefinition>;
+};
+
+/**
+ * The document-history schema extension: one `versions` table, auto-namespaced
+ * to `documentHistory_versions` at merge time.
+ */
+// Explicit type on this exported const (isolatedDeclarations can't infer it from
+// the generic call), matching `presenceExtension`.
+const documentHistoryExtension = defineSchemaExtension(DOCUMENT_HISTORY_KEY, {
+    tables: {
+        [DOCUMENT_HISTORY_BARE_TABLE]: defineTable({
+            doc: v.optional(v.string()),
+            documentId: v.string(),
+            op: v.string(),
+            previous: v.optional(v.string()),
+            recordedAt: v.number(),
+            tableName: v.string(),
+            truncated: v.optional(v.boolean()),
+        })
+            // Drives `listForDocument`, newest-first and optionally bounded by `before`.
+            .index("byDocumentRecordedAt", ["documentId", "recordedAt"])
+            // Drives `vacuum`'s oldest-first scan.
+            .index("byRecordedAt", ["recordedAt"]),
+    },
+}) as unknown as SchemaExtension<{ [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable> }>;
+
+// No generated server here, so bind the base contexts via the builder factory —
+// same as `definePresence`.
+const { internalMutation, internalQuery } = initLunora.dataModel().create();
+
+/**
+ * Build a document-history {@link Component} — schema extension, the
+ * `.triggers()` recorder, and the `listForDocument` / `vacuum` functions.
+ * @param options history configuration (retention, redaction, snapshot cap).
+ * @returns a component bundling the extension, the functions, and the recorder.
+ */
+const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): DocumentHistoryComponent => {
+    // `Number.isFinite` first: a `NaN`/`Infinity` option would otherwise flow
+    // through unchanged and land in a comparison nothing can satisfy.
+    const retentionMs =
+        options.retentionMs !== undefined && Number.isFinite(options.retentionMs) ? Math.max(1, Math.floor(options.retentionMs)) : DEFAULT_RETENTION_MS;
+    const maxSnapshotBytes =
+        options.maxSnapshotBytes !== undefined && Number.isFinite(options.maxSnapshotBytes)
+            ? Math.max(1, Math.floor(options.maxSnapshotBytes))
+            : DEFAULT_MAX_SNAPSHOT_BYTES;
+    const redacted = new Set([...DEFAULT_REDACTED_FIELDS, ...(options.redact ?? [])]);
+
+    /** A shallow copy with the secret-shaped fields removed. */
+    const redact = (row: Record<string, unknown> | undefined): Record<string, unknown> | undefined =>
+        row === undefined ? undefined : Object.fromEntries(Object.entries(row).filter(([key]) => !redacted.has(key)));
+
+    const write = async (
+        context: TriggerContext,
+        entry: { doc?: Record<string, unknown>; documentId: string; op: string; previous?: Record<string, unknown>; tableName: string },
+    ): Promise<void> => {
+        const documentJson = entry.doc === undefined ? undefined : JSON.stringify(redact(entry.doc));
+        const previousJson = entry.previous === undefined ? undefined : JSON.stringify(redact(entry.previous));
+        const bytes = new TextEncoder().encode(`${documentJson ?? ""}${previousJson ?? ""}`).length;
+        const truncated = bytes > maxSnapshotBytes;
+
+        await context.db.insert(DOCUMENT_HISTORY_TABLE, {
+            documentId: entry.documentId,
+            op: entry.op,
+            recordedAt: Date.now(),
+            tableName: entry.tableName,
+            // Past the cap the entry keeps its metadata and loses its payload:
+            // "this row changed at this time" survives, which is the part a trail
+            // cannot afford to drop.
+            ...(truncated ? { truncated: true } : {}),
+            ...(truncated || documentJson === undefined ? {} : { doc: documentJson }),
+            ...(truncated || previousJson === undefined ? {} : { previous: previousJson }),
+        });
+    };
+
+    const record =
+        () =>
+        (t: TriggerBuilder): Record<string, TriggerDefinition> => {return {
+            // `after*` on all three: a `before*` handler runs while the write can
+            // still be aborted, and an entry for a write that never landed is a
+            // lie the reader cannot detect.
+            documentHistoryDelete: t.afterDelete(async (context, event) =>
+                write(context, { documentId: event.id, op: "delete", previous: event.previous, tableName: event.table }),
+            ),
+            documentHistoryInsert: t.afterInsert(async (context, event) =>
+                write(context, { doc: event.doc, documentId: event.id, op: "insert", tableName: event.table }),
+            ),
+            documentHistoryUpdate: t.afterUpdate(async (context, event) =>
+                write(context, { doc: event.doc, documentId: event.id, op: "update", previous: event.previous, tableName: event.table }),
+            ),
+        }};
+
+    const listForDocument = internalQuery
+        .input({ before: v.optional(v.number()), documentId: v.string(), limit: v.optional(v.number()) })
+        .query(async ({ args, ctx: context }): Promise<DocumentHistoryEntry[]> => {
+            const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : PAGE;
+
+            const rows = await context.db
+                .query(DOCUMENT_HISTORY_TABLE)
+                .withIndex("byDocumentRecordedAt", (q) =>
+                    args.before === undefined ? q.eq("documentId", args.documentId) : q.eq("documentId", args.documentId).lte("recordedAt", args.before),
+                )
+                .order("desc")
+                .take(limit);
+
+            return rows.map((row) => {return {
+                documentId: row["documentId"] as string,
+                op: row["op"] as DocumentHistoryEntry["op"],
+                recordedAt: row["recordedAt"] as number,
+                tableName: row["tableName"] as string,
+                ...(row["doc"] === undefined ? {} : { doc: JSON.parse(row["doc"] as string) as Record<string, unknown> }),
+                ...(row["previous"] === undefined ? {} : { previous: JSON.parse(row["previous"] as string) as Record<string, unknown> }),
+                ...(row["truncated"] === true ? { truncated: true } : {}),
+            }});
+        });
+
+    const vacuum = internalMutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
+        const cutoff = Date.now() - retentionMs;
+        const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : PAGE * MAX_VACUUM_ROUNDS;
+
+        let deleted = 0;
+
+        for (let round = 0; round < MAX_VACUUM_ROUNDS && deleted < limit; round += 1) {
+            // eslint-disable-next-line no-await-in-loop -- each round deletes the page the previous one read; the reads are inherently sequential
+            const page = await context.db
+                .query(DOCUMENT_HISTORY_TABLE)
+                .withIndex("byRecordedAt", (q) => q.lt("recordedAt", cutoff))
+                .order("asc")
+                .take(Math.min(PAGE, limit - deleted));
+
+            if (page.length === 0) {
+                return { deleted };
+            }
+
+            // eslint-disable-next-line no-await-in-loop -- see above
+            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as never)));
+            deleted += page.length;
+        }
+
+        return { deleted };
+    });
+
+    const component = defineComponent(DOCUMENT_HISTORY_KEY, {
+        extension: documentHistoryExtension,
+        functions: { listForDocument, vacuum },
+    }) as DocumentHistoryComponent;
+
+    return { ...component, record };
+};
+
+export type { DefineDocumentHistoryOptions, DocumentHistoryComponent, DocumentHistoryEntry, DocumentHistoryFunctions };
+export { defineDocumentHistory, DEFAULT_REDACTED_FIELDS as DOCUMENT_HISTORY_REDACTED_FIELDS, DOCUMENT_HISTORY_TABLE, documentHistoryExtension };

--- a/packages/server/src/document-history.ts
+++ b/packages/server/src/document-history.ts
@@ -95,19 +95,25 @@ const DEFAULT_VACUUM_LIMIT = 512;
 const MAX_REDACT_DEPTH = 16;
 
 /**
- * Tie-breaker for entries written in the same millisecond.
+ * Ordering, in two parts, because no single value gives both halves.
  *
- * Workers do not advance the clock between I/O operations, so EVERY entry
- * written by one mutation shares a `recordedAt` — two updates to a row, or an
- * update plus a cascade, are the common case rather than a race. Without a
- * second sort key `.order("desc")` returns them in an arbitrary order, and a
- * point-in-time read picks arbitrarily among them.
+ * `_commitSeq` (from `.commitOrdered()` on the table) is a per-shard integer
+ * allocated ONCE PER MUTATION and strictly increasing in commit order. It is
+ * durable, so it keeps ordering across a Durable Object restart — which
+ * `recordedAt` cannot, being wall-clock, and which an in-process counter cannot,
+ * being reset by the restart.
  *
- * Module-scoped, so it is monotonic for the life of an isolate. A cold start
- * resets it, which is harmless: the clock will have moved on, and `recordedAt`
- * orders across isolates.
+ * What `_commitSeq` does NOT do is separate entries written by the SAME mutation,
+ * and that is the common case rather than a race: Workers do not advance the
+ * clock between I/O operations, so two updates to a row, or an update plus a
+ * cascade, share both a `recordedAt` and a `_commitSeq`. The per-component `seq`
+ * counter supplies that inner order.
+ *
+ * So the sort key is `[_commitSeq, seq]`: durable across mutations, defined
+ * within one. `seq` is per-component rather than module-scoped so its lifetime is
+ * visible and a test can simulate a restart by building a second component.
  */
-let sequence = 0;
+const ORDER_KEYS = ["_commitSeq", "seq"] as const;
 
 /**
  * Fields never written into a snapshot, whatever table they appear on.
@@ -239,6 +245,8 @@ const documentHistoryExtension = defineSchemaExtension(DOCUMENT_HISTORY_KEY, {
             tableName: v.string(),
             truncated: v.optional(v.boolean()),
         })
+            // Stamps `_commitSeq` on every row: the durable half of the sort key.
+            .commitOrdered()
             // Drives `listForDocument`, newest-first and optionally bounded by
             // `before`. `seq` is part of the key so entries sharing a millisecond
             // still have one defined order.
@@ -268,6 +276,16 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
             ? Math.max(1, Math.floor(options.maxSnapshotBytes))
             : DEFAULT_MAX_SNAPSHOT_BYTES;
     const redacted = new Set([...DEFAULT_REDACTED_FIELDS, ...(options.redact ?? [])]);
+
+    // Separates entries sharing one mutation's `_commitSeq`. Only ever compared
+    // WITHIN a `_commitSeq`, so a reset on restart cannot reorder anything: a
+    // later mutation always carries a higher `_commitSeq` than an earlier one.
+    let sequence = 0;
+    const nextSequence = (): number => {
+        sequence += 1;
+
+        return sequence;
+    };
 
     /**
      * Strip the secret-shaped fields, at every depth.
@@ -336,13 +354,11 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
         const previousJson = snapshot(entry.previous);
         const truncated = (entry.doc !== undefined && documentJson === undefined) || (entry.previous !== undefined && previousJson === undefined);
 
-        sequence += 1;
-
         await context.db.insert(DOCUMENT_HISTORY_TABLE, {
             documentId: entry.documentId,
             op: entry.op,
             recordedAt: Date.now(),
-            seq: sequence,
+            seq: nextSequence(),
             tableName: entry.tableName,
             // Past the cap the entry keeps its metadata and loses that payload:
             // "this row changed at this time" survives, which is the part a trail
@@ -382,6 +398,28 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
                 )
                 .order("desc")
                 .take(limit);
+
+            // Re-sorted on the durable key. The index reads by `recordedAt`, which
+            // is what `before` bounds against and what a caller asks in — but wall
+            // clock is not commit order, and a restart can hand two mutations the
+            // same millisecond. `_commitSeq` is the shard's own commit counter, so
+            // it separates them; `seq` separates entries inside one mutation, which
+            // share a `_commitSeq`.
+            //
+            // Sorting the page rather than the table is exact for everything the
+            // page contains. A tie group straddling `limit` can still be cut
+            // mid-group — raise `limit` if you are reconstructing across one.
+            rows.sort((a, b) => {
+                for (const key of ORDER_KEYS) {
+                    const delta = ((b[key] as number | undefined) ?? 0) - ((a[key] as number | undefined) ?? 0);
+
+                    if (delta !== 0) {
+                        return delta;
+                    }
+                }
+
+                return 0;
+            });
 
             return rows.map((row) => {
                 return {

--- a/packages/server/src/document-history.ts
+++ b/packages/server/src/document-history.ts
@@ -21,7 +21,7 @@
  * export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });
  *
  * // lunora/schema.ts — attach to each table you want versioned
- * const threads = defineTable({ ... }).triggers(history.record());
+ * const threads = defineTable({ ... }).triggers(history.record);
  *
  * export const schema = defineSchema({ threads }).extend(history.extension);
  *
@@ -38,11 +38,18 @@
  * unattributed trail and *calling* it an audit log would be worse than not having
  * one, so the field simply does not exist.
  *
- * **Redacted by default.** The point of keeping a snapshot is that it is readable
- * later, and a stored `hashedPassword` is a credential at rest — one that outlives
- * the rotation that was supposed to retire it. Secret-shaped fields are dropped
- * before the row is written; {@link DefineDocumentHistoryOptions.redact} extends
- * the list.
+ * **Redacted by default, at every depth.** The point of keeping a snapshot is that
+ * it is readable later, and a stored `hashedPassword` is a credential at rest —
+ * one that outlives the rotation that was supposed to retire it. Secret-shaped
+ * fields are dropped before the row is written, recursively, so a credential
+ * inside a `v.object(...)` column or an `oauth: { refreshToken }` blob goes too.
+ * Matching is by exact field NAME, which is all a trigger can see, so
+ * {@link DefineDocumentHistoryOptions.redact} is how you cover `api_key`,
+ * `sessionToken`, and anything else this list does not spell the same way.
+ *
+ * **It has one blind spot.** `insertManyUnsafe` skips triggers by design, so seed,
+ * migration, and admin-import writes leave no entry. If the trail is being used
+ * for compliance rather than for undo, that gap has to be closed elsewhere.
  *
  * **Reads are internal.** An entry is a full row snapshot, including columns the
  * table's own RLS would hide. `listForDocument` is registered as an internal
@@ -50,8 +57,10 @@
  * whatever authorization the surface needs.
  */
 
+import type { Id } from "@lunora/values";
 import { v } from "@lunora/values";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import { initLunora } from "./builder/index";
 import type { Component, SchemaExtension } from "./plugin";
 import { defineComponent, defineSchemaExtension } from "./plugin";
@@ -75,6 +84,30 @@ const PAGE = 200;
 
 /** Pages `vacuum` will walk in one call, so a stuck read cannot spin forever. */
 const MAX_VACUUM_ROUNDS = 64;
+
+/**
+ * Default entries `vacuum` removes per call. One transaction's worth: a cron
+ * that finds more re-runs, which is cheaper than opening a very large write.
+ */
+const DEFAULT_VACUUM_LIMIT = 512;
+
+/** How deep the redaction filter walks before dropping a branch it cannot fully inspect. */
+const MAX_REDACT_DEPTH = 16;
+
+/**
+ * Tie-breaker for entries written in the same millisecond.
+ *
+ * Workers do not advance the clock between I/O operations, so EVERY entry
+ * written by one mutation shares a `recordedAt` — two updates to a row, or an
+ * update plus a cascade, are the common case rather than a race. Without a
+ * second sort key `.order("desc")` returns them in an arbitrary order, and a
+ * point-in-time read picks arbitrarily among them.
+ *
+ * Module-scoped, so it is monotonic for the life of an isolate. A cold start
+ * resets it, which is harmless: the clock will have moved on, and `recordedAt`
+ * orders across isolates.
+ */
+let sequence = 0;
 
 /**
  * Fields never written into a snapshot, whatever table they appear on.
@@ -171,18 +204,19 @@ interface DocumentHistoryFunctions {
 }
 
 /** The component shape {@link defineDocumentHistory} returns. */
-type DocumentHistoryComponent = Component<{ [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable> }> & {
+type DocumentHistoryComponent = {
     functions: DocumentHistoryFunctions;
 
     /**
-     * The `.triggers(...)` argument that records this table's versions.
+     * The `.triggers(...)` argument that records this table's versions —
+     * `.triggers(history.record)`.
      *
      * `after*` on all three ops: a `before*` handler runs while the write can
      * still be aborted, and a history entry for a write that never happened is a
      * lie the reader has no way to detect.
      */
-    record: () => (t: TriggerBuilder) => Record<string, TriggerDefinition>;
-};
+    record: (t: TriggerBuilder) => Record<string, TriggerDefinition>;
+} & Component<{ [DOCUMENT_HISTORY_BARE_TABLE]: ReturnType<typeof defineTable> }>;
 
 /**
  * The document-history schema extension: one `versions` table, auto-namespaced
@@ -195,14 +229,20 @@ const documentHistoryExtension = defineSchemaExtension(DOCUMENT_HISTORY_KEY, {
         [DOCUMENT_HISTORY_BARE_TABLE]: defineTable({
             doc: v.optional(v.string()),
             documentId: v.string(),
-            op: v.string(),
+            // A union rather than a bare string: the invariant belongs on the
+            // column, and the read side then needs no cast back to it.
+            op: v.union(v.literal("delete"), v.literal("insert"), v.literal("update")),
             previous: v.optional(v.string()),
             recordedAt: v.number(),
+            /** Tie-breaker within one `recordedAt`; see the module-level `sequence`. */
+            seq: v.number(),
             tableName: v.string(),
             truncated: v.optional(v.boolean()),
         })
-            // Drives `listForDocument`, newest-first and optionally bounded by `before`.
-            .index("byDocumentRecordedAt", ["documentId", "recordedAt"])
+            // Drives `listForDocument`, newest-first and optionally bounded by
+            // `before`. `seq` is part of the key so entries sharing a millisecond
+            // still have one defined order.
+            .index("byDocumentRecordedAt", ["documentId", "recordedAt", "seq"])
             // Drives `vacuum`'s oldest-first scan.
             .index("byRecordedAt", ["recordedAt"]),
     },
@@ -229,36 +269,92 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
             : DEFAULT_MAX_SNAPSHOT_BYTES;
     const redacted = new Set([...DEFAULT_REDACTED_FIELDS, ...(options.redact ?? [])]);
 
-    /** A shallow copy with the secret-shaped fields removed. */
-    const redact = (row: Record<string, unknown> | undefined): Record<string, unknown> | undefined =>
-        row === undefined ? undefined : Object.fromEntries(Object.entries(row).filter(([key]) => !redacted.has(key)));
+    /**
+     * Strip the secret-shaped fields, at every depth.
+     *
+     * Recursive, not a top-level filter: a credential is at least as likely to sit
+     * inside a `v.object({ apiKey })` column or an `oauth: { refreshToken }` blob
+     * as at the root, and this table retains what it is given for months. Arrays
+     * are walked too, so a list of connection objects is covered.
+     *
+     * `MAX_REDACT_DEPTH` bounds a pathological or cyclic shape; past it the branch
+     * is dropped rather than copied, because a value this module cannot fully
+     * inspect is not one it should store.
+     */
+    const redact = (value: unknown, depth = 0): unknown => {
+        if (Array.isArray(value)) {
+            return depth >= MAX_REDACT_DEPTH ? undefined : value.map((item) => redact(item, depth + 1));
+        }
+
+        if (typeof value !== "object" || value === null) {
+            return value;
+        }
+
+        // Only plain objects are walked. A `Date`, a `Map`, bytes — anything the
+        // wire codec carries as a leaf — is passed through whole; recursing into
+        // one would corrupt it, and none of them holds a named field.
+        if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+            return value;
+        }
+
+        if (depth >= MAX_REDACT_DEPTH) {
+            return undefined;
+        }
+
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>)
+                .filter(([key]) => !redacted.has(key))
+                .map(([key, member]) => [key, redact(member, depth + 1)]),
+        );
+    };
+
+    /**
+     * Serialize one snapshot, or `undefined` when it is absent or over the cap.
+     *
+     * Through the wire codec, because this runs inside an AFTER-trigger: raw
+     * `JSON.stringify` throws on a `bigint`, and a throw here aborts the write it
+     * is recording. A table with a `v.bigint()` column and history attached would
+     * have failed every insert, update and delete.
+     */
+    const snapshot = (row: Record<string, unknown> | undefined): string | undefined => {
+        if (row === undefined) {
+            return undefined;
+        }
+
+        const serialized = JSON.stringify(encodeWire(redact(row)));
+
+        // Each side is capped on its own: a large `previous` should not discard a
+        // small `doc`, which is usually the more useful half.
+        return new TextEncoder().encode(serialized).length > maxSnapshotBytes ? undefined : serialized;
+    };
 
     const write = async (
         context: TriggerContext,
-        entry: { doc?: Record<string, unknown>; documentId: string; op: string; previous?: Record<string, unknown>; tableName: string },
+        entry: { doc?: Record<string, unknown>; documentId: string; op: DocumentHistoryEntry["op"]; previous?: Record<string, unknown>; tableName: string },
     ): Promise<void> => {
-        const documentJson = entry.doc === undefined ? undefined : JSON.stringify(redact(entry.doc));
-        const previousJson = entry.previous === undefined ? undefined : JSON.stringify(redact(entry.previous));
-        const bytes = new TextEncoder().encode(`${documentJson ?? ""}${previousJson ?? ""}`).length;
-        const truncated = bytes > maxSnapshotBytes;
+        const documentJson = snapshot(entry.doc);
+        const previousJson = snapshot(entry.previous);
+        const truncated = (entry.doc !== undefined && documentJson === undefined) || (entry.previous !== undefined && previousJson === undefined);
+
+        sequence += 1;
 
         await context.db.insert(DOCUMENT_HISTORY_TABLE, {
             documentId: entry.documentId,
             op: entry.op,
             recordedAt: Date.now(),
+            seq: sequence,
             tableName: entry.tableName,
-            // Past the cap the entry keeps its metadata and loses its payload:
+            // Past the cap the entry keeps its metadata and loses that payload:
             // "this row changed at this time" survives, which is the part a trail
             // cannot afford to drop.
             ...(truncated ? { truncated: true } : {}),
-            ...(truncated || documentJson === undefined ? {} : { doc: documentJson }),
-            ...(truncated || previousJson === undefined ? {} : { previous: previousJson }),
+            ...(documentJson === undefined ? {} : { doc: documentJson }),
+            ...(previousJson === undefined ? {} : { previous: previousJson }),
         });
     };
 
-    const record =
-        () =>
-        (t: TriggerBuilder): Record<string, TriggerDefinition> => {return {
+    const record = (t: TriggerBuilder): Record<string, TriggerDefinition> => {
+        return {
             // `after*` on all three: a `before*` handler runs while the write can
             // still be aborted, and an entry for a write that never landed is a
             // lie the reader cannot detect.
@@ -271,7 +367,8 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
             documentHistoryUpdate: t.afterUpdate(async (context, event) =>
                 write(context, { doc: event.doc, documentId: event.id, op: "update", previous: event.previous, tableName: event.table }),
             ),
-        }};
+        };
+    };
 
     const listForDocument = internalQuery
         .input({ before: v.optional(v.number()), documentId: v.string(), limit: v.optional(v.number()) })
@@ -286,20 +383,24 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
                 .order("desc")
                 .take(limit);
 
-            return rows.map((row) => {return {
-                documentId: row["documentId"] as string,
-                op: row["op"] as DocumentHistoryEntry["op"],
-                recordedAt: row["recordedAt"] as number,
-                tableName: row["tableName"] as string,
-                ...(row["doc"] === undefined ? {} : { doc: JSON.parse(row["doc"] as string) as Record<string, unknown> }),
-                ...(row["previous"] === undefined ? {} : { previous: JSON.parse(row["previous"] as string) as Record<string, unknown> }),
-                ...(row["truncated"] === true ? { truncated: true } : {}),
-            }});
+            return rows.map((row) => {
+                return {
+                    documentId: row["documentId"] as string,
+                    op: row["op"] as DocumentHistoryEntry["op"],
+                    recordedAt: row["recordedAt"] as number,
+                    tableName: row["tableName"] as string,
+                    // Decoded through the same codec that wrote it, so a `bigint`
+                    // or `Date` column comes back as itself, not as a tagged form.
+                    ...(row["doc"] === undefined ? {} : { doc: decodeWire(JSON.parse(row["doc"] as string)) as Record<string, unknown> }),
+                    ...(row["previous"] === undefined ? {} : { previous: decodeWire(JSON.parse(row["previous"] as string)) as Record<string, unknown> }),
+                    ...(row["truncated"] === true ? { truncated: true } : {}),
+                };
+            });
         });
 
     const vacuum = internalMutation.input({ limit: v.optional(v.number()) }).mutation(async ({ args, ctx: context }): Promise<{ deleted: number }> => {
         const cutoff = Date.now() - retentionMs;
-        const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : PAGE * MAX_VACUUM_ROUNDS;
+        const limit = args.limit !== undefined && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : DEFAULT_VACUUM_LIMIT;
 
         let deleted = 0;
 
@@ -316,7 +417,7 @@ const defineDocumentHistory = (options: DefineDocumentHistoryOptions = {}): Docu
             }
 
             // eslint-disable-next-line no-await-in-loop -- see above
-            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as never)));
+            await Promise.all(page.map(async (row) => context.db.delete(row["_id"] as Id<string>)));
             deleted += page.length;
         }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,8 @@ export { initLunora } from "./builder/index";
 export { createSecrets } from "./create-secrets";
 export type { DeferredDeleteFlushResult } from "./deferred-deletes";
 export { flushDeferredDeletes, withDeferredDeletes } from "./deferred-deletes";
+export type { DefineDocumentHistoryOptions, DocumentHistoryComponent, DocumentHistoryEntry, DocumentHistoryFunctions } from "./document-history";
+export { defineDocumentHistory, DOCUMENT_HISTORY_REDACTED_FIELDS, DOCUMENT_HISTORY_TABLE, documentHistoryExtension } from "./document-history";
 export type { EnvAccessor, EnvKeyFailure, EnvShape, InferEnv } from "./env";
 export { defineEnv, LunoraEnvError, redactSecrets } from "./env";
 export type { LunoraErrorCode } from "./error";


### PR DESCRIPTION
## What

`defineDocumentHistory(options)` — an append-only record of what a table's rows looked like, written by the table's own triggers.

```ts
export const history = defineDocumentHistory({ retentionMs: 90 * 24 * 60 * 60 * 1000 });

const threads = defineTable({ ... }).triggers(history.record());

export const schema = defineSchema({ threads }).extend(history.extension);
export const { listForDocument, vacuum } = history.functions;
```

`listForDocument({ documentId, before?, limit? })` returns that row's versions newest-first; with `before`, the first entry back is the last version at or before that instant — a point-in-time reconstruction in one read. `vacuum` drops entries past the retention window and reports the count.

## Why

`.triggers()` already fires on every insert/update/delete with the merged row **and** the pre-write row in hand — exactly the pair a version history needs. What was missing was somewhere to put them and the discipline about what not to put there, so an app that wanted an audit trail, an undo stack, or a GDPR "what did we hold about this person" export had to build all three, including the parts that are easy to get quietly wrong.

Same shape as `definePresence` and `defineActionCache`: schema extension for the table, the existing builder for the write path. No new package, no DO-level support.

## Three deliberate positions

**It records what changed and when, not who.** `TriggerCtx` carries `db` and `scheduler` and no identity. There is no actor to record, so the field does not exist. Recording an unattributed trail and *calling* it an audit log would be worse than not having one. Attribution needs the actor to reach the trigger — a change to `TriggerCtx`, not something a preset can paper over. Happy to follow up on that separately if you want the attributed version.

**Snapshots are redacted by default.** The point of keeping a snapshot is that it is readable later, and a stored `hashedPassword` is a credential at rest — one that outlives the rotation meant to retire it. Matching is by field name (`hashedPassword`, `apiKey`, `refreshToken`, `totpSecret`, …) because that is the only signal a trigger has: it sees values, not the column metadata that would say "this one is a secret". `redact` extends the list; the built-in one is a floor, not a guarantee, and the docs say so.

**Reads are internal.** An entry is a full row snapshot, including columns the table's own RLS hides. `listForDocument` is registered as an internal query so it cannot be reached from a client; apps wrap it with their own authorization.

## Other decisions

- **`after*` on all three ops, never `before*`.** A before handler runs while the write can still be aborted, so an entry written there could describe a write that never landed — and nothing downstream could tell.
- **Over-cap snapshots are dropped, the entry is kept** and marked `truncated`. "This row changed, at this time" is the part a trail cannot afford to lose; silently skipping the largest rows would be worse than saying so.
- **`vacuum` is bounded** and reports `deleted`, so a cron compares it against `limit` rather than assuming one pass drained the backlog.

## Scope

Additive. No existing export changes shape.

- `packages/server/src/document-history.ts` — the preset
- `packages/server/src/index.ts` — exports
- `packages/server/__tests__/document-history.test.ts` — 12 tests: trigger binding (all three `after`, no `before`), insert/update/delete recording, default and caller-supplied redaction, the truncation path, `listForDocument` ordering / `before` bound / no cross-row leakage, and `vacuum` retention + limit
- `packages/server/docs/index.mdx` — new section
- `api-snapshots/{server,lunora}.api.md`

## Checks

- `pnpm run lint:types` (all 56 projects) — clean
- `pnpm run build:packages` — clean (the `--isolatedDeclarations` gate that only `build` catches)
- `pnpm --filter "@lunora/server" run test` — 636 passed (12 new)
- `pnpm --filter "@lunora/server" run lint:eslint` — clean; `lint:package-json` clean
- `pnpm run api:update` after a full build; diffs limited to the new exports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added document history tracking for inserts, updates, and deletes.
  - Supports point-in-time document reads and version listing.
  - Automatically redacts secret-shaped fields, including nested values.
  - Preserves encoded values and independently truncates oversized snapshots.
  - Orders history entries consistently, including same-millisecond changes.
  - Provides history retention cleanup and public configuration APIs.

- **Documentation**
  - Added guidance for configuring document history, protecting history data with required access controls, internal-read authorization, and understanding bulk-operation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->