### PR TITLE
perf(shard-engine): row fingerprinting, and fix the codegen bench measuring nothing

### DIFF
--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -15,7 +15,7 @@
 
 import { ID_FIELD, insertionIndexFor, PAGE_DELTA_CAPABILITY, PAGE_FIELD } from "../../../shared/page-result";
 import { stableStringify } from "../../../shared/stable-key";
-import { encodeWire, isPlainObject } from "../../../shared/wire-codec";
+import { encodeWire, isPlainObject, needsWireEncoding } from "../../../shared/wire-codec";
 import type { MutationDelta } from "./types";
 
 /**
@@ -131,7 +131,11 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
         // the already-encoded baseline (see the `data`-frame `json`), so it is NOT
         // re-encoded. For a pure-JSON row `encodeWire` is structurally identical,
         // so the fingerprint compare and the frame stay byte-identical.
-        const nextFingerprint = JSON.stringify(encodeWire(nextRow));
+        // "For a pure-JSON row `encodeWire` is structurally identical" (above) is
+        // exactly what `needsWireEncoding` decides, so ask instead of rebuilding
+        // the row every time. This runs per row per refresh — a 200-row
+        // subscription re-encoded all 200 to find one changed row.
+        const nextFingerprint = JSON.stringify(needsWireEncoding(nextRow) ? encodeWire(nextRow) : nextRow);
         const previousFingerprint = previousRow === undefined ? undefined : JSON.stringify(previousRow);
 
         if (previousFingerprint === nextFingerprint) {


### PR DESCRIPTION
> **Stacked on #490** (→ #489 → #488). Base is `perf/where-compiler`, so this diff shows only the two commits below.

A survey of paths this line of work had not profiled — the client SDK, the React adapter, codegen, and the subscription refresh. It turned up one optimization, one **broken CI gate**, and one bounded finding left for its own change.

## 1. Subscription refresh re-encoded every row

`collectUpsertDeltas` fingerprints **every row** of a subscription on every refresh to find which changed, and each fingerprint rebuilt the row through `encodeWire` first. The comment directly above it already said "for a pure-JSON row `encodeWire` is structurally identical" — which is exactly what `needsWireEncoding` decides.

| | before | after | |
|---|---|---|---|
| 1 of 200 rows changed | 3,871 hz | 4,068 hz | **+5.1%** |
| 100 of 200 rows changed | 3,843 hz | 4,005 hz | +4.2% |
| 200 of 200 rows changed | 3,716 hz | 3,790 hz | +2.0% |

Three alternating rounds. The gain is largest where the fewest rows changed — the common case for a live subscription.

## 2. The codegen bench was measuring nothing

`test:bench` for `@lunora/codegen` printed no rows and a summary reading `NaNx faster than warm run`, and **exited 0**. CodSpeed has been tracking that as a number.

The cause: `beforeAll` runs in a **different context** from the bench bodies under the instrumented runner, so `warmWorkdir` read back `undefined` inside them. The warm bench threw `The "path" argument must be of type string` on every iteration — and one throwing bench **discards the whole file's samples**, silently, with a zero exit. That is why the cold run reported nothing either.

The file already carried a comment explaining that tinybench's `setup`/`teardown` are ignored by that runner, which is why the author moved to `beforeAll`. The second workaround failed the same way, and nothing said so.

Priming lazily on first call sidesteps both. Both benches now report — and that immediately surfaces what the bench existed to show and could not:

```
cold run — fresh workdir, full project setup      11.38 hz  (87.9 ms)
warm run — same workdir, only emit phase changes  11.32 hz  (88.3 ms)
```

**The warm run is not cheaper than the cold one.** `writeIfChanged` no-opping the emit saves nothing measurable, because ts-morph project setup and the AST walk dominate. Codegen pays close to full price on every dev save whether or not its output changed — against the ~200 ms HMR budget the file's own docstring cites. That is a real dev-loop finding, now visible instead of hidden behind a NaN. It is reported, not fixed, here.

## 3. Bounded, not taken: the refresh cost is flat in the delta

The refresh costs the same whether **1 row changed or 200** — 4,068 vs 3,790 hz even after commit 1. Roughly 93% of the work is independent of the delta size, which is the wrong shape for a reactive core: a busy 200-row subscription pays full price for a one-row write.

Per row it walks the next row, stringifies it, and **re-stringifies the previous row** parsed out of the stored `lastJson`. That third step is pure re-derivation — the memo already holds the baseline, just as text rather than per-row fingerprints. Stubbing it out bounds the win:

| | current | previous fingerprints cached |
|---|---|---|
| 1 of 200 changed | 4,068 hz | **5,309 hz (+30%)** |

Conservative, since the stub also forces every row down the changed path.

**Why not here.** It means threading a fingerprint map from the memo through `subscriptionFrames` → `collectFramedDeltas` → `collectUpsertDeltas` and changing the memo's shape. The failure mode is specific and bad: a stale map paired with a fresh `lastJson` reports changed rows as unchanged, and clients silently stop receiving updates. That wants its own review and a test pinning the two halves of the memo together.

## Searched, nothing found

**`@lunora/client`** and **`@lunora/react`** — their benches are old-vs-new regression guards for fixes already shipped (`applyOptimisticUpdates` arg matching, the cache-event early-return). No new signal.

## Verification

`@lunora/shard-engine` 1,349 · `@lunora/codegen` 1,366 · `api:check` 54/54 · `lint:types` · `lint:eslint` · `lint:prettier`.

The full `test --no-cache` run has `studio` and `cli` failing on jsdom/CLI timeouts (4.2 s, 6.5 s, 10.1 s). Both pass in isolation — studio 1,186/1,186 and cli 1,311/1,311, verified again for this PR — and neither package is touched here. This is the parallel-load flake that has recurred throughout this line of work, and it is worth chasing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc
