### PR TITLE
docs: repair 404 package links, and document .source() in the hyperdrive readme

### DIFF
--- a/packages/advisor/README.md
+++ b/packages/advisor/README.md
@@ -148,7 +148,7 @@ if (diff.regressed) {
 
 `@lunora/codegen` exposes `toAdvisorContext()` to build the context straight from the feeder, and `lunora advisor` wraps all of this as a command. Full reference for the scoring, verdicts, and the baseline gate is in the [package docs](https://lunora.sh/docs/packages/advisor).
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/studio)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/studio)**.
 
 ## Related
 

--- a/packages/advisor/README.md
+++ b/packages/advisor/README.md
@@ -148,7 +148,7 @@ if (diff.regressed) {
 
 `@lunora/codegen` exposes `toAdvisorContext()` to build the context straight from the feeder, and `lunora advisor` wraps all of this as a command. Full reference for the scoring, verdicts, and the baseline gate is in the [package docs](https://lunora.sh/docs/packages/advisor).
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/studio)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/advisor)**.
 
 ## Related
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -109,7 +109,7 @@ const browser = createBrowser({ binding: env.BROWSER, launch, allowPrivateTarget
 
 Only set `allowPrivateTargets` when every URL is trusted — it re-opens the SSRF surface. The guard does not resolve DNS, so a public hostname that resolves to a private address (DNS rebinding) is out of scope; keep caller-supplied URLs trusted regardless.
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/browser)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/browser)**.
 
 ## Related
 

--- a/packages/container/README.md
+++ b/packages/container/README.md
@@ -196,7 +196,7 @@ await lunora.mutation("jobs:markDone", { id: pending[0].id });
 
 The token is a bearer your Worker's `resolveIdentity` recognizes — pass it to the container as a `secret`. Non-JS containers can `POST /_lunora/rpc` with `{ functionPath, args }` directly.
 
-Secure the bridge in `resolveIdentity`: read `request.headers.get("authorization")`, strip the `Bearer ` prefix, and compare the token against a Worker secret (e.g. `env.LUNORA_CONTAINER_TOKEN`) you also forward to the container. Return a `{ userId }` identity only on a match and `null` otherwise — an unrecognised request then runs anonymously and is rejected by your functions' own authorization checks. See [Securing the bridge](https://lunora.sh/docs/addons/containers#securing-the-bridge) for the full example.
+Secure the bridge in `resolveIdentity`: read `request.headers.get("authorization")`, strip the `Bearer ` prefix, and compare the token against a Worker secret (e.g. `env.LUNORA_CONTAINER_TOKEN`) you also forward to the container. Return a `{ userId }` identity only on a match and `null` otherwise — an unrecognised request then runs anonymously and is rejected by your functions' own authorization checks. See [Securing the bridge](https://lunora.sh/docs/packages/container#securing-the-bridge) for the full example.
 
 ### Entry points
 
@@ -204,7 +204,7 @@ Secure the bridge in `resolveIdentity`: read `request.headers.get("authorization
 - `@lunora/container/do` — workerd-only: the `LunoraContainer` base class the generated DO classes extend (pulls in `@cloudflare/containers`).
 - `@lunora/container/bridge` — runtime-agnostic: `createContainerBridge` for calling Lunora functions from inside a container.
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/containers)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/container)**.
 
 ### Known platform limitations
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -89,7 +89,7 @@ Keep a **single `db` instance**, and treat its collections as the one source of
 truth per table — don't mirror rows into your own store. A derived index (a tree,
 a search index, an undo capture) built from a copy of the rows can silently read
 stale data while the UI renders through `useLiveQuery`. See [One source of truth
-per table](https://lunora.sh/docs/addons/db#one-source-of-truth-per-table).
+per table](https://lunora.sh/docs/packages/db#one-source-of-truth-per-table).
 
 ### Local-first sync engine
 
@@ -103,7 +103,7 @@ every sync tick). The framework adapters add a `useMutator` / `createMutator` /
 `mutator` hook over a bound handle. See the
 **[local-first guide](https://lunora.sh/docs/concepts/local-first)**.
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/db)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/db)**.
 
 ## Related
 

--- a/packages/hyperdrive/README.md
+++ b/packages/hyperdrive/README.md
@@ -146,7 +146,7 @@ Three things to know before you build on it:
 
 - **It polls; it is not logical replication.** Freshness is the refresh cadence: every alarm tick by default, `refresh: { everyMs }` to throttle, `refresh: "manual"` to drive it yourself. Writes from other systems land on the next pull.
 - **`tenantBy` is the isolation boundary.** `defineSchema` throws at load if a sourced `.shardBy()` table omits it, and the `external_source_unscoped` advisor lint catches it at build time. Without it, one tenant's DO pulls every tenant's rows.
-- **`mode: "full-pull"` (the default) diffs the whole slice each tick**, so upstream deletes are detected for free, at a bench ceiling around 10k rows. Past that, `mode: "incremental"` pulls only rows past a durable watermark via a cursor column, and needs a periodic reconcile to see deletes.
+- **`mode: "full-pull"` (the default) diffs the whole slice each tick**, so upstream deletes are detected for free, at a bench ceiling around 10k rows. Past that, `mode: "incremental"` pulls only rows past a durable watermark via a cursor column. An incremental slice cannot see a delete on its own — an absent row means "unchanged", not "deleted" — so it **requires** a delete-visibility path: either `reconcileEveryMs` (a periodic full-pull sweep) or `softDeleteColumn` (an upstream tombstone column the cursor query returns, so do not filter it out). `defineSchema` throws and the `external_source_incremental_no_delete_path` lint fails the build if an incremental source declares neither.
 
 `.source()` cannot be combined with `.global()` — they are contradictory tiers, and `defineSchema` rejects it.
 

--- a/packages/hyperdrive/README.md
+++ b/packages/hyperdrive/README.md
@@ -113,6 +113,43 @@ export const syncCustomer = action.input({ orgId: v.string() }).action(async ({ 
 | `pg` (node-postgres)     | `fromNodePg`     | `$1, $2, …`  |
 | `mysql2/promise`         | `fromMysql2`     | `?`          |
 
+## Reactive reads over your schema: the `.source()` modifier
+
+The projection above is the escape hatch. For the common case — an existing Postgres you are not going to move, and a read path that should feel live — declare the source on the table and Lunora runs the whole loop on the shard's alarm: pull, diff, materialize, poke subscribers. No action, no mutation, no cron to write:
+
+```ts
+// lunora/schema.ts
+export default defineSchema({
+    messages: defineTable({ body: v.string(), channelId: v.string() })
+        .shardBy("channelId")
+        .source({
+            binding: "HYPERDRIVE_MESSAGES",
+            query: 'select id, body, channel_id as "channelId" from messages where channel_id = $1',
+            tenantBy: (shardKey) => [shardKey], // mandatory under .shardBy() — the tenant boundary
+        }),
+});
+
+export const channelMessages = defineShape({ table: "messages", where: () => ({}) });
+```
+
+Supply the driver once, when the shard DO is constructed. Lunora memoizes it per binding:
+
+```ts
+createShardDO({
+    sourceClient: (env, binding) => fromPostgresJs(postgres((env[binding] as { connectionString: string }).connectionString)),
+});
+```
+
+Clients subscribe with the shape they would use over any table — external data stops being external once it is materialized.
+
+Three things to know before you build on it:
+
+- **It polls; it is not logical replication.** Freshness is the refresh cadence: every alarm tick by default, `refresh: { everyMs }` to throttle, `refresh: "manual"` to drive it yourself. Writes from other systems land on the next pull.
+- **`tenantBy` is the isolation boundary.** `defineSchema` throws at load if a sourced `.shardBy()` table omits it, and the `external_source_unscoped` advisor lint catches it at build time. Without it, one tenant's DO pulls every tenant's rows.
+- **`mode: "full-pull"` (the default) diffs the whole slice each tick**, so upstream deletes are detected for free, at a bench ceiling around 10k rows. Past that, `mode: "incremental"` pulls only rows past a durable watermark via a cursor column, and needs a periodic reconcile to see deletes.
+
+`.source()` cannot be combined with `.global()` — they are contradictory tiers, and `defineSchema` rejects it.
+
 ## Reactive `.global()` over Hyperdrive
 
 The `@lunora/hyperdrive/global` subpath is the opposite trade-off: Lunora **owns** the schema and a `.global()` table gets a real column-per-field layout on your Postgres/MySQL, with every write routed through the shared store core. Live queries stay reactive — identical to D1 — because the writer drives the same broadcast hook. Build the writer inside the Durable Object that hosts the `.global()` store and inject it as `globalDb`:
@@ -127,7 +164,7 @@ const globalDb = createPostgresGlobalCtxDb({ query: (text, params) => sql.unsafe
 
 For MySQL use `createMysqlGlobalCtxDb` with a `mysql2/promise` pool created with `flags: ["FOUND_ROWS"]` — without `CLIENT_FOUND_ROWS` the affected-rows OCC guard sees changed (not matched) rows and raises spurious conflicts. Lower-level building blocks (`buildPgExec`, `buildMysqlExec`, `postgresDialect`, `mysqlDialect`, `createHyperdriveGlobalCtxDb`) are exported for custom wiring.
 
-> This README covers the basics. For the full API and the determinism/realtime rationale, see the **[documentation](https://lunora.sh/docs/addons/hyperdrive)**.
+> This README covers the basics. For the full API and the determinism/realtime rationale, see the **[documentation](https://lunora.sh/docs/packages/hyperdrive)**.
 
 ## Non-goals
 

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -104,7 +104,7 @@ crons.daily("send digest", { hourUTC: 9, minuteUTC: 0 }, internal.email.digest, 
 export default crons;
 ```
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/scheduler)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/scheduler)**.
 
 ## Related
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -104,7 +104,7 @@ await storage.upload("uploads/avatar.png", bytes, { contentType: "image/png", ma
 const url = await storage.getSignedUrl("uploads/avatar.png", { expiresInSeconds: 600 });
 ```
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/storage)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/storage)**.
 
 ## Related
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -86,7 +86,7 @@ const functions = [
 
 Both surfaces are read-only until you opt in: pass `dataEditable` to allow row insert/edit/delete, and `runAsIdentity` to let the runner execute as a chosen identity (loopback-dev only — it forges identity on an admin RPC). Every admin surface stays disabled unless the worker sets `LUNORA_ADMIN_TOKEN` and the client presents a matching `Authorization: Bearer` token.
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/studio)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/studio)**.
 
 ## Related
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -246,7 +246,7 @@ const detail = await client.getInstance({ workflowName: "order-pipeline", instan
 await client.setInstanceStatus({ workflowName: "order-pipeline", instanceId: detail.id, action: "terminate" });
 ```
 
-> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/addons/workflows)**.
+> This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/workflow)**.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Two documentation bugs in `@lunora/hyperdrive` and eight other package READMEs, found while answering a user question about putting Lunora in front of an existing Postgres.

**Every package "documentation" link was a 404.** Nine READMEs link to `lunora.sh/docs/addons/<pkg>` under the line "This README covers the basics. For the full API, options, and guides, see the documentation." That route does not exist; the live one is `/docs/packages/<pkg>`. Affected: `advisor`, `browser`, `container`, `db`, `hyperdrive`, `scheduler`, `storage`, `studio`, `workflow`.

Two were wrong twice: `container` linked `/containers` and `workflow` linked `/workflows`, plural slugs that exist under neither prefix, so fixing the prefix alone would have left them broken. A third, `advisor`, pointed its closing link at the **Studio** docs entirely.

Rather than spot-check, every `lunora.sh/docs/packages/<slug>` reference in every package README is now diffed against `apps/docs/src/content/docs/packages/`, and every closing link is checked against its own package name. All 16 distinct slugs resolve and `advisor` was the only cross-package mismatch.

**The hyperdrive README omitted `.source()`.** There are three ways to reach an external database and it documented two: action-only `ctx.sql` with a hand-written projection, and `.global()` where Lunora owns the schema. The declarative `.source()` modifier, which keeps your schema and gives reactive reads, appeared only in `docs/index.mdx`. It is the one most people want and the direct answer to "can this sit in front of my existing Postgres", so reading the README alone gave a materially worse answer than the truth.

The new section sits between the projection and `.global()`, since the three paths are an escalation of ownership. It carries the limits that decide whether it fits: it polls rather than replicating, `tenantBy` is a hard isolation boundary enforced at load and by lint, and `full-pull` tops out around 10k rows before you move to an incremental cursor, which itself **requires** a delete-visibility path (`reconcileEveryMs` or `softDeleteColumn`) or `defineSchema` throws.

Touches `@lunora/hyperdrive` docs plus the README of `@lunora/advisor`, `@lunora/browser`, `@lunora/container`, `@lunora/db`, `@lunora/scheduler`, `@lunora/storage`, `@lunora/studio` and `@lunora/workflow`.

## Linked issues

None. Found while answering a user question on social, not from a filed issue.

## Test plan

Documentation only, no code paths touched, so the type/eslint/test suites are unaffected by construction. What was actually verified:

- [x] Every `docs/packages/<slug>` in every package README diffed against `apps/docs/src/content/docs/packages/` — all 16 slugs resolve
- [x] Every closing "documentation" link checked against its own package name — `advisor` was the only mismatch, now fixed
- [x] `/docs/packages/hyperdrive`, `/docs/packages/storage` and `/docs/packages/container` fetched live and confirmed to render
- [x] `/docs/addons/hyperdrive` and `/docs/packages/containers` fetched and confirmed to 404, i.e. the bug is real
- [x] Every claim in the new `.source()` section checked against `packages/hyperdrive/docs/index.mdx`
- [x] `prettier --write` clean on both touched READMEs
- [ ] Reviewer: the Netlify deploy preview renders the hyperdrive package page

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change — n/a, documentation only
- [x] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs) — this PR is that update
- [x] No `package.json` files in `packages/*` modified outside the touched package — no `package.json` touched at all
- [ ] If a new package was added — n/a
- [ ] If migration impact — none, no behaviour change

## Notes for reviewers

The link fix matters more than it looks. GitHub is where developers evaluate a package, and the single link inviting them deeper was dead across nine packages, sitting directly under a sentence promising "the full API, options, and guides".

The `.source()` section is new prose rather than a copy of the docs page, so it is worth reading for accuracy rather than diffing. Two review findings on the first commit are addressed in `5f1729a`: the advisor cross-package link, and an incomplete description of incremental delete visibility that named only `reconcileEveryMs` and omitted `softDeleteColumn`.

The `Non-goals` entry about CDC ingestion is deliberately left alone. `.source()` polls, so "no logical-replication ingestion" is still accurate and rewriting the positioning is not this PR's job.

A blog post covering the same ground is written but deliberately kept out of this PR so a docs bugfix is not blocked on reviewing marketing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WseJPg5Lte4U6Wi44xKWjw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated package README links to the current documentation locations.
  - Added guidance for reactive reads over existing PostgreSQL schemas, including polling, refresh modes, tenant isolation, synchronization options, driver setup, and configuration requirements for delete visibility.
  - Clarified bridge security documentation links for the container package.
  - Corrected documentation references across advisor, browser, database, scheduler, storage, studio, and workflow packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->