### PR TITLE
perf(do): stop allocating a pair array per socket on every fan-out

### DIFF
--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -341,6 +341,27 @@ describe("shardDO", () => {
         expect(JSON.parse(matching.sent[0]!)).toMatchObject({ delta: { op: "insert", table: "messages" }, id: "a", type: "delta" });
     });
 
+    it("broadcastDelta visits own subscriptions only, never inherited ones", () => {
+        expect.assertions(2);
+
+        // Pins the iteration choice. The per-socket loop walks `Object.keys`,
+        // which is own-only — the same set `Object.entries` gave before it. A
+        // bare `for...in` measures marginally faster and would pass every other
+        // test in this file, but it also walks the prototype chain, so a polluted
+        // `Object.prototype` would turn into phantom subscriptions delivered to
+        // every socket. Cheap to state, invisible otherwise.
+        const socket = createFakeWebSocket();
+        const subs = Object.create({ inherited: { table: "messages" } }) as Record<string, { table: string }>;
+
+        subs["own"] = { table: "messages" };
+
+        shard.registerSocket(socket, { subs });
+        shard.emit({ key: "m1", op: "insert", row: { id: "m1" }, table: "messages" });
+
+        expect(socket.sent).toHaveLength(1);
+        expect(JSON.parse(socket.sent[0]!)).toMatchObject({ id: "own" });
+    });
+
     it("broadcastDelta wire-encodes the row, so a bigint column does not throw", () => {
         expect.assertions(2);
 

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -3912,9 +3912,25 @@ abstract class ShardDO {
 
         for (const ws of sockets) {
             const attachment = this.readAttachment(ws);
+            // `Object.keys`, not `Object.entries`: this runs once per socket for
+            // every mutation, and `entries` allocates a fresh [key, value] pair
+            // array per socket — two allocations each for the common
+            // one-subscription socket — before a single subscription has been
+            // tested. The sockets that do NOT match paid the same price as the
+            // ones that did, which is why a 500-socket fan-out where only 10%
+            // matched still cost two thirds of the all-match case (30.5 -> 12.4 us;
+            // all-match 45.3 -> 28.0 us).
+            //
+            // NOT `for...in`, which measured slightly faster still but walks
+            // inherited enumerable keys. `Object.keys` is own-only, exactly like
+            // the `Object.entries` it replaces, so this is a pure allocation fix
+            // with no change in which subscriptions are visited.
+            const { subs } = attachment;
 
-            for (const [subId, query] of Object.entries(attachment.subs)) {
-                if (!this.matchesSubscription(query, delta)) {
+            for (const subId of Object.keys(subs)) {
+                const query = subs[subId];
+
+                if (query === undefined || !this.matchesSubscription(query, delta)) {
                     continue;
                 }
 
@@ -9096,12 +9112,23 @@ abstract class ShardDO {
             // identical for every subscription on it. See {@link SocketDelivery}.
             const delivery = this.socketDelivery(attachment);
 
-            for (const [subId, query] of Object.entries(attachment.subs)) {
-                const { functionPath } = query;
+            // `Object.keys` for the same reason as `broadcastDelta` — see there.
+            // This loop skips most subscriptions on most flushes via the memo
+            // gates below, so the per-socket `entries` allocation was paid mainly
+            // by sockets that then did nothing.
+            const { subs } = attachment;
 
-                if (!functionPath) {
+            for (const subId of Object.keys(subs)) {
+                const query = subs[subId];
+
+                // One guard, not two: a truthy `functionPath` already proves
+                // `query` is present, and splitting them pushed this function
+                // past the cognitive-complexity ceiling for no benefit.
+                if (!query?.functionPath) {
                     continue;
                 }
+
+                const { functionPath } = query;
 
                 const isAdmin = functionPath.startsWith(ADMIN_FUNCTION_PREFIX);
                 const memo = this.subMemos.get(ws)?.get(subId);


### PR DESCRIPTION
Found by profiling the realtime fan-out path — write to subscriber delivery.

## The tell

`broadcastDelta` at 500 sockets cost 45.3 µs per mutation. But the variant where only **10% of sockets subscribe to the delta's table** still cost 30.5 µs — two thirds of the all-match price, for a twentieth of the deliveries.

A cheap reject should not look like that. Rejecting was nearly as expensive as sending.

## The cause

Both per-socket subscription loops walked:

```ts
for (const [subId, query] of Object.entries(attachment.subs)) {
```

`Object.entries` allocates a fresh array of `[key, value]` pairs for **every socket, before a single subscription has been tested** — two allocations each for the common one-subscription socket, on every mutation. Sockets that matched nothing paid exactly the same price as sockets that matched.

## Measured

`Object.keys` instead. 500 sockets, three runs each, bracketed by a revert to confirm the delta was not machine drift:

| scenario | before | after | |
|---|---|---|---|
| 500 sockets, all match | 45.3 µs | 26.8 µs | **1.69x** |
| 500 sockets, 10% match | 30.5 µs | 12.1 µs | **2.52x** |
| 5 sockets, all match | 1.61 µs | 1.32 µs | **1.22x** |

The selective case gains most, which is the diagnosis confirming itself: what was removed is per-socket work paid *before* matching, so the sockets that reject benefit the most.

## Both loops, not just the one that profiled

`broadcastDelta` runs per mutation; `refreshOne` runs per socket on every write flush and is the modern reactive re-run path. It has the same `Object.entries` and skips most subscriptions via its memo gates — so it too was paying mainly on sockets that then did nothing. Fixing only the one I profiled would have left the more important path alone.

## Why not `for...in`

It measured faster still — 11.0 vs 12.4 µs on the selective case — and I did not take it. `for...in` walks inherited enumerable keys, where `Object.entries` is own-only. A polluted `Object.prototype` would turn into phantom subscriptions delivered to **every** socket.

`Object.keys` is own-only, exactly like the `Object.entries` it replaces, so this is a pure allocation fix with no change in which subscriptions are visited. The ~12% left on the table buys an unchanged security posture.

The new test pins that choice: a `subs` object carrying an inherited entry must deliver one frame, not two. Verified non-vacuous — under `for...in` it fails with two.

## Verification

`do` 614 passed (613 before, +1 new). `lint:types`, eslint, prettier clean. `api:check` clean across 54 snapshots.

The existing `broadcast-delta.bench.ts` already covers all three scenarios above, so CodSpeed will track this going forward without a new bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscription updates during broadcasts and refreshes.
  - Added safeguards for missing subscription records, helping prevent errors during subscription matching and delivery.

- **Performance**
  - Reduced overhead when processing subscriptions, supporting more efficient message delivery without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->