### PR TITLE
perf(do): render write statements once per table

### DIFF
--- a/packages/do/__tests__/dispatch-lifecycle.test.ts
+++ b/packages/do/__tests__/dispatch-lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * `beginDispatch` stamps the per-request state off an inbound RPC request and
+ * `endDispatch` clears it. The invariant that matters is the pairing: a field
+ * one sets and the other forgets does not fail anything locally — it survives
+ * into the NEXT request served by the same Durable Object instance, which for
+ * `currentRequestUserId` / `currentRequestIdentity` means one caller's identity
+ * answering another caller's request.
+ *
+ * That is why this reads the source rather than exercising behaviour. The leak
+ * only shows up when two requests hit the same warm instance in the right order,
+ * so a behavioural test would have to guess the shape of a field that does not
+ * exist yet. Comparing the two assignment sets catches the omission the moment
+ * the field is added.
+ */
+
+const source = readFileSync(fileURLToPath(new URL("../src/shard-do.ts", import.meta.url)), "utf8");
+
+/**
+ * Body of a method declared as `private <name>(`.
+ *
+ * Delimited by indentation, not by brace matching: a wrapped return type puts an
+ * object literal between the signature and the body, and matching from the first
+ * `{` returns that type instead — which made this test read an empty body and
+ * pass vacuously. Every method in this class closes on `\n    }` at four spaces,
+ * and nested blocks close at eight or more, so that sequence ends the method.
+ */
+const methodBody = (name: string): string => {
+    const start = source.indexOf(`    private ${name}(`);
+
+    if (start === -1) {
+        throw new Error(`method ${name} not found — this test pins its existence too`);
+    }
+
+    // The trailing newline matters: a wrapped return type closes with `    } {`,
+    // also at four spaces, and matching that slices the body away to nothing.
+    const end = source.indexOf("\n    }\n", start);
+
+    if (end === -1) {
+        throw new Error(`no closing brace at method indent for ${name}`);
+    }
+
+    return source.slice(start, end);
+};
+
+/** Fields the body assigns directly (`this.x = …`), ignoring method calls and compound reads. */
+const assignedFields = (body: string): Set<string> => new Set([...body.matchAll(/\bthis\.(\w+)\s*=[^=]/gu)].map((match) => match[1] as string));
+
+describe("per-request dispatch state", () => {
+    it("clears every field it stamps", () => {
+        expect.hasAssertions();
+
+        const stamped = assignedFields(methodBody("beginDispatch"));
+        const cleared = assignedFields(methodBody("endDispatch"));
+
+        // Sanity that the extraction still looks like itself — a regex that
+        // silently matched nothing would make this test vacuously green.
+        expect(stamped.size).toBeGreaterThan(10);
+
+        const leaked = [...stamped].filter((field) => !cleared.has(field)).toSorted((left, right) => left.localeCompare(right));
+
+        expect(leaked).toStrictEqual([]);
+    });
+
+    it("stamps the identity fields a stale value would cross-contaminate", () => {
+        expect.hasAssertions();
+
+        // Named explicitly rather than left to the set comparison: these are the
+        // fields whose leak is a security problem rather than a stale reading.
+        const stamped = assignedFields(methodBody("beginDispatch"));
+
+        for (const field of ["currentRequestIdentity", "currentRequestIp", "currentRequestSystem", "currentRequestUserId"]) {
+            expect(stamped).toContain(field);
+        }
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -5251,6 +5251,26 @@ abstract class ShardDO {
     }
 
     /**
+     * Stamp everything one RPC dispatch needs off its request, and reset every
+     * per-request capture the handler will fill.
+     *
+     * Split from {@link ShardDO.handleFetchCloudflare} together with
+     * {@link ShardDO.endDispatch}, and the pairing is the point: these two own
+     * the same set of fields, and the whole correctness story for them is that
+     * every field one sets, the other clears. Spread across a 479-line method
+     * the two ends were 350 lines apart, so a newly-added per-request field
+     * stamped here and forgotten there leaks into the NEXT request on the same
+     * DO instance — a cross-request identity bleed with no local symptom.
+     * `__tests__/dispatch-lifecycle.test.ts` asserts the symmetry directly.
+     *
+     * Returns the two values the caller must hold in locals rather than read
+     * back off `this`: an `await`-interleaved concurrent dispatch can re-set the
+     * shared fields, and the `finally` would then file this dispatch's telemetry
+     * under another request's trace (see the comments inside).
+     * @returns this dispatch's trace anchor and its transaction-headroom tracker
+     */
+
+    /**
      * Cloudflare-specific fetch implementation — WebSocket upgrades and the RPC
      * routes. Injected into {@link ShardRunner} as the host-specific handler while
      * the engine is progressively extracted.
@@ -5314,91 +5334,7 @@ abstract class ShardDO {
         // Stash the inbound D1 bookmark and identity headers for the
         // duration of the handler call so getters return the right
         // values. Cleared on exit so the next request starts fresh.
-        this.currentRequestBookmark = request.headers.get("x-d1-bookmark") ?? undefined;
-        this.currentResponseBookmark = undefined;
-        // `decodeUserIdHeader` inverts the runtime's `encodeUserIdHeader`: a
-        // Latin-1-safe id is forwarded unchanged, a non-Latin-1 one arrives
-        // base64url-encoded behind a leading `=` sentinel. See shared/identity-header.ts.
-        this.currentRequestUserId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
-        this.currentRequestMutationId = request.headers.get("x-lunora-mutation-id") ?? undefined;
-        // Custom-mutator push identity: a stable per-device client id plus a
-        // monotonic per-client sequence. Present only on custom-mutator pushes;
-        // the watermark dispatch below classifies the sequence against the
-        // shard's `__client_watermark`. A non-numeric/absent seq disables the
-        // watermark path (the call falls back to the legacy idempotency dedup).
-        this.currentRequestClientId = request.headers.get("x-lunora-client-id") ?? undefined;
-        this.currentRequestClientSeq = parseClientSeqHeader(request.headers.get("x-lunora-client-seq"));
-        // Reset the in-transaction bookkeeping handshake: `handleRpc` sets the
-        // classification + flag for a mutation push so the writes, dedup row, and
-        // watermark advance all commit atomically (see `commitMutationBookkeeping`).
-        this.currentMutatorClass = undefined;
-        this.mutationBookkeepingCommitted = false;
-        this.currentRequestIdentity = parseIdentityHeader(request.headers.get("x-lunora-identity"));
-        // The caller's IP, forwarded server-side from Cloudflare's trusted
-        // `CF-Connecting-IP` (never copied from a client header). Surfaced as
-        // `ctx.ip` so handlers/middleware can key on it (e.g. rate-limit
-        // unauthenticated traffic by IP).
-        this.currentRequestIp = request.headers.get("x-lunora-client-ip") ?? undefined;
-        this.currentRequestSystem = request.headers.get("x-lunora-system") === "1";
-        this.currentRequestTraceparent = request.headers.get("traceparent") ?? undefined;
-        // Resolve the dispatch's trace anchor once, here, so `ctx.trace` spans and
-        // the synthetic root span recorded on the way out agree on the ids even
-        // when there is no inbound `traceparent` to derive them from.
-        this.currentRequestTrace = resolveTraceAnchor(this.currentRequestTraceparent);
-        // Captured into a local as well: the `finally` below runs after the
-        // handler's awaits, by which point an interleaved dispatch may have
-        // re-set the shared field — reading it there would file this dispatch's
-        // root span under another request's trace (and leave that one rootless).
-        const dispatchTrace = this.currentRequestTrace;
-        // Trace-sampling verdict propagated by the runtime: the `traceparent`
-        // sampled flag carries the head decision (absent → keep, so this path is
-        // unchanged for alarms / subscription re-runs / non-Lunora callers) and
-        // `x-lunora-sample-errors` carries the tail-bias toggle. Registered keyed by
-        // THIS dispatch's `traceId` (not a flat field) so a concurrent dispatch's
-        // `recordSpan` / `finally` reads its own verdict — see `traceSampling`.
-        this.traceSampling.set(dispatchTrace.traceId, {
-            keepErrors: request.headers.get("x-lunora-sample-errors") !== "0",
-            sampled: parseTraceparent(this.currentRequestTraceparent)?.sampled ?? true,
-        });
-        // Reset the per-request read/cache capture (filled by `runCachedQuery`
-        // for cached query paths) so a previous dispatch can't leak into this
-        // entry's logged read set / cache-hit flag.
-        this.currentRequestReadTables = undefined;
-        this.currentRequestCacheHit = undefined;
-
-        this.metrics.requests += 1;
-        const dispatchStartedAt = Date.now();
-
-        // Collect the tables this dispatch full-scans (stamped by the
-        // ctx-db read hook) so `recordFunctionCall` can persist the causal
-        // attribution. Fresh per request; drained below.
-        this.currentScannedTables = new Set<string>();
-
-        // Captured in a LOCAL, not just the instance field: `handleRpc` below
-        // receives it BY VALUE (see its docstring), so this dispatch's ctx-build
-        // never depends on `this.currentTransactionHeadroom` still pointing at
-        // THIS tracker by the time an `await`-interleaved concurrent dispatch's
-        // `finally` clears it. Still assigned to the field too — the fallback
-        // `dispatchLifecycle`/`handleRunAs` (which mint no tracker of their own)
-        // and any other reader of `transactionHeadroom()` keep working exactly as
-        // before this parameter existed.
-        const dispatchHeadroom = new TransactionHeadroomTracker(this.transactionLimits());
-
-        this.currentTransactionHeadroom = dispatchHeadroom;
-
-        // Collect the declared indexes this dispatch exercises (stamped by
-        // the ctx-db index-use hook) so `recordFunctionCall` can persist the
-        // per-index hit counter behind the dead-index lint. Fresh per
-        // request; drained below.
-        this.currentIndexHits = new Set<string>();
-
-        // Collect per-statement SQL samples from the instrumented `sql`
-        // getter so `flushStmtSamples` can persist them to the durable
-        // `__lunora_metrics_queries` table after the handler resolves.
-        // Allocating a fresh map here activates the instrumentation (the
-        // `sql` getter only wraps when this field is defined).
-        this.currentStmtSamples = new Map<string, StmtSample>();
-        this.currentStmtSamplesTruncated = undefined;
+        const { dispatchHeadroom, dispatchStartedAt, dispatchTrace } = this.beginDispatch(request);
 
         // Outcome of the dispatch, for the synthetic root span recorded in the
         // `finally` below. A sentinel rather than a boolean so the `catch` can
@@ -5701,39 +5637,7 @@ abstract class ShardDO {
             // spans already streamed live).
             this.flushSampledOutTrace(dispatchTrace, dispatchError !== undefined);
             this.traceSampling.delete(dispatchTrace.traceId);
-            this.currentRequestTrace = undefined;
-            this.currentRequestBookmark = undefined;
-            this.currentResponseBookmark = undefined;
-            this.currentRequestUserId = undefined;
-            this.currentRequestMutationId = undefined;
-            this.currentRequestClientId = undefined;
-            this.currentRequestClientSeq = undefined;
-            this.currentMutatorClass = undefined;
-            this.mutationBookkeepingCommitted = false;
-            this.currentRequestIdentity = undefined;
-            this.currentRequestIp = undefined;
-            this.currentRequestSystem = false;
-            this.currentRequestTraceparent = undefined;
-            this.currentScannedTables = undefined;
-            // Identity-guarded, not an unconditional clear: `handleRpc` above is
-            // already value-threaded with `dispatchHeadroom` for the ctx-build
-            // itself, but the field is still the fallback `dispatchLifecycle` /
-            // `handleRunAs` (and `transactionHeadroom()` readers generally) use.
-            // An unconditional clear here would let THIS dispatch's `finally` wipe
-            // a DIFFERENT, still-in-flight dispatch's tracker out from under it —
-            // the exact shared-field race this whole mechanism exists to avoid.
-            // Only clear it if it still points at the tracker THIS dispatch set.
-            if (this.currentTransactionHeadroom === dispatchHeadroom) {
-                this.currentTransactionHeadroom = undefined;
-            }
-            this.currentIndexHits = undefined;
-            this.currentRequestReadTables = undefined;
-            this.currentRequestCacheHit = undefined;
-            this.currentStmtSamples = undefined;
-            this.currentStmtSamplesTruncated = undefined;
-            // Drop the cached proxy with the samples map it folds into, so the
-            // finished dispatch's map is not held alive by it.
-            this.instrumentedSql = undefined;
+            this.endDispatch(dispatchHeadroom);
         }
     }
 
@@ -10318,6 +10222,143 @@ abstract class ShardDO {
     // eslint-disable-next-line class-methods-use-this, @typescript-eslint/member-ordering -- base-class override hook (the codegen subclass overrides it and uses `this` to build the global writer), co-located with the poll tick it opens rather than hoisted away from its only caller
     protected readGlobalChangedTables(_sinceSeq: number, _cursorOnly?: boolean): Promise<{ cursor: number; floor?: number; tables: string[] } | undefined> {
         return Promise.resolve(undefined);
+    }
+
+    private beginDispatch(request: Request): {
+        dispatchHeadroom: TransactionHeadroomTracker;
+        dispatchStartedAt: number;
+        dispatchTrace: { rootSpanId: string; traceId: string };
+    } {
+        this.currentRequestBookmark = request.headers.get("x-d1-bookmark") ?? undefined;
+        this.currentResponseBookmark = undefined;
+        // `decodeUserIdHeader` inverts the runtime's `encodeUserIdHeader`: a
+        // Latin-1-safe id is forwarded unchanged, a non-Latin-1 one arrives
+        // base64url-encoded behind a leading `=` sentinel. See shared/identity-header.ts.
+        this.currentRequestUserId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
+        this.currentRequestMutationId = request.headers.get("x-lunora-mutation-id") ?? undefined;
+        // Custom-mutator push identity: a stable per-device client id plus a
+        // monotonic per-client sequence. Present only on custom-mutator pushes;
+        // the watermark dispatch below classifies the sequence against the
+        // shard's `__client_watermark`. A non-numeric/absent seq disables the
+        // watermark path (the call falls back to the legacy idempotency dedup).
+        this.currentRequestClientId = request.headers.get("x-lunora-client-id") ?? undefined;
+        this.currentRequestClientSeq = parseClientSeqHeader(request.headers.get("x-lunora-client-seq"));
+        // Reset the in-transaction bookkeeping handshake: `handleRpc` sets the
+        // classification + flag for a mutation push so the writes, dedup row, and
+        // watermark advance all commit atomically (see `commitMutationBookkeeping`).
+        this.currentMutatorClass = undefined;
+        this.mutationBookkeepingCommitted = false;
+        this.currentRequestIdentity = parseIdentityHeader(request.headers.get("x-lunora-identity"));
+        // The caller's IP, forwarded server-side from Cloudflare's trusted
+        // `CF-Connecting-IP` (never copied from a client header). Surfaced as
+        // `ctx.ip` so handlers/middleware can key on it (e.g. rate-limit
+        // unauthenticated traffic by IP).
+        this.currentRequestIp = request.headers.get("x-lunora-client-ip") ?? undefined;
+        this.currentRequestSystem = request.headers.get("x-lunora-system") === "1";
+        this.currentRequestTraceparent = request.headers.get("traceparent") ?? undefined;
+        // Resolve the dispatch's trace anchor once, here, so `ctx.trace` spans and
+        // the synthetic root span recorded on the way out agree on the ids even
+        // when there is no inbound `traceparent` to derive them from.
+        this.currentRequestTrace = resolveTraceAnchor(this.currentRequestTraceparent);
+        // Captured into a local as well: the `finally` below runs after the
+        // handler's awaits, by which point an interleaved dispatch may have
+        // re-set the shared field — reading it there would file this dispatch's
+        // root span under another request's trace (and leave that one rootless).
+        const dispatchTrace = this.currentRequestTrace;
+        // Trace-sampling verdict propagated by the runtime: the `traceparent`
+        // sampled flag carries the head decision (absent → keep, so this path is
+        // unchanged for alarms / subscription re-runs / non-Lunora callers) and
+        // `x-lunora-sample-errors` carries the tail-bias toggle. Registered keyed by
+        // THIS dispatch's `traceId` (not a flat field) so a concurrent dispatch's
+        // `recordSpan` / `finally` reads its own verdict — see `traceSampling`.
+        this.traceSampling.set(dispatchTrace.traceId, {
+            keepErrors: request.headers.get("x-lunora-sample-errors") !== "0",
+            sampled: parseTraceparent(this.currentRequestTraceparent)?.sampled ?? true,
+        });
+        // Reset the per-request read/cache capture (filled by `runCachedQuery`
+        // for cached query paths) so a previous dispatch can't leak into this
+        // entry's logged read set / cache-hit flag.
+        this.currentRequestReadTables = undefined;
+        this.currentRequestCacheHit = undefined;
+
+        this.metrics.requests += 1;
+        const dispatchStartedAt = Date.now();
+
+        // Collect the tables this dispatch full-scans (stamped by the
+        // ctx-db read hook) so `recordFunctionCall` can persist the causal
+        // attribution. Fresh per request; drained below.
+        this.currentScannedTables = new Set<string>();
+
+        // Captured in a LOCAL, not just the instance field: `handleRpc` below
+        // receives it BY VALUE (see its docstring), so this dispatch's ctx-build
+        // never depends on `this.currentTransactionHeadroom` still pointing at
+        // THIS tracker by the time an `await`-interleaved concurrent dispatch's
+        // `finally` clears it. Still assigned to the field too — the fallback
+        // `dispatchLifecycle`/`handleRunAs` (which mint no tracker of their own)
+        // and any other reader of `transactionHeadroom()` keep working exactly as
+        // before this parameter existed.
+        const dispatchHeadroom = new TransactionHeadroomTracker(this.transactionLimits());
+
+        this.currentTransactionHeadroom = dispatchHeadroom;
+
+        // Collect the declared indexes this dispatch exercises (stamped by
+        // the ctx-db index-use hook) so `recordFunctionCall` can persist the
+        // per-index hit counter behind the dead-index lint. Fresh per
+        // request; drained below.
+        this.currentIndexHits = new Set<string>();
+
+        // Collect per-statement SQL samples from the instrumented `sql`
+        // getter so `flushStmtSamples` can persist them to the durable
+        // `__lunora_metrics_queries` table after the handler resolves.
+        // Allocating a fresh map here activates the instrumentation (the
+        // `sql` getter only wraps when this field is defined).
+        this.currentStmtSamples = new Map<string, StmtSample>();
+        this.currentStmtSamplesTruncated = undefined;
+
+        return { dispatchHeadroom, dispatchStartedAt, dispatchTrace };
+    }
+
+    /**
+     * Clear every per-request field {@link ShardDO.beginDispatch} stamped.
+     *
+     * `dispatchHeadroom` is passed rather than read off `this` so the headroom
+     * clear stays identity-guarded — see the comment on it.
+     */
+
+    private endDispatch(dispatchHeadroom: TransactionHeadroomTracker): void {
+        this.currentRequestTrace = undefined;
+        this.currentRequestBookmark = undefined;
+        this.currentResponseBookmark = undefined;
+        this.currentRequestUserId = undefined;
+        this.currentRequestMutationId = undefined;
+        this.currentRequestClientId = undefined;
+        this.currentRequestClientSeq = undefined;
+        this.currentMutatorClass = undefined;
+        this.mutationBookkeepingCommitted = false;
+        this.currentRequestIdentity = undefined;
+        this.currentRequestIp = undefined;
+        this.currentRequestSystem = false;
+        this.currentRequestTraceparent = undefined;
+        this.currentScannedTables = undefined;
+        // Identity-guarded, not an unconditional clear: `handleRpc` above is
+        // already value-threaded with `dispatchHeadroom` for the ctx-build
+        // itself, but the field is still the fallback `dispatchLifecycle` /
+        // `handleRunAs` (and `transactionHeadroom()` readers generally) use.
+        // An unconditional clear here would let THIS dispatch's `finally` wipe
+        // a DIFFERENT, still-in-flight dispatch's tracker out from under it —
+        // the exact shared-field race this whole mechanism exists to avoid.
+        // Only clear it if it still points at the tracker THIS dispatch set.
+        if (this.currentTransactionHeadroom === dispatchHeadroom) {
+            this.currentTransactionHeadroom = undefined;
+        }
+        this.currentIndexHits = undefined;
+        this.currentRequestReadTables = undefined;
+        this.currentRequestCacheHit = undefined;
+        this.currentStmtSamples = undefined;
+        this.currentStmtSamplesTruncated = undefined;
+        // Drop the cached proxy with the samples map it folds into, so the
+        // finished dispatch's map is not held alive by it.
+        this.instrumentedSql = undefined;
     }
 
     /**

--- a/packages/shard-engine/__tests__/row-statements.test.ts
+++ b/packages/shard-engine/__tests__/row-statements.test.ts
@@ -1,0 +1,178 @@
+import { sql as dsql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { CDC_APPEND_SQL } from "../src/ctx-db-cdc";
+import { DOC_COLUMN } from "../src/do-sql";
+import { renderSql, unionAll } from "../src/drizzle";
+import { CHANGES_PROBE_SQL, deleteRowSql, insertRowSql, patchRowSql, replaceRowSql, rowProbeParams, rowProbeSql } from "../src/row-statements";
+
+/**
+ * The write path used to build each of these through a drizzle `sql` template on
+ * every write. They are now literal text, rendered once per table — which is
+ * only safe while the text is *identical* to what those templates produced.
+ *
+ * So each case rebuilds the original template verbatim and asserts byte
+ * equality with the statement that replaced it. A change to either side that
+ * does not match the other fails here rather than reaching SQLite, where the
+ * symptom would be a syntax error at best and a wrong `WHERE` at worst.
+ *
+ * The parameter ORDER is asserted alongside, because that is the other half of
+ * the contract: the call sites now pass a positional array instead of
+ * interpolating values into a template, so a statement whose placeholders moved
+ * would bind the wrong values with no type error.
+ */
+
+const TABLE = "messages";
+
+/** What `renderSql` produced for a template, as the pair the call sites now pass. */
+const rendered = (query: Parameters<typeof renderSql>[1]): { params: unknown[]; sql: string } => renderSql("sqlite", query);
+
+describe("row statements match the drizzle templates they replaced", () => {
+    it("insert", () => {
+        expect.assertions(2);
+
+        const id = "m1";
+        const creationTime = 1_700_000_000_000;
+        const doc = '{"a":1}';
+        const original = rendered(
+            dsql`INSERT INTO ${dsql.identifier(TABLE)} (id, _creationTime, ${dsql.identifier(DOC_COLUMN)}) VALUES (${id}, ${creationTime}, ${doc})`,
+        );
+
+        expect(insertRowSql(TABLE)).toBe(original.sql);
+        expect(original.params).toStrictEqual([id, creationTime, doc]);
+    });
+
+    it("patch", () => {
+        expect.assertions(2);
+
+        const next = '{"a":2}';
+        const id = "m1";
+        const existing = '{"a":1}';
+        const original = rendered(
+            dsql`UPDATE ${dsql.identifier(TABLE)} SET ${dsql.identifier(DOC_COLUMN)} = ${next} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existing}`,
+        );
+
+        expect(patchRowSql(TABLE)).toBe(original.sql);
+        expect(original.params).toStrictEqual([next, id, existing]);
+    });
+
+    it("replace", () => {
+        expect.assertions(2);
+
+        const creationTime = 1_700_000_000_000;
+        const next = '{"a":2}';
+        const id = "m1";
+        const existing = '{"a":1}';
+        const original = rendered(
+            dsql`UPDATE ${dsql.identifier(TABLE)} SET _creationTime = ${creationTime}, ${dsql.identifier(DOC_COLUMN)} = ${next} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existing}`,
+        );
+
+        expect(replaceRowSql(TABLE)).toBe(original.sql);
+        expect(original.params).toStrictEqual([creationTime, next, id, existing]);
+    });
+
+    it("delete", () => {
+        expect.assertions(2);
+
+        const id = "m1";
+        const existing = '{"a":1}';
+        const original = rendered(dsql`DELETE FROM ${dsql.identifier(TABLE)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existing}`);
+
+        expect(deleteRowSql(TABLE)).toBe(original.sql);
+        expect(original.params).toStrictEqual([id, existing]);
+    });
+
+    it("changes() probe", () => {
+        expect.assertions(1);
+
+        expect(CHANGES_PROBE_SQL).toBe(rendered(dsql`SELECT changes() AS changed`).sql);
+    });
+
+    it("cdc append", () => {
+        expect.assertions(2);
+
+        const ts = 1_700_000_000_000;
+        const table = TABLE;
+        const id = "m1";
+        const op = "insert";
+        const doc = '{"a":1}';
+        const original = rendered(
+            dsql`INSERT INTO ${dsql.identifier("__cdc_log")} (ts, ${dsql.identifier("table")}, id, op, doc) VALUES (${ts}, ${table}, ${id}, ${op}, ${doc})`,
+        );
+
+        expect(CDC_APPEND_SQL).toBe(original.sql);
+        expect(original.params).toStrictEqual([ts, table, id, op, doc]);
+    });
+});
+
+describe("by-id row probe", () => {
+    /** The template the probe replaced, for one chunk of tables. */
+    const originalProbe = (tables: string[], id: string) =>
+        rendered(
+            dsql`${unionAll(
+                tables.map(
+                    (table) =>
+                        dsql`SELECT ${dsql.raw(`'${table.replaceAll("'", "''")}'`)} AS __t__, id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(table)} WHERE id = ${id}`,
+                ),
+            )} LIMIT 1`,
+        );
+
+    it.each([[["messages"]], [["messages", "users"]], [["a", "b", "c", "d", "e"]], [["a", "b", "c", "d", "e", "f", "g"]]])(
+        "matches the template it replaced for %j",
+        (tables) => {
+            expect.assertions(2);
+
+            // The 7-table case is past workerd's five-term compound-SELECT cap, so
+            // it exercises `unionAll`'s nesting — the structural part that is
+            // rendered rather than hand-written.
+            const original = originalProbe(tables, "row_1");
+
+            expect(rowProbeSql(tables)).toBe(original.sql);
+            // One bound `id` per branch, in branch order.
+            expect(rowProbeParams("row_1", tables)).toStrictEqual(original.params);
+        },
+    );
+
+    it("does not let two different table lists share one cached statement", () => {
+        expect.assertions(2);
+
+        // A table name may contain any character, so a key built by joining on a
+        // separator would serve one list's SQL to the other — a wrong-table read.
+        const left = rowProbeSql(["a b", "c"]);
+        const right = rowProbeSql(["a", "b c"]);
+
+        expect(left).not.toBe(right);
+        expect(right).toBe(originalProbe(["a", "b c"], "row_1").sql);
+    });
+
+    it("escapes a single quote in the table discriminator", () => {
+        expect.assertions(1);
+
+        // The discriminator is an inline literal, not a bound value — the one
+        // place in these statements where a table name reaches the text unquoted.
+        expect(rowProbeSql(["ev'il"])).toContain("'ev''il' AS __t__");
+    });
+});
+
+describe("per-table statement caching", () => {
+    it("returns the same string for a repeated table and a distinct one per table", () => {
+        expect.assertions(3);
+
+        expect(insertRowSql(TABLE)).toBe(insertRowSql(TABLE));
+        expect(insertRowSql("other")).not.toBe(insertRowSql(TABLE));
+        expect(insertRowSql("other")).toContain('"other"');
+    });
+
+    it("escapes a table name carrying a double quote the way drizzle does", () => {
+        expect.assertions(2);
+
+        // The cache is keyed by raw table name and the text is spliced, so this is
+        // the one input where a wrong quoter becomes identifier injection rather
+        // than a syntax error.
+        const nasty = 'ev"il';
+        const original = rendered(dsql`DELETE FROM ${dsql.identifier(nasty)} WHERE id = ${"x"} AND ${dsql.identifier(DOC_COLUMN)} = ${"y"}`);
+
+        expect(deleteRowSql(nasty)).toBe(original.sql);
+        expect(deleteRowSql(nasty)).toContain('"ev""il"');
+    });
+});

--- a/packages/shard-engine/src/ctx-db-cdc.ts
+++ b/packages/shard-engine/src/ctx-db-cdc.ts
@@ -16,13 +16,25 @@ import { LunoraError } from "@lunora/errors";
 import type { SQL } from "drizzle-orm";
 import { sql as dsql } from "drizzle-orm";
 
+import { quoteIdentifier } from "../../../shared/quote-identifier";
 import type { DatabaseWriterLike, SqlExec } from "./ctx-db";
-import { runDrizzle } from "./do-exec";
+import { runDrizzle, runSql } from "./do-exec";
 import { decodeDocJson, encodeDocJson } from "./do-sql";
 import { ConflictError } from "./transaction";
 
 /** Reserved append-only changelog table backing CDC streaming export and replay-PITR. */
 const CDC_LOG_TABLE = "__cdc_log";
+
+/**
+ * The changelog append, as text. Fully constant — one table, fixed columns, every
+ * value bound — and it runs once per committed mutation, so building it through
+ * a drizzle template per write was pure overhead (see `row-statements.ts`, which
+ * holds the per-table statements for the same reason; this one lives here
+ * because the table name is private to this module).
+ *
+ * `__tests__/row-statements.test.ts` pins this against what the template rendered.
+ */
+const CDC_APPEND_SQL = `INSERT INTO ${quoteIdentifier(CDC_LOG_TABLE)} (ts, ${quoteIdentifier("table")}, id, op, doc) VALUES (?, ?, ?, ?, ?)`;
 
 /** One change-data-capture entry: a committed mutation, in monotonic `seq` order. */
 interface CdcChange {
@@ -97,10 +109,7 @@ const appendCdcChange = (sql: SqlExec, ts: number, table: string, id: string, op
     // eslint-disable-next-line unicorn/no-null -- SQL NULL is the correct post-image for a delete; the `id` column identifies the removed row.
     const docValue = doc === undefined ? null : encodeDocJson(doc);
 
-    runDrizzle(
-        sql,
-        dsql`INSERT INTO ${dsql.identifier(CDC_LOG_TABLE)} (ts, ${dsql.identifier("table")}, id, op, doc) VALUES (${ts}, ${table}, ${id}, ${op}, ${docValue})`,
-    );
+    runSql(sql, CDC_APPEND_SQL, ts, table, id, op, docValue);
 };
 
 /**
@@ -675,3 +684,5 @@ export {
     trimCdcChanges,
 };
 export type { CdcChange, CdcChangeKey };
+
+export { CDC_APPEND_SQL };

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -64,7 +64,7 @@ import { isMemoryTable } from "./ctx-db-memory";
 import type { RankPageDeps } from "./ctx-db-rank-page";
 import { computeRankPage } from "./ctx-db-rank-page";
 import { SCAN_DEP } from "./dependency-tracker";
-import { runDrizzle } from "./do-exec";
+import { runDrizzle, runSql } from "./do-exec";
 import {
     AGG_COUNT,
     AGG_KEY,
@@ -81,7 +81,7 @@ import {
     tableColumns,
     tryRowToDocument,
 } from "./do-sql";
-import { sqliteInList, unionAll, WORKERD_SQLITE_LIMITS } from "./drizzle";
+import { renderSql, sqliteInList, unionAll, WORKERD_SQLITE_LIMITS } from "./drizzle";
 import { boundingBoxGeohashes, coveringGeohashes, haversineMeters, pointInBoundingBox } from "./geo";
 import { NotFoundError } from "./not-found-error";
 import { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope } from "./query-args";
@@ -93,6 +93,7 @@ import type { RelationExistsMarker } from "./relation-predicates";
 import { assertFlatPredicate as assertFlatRelationPredicate, resolveRelationPredicates } from "./relation-predicates";
 import { applyOnDelete, fanOutScalarCounts, relationHooks, resolveWith, runRowValidators } from "./relations";
 import { guardWriter } from "./rls-guard";
+import { CHANGES_PROBE_SQL, deleteRowSql, insertRowSql, patchRowSql, replaceRowSql, rowProbeParams, rowProbeSql } from "./row-statements";
 import type {
     BroadcastDelta,
     DatabaseWriterLike,
@@ -1795,9 +1796,19 @@ const UNIQUE_VIOLATION_RE = /unique constraint failed/i;
 const isUniqueViolation = (error: unknown): boolean => error instanceof Error && UNIQUE_VIOLATION_RE.test(error.message);
 
 /** Run a write, remapping a UNIQUE-index breach to a {@link ConflictError} (code `CONFLICT`, 409). */
-const runWrite = (sql: SqlExec, table: string, query: SQL): void => {
+
+/**
+ * Run a single-row write, mapping a UNIQUE violation onto {@link ConflictError}.
+ *
+ * Takes rendered text plus its bound values rather than a drizzle `SQL`, because
+ * every statement that reaches it has text that is a constant for its table —
+ * see `row-statements.ts` for the shapes and for why they are no longer built
+ * per write. The one caller with a genuinely variable statement (the batch
+ * INSERT's `VALUES` list) renders it itself and passes the result through.
+ */
+const runWrite = (sql: SqlExec, table: string, text: string, params: ReadonlyArray<unknown>): void => {
     try {
-        runDrizzle(sql, query);
+        runSql(sql, text, ...params);
     } catch (error) {
         if (isUniqueViolation(error)) {
             throw new ConflictError(`unique constraint violation on "${table}"`, "unique");
@@ -1815,10 +1826,10 @@ const runWrite = (sql: SqlExec, table: string, query: SQL): void => {
  * the snapshot. `changes()` reports the row count of the most recent
  * INSERT/UPDATE/DELETE, available in both workerd SQLite and `node:sqlite`.
  */
-const runGuardedWrite = (sql: SqlExec, table: string, query: SQL): void => {
-    runWrite(sql, table, query);
+const runGuardedWrite = (sql: SqlExec, table: string, text: string, params: ReadonlyArray<unknown>): void => {
+    runWrite(sql, table, text, params);
 
-    const changedRow = runDrizzle<{ changed: number }>(sql, dsql`SELECT changes() AS changed`).one();
+    const changedRow = runSql<{ changed: number }>(sql, CHANGES_PROBE_SQL).one();
 
     if (changedRow.changed === 0) {
         throw new ConflictError(`optimistic concurrency conflict on "${table}" — the row changed during this mutation; refetch and retry`, "occ");
@@ -2558,13 +2569,11 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
         const nonGlobalTables = nonGlobalTableNames(expectedTable);
 
         for (let start = 0; start < nonGlobalTables.length; start += MAX_PROBE_BRANCHES) {
-            const branches = nonGlobalTables.slice(start, start + MAX_PROBE_BRANCHES).map(
-                (tableName) =>
-                    // The table-name discriminator stays an inline literal (escaped) rather than a bound param so it reads as `'<table>' AS __t__`.
-                    dsql`SELECT ${dsql.raw(`'${tableName.replaceAll("'", "''")}'`)} AS __t__, id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(tableName)} WHERE id = ${id}`,
-            );
-
-            const [firstRow] = runDrizzle(sql, dsql`${unionAll(branches)} LIMIT 1`).toArray();
+            const chunk = nonGlobalTables.slice(start, start + MAX_PROBE_BRANCHES);
+            // Text depends only on the chunk's table list, so it is rendered once
+            // per distinct list rather than per read — this probe runs on every
+            // get/patch/replace/delete. See `row-statements.ts`.
+            const [firstRow] = runSql(sql, rowProbeSql(chunk), ...rowProbeParams(id, chunk)).toArray();
 
             if (!firstRow) {
                 continue;
@@ -2959,11 +2968,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // tombstone and would keep serving a row its source considers gone.
                 const merged: Record<string, unknown> = { ...existing, ...commitSeqFields(tableName), [softField]: clock(), _id: id };
 
-                runGuardedWrite(
-                    sql,
-                    tableName,
-                    dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
-                );
+                runGuardedWrite(sql, tableName, patchRowSql(tableName), [encodeDocJson(merged), id, existingJson]);
 
                 // Search stays maintained (the marker filter hides it on read), but
                 // the rank companion and external stores (Vectorize) have NO read-time
@@ -3006,11 +3011,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // rows and raises ConflictError rather than clobbering that write —
             // and keeps `existing` (used for the aggregate/rank -prev steps) in
             // sync with what was actually on disk.
-            runGuardedWrite(
-                sql,
-                tableName,
-                dsql`DELETE FROM ${dsql.identifier(tableName)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
-            );
+            runGuardedWrite(sql, tableName, deleteRowSql(tableName), [id, existingJson]);
 
             syncSearch(tableName, id, undefined);
             syncGeo(tableName, id, undefined);
@@ -3586,11 +3587,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             ensureBackfilledForTable(tableName);
             ensureRankBackfilledForTable(tableName);
 
-            runWrite(
-                sql,
-                tableName,
-                dsql`INSERT INTO ${dsql.identifier(tableName)} (id, _creationTime, ${dsql.identifier(DOC_COLUMN)}) VALUES (${id}, ${creationTime}, ${encodeDocJson(documentWithMeta)})`,
-            );
+            runWrite(sql, tableName, insertRowSql(tableName), [id, creationTime, encodeDocJson(documentWithMeta)]);
 
             syncCompanionsForInsert(tableName, id, documentWithMeta);
 
@@ -3713,11 +3710,15 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                     dsql`, `,
                 );
 
-                runWrite(
-                    sql,
-                    tableName,
+                // The only write whose text genuinely varies: the `VALUES` list grows
+                // with the chunk, so it is built and rendered per batch rather than
+                // cached per table like the single-row statements.
+                const batch = renderSql(
+                    "sqlite",
                     dsql`INSERT INTO ${dsql.identifier(tableName)} (id, _creationTime, ${dsql.identifier(DOC_COLUMN)}) VALUES ${valuesSql}`,
                 );
+
+                runWrite(sql, tableName, batch.sql, batch.params);
             }
 
             // Companions + notifications ARE still maintained per row (shared with
@@ -3863,11 +3864,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // and raise ConflictError instead of silently clobbering it (and
             // keeps `existing` — used for the aggregate/rank -prev steps — in
             // sync with what is actually on disk).
-            runGuardedWrite(
-                sql,
-                tableName,
-                dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
-            );
+            runGuardedWrite(sql, tableName, patchRowSql(tableName), [encodeDocJson(merged), id, existingJson]);
 
             syncSearch(tableName, id, merged, existing);
             syncGeo(tableName, id, merged);
@@ -4283,11 +4280,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // trigger `await` raises ConflictError instead of being silently
             // clobbered (and keeps `previous` — used for the aggregate/rank
             // -prev steps — in sync with disk).
-            runGuardedWrite(
-                sql,
-                tableName,
-                dsql`UPDATE ${dsql.identifier(tableName)} SET _creationTime = ${creationTime}, ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(replaced)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
-            );
+            runGuardedWrite(sql, tableName, replaceRowSql(tableName), [creationTime, encodeDocJson(replaced), id, existingJson]);
 
             syncSearch(tableName, id, replaced, previous);
             syncGeo(tableName, id, replaced);

--- a/packages/shard-engine/src/row-statements.ts
+++ b/packages/shard-engine/src/row-statements.ts
@@ -1,0 +1,162 @@
+/**
+ * The row store's fixed-shape write statements.
+ *
+ * Every statement a single-row write emits — the INSERT, the two OCC-guarded
+ * UPDATEs, the OCC-guarded DELETE, the `changes()` probe behind them, and the
+ * changelog append — has SQL text that is a pure function of the table name.
+ * Nothing else varies: ids, documents and OCC snapshots are all bound
+ * parameters. So the text is rendered once per table and thereafter only
+ * re-bound.
+ *
+ * ## Why this module exists
+ *
+ * These were drizzle `sql` templates built and rendered inside the write path.
+ * Profiling a DO insert+CDC workload over real SQLite (with statement caching
+ * in the harness, matching what workerd does) put drizzle's build+render at
+ * **21.9%** of the write path against **20.1%** for all of shard-engine's own
+ * logic — because each write re-derived one of six constant strings through the
+ * template machinery, the chunk walk, and the identifier escaper.
+ *
+ * It is also the more legible form. A reader of `patch` now sees
+ * `UPDATE <t> SET __doc__ = ? WHERE id = ? AND __doc__ = ?` as text, rather
+ * than reconstructing it from an interpolated template.
+ *
+ * ## The one rule
+ *
+ * These strings must stay byte-identical to what the drizzle templates
+ * rendered, because that is the only thing establishing they are correct SQL
+ * for this store. `__tests__/row-statements.test.ts` asserts exactly that,
+ * statement by statement, by rendering the original template through
+ * `renderSql` and comparing — so a divergence fails a test rather than
+ * reaching SQLite.
+ *
+ * Identifiers go through {@link quoteIdentifier}, the same escaper drizzle's
+ * `sql.identifier` uses, so a table name carrying a double quote is quoted
+ * identically here. Never interpolate a *value* into these — they are cached by
+ * table name, so a bound value spliced into the text would be served to every
+ * later write on that table.
+ */
+
+import { sql as dsql } from "drizzle-orm";
+
+import { quoteIdentifier } from "../../../shared/quote-identifier";
+import { DOC_COLUMN } from "./do-sql";
+import { renderSql, unionAll } from "./drizzle";
+
+/**
+ * Memoize a per-table statement builder.
+ *
+ * A shard's table set is fixed by its schema, so this is bounded by the schema's
+ * width and never grows with traffic — the reason a plain `Map` is safe here
+ * where an unbounded cache keyed by arbitrary input would not be.
+ */
+const perTable = (build: (quotedTable: string) => string): ((table: string) => string) => {
+    const cache = new Map<string, string>();
+
+    return (table: string): string => {
+        const cached = cache.get(table);
+
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const text = build(quoteIdentifier(table));
+
+        cache.set(table, text);
+
+        return text;
+    };
+};
+
+/** The stored-document column, pre-quoted once — it appears in five of the six statements. */
+const DOC = quoteIdentifier(DOC_COLUMN);
+
+/** `INSERT INTO <table> (id, _creationTime, __doc__) VALUES (?, ?, ?)` — binds `id`, `creationTime`, `doc`. */
+const insertRowSql = perTable((table) => `INSERT INTO ${table} (id, _creationTime, ${DOC}) VALUES (?, ?, ?)`);
+
+/**
+ * `UPDATE <table> SET __doc__ = ? WHERE id = ? AND __doc__ = ?` — binds `nextDoc`, `id`, `existingDoc`.
+ *
+ * The trailing `__doc__ = ?` is the optimistic-concurrency guard: it matches the
+ * document as it was read, so a concurrent write during the intervening `await`
+ * makes this touch zero rows and `runGuardedWrite` raises instead.
+ */
+const patchRowSql = perTable((table) => `UPDATE ${table} SET ${DOC} = ? WHERE id = ? AND ${DOC} = ?`);
+
+/** `UPDATE <table> SET _creationTime = ?, __doc__ = ? WHERE id = ? AND __doc__ = ?` — binds `creationTime`, `nextDoc`, `id`, `existingDoc`. */
+const replaceRowSql = perTable((table) => `UPDATE ${table} SET _creationTime = ?, ${DOC} = ? WHERE id = ? AND ${DOC} = ?`);
+
+/** `DELETE FROM <table> WHERE id = ? AND __doc__ = ?` — binds `id`, `existingDoc`. Same OCC guard as {@link patchRowSql}. */
+const deleteRowSql = perTable((table) => `DELETE FROM ${table} WHERE id = ? AND ${DOC} = ?`);
+
+/**
+ * Row count of the most recent INSERT/UPDATE/DELETE, for the OCC check.
+ *
+ * Fully constant, so it is a value rather than a builder. `data-migration.ts`
+ * already ran this as a plain string; the write path rendered the identical text
+ * through drizzle on every guarded write.
+ */
+const CHANGES_PROBE_SQL = "SELECT changes() AS changed";
+
+/**
+ * The by-id row probe: one UNION-ALL branch per candidate table, each tagged
+ * with its source table so a hit names its owner.
+ *
+ * Unlike the statements above this one is NOT hand-written. Its text depends on
+ * how {@link unionAll} nests branches to stay under workerd's five-term
+ * compound-SELECT cap, and reproducing that nesting by hand would be the kind of
+ * duplicated structural logic this module exists to avoid. So the drizzle build
+ * still runs — just once per distinct table list, instead of once per read.
+ *
+ * The cache key is the ordered table list, because the order is what the text
+ * encodes. Values never enter the text: every branch binds the same `id`, so the
+ * caller passes `id` once per branch (see {@link rowProbeParams}).
+ */
+const probeCache = new Map<string, string>();
+
+/** Stand-in bound value used only to render {@link rowProbeSql}; it becomes a `?`. */
+const PROBE_ID_PLACEHOLDER = "";
+
+/**
+ * @param tables candidate tables for this chunk, in probe order
+ * @returns the rendered probe text for exactly this chunk
+ */
+const rowProbeSql = (tables: ReadonlyArray<string>): string => {
+    // `JSON.stringify`, not a `join` — a table name may contain whatever
+    // separator is chosen, and `["a b", "c"]` colliding with `["a", "b c"]`
+    // would serve one list's SQL to the other. This cache returns executable
+    // text, so an ambiguous key is a wrong-table read, not a mere cache miss.
+    const key = JSON.stringify(tables);
+    const cached = probeCache.get(key);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const branches = tables.map(
+        (table) =>
+            // The table-name discriminator stays an inline literal (escaped) rather
+            // than a bound param so it reads as `'<table>' AS __t__`.
+            dsql`SELECT ${dsql.raw(`'${table.replaceAll("'", "''")}'`)} AS __t__, id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(table)} WHERE id = ${PROBE_ID_PLACEHOLDER}`,
+    );
+
+    // Rendering replaces the bound value with `?`, so the placeholder never
+    // reaches the text — only the shape does.
+    const { sql: text } = renderSql("sqlite", dsql`${unionAll(branches)} LIMIT 1`);
+
+    probeCache.set(key, text);
+
+    return text;
+};
+
+/**
+ * The probe binds the same `id` once per branch, in branch order.
+ *
+ * Takes the table list rather than a count so the result is typed `string[]` by
+ * construction: `Array.from({ length }).fill(id)` (what the repo lint rule steers
+ * toward) yields `unknown[]`, and the `Array.from({ length }, () => id)` form the
+ * type checker prefers is what that rule rejects.
+ */
+const rowProbeParams = (id: string, tables: ReadonlyArray<string>): string[] => tables.map(() => id);
+
+export { CHANGES_PROBE_SQL, deleteRowSql, insertRowSql, patchRowSql, replaceRowSql, rowProbeParams, rowProbeSql };


### PR DESCRIPTION
Follow-on to #487, which ended by reporting a finding it deliberately did not act on: profiling the Durable Object write path put **drizzle-orm's SQL building and rendering at 21.9%** of it, against 20.1% for all of shard-engine's own logic. This is that change, plus the maintainability half of the same area.

## Why drizzle cost that much

I counted the distinct SQL a write actually emits:

| op | distinct texts | statements/op |
|---|---|---|
| insert | 2 | 2.0 |
| patch / replace / delete | 4 | 4.0 |

```
INSERT INTO "messages" (id, _creationTime, "__doc__") VALUES (?, ?, ?)
UPDATE "messages" SET "__doc__" = ? WHERE id = ? AND "__doc__" = ?
DELETE FROM "messages" WHERE id = ? AND "__doc__" = ?
SELECT changes() AS changed
INSERT INTO "__cdc_log" (ts, "table", id, op, doc) VALUES (?, ?, ?, ?, ?)
```

Every one is a pure function of the table name — ids, documents and OCC snapshots are all bound. They were nonetheless rebuilt through a `sql` template and re-rendered on every single write.

`row-statements.ts` now holds them as literal text, memoized per table, and `runWrite`/`runGuardedWrite` take rendered text plus bound values instead of a drizzle `SQL`.

The by-id probe is the one exception: its text depends on how `unionAll` nests branches under workerd's five-term compound-SELECT cap, and rebuilding that nesting by hand would duplicate structural logic. It keeps the drizzle build but renders **once per distinct table list** instead of once per read. That alone moved patch from +35% to +87%.

| | before | after | |
|---|---|---|---|
| insert + CDC | 10.65 µs/write | 6.29 µs | **+69%** |
| patch + CDC | 18.13 µs/write | 9.67 µs | **+87%** |

Three alternating rounds each, every one favouring the change. Re-profiling puts drizzle at **0.4%** of the write path.

> The commit body carries slightly different figures (+70% / +83%) — those were measured before rebasing onto #487, whose `tableColumns` memo now sits underneath. Both are honest; the table above is what reproduces on this branch.

A note on the profile itself: the first one was wrong. My harness re-`prepare`d every statement while workerd caches them, so it blamed SQLite for work a real Durable Object never repeats. The 21.9% figure is from the corrected harness.

## What makes replacing the templates safe

The text has to be identical to what the templates produced, so `__tests__/row-statements.test.ts` rebuilds each original template and compares **byte for byte** — including `unionAll`'s nesting past five branches, and the **parameter order**, since call sites now pass a positional array where they used to interpolate values.

Identifier escaping is covered both ways: `quoteIdentifier` is the same escaper `sql.identifier` uses, and a table name carrying a double quote — plus, for the probe's inline discriminator, a single quote — is asserted to come out the same.

One bug I introduced and caught: the probe cache first keyed on `tables.join(" ")`. A table name can contain a space, so `["a b", "c"]` and `["a", "b c"]` collide onto one key — and this cache returns *executable SQL*, so that is a wrong-table read, not a cache miss. Keyed on `JSON.stringify` now, with a test.

## Maintainability

`handleFetchCloudflare` was 479 lines. Roughly 120 of them were a per-request state prologue — stamping identity, bookmark, mutation and trace headers, then resetting every capture the handler fills — and a matching epilogue clearing the same fields, **350 lines apart** at opposite ends of the method. They are now `beginDispatch` / `endDispatch`, move-only. **479 → 363 lines.**

The pairing is the point, not the line count. Those two own the same fields, and their whole correctness story is that every field one sets, the other clears. A field stamped and forgotten does not fail anything locally — it survives into the **next** request served by the same warm DO instance, which for `currentRequestUserId` / `currentRequestIdentity` means one caller's identity answering another caller's request. `__tests__/dispatch-lifecycle.test.ts` asserts that symmetry by comparing the two assignment sets; deleting one clear makes it fail and name the field.

Two things worth stating plainly:

- This does **not** shrink `shard-do.ts` — it grows by the doc comments.
- `handleWebSocketMessage` is still 312 lines and untouched.

The repo's own note said a `shard-do.ts` split had been measured and rejected on the grounds of "no oversized method to break up, largest 319". At 11.3k lines that no longer holds, and re-running the measurement is what surfaced these two methods.

## Verification

On this branch, rebased onto current `alpha`:

- `@lunora/shard-engine` 1264 tests, `@lunora/do` 613 tests
- `api:check` 54/54 · `lint:types` · `lint:eslint` · `lint:prettier` · `lint:package-json`
- `build:packages:prod` + `dist:check` — 1355 files across 54 packages, no development-build markers

**Caveat worth flagging:** I could not get a clean full-suite `pnpm run test --no-cache` run on this machine. Two attempts failed on *different* unrelated packages — CLI `mcp-handler` (10010 ms timeout signature) and three studio jsdom component tests. Both pass in isolation (studio: 1186/1186), and neither package touches anything here. That is the fourth and fifth instance of this parallel-load flake across the session, each in a different package. Reporting it rather than claiming green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling to ensure dispatch state and telemetry are consistently initialized and cleaned up.
  * Strengthened database write and lookup operations for more reliable behavior across single-row and batch updates.

* **Performance**
  * Reduced overhead for frequent database operations through optimized, reusable SQL execution paths.
  * Preserved safe parameter handling and efficient batching for larger data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->