### PR TITLE
perf(client): encode stable cache keys without the throwaway arrays

### DIFF
--- a/packages/client/__tests__/stable-key.test.ts
+++ b/packages/client/__tests__/stable-key.test.ts
@@ -18,6 +18,39 @@ describe("stableStringify fail-loud contract", () => {
         expect(stableStringify({ b: undefined, a: 1 })).toBe('{"a":1}');
     });
 
+    it("escapes strings exactly as JSON.stringify does, in both keys and values", () => {
+        // 15 hazards, asserted as both a value and a key.
+        expect.assertions(30);
+
+        // The encoder skips `JSON.stringify` for strings that provably cannot
+        // escape. Every hazard below must still encode identically, or two
+        // distinct values could share one cache key and be served each other's
+        // data. Lone surrogates are the subtle case: `JSON.stringify` escapes a
+        // lone half to `\udXXX` while a well-formed pair passes through.
+        const hazards = [
+            "plain",
+            "",
+            '"',
+            "\\",
+            'say "hi"',
+            "tab\there",
+            "newline\nhere",
+            "\u0000",
+            "\u001F",
+            "\u007F",
+            "café",
+            "\u{1F680}",
+            "\uD800",
+            "\uDFFF",
+            "a\uDC00b",
+        ];
+
+        for (const text of hazards) {
+            expect(stableStringify(text)).toBe(JSON.stringify(text));
+            expect(stableStringify({ [text]: 1 })).toBe(`{${JSON.stringify(text)}:1}`);
+        }
+    });
+
     it("throws a clear error on a bigint instead of JSON.stringify's cryptic one", () => {
         expect.assertions(2);
 

--- a/shared/stable-key.ts
+++ b/shared/stable-key.ts
@@ -48,14 +48,26 @@
  * does not skip `undefined` fields). The two are different contracts.
  */
 
-/** Code-point-stable key comparator (no locale dependence) for deterministic encoding. */
-const compareKeys = (a: string, b: string): number => {
-    if (a < b) {
-        return -1;
-    }
+/**
+ * Whether a string needs JSON escaping — a quote, a backslash, a control
+ * character, or any surrogate code unit.
+ *
+ * Surrogates are excluded from the fast path wholesale, pairs included, even
+ * though a well-formed pair passes through `JSON.stringify` unchanged. Only a
+ * LONE surrogate is escaped (to `\udXXX`), and telling the two apart costs more
+ * than handing the whole string to `JSON.stringify`. Emoji keys therefore take
+ * the slow path, which is correct and rare.
+ */
+const NEEDS_ESCAPE = /["\\\u0000-\u001F\uD800-\uDFFF]/;
 
-    return a > b ? 1 : 0;
-};
+/**
+ * `JSON.stringify` for a string, skipped when nothing in it can escape.
+ *
+ * Keys and short string leaves dominate these encodings and almost never need
+ * escaping, and wrapping in quotes directly measured ~1.2x over the generic
+ * call on realistic query args.
+ */
+const quote = (text: string): string => (NEEDS_ESCAPE.test(text) ? JSON.stringify(text) : `"${text}"`);
 
 const stableStringify = (value: unknown): string => {
     // Encode `undefined` as `null` (mirrors `JSON.stringify`'s array-element
@@ -98,12 +110,26 @@ const stableStringify = (value: unknown): string => {
         }
     }
 
+    if (typeof value === "string") {
+        return quote(value);
+    }
+
     if (value === null || typeof value !== "object") {
         return JSON.stringify(value);
     }
 
     if (Array.isArray(value)) {
-        return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+        let out = "[";
+
+        for (let index = 0; index < value.length; index++) {
+            if (index > 0) {
+                out += ",";
+            }
+
+            out += stableStringify(value[index]);
+        }
+
+        return out + "]";
     }
 
     // Reject non-plain objects (`Date`, `ArrayBuffer`, typed arrays, `Map`, `Set`,
@@ -123,8 +149,14 @@ const stableStringify = (value: unknown): string => {
     }
 
     const record = value as Record<string, unknown>;
-    const keys = Object.keys(record).toSorted(compareKeys);
-    const parts: string[] = [];
+    // `sort()` with no comparator, not `toSorted(compareKeys)`. The default
+    // comparator sorts strings by UTF-16 code unit — byte-identical to the
+    // `a < b` comparator this replaces (verified by fuzzing both over random
+    // key sets), and it is NOT locale-sensitive; that is `localeCompare`.
+    // Sorting in place is safe because `Object.keys` hands back a fresh array.
+    const keys = Object.keys(record).sort();
+    let out = "{";
+    let first = true;
 
     for (const key of keys) {
         const raw = record[key];
@@ -133,10 +165,18 @@ const stableStringify = (value: unknown): string => {
             continue;
         }
 
-        parts.push(`${JSON.stringify(key)}:${stableStringify(raw)}`);
+        if (first) {
+            first = false;
+        } else {
+            out += ",";
+        }
+
+        out += quote(key);
+        out += ":";
+        out += stableStringify(raw);
     }
 
-    return `{${parts.join(",")}}`;
+    return out + "}";
 };
 
 export { stableStringify };


### PR DESCRIPTION
`stableStringify` backs every cache, dedup and subscription key in the client, React, Angular, flags, observability and the DO. It runs on every `useSubscription` render and once per DO dispatch, and it was doing three avoidable things per call.

## What changed

**The comparator was redundant.** `toSorted(compareKeys)` passed a JS callback comparing strings with `<` — precisely what the default comparator already does, since it orders by UTF-16 code unit. Fuzzing both over random key sets found zero disagreements. The default is also not locale-sensitive; that is `localeCompare`. Dropping it drops the array copy too, because `Object.keys` returns a fresh array that is safe to sort in place.

**Two throwaway arrays per node.** Objects and arrays each built an intermediate array only to `join(",")` it. Accumulating the string directly removes one allocation per node.

**`JSON.stringify` per key and per string leaf,** where almost nothing can escape. One regex test for the characters that can — quote, backslash, control, surrogate — lets the rest be wrapped in quotes directly.

## Measured

Interleaved A/B slices, median of 41, realistic query args:

| shape | before | after | |
|---|---|---|---|
| flat 2 keys | 277 ns | 193 ns | **1.44x** |
| flat 5 keys | 565 ns | 373 ns | **1.51x** |
| flat 12 keys | 1299 ns | 917 ns | **1.42x** |
| nested + array | 935 ns | 583 ns | **1.60x** |
| page of 10 rows | 3710 ns | 2338 ns | **1.59x** |

## Why the correctness work is the bulk of this

This is a cache key. A changed encoding does not fail loudly — it silently serves one value's cached data for another. So output must be byte-identical, not merely equivalent.

Verified by fuzzing **400,000** generated values against the previous implementation for identical output *and* identical throws. The fuzzer was then confirmed non-vacuous by disabling the escape test, which produced **197,487 divergences** — among them the lone-surrogate case, which is why the regex excludes surrogate pairs it does not strictly need to.

Adds the escaping test the file was missing: every hazard, as both a value and a key, pinned against `JSON.stringify`. Sabotaging the fast path fails that test and an existing protocol-conformance fixture.

## Verification

`@lunora/client` 755 passed, plus every other consumer of this file — `do` 613, `studio` 1186, `react` 163, `observability` 240, `angular` 126, `flags` 72. `api:check` clean across 54 snapshots, `lint:types` clean across 75 projects, eslint and prettier clean.

Note for reviewers: `shared/` is not in any package's vis cache key, so a cached `build:packages` will happily leave every consumer's `dist/` on the old code. This was built with `--no-cache` and the emitted bundles checked for the new encoder.

## Measured and declined

- **Fusing `encodeWire` into `stableWireKey`'s traversal.** `encodeWire` is only 17–24% of that call; the rest is this encoder, already sped up here. Not worth reproducing the wire vocabulary byte-identically in a second place.
- **A tag-skipping guard for `decodeWire`.** Worth 1.36–1.55x on plain rows, but the naive form drops decode's depth cap — a deliberate, tested guard against untrusted input. Restoring the cap soundly costs more than the win: a `charCodeAt` scan lands 5–6% net negative, and a regex form backtracks catastrophically at **45x–152x slower**. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc
