### PR TITLE
perf(shard-engine): sort the id tiebreak the way the key it breaks sorts

### DIFF
--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -4642,6 +4642,12 @@ const tableFromDepKey: (dep: string) => string;
 const throwingScheduler: SchedulerLike;
 ```
 
+### `tiebreakDirectionFor` (const)
+
+```ts
+const tiebreakDirectionFor: (keys: ReadonlyArray<OrderKey>) => SortDirection;
+```
+
 ### `trimCdcChanges` (const)
 
 ```ts

--- a/packages/shard-engine/__tests__/ctx-db.order-tiebreak.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.order-tiebreak.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The implicit `id` tiebreak sorts the same way the key it breaks does.
+ *
+ * Two things depend on that and they are in different files, which is what made
+ * the mismatch survive:
+ *
+ * Correctness: `buildSeekWhere` (`query-args.ts`) and the ORDER BY builders
+ * (`ctx-db.ts`) must agree. A seek that selects `id > cursor` under an `id DESC`
+ * ordering walks away from the page it just returned, skipping or repeating rows
+ * wherever a page boundary lands inside a group of rows that tie on the real sort
+ * key. Ties are not exotic: `_creationTime` has millisecond resolution, so a loop
+ * of writes produces them constantly.
+ *
+ * Performance: declared indexes are built `(<fields>, _creationTime, id)`, all
+ * ascending. A single-direction index answers `... DESC, id DESC` by being read
+ * backwards, but cannot answer the mixed `... DESC, id ASC` at all; SQLite falls
+ * back to `USE TEMP B-TREE FOR LAST TERM OF ORDER BY`.
+ */
+
+const schema: SchemaLike = {
+    tables: {
+        events: {
+            indexes: [{ fields: ["room"], name: "by_room" }],
+            shape: {
+                room: { kind: "string" },
+                seq: { kind: "number" },
+            },
+        },
+    },
+};
+
+const seeded = async (rows: number) => {
+    const harness = createSqliteExec();
+
+    runShardMigrations(harness.sql, schema);
+
+    // One fixed clock value for every row, so every row ties on `_creationTime`
+    // and the tiebreak alone decides the order. This is the case that separates
+    // an agreeing seek from a disagreeing one.
+    const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+
+    for (let index = 0; index < rows; index += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seeding, test setup only
+        await writer.insert("events", { room: "r-1", seq: index });
+    }
+
+    return { harness, writer };
+};
+
+describe("implicit id tiebreak follows the sort direction", () => {
+    it("pages a descending read over fully-tied rows without skipping or repeating", async () => {
+        expect.assertions(43);
+
+        const { harness, writer } = await seeded(40);
+
+        const seen: string[] = [];
+        let cursor: null | string | undefined;
+
+        for (let guard = 0; guard < 20; guard += 1) {
+            // eslint-disable-next-line no-await-in-loop -- paging is inherently sequential: each request needs the previous page's cursor
+            const page: { continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] } = await writer.findMany("events", {
+                cursor,
+                limit: 7,
+                orderBy: [{ _creationTime: "desc" }],
+            });
+
+            for (const row of page.page) {
+                expect(typeof row["_id"]).toBe("string");
+
+                seen.push(String(row["_id"]));
+            }
+
+            if (page.isDone) {
+                break;
+            }
+
+            cursor = page.continueCursor;
+        }
+
+        harness.close();
+
+        expect(seen).toHaveLength(40);
+        expect(new Set(seen).size).toBe(40);
+        // Descending overall: with every `_creationTime` equal, the tiebreak is
+        // the whole ordering, so the ids must come back strictly descending.
+        expect(seen).toStrictEqual(seen.toSorted((left, right) => right.localeCompare(left)));
+    });
+
+    it("keeps the declared index usable for a descending page (no temp b-tree)", async () => {
+        expect.assertions(2);
+
+        const { harness } = await seeded(200);
+
+        const plan = (order: string) =>
+            harness
+                .raw(
+                    `EXPLAIN QUERY PLAN SELECT id, _creationTime, "__doc__" FROM "events" WHERE json_extract(__doc__, '$.room') = 'r-1' ORDER BY ${order} LIMIT 21`,
+                )
+                .map((row) => String(row["detail"]))
+                .join(" | ");
+
+        // What the builders emit today.
+        expect(plan("_creationTime DESC, id DESC")).not.toContain("TEMP B-TREE");
+        // What they emitted before, pinned so a revert is loud rather than slow.
+        expect(plan("_creationTime DESC, id ASC")).toContain("TEMP B-TREE");
+
+        harness.close();
+    });
+});

--- a/packages/shard-engine/__tests__/query-args.test.ts
+++ b/packages/shard-engine/__tests__/query-args.test.ts
@@ -89,15 +89,20 @@ describe("buildSeekWhere", () => {
         });
     });
 
-    it("descending key uses < for the strict comparison", () => {
+    it("descending key uses < for the strict comparison, tiebreak included", () => {
         expect.assertions(1);
 
         const where = buildSeekWhere([{ direction: "desc", field: "createdAt" }], [1700, "row_42"]);
         const compiled = compile(where);
 
+        // `id < ?`, not `id > ?`: the implicit tiebreak sorts the same way the
+        // key it breaks does, so the ORDER BY reads `createdAt DESC, id DESC` and
+        // the seek has to select rows below the cursor on BOTH terms. A seek that
+        // disagreed with its own ORDER BY here would skip or repeat rows at a page
+        // boundary that lands inside a group of equal `createdAt`.
         expect(compiled).toEqual({
             params: [1700, 1700, "row_42"],
-            sql: `(${json("createdAt")} < ?) OR ((${json("createdAt")} = ?) AND (id > ?))`,
+            sql: `(${json("createdAt")} < ?) OR ((${json("createdAt")} = ?) AND (id < ?))`,
         });
     });
 
@@ -115,7 +120,7 @@ describe("buildSeekWhere", () => {
 
         // Balanced grouping (see `joinClauses`); same terms, same param order.
         expect(compiled.sql).toBe(
-            `(${json("a")} > ?) OR (((${json("a")} = ?) AND (${json("b")} < ?)) OR ((${json("a")} = ?) AND ((${json("b")} = ?) AND (id > ?))))`,
+            `(${json("a")} > ?) OR (((${json("a")} = ?) AND (${json("b")} < ?)) OR ((${json("a")} = ?) AND ((${json("b")} = ?) AND (id < ?))))`,
         );
         expect(compiled.params).toEqual(["av", "av", "bv", "av", "bv", "row_1"]);
     });

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -86,7 +86,16 @@ import {
 import { renderSql, sqliteInList, unionAll, WORKERD_SQLITE_LIMITS } from "./drizzle";
 import { boundingBoxGeohashes, coveringGeohashes, haversineMeters, pointInBoundingBox } from "./geo";
 import { NotFoundError } from "./not-found-error";
-import { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope } from "./query-args";
+import {
+    applySelect,
+    buildSeekBeforeWhere,
+    buildSeekWhere,
+    decodeCursor,
+    encodeCursor,
+    normalizeOrderKeys,
+    softDeleteScope,
+    tiebreakDirectionFor,
+} from "./query-args";
 import { encodePartitionKey, RANK_TIEBREAK, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
 import type { ReactiveCache } from "./reactive-cache";
 import type { IndexKeyEntry, KeyRange } from "./read-write-set";
@@ -1187,7 +1196,7 @@ const compileOrderByText = (keys: OrderKey[]): string => {
     const parts = keys.map((key) => `${jsonPath(key.field)} ${key.direction === "desc" ? "DESC" : "ASC"}`);
 
     if (!keys.some((key) => key.field === "_id" || key.field === "id")) {
-        parts.push(`${jsonPath("id")} ASC`);
+        parts.push(`${jsonPath("id")} ${tiebreakDirectionFor(keys) === "desc" ? "DESC" : "ASC"}`);
     }
 
     return parts.join(", ");
@@ -1198,7 +1207,7 @@ const compileOrderBySql = (keys: OrderKey[]): SQL => {
     const parts = keys.map((key) => dsql`${jsonPathSql(key.field)} ${dsql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 
     if (!keys.some((key) => key.field === "_id" || key.field === "id")) {
-        parts.push(dsql`${jsonPathSql("id")} ASC`);
+        parts.push(dsql`${jsonPathSql("id")} ${dsql.raw(tiebreakDirectionFor(keys) === "desc" ? "DESC" : "ASC")}`);
     }
 
     return dsql.join(parts, dsql`, `);
@@ -1508,7 +1517,8 @@ const buildReader = (
         }
 
         if (!orderFields.some((field) => field === "_id" || field === "id")) {
-            parts.push(dsql`${jsonPathSql("id")} ASC`);
+            // Same direction as everything above it — see `tiebreakDirectionFor`.
+            parts.push(dsql`${jsonPathSql("id")} ${dsql.raw(orderDirection)}`);
         }
 
         return dsql.join(parts, dsql`, `);

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -262,7 +262,16 @@ export { clearCapturedMail, ensureMailTable, MAIL_RETENTION, MAIL_TABLE, readCap
 export { NotFoundError } from "./not-found-error";
 export type { PitrBookmarkResult, PitrRestoreArgs, PitrRestoreResult, PitrStorage } from "./pitr";
 export { armRestore, readBookmark } from "./pitr";
-export { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope } from "./query-args";
+export {
+    applySelect,
+    buildSeekBeforeWhere,
+    buildSeekWhere,
+    decodeCursor,
+    encodeCursor,
+    normalizeOrderKeys,
+    softDeleteScope,
+    tiebreakDirectionFor,
+} from "./query-args";
 // Consumed by `@lunora/do` internals rather than by end users: these were
 // module-private inside `@lunora/do` before the relocation, and are published
 // here only because the import now crosses a package boundary. They are not

--- a/packages/shard-engine/src/query-args.ts
+++ b/packages/shard-engine/src/query-args.ts
@@ -24,6 +24,25 @@ import type { WhereInput } from "./where-types";
 /** The implicit tiebreak appended to every sort so the order is total. */
 const TIEBREAK_FIELD = "id";
 
+/**
+ * Which way the implicit `id` tiebreak sorts: the same way the last real sort
+ * key does.
+ *
+ * It used to be pinned `asc`. That made a descending read emit
+ * `_creationTime DESC, id ASC` — two directions in one ORDER BY, which no
+ * single-direction index can satisfy. SQLite answered it with
+ * `USE TEMP B-TREE FOR LAST TERM OF ORDER BY`, sorting each tie group instead
+ * of walking the index backwards, and a descending page measured 1.4-2.0x
+ * slower than the aligned form. The DO builds every declared index as
+ * `(<fields>, _creationTime, id)`, so following the last key's direction is
+ * exactly what lets that index be read forwards OR backwards.
+ *
+ * {@link buildSeek} and every ORDER BY builder MUST use this one rule. A cursor
+ * seek that disagrees with its own ORDER BY about tie direction skips or repeats
+ * rows at a page boundary where the sort keys tie.
+ */
+const tiebreakDirectionFor = (keys: ReadonlyArray<OrderKey>): SortDirection => (keys.at(-1)?.direction === "desc" ? "desc" : "asc");
+
 const ID_FIELDS = new Set(["_id", "id"]);
 
 /**
@@ -130,7 +149,9 @@ const decodeCursor = (cursor: string): unknown[] => {
  * prefix equalities with the pivot comparison `operatorFor` chooses.
  */
 const buildSeek = (keys: OrderKey[], cursorValues: unknown[], operatorFor: (direction: SortDirection, isFinal: boolean) => string): WhereInput => {
-    const columns: OrderKey[] = keys.some((key) => ID_FIELDS.has(key.field)) ? keys : [...keys, { direction: "asc", field: TIEBREAK_FIELD }];
+    const columns: OrderKey[] = keys.some((key) => ID_FIELDS.has(key.field))
+        ? keys
+        : [...keys, { direction: tiebreakDirectionFor(keys), field: TIEBREAK_FIELD }];
 
     const branches: WhereInput[] = [];
 
@@ -266,6 +287,7 @@ export {
     isLiveForCompanion,
     normalizeOrderKeys,
     softDeleteScope,
+    tiebreakDirectionFor,
     toBase64,
 };
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -151,7 +151,11 @@ const compileOrderBySql = (keys: ReadonlyArray<{ direction?: string; field: stri
     const parts = keys.map((key) => sql`${columnRefSql(key.field)} ${sql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 
     if (!keys.some((key) => ID_ORDER_FIELDS.has(key.field))) {
-        const tiebreak = tiebreakDirectionFor(keys.map((key) => {return { direction: key.direction === "desc" ? "desc" : "asc", field: key.field }}));
+        const tiebreak = tiebreakDirectionFor(
+            keys.map((key) => {
+                return { direction: key.direction === "desc" ? "desc" : "asc", field: key.field };
+            }),
+        );
 
         parts.push(sql`${columnRefSql("id")} ${sql.raw(tiebreak === "desc" ? "DESC" : "ASC")}`);
     }

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -99,6 +99,7 @@ import {
     softDeleteScope,
     sortColumnName,
     throwingScheduler,
+    tiebreakDirectionFor,
 } from "@lunora/shard-engine";
 import type { SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
@@ -113,7 +114,7 @@ import type { SqlCtxExec } from "./sql-exec";
 import { columnRefSql, createIndexIfNotExists, decodeRow, decodeRows, forEachRowPaged, queryAll, queryBatch, queryRun, serializeColumnValue } from "./sql-exec";
 import { effectiveColumnKind } from "./value-codec";
 
-/** Order fields that already provide a stable tiebreak (no extra `id ASC` needed). */
+/** Order fields that already provide a stable tiebreak (no extra `id` term needed). */
 const ID_ORDER_FIELDS = new Set(["_id", "id"]);
 
 /**
@@ -137,14 +138,22 @@ const nullSafeEqualsSql = (engine: SqlDialect["name"], reference: SQL, value: un
 
 /**
  * Drizzle `ORDER BY` list — the SQL-object twin of `@lunora/do`'s string
- * `compileOrderBy`: each key as `<col> ASC|DESC`, with an `id ASC` tiebreak
- * appended unless an id field is already ordered (keeps paging deterministic).
+ * `compileOrderBy`: each key as `<col> ASC|DESC`, with an `id` tiebreak appended
+ * unless an id field is already ordered (keeps paging deterministic).
+ *
+ * The tiebreak follows the last key's direction, via the shared
+ * `tiebreakDirectionFor`. This backend does not append sort keys to its declared
+ * indexes the way the DO does, so it gains nothing directly — but it shares
+ * `buildSeekWhere`, and a cursor seek that disagrees with its own ORDER BY about
+ * tie direction skips or repeats rows at a page boundary where the keys tie.
  */
 const compileOrderBySql = (keys: ReadonlyArray<{ direction?: string; field: string }>): SQL => {
     const parts = keys.map((key) => sql`${columnRefSql(key.field)} ${sql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 
     if (!keys.some((key) => ID_ORDER_FIELDS.has(key.field))) {
-        parts.push(sql`${columnRefSql("id")} ASC`);
+        const tiebreak = tiebreakDirectionFor(keys.map((key) => {return { direction: key.direction === "desc" ? "desc" : "asc", field: key.field }}));
+
+        parts.push(sql`${columnRefSql("id")} ${sql.raw(tiebreak === "desc" ? "DESC" : "ASC")}`);
     }
 
     return sql.join(parts, sql`, `);


### PR DESCRIPTION
Found by profiling the DO read path rather than by reading code, which is why it had survived: nothing about the source looks wrong, and the comment on the offending line asserts the opposite of what it does.

## The defect

A descending read emitted:

```sql
ORDER BY _creationTime DESC, id ASC
```

Two directions in one ORDER BY. No single-direction index can satisfy that, so SQLite answers it with `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` — sorting each group of tied rows instead of walking the index backwards.

Declared indexes are built `(<fields>, _creationTime, id)`, all ascending. That index serves `... DESC, id DESC` perfectly well by being read backwards. The pinned `id ASC` was the only thing stopping it — and the comment directly above it already claimed the opposite:

> the same order the declared index is physically built in (`<fields>, _creationTime, id`), so it stays an index walk

It stayed an index walk for ascending reads only. Descending — "latest N", the most common read shape there is — silently fell back to a sort.

## Measured

Interleaved A/B of the two ORDER BY forms, median of 31 alternating slices:

| rows per key | mixed (`id ASC`) | aligned (`id DESC`) | |
|---|---|---|---|
| 50 | 33.8 µs | 21.4 µs | **1.58x** |
| 250 | 19.6 µs | 11.7 µs | **1.68x** |
| 1000 | 20.0 µs | 11.4 µs | **1.76x** |
| 5000 | 20.8 µs | 10.7 µs | **1.95x** |

It widens with rows-per-key because bigger tie groups mean more to sort. It does not explode, because SQLite only sorts the *last* term — the index still bounds the scan.

## The risk here is correctness, not speed

`buildSeekWhere` carried the same pinned `asc`, and it has to move in lockstep. A seek that selects `id > cursor` under an `id DESC` ordering walks away from the page it just returned, skipping or repeating rows wherever a page boundary lands inside a group of tied rows. Ties are not exotic — `_creationTime` is milliseconds, so a loop of writes produces them constantly.

Both sides now derive from one `tiebreakDirectionFor`. The new test pins the invariant end to end: 40 rows sharing a single `_creationTime`, so the tiebreak *is* the entire ordering, paged 7 at a time. Reintroducing the mismatch returns **13 of the 40 rows** — the test was checked against that, not just observed to pass.

A second test pins the query plan both ways: the emitted form must not use a temp b-tree, and the old form must, so a revert is loud rather than merely slow.

`sql-store` gains nothing directly — it does not append sort keys to its declared indexes — but it shares `buildSeekWhere`, so its ORDER BY moves too or its cursor and its ordering disagree.

## Verification

`shard-engine` 1350 passed, `do` 613, `d1` 274, `sql-store` 112. `lint:types` clean across 75 projects, eslint and prettier clean. `api:update` for the one added export, diff included.

Note: two existing `buildSeekWhere` tests asserted the old `id > ?`. They were pinning the previous contract, and are updated with the reasoning inline rather than silently flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sorting consistency when results are ordered descending.
  - Fixed cursor-based pagination to maintain the selected sort direction, including consistent handling of tied records.
  - Ensured database queries and paginated results use matching ordering behavior.
  - Prevented records from appearing out of order or being skipped when navigating through descending result sets.
  - Applied consistent tie-breaking across sorting and pagination for more predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->