### PR TITLE
fix(shard-engine): reject cursors minted before the tiebreak changed direction

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,6 +25,10 @@
 
     "path_filters":
         - "packages/**"
+        # `shared/` is bundler-inlined rather than a package, so it matched no
+        # filter here and was skipped in full — including the cache-key encoder
+        # and the base64url codec on the HMAC signed-URL path.
+        - "shared/**"
         - "apps/**"
         - "tools/**"
         - "scripts/**"

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -320,6 +320,12 @@ const COMMIT_SEQ_FIELD = "_commitSeq";
 const COMMIT_SEQ_TABLE = "__commit_seq";
 ```
 
+### `CURSOR_PREFIX` (const)
+
+```ts
+const CURSOR_PREFIX = "~2";
+```
+
 ### `CacheEntry` (interface)
 
 ```ts
@@ -4645,7 +4651,9 @@ const throwingScheduler: SchedulerLike;
 ### `tiebreakDirectionFor` (const)
 
 ```ts
-const tiebreakDirectionFor: (keys: ReadonlyArray<OrderKey>) => SortDirection;
+const tiebreakDirectionFor: (keys: ReadonlyArray<{
+    direction?: string;
+}>) => SortDirection;
 ```
 
 ### `trimCdcChanges` (const)

--- a/examples/team-chat/__tests__/chat.test.ts
+++ b/examples/team-chat/__tests__/chat.test.ts
@@ -65,11 +65,10 @@ it("posts messages into a channel and reads them back", async () => {
     // disagree. A table that needs write order declares `.commitOrdered()` and
     // reads `orderBy: [{ _commitSeq: "asc" }]`; two chat messages a millisecond
     // apart do not need it.
-    expect(messages).toHaveLength(2);
-    expect(messages.map((message) => `${message.authorId}:${message.content}`).toSorted((left, right) => left.localeCompare(right))).toStrictEqual([
-        "u-ada:hello",
-        "u-grace:hi back",
-    ]);
+    // Compared as a set, with no comparator: `localeCompare` would make this
+    // assertion depend on the runner's ICU build, which is exactly the locale
+    // sensitivity the shared key encoder documents avoiding.
+    expect(new Set(messages.map((message) => `${message.authorId}:${message.content}`))).toStrictEqual(new Set(["u-ada:hello", "u-grace:hi back"]));
 });
 
 it("keeps channels apart", async () => {

--- a/packages/codegen/__bench__/run-codegen.bench.ts
+++ b/packages/codegen/__bench__/run-codegen.bench.ts
@@ -27,16 +27,20 @@ let warmWorkdir: string | undefined;
 /**
  * A workdir with `_generated/*` already written, created on first use.
  *
- * Neither of the two obvious places for this works under the instrumented
- * runner. tinybench's `setup`/`teardown` options are ignored by it outright;
- * `beforeAll` runs in a DIFFERENT context from the bench bodies, so the variable
- * it assigns reads back `undefined` inside them.
+ * tinybench's `setup`/`teardown` options are ignored by the instrumented
+ * runner outright, so the priming cannot live there.
  *
- * That second failure is why this bench measured nothing at all. The warm body
- * threw `The "path" argument must be of type string` on every iteration — and a
- * bench that throws takes the whole FILE's samples with it, silently and with a
- * zero exit, so the cold run reported nothing either and the summary printed
- * `NaNx faster than`. CodSpeed was tracking a number that was never measured.
+ * `beforeAll` DOES run under it — `AnalysisRunner` calls the suite's
+ * `beforeAll`/`afterAll` hooks around the benchmarks, in the same process as the
+ * bodies. An earlier version of this comment claimed otherwise; that was wrong,
+ * and the claim is corrected here rather than left to mislead the next reader
+ * into thinking every `beforeAll` in `__bench__` is inert. It is not.
+ *
+ * Priming lazily on first use is still the better shape, for a reason that does
+ * hold: the workdir is then owned by the code that needs it, cleanup is tied to
+ * process exit rather than to a hook whose ordering relative to repeated
+ * instrumented invocations is easy to get wrong, and a cold run stays entirely
+ * self-contained.
  *
  * Lazily initialising on first call sidesteps both: it runs in whichever context
  * the bench body runs in, and it primes exactly once per context.

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -3913,18 +3913,12 @@ abstract class ShardDO {
         for (const ws of sockets) {
             const attachment = this.readAttachment(ws);
             // `Object.keys`, not `Object.entries`: this runs once per socket for
-            // every mutation, and `entries` allocates a fresh [key, value] pair
-            // array per socket — two allocations each for the common
-            // one-subscription socket — before a single subscription has been
-            // tested. The sockets that do NOT match paid the same price as the
-            // ones that did, which is why a 500-socket fan-out where only 10%
-            // matched still cost two thirds of the all-match case (30.5 -> 12.4 us;
-            // all-match 45.3 -> 28.0 us).
+            // every mutation, and `entries` allocates a pair array per socket
+            // before any subscription has been tested — so sockets that match
+            // nothing pay the same as sockets that do.
             //
-            // NOT `for...in`, which measured slightly faster still but walks
-            // inherited enumerable keys. `Object.keys` is own-only, exactly like
-            // the `Object.entries` it replaces, so this is a pure allocation fix
-            // with no change in which subscriptions are visited.
+            // NOT `for...in`: it walks inherited enumerable keys, where
+            // `Object.entries` was own-only. See the "never inherited ones" test.
             const { subs } = attachment;
 
             for (const subId of Object.keys(subs)) {
@@ -9113,9 +9107,6 @@ abstract class ShardDO {
             const delivery = this.socketDelivery(attachment);
 
             // `Object.keys` for the same reason as `broadcastDelta` — see there.
-            // This loop skips most subscriptions on most flushes via the memo
-            // gates below, so the per-socket `entries` allocation was paid mainly
-            // by sockets that then did nothing.
             const { subs } = attachment;
 
             for (const subId of Object.keys(subs)) {

--- a/packages/notify/src/web.ts
+++ b/packages/notify/src/web.ts
@@ -14,6 +14,8 @@
  */
 
 /** A plain, JSON-serialisable Web Push subscription (the shape `ctx.push.register` accepts). */
+import { fromBase64Url } from "../../../shared/base64";
+
 interface SerializedPushSubscription {
     endpoint: string;
     expirationTime: number | null;
@@ -42,18 +44,7 @@ interface SubscribeToPushOptions {
 }
 
 /** Convert a base64url string to the `Uint8Array` `pushManager.subscribe` wants for `applicationServerKey`. */
-const urlBase64ToUint8Array = (base64: string): Uint8Array => {
-    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
-    const normalized = (base64 + padding).replaceAll("-", "+").replaceAll("_", "/");
-    const raw = atob(normalized);
-    const output = new Uint8Array(raw.length);
-
-    for (let index = 0; index < raw.length; index += 1) {
-        output[index] = raw.codePointAt(index) ?? 0;
-    }
-
-    return output;
-};
+const urlBase64ToUint8Array = (base64: string): Uint8Array => fromBase64Url(base64);
 
 /** Byte-for-byte equality of two `Uint8Array`s (VAPID application-server keys). */
 const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => a.length === b.length && a.every((byte, index) => byte === b[index]);

--- a/packages/runtime/src/connector-cdc.ts
+++ b/packages/runtime/src/connector-cdc.ts
@@ -6,6 +6,7 @@
  * the connector wire shape. All functions here are pure — no worker options, no
  * I/O — so they live free of `create-worker` and are unit-testable in isolation.
  */
+import { fromBase64Url, toBase64Url } from "../../../shared/base64";
 import type { ConnectorChange } from "./connector-format";
 
 /** Reusable encoder for the cursor codec (base64url over the JSON state). */
@@ -31,17 +32,7 @@ interface ConnectorCursorState {
  * consumer stores it verbatim and re-posts it to resume — it never parses it,
  * so the internal shape stays free to change behind the version tag.
  */
-const encodeConnectorCursor = (state: ConnectorCursorState): string => {
-    const json = JSON.stringify(state);
-    const bytes = CURSOR_ENCODER.encode(json);
-    let binary = "";
-
-    for (const byte of bytes) {
-        binary += String.fromCodePoint(byte);
-    }
-
-    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
-};
+const encodeConnectorCursor = (state: ConnectorCursorState): string => toBase64Url(CURSOR_ENCODER.encode(JSON.stringify(state)));
 
 /**
  * Decode an opaque connector cursor token back to its {@link ConnectorCursorState}.
@@ -57,14 +48,7 @@ const decodeConnectorCursor = (token: unknown): ConnectorCursorState => {
     }
 
     try {
-        const binary = atob(token.replaceAll("-", "+").replaceAll("_", "/"));
-        const bytes = new Uint8Array(binary.length);
-
-        for (let index = 0; index < binary.length; index += 1) {
-            bytes[index] = binary.codePointAt(index) ?? 0;
-        }
-
-        const parsed = JSON.parse(new TextDecoder().decode(bytes)) as Partial<ConnectorCursorState>;
+        const parsed = JSON.parse(new TextDecoder().decode(fromBase64Url(token))) as Partial<ConnectorCursorState>;
         const shards = parsed.s && typeof parsed.s === "object" ? parsed.s : {};
         const sanitized: Record<string, number> = {};
 

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -1,3 +1,4 @@
+import { toBase64Url } from "../../../shared/base64";
 import { jsonResponse } from "../../../shared/json-response";
 import type { RetryPolicy, ScheduleRecord } from "./types";
 
@@ -122,17 +123,7 @@ const MAX_SCHEDULED_FOR_MS = 999_999_999_999_999;
 const TIME_PAD = 15;
 const padTime = (n: number): string => String(n).padStart(TIME_PAD, "0");
 
-const base64url = (bytes: Uint8Array): string => {
-    let binary = "";
-
-    for (const byte of bytes) {
-        binary += String.fromCodePoint(byte);
-    }
-
-    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
-};
-
-const generateId = (): string => base64url(crypto.getRandomValues(new Uint8Array(12)));
+const generateId = (): string => toBase64Url(crypto.getRandomValues(new Uint8Array(12)));
 
 interface ScheduleRequestBody {
     args: Record<string, unknown>;
@@ -878,7 +869,7 @@ class SchedulerDO {
         const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { hash: "SHA-256", name: "HMAC" }, false, ["sign"]);
         const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
 
-        return base64url(new Uint8Array(signature));
+        return toBase64Url(new Uint8Array(signature));
     }
 
     /**

--- a/packages/shard-engine/__tests__/ctx-db.order-tiebreak.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.order-tiebreak.test.ts
@@ -92,6 +92,49 @@ describe("implicit id tiebreak follows the sort direction", () => {
         expect(seen).toStrictEqual(seen.toSorted((left, right) => right.localeCompare(left)));
     });
 
+    it("refuses a cursor minted before the tiebreak changed direction", async () => {
+        expect.assertions(4);
+
+        const { harness, writer } = await seeded(6);
+
+        // What a pre-change build handed the client: the raw base64 tuple, with
+        // no marker. The BYTES of a cursor never changed — only the direction the
+        // seek reads them in — so this is byte-for-byte what was in flight.
+        const legacy = btoa(JSON.stringify([1_700_000_000_000, "b"]));
+
+        // Seeking with it used to return rows from the wrong side of the tie
+        // group: measured on this exact fixture it produced a row from the
+        // PREVIOUS page and made four rows unreachable. Silently, and shaped
+        // exactly like a correct page. A typed 400 is recoverable; that is not.
+        await expect(writer.findMany("events", { cursor: legacy, limit: 2, orderBy: [{ _creationTime: "desc" }] })).rejects.toThrow(/invalid cursor/iu);
+
+        // The case above rejects even without the marker check, because slicing
+        // two characters off unaligned base64 happens to break JSON.parse — an
+        // accident, not a guarantee. This one does not: it is a real payload
+        // behind a WRONG two-character marker, so dropping the check would slice
+        // it cleanly and seek with values it should have refused. It also covers
+        // a future marker being handed to this build.
+        const wrongMarker = `~9${legacy}`;
+
+        await expect(writer.findMany("events", { cursor: wrongMarker, limit: 2, orderBy: [{ _creationTime: "desc" }] })).rejects.toThrow(/invalid cursor/iu);
+
+        // A cursor this build mints round-trips, and carries the marker that
+        // makes the two distinguishable at all.
+        const page = await writer.findMany("events", { limit: 2, orderBy: [{ _creationTime: "desc" }] });
+
+        expect(page.continueCursor).toMatch(/^~2/u);
+
+        const next: { page: Record<string, unknown>[] } = await writer.findMany("events", {
+            cursor: page.continueCursor,
+            limit: 2,
+            orderBy: [{ _creationTime: "desc" }],
+        });
+
+        expect(next.page).toHaveLength(2);
+
+        harness.close();
+    });
+
     it("keeps the declared index usable for a descending page (no temp b-tree)", async () => {
         expect.assertions(2);
 

--- a/packages/shard-engine/__tests__/query-args.test.ts
+++ b/packages/shard-engine/__tests__/query-args.test.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { renderSql } from "../src/drizzle";
-import { buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "../src/query-args";
+import { buildSeekWhere, CURSOR_PREFIX, decodeCursor, encodeCursor, normalizeOrderKeys } from "../src/query-args";
 import type { WhereSqlStrategy } from "../src/where-sql";
 import { compileWhereSql } from "../src/where-sql";
 import type { WhereInput } from "../src/where-types";
@@ -70,9 +70,21 @@ describe("encodeCursor / decodeCursor", () => {
     it("rejects a non-array payload", () => {
         expect.assertions(1);
 
-        const bogus = btoa(JSON.stringify({ not: "an array" }));
+        // Carries the format marker on purpose. Without it the marker check
+        // rejects first and this stops exercising the shape check it is named
+        // for — passing for the wrong reason.
+        const bogus = CURSOR_PREFIX + btoa(JSON.stringify({ not: "an array" }));
 
         expect(() => decodeCursor(bogus)).toThrow("invalid cursor");
+    });
+
+    it("rejects a cursor with no format marker", () => {
+        expect.assertions(1);
+
+        // A cursor minted before the tiebreak direction changed. Its bytes are a
+        // perfectly good payload; only the seek's reading of them moved, so the
+        // marker is the sole thing that can tell the two apart.
+        expect(() => decodeCursor(btoa(JSON.stringify([1, "row-1"])))).toThrow("invalid cursor");
     });
 });
 

--- a/packages/shard-engine/src/ctx-db-migrations.ts
+++ b/packages/shard-engine/src/ctx-db-migrations.ts
@@ -60,7 +60,9 @@ import { recordSchemaVersion } from "./schema-history";
  * gone from the plan.
  *
  * DESC reads keep the index too (SQLite walks it backwards); only a MIXED
- * direction (`_creationTime DESC, id ASC`) still needs a partial sort.
+ * direction would still need a partial sort — which is why the implicit `id`
+ * tiebreak follows the last sort key's direction (see `tiebreakDirectionFor`),
+ * so a descending read stays an index walk rather than producing that shape.
  *
  * The geo and rank companions (below) already index their sort keys. This brings
  * the user-declared index in line with them.

--- a/packages/shard-engine/src/ctx-db-rank-page.ts
+++ b/packages/shard-engine/src/ctx-db-rank-page.ts
@@ -31,7 +31,7 @@ import type { SchemaLike, SqlExec, TableDefinitionLike } from "./ctx-db";
 import { SCAN_DEP } from "./dependency-tracker";
 import { runDrizzle } from "./do-exec";
 import { sqliteInList } from "./drizzle";
-import { decodeCursor, toBase64 } from "./query-args";
+import { CURSOR_PREFIX, decodeCursor, toBase64 } from "./query-args";
 import { encodePartitionKey, RANK_TIEBREAK, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
 import type { RankDirection, RankIndexDefinitionLike, RankPageOptions, RankPageRowKey } from "./schema-types";
 
@@ -44,7 +44,7 @@ const DOC_COLUMN = "__doc__";
  * `findMany`/`paginate`. Not `encodeCursor` (which is row-shaped) — rank
  * cursors are N-tuples.
  */
-const encodeRankCursor = (values: ReadonlyArray<unknown>): string => toBase64(JSON.stringify(values));
+const encodeRankCursor = (values: ReadonlyArray<unknown>): string => CURSOR_PREFIX + toBase64(JSON.stringify(values));
 
 /**
  * Resolve a `rankPage` keyset resume point to the flat `[partitionKey,

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -1202,7 +1202,7 @@ const compileOrderByText = (keys: OrderKey[]): string => {
     return parts.join(", ");
 };
 
-/** Drizzle ORDER BY for the DO: each key as `<jsonPath> ASC|DESC`, with an `id ASC` tiebreak unless an id field is already ordered (keeps paging deterministic). The drizzle twin of `compileOrderBy`. */
+/** Drizzle ORDER BY for the DO: each key as `<jsonPath> ASC|DESC`, with an `id` tiebreak in the last key's direction (see `tiebreakDirectionFor`) unless an id field is already ordered. The drizzle twin of `compileOrderBy`. */
 const compileOrderBySql = (keys: OrderKey[]): SQL => {
     const parts = keys.map((key) => dsql`${jsonPathSql(key.field)} ${dsql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -266,6 +266,7 @@ export {
     applySelect,
     buildSeekBeforeWhere,
     buildSeekWhere,
+    CURSOR_PREFIX,
     decodeCursor,
     encodeCursor,
     normalizeOrderKeys,

--- a/packages/shard-engine/src/query-args.ts
+++ b/packages/shard-engine/src/query-args.ts
@@ -41,7 +41,7 @@ const TIEBREAK_FIELD = "id";
  * seek that disagrees with its own ORDER BY about tie direction skips or repeats
  * rows at a page boundary where the sort keys tie.
  */
-const tiebreakDirectionFor = (keys: ReadonlyArray<OrderKey>): SortDirection => (keys.at(-1)?.direction === "desc" ? "desc" : "asc");
+const tiebreakDirectionFor = (keys: ReadonlyArray<{ direction?: string }>): SortDirection => (keys.at(-1)?.direction === "desc" ? "desc" : "asc");
 
 const ID_FIELDS = new Set(["_id", "id"]);
 
@@ -97,6 +97,28 @@ const fromBase64 = (encoded: string): string => {
 };
 
 /**
+ * Prefix stamped on every cursor this build mints.
+ *
+ * A cursor is an opaque `[...sortValues, id]` tuple with no self-describing
+ * shape, so its BYTES cannot tell you which seek predicate was meant to read
+ * them. When the implicit `id` tiebreak changed direction (see
+ * {@link tiebreakDirectionFor}), the bytes stayed identical and only their
+ * MEANING moved: a cursor minted under `… DESC, id ASC` fed to the `… DESC,
+ * id DESC` predicate seeks the wrong way through a group of rows that tie on
+ * the real sort key.
+ *
+ * That is not hypothetical. A mounted paginated feed holds its page boundaries
+ * in client state for the life of the component and replays them on every
+ * reactive re-run, so a deploy hands pre-change cursors straight to the changed
+ * predicate. Measured on six rows tied on one `_creationTime`: the page came
+ * back holding a row from the PREVIOUS page while four rows became unreachable.
+ *
+ * `~` is deliberately outside the base64 alphabet, so a legacy (unprefixed)
+ * cursor can never be mistaken for a prefixed one whatever its payload.
+ */
+const CURSOR_PREFIX = "~2";
+
+/**
  * Encode the sort key of `doc` (the values of each `orderBy` field, then its
  * id) as an opaque base64 cursor. The id is always included so the seek has a
  * unique terminal column.
@@ -111,7 +133,7 @@ const encodeCursor = (record: Record<string, unknown>, keys: OrderKey[]): string
     // in here and threw `TypeError: Do not know how to serialize a BigInt` — the
     // same defect class this store's blob codec exists to fix, surviving in the
     // cursor. Identity for pure-JSON keys, so existing cursors are byte-identical.
-    return toBase64(JSON.stringify(encodeWire(values)));
+    return CURSOR_PREFIX + toBase64(JSON.stringify(encodeWire(values)));
 };
 
 /**
@@ -124,10 +146,19 @@ const invalidCursor = (): LunoraError => new LunoraError("BAD_REQUEST", "invalid
 
 /** Decode a cursor back into its ordered sort-key values (orderBy fields, then id). */
 const decodeCursor = (cursor: string): unknown[] => {
+    // Refuse an unprefixed cursor rather than seek with it. It was minted by a
+    // build whose tiebreak ran the other way, so reading it here returns rows
+    // from the wrong side of the tie group — silently, and looking exactly like
+    // a correct page. A typed 400 is recoverable (the client resets the feed);
+    // wrong rows presented as right ones are not.
+    if (!cursor.startsWith(CURSOR_PREFIX)) {
+        throw invalidCursor();
+    }
+
     let decoded: unknown;
 
     try {
-        decoded = decodeWire(JSON.parse(fromBase64(cursor)));
+        decoded = decodeWire(JSON.parse(fromBase64(cursor.slice(CURSOR_PREFIX.length))));
     } catch {
         // atob() throws InvalidCharacterError on non-base64 input, JSON.parse
         // throws SyntaxError on malformed JSON, and `decodeWire` throws
@@ -280,6 +311,7 @@ export {
     applySelect,
     buildSeekBeforeWhere,
     buildSeekWhere,
+    CURSOR_PREFIX,
     decodeCursor,
     encodeCursor,
     fromBase64,

--- a/packages/sql-store/__tests__/ctx-db.test.ts
+++ b/packages/sql-store/__tests__/ctx-db.test.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 
 import { MAX_SEARCH_SCAN } from "@lunora/search-core";
 import type { SchemaLike, ValidatorLike } from "@lunora/shard-engine";
+import { CURSOR_PREFIX } from "@lunora/shard-engine";
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -755,7 +756,9 @@ describe("createSqlCtxDb — cross-dialect SQL rendering", () => {
             const writer = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(engine), exec, schema: rankSchema });
 
             // A 4-element cursor matches [partition, sort_0, sort_1, __id__].
-            const cursor = btoa(JSON.stringify(["0", 30, "a", "x"]));
+            // Minted the way the engine mints them: `decodeCursor` refuses a
+            // cursor without the format marker.
+            const cursor = CURSOR_PREFIX + btoa(JSON.stringify(["0", 30, "a", "x"]));
 
             await writer.rankPage("notes", "byPriority", { cursor, take: 2 });
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -67,6 +67,7 @@ import {
     compileWhereSql,
     ConflictError,
     CountRlsUnsupportedError,
+    CURSOR_PREFIX,
     cursorBelowRetainedFloor,
     decodeCursor,
     encodeAggregateKey,
@@ -151,11 +152,9 @@ const compileOrderBySql = (keys: ReadonlyArray<{ direction?: string; field: stri
     const parts = keys.map((key) => sql`${columnRefSql(key.field)} ${sql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 
     if (!keys.some((key) => ID_ORDER_FIELDS.has(key.field))) {
-        const tiebreak = tiebreakDirectionFor(
-            keys.map((key) => {
-                return { direction: key.direction === "desc" ? "desc" : "asc", field: key.field };
-            }),
-        );
+        // No adaptation: the helper reads `direction` off the last key and
+        // nothing else, so the keys go in as they are.
+        const tiebreak = tiebreakDirectionFor(keys);
 
         parts.push(sql`${columnRefSql("id")} ${sql.raw(tiebreak === "desc" ? "DESC" : "ASC")}`);
     }
@@ -641,7 +640,14 @@ const hydrateRankRows = async (
     return documents;
 };
 
-/** Base64-encode a rankPage continuation cursor (the `[partition, ...sortValues, id]` tuple) as JSON. */
+/**
+ * Base64-encode a rankPage continuation cursor (the `[partition, ...sortValues, id]`
+ * tuple) as JSON, behind the shared cursor marker.
+ *
+ * The marker is not decoration: `decodeCursor` refuses anything without it, so
+ * a mint site that forgets it produces cursors its own reader rejects. This one
+ * did, and only the rank pagination test caught it.
+ */
 const encodeRankCursor = (cursorValues: ReadonlyArray<unknown>): string => {
     const json = JSON.stringify(cursorValues);
     const bytes = new TextEncoder().encode(json);
@@ -651,7 +657,7 @@ const encodeRankCursor = (cursorValues: ReadonlyArray<unknown>): string => {
         binary += String.fromCodePoint(byte);
     }
 
-    return btoa(binary);
+    return CURSOR_PREFIX + btoa(binary);
 };
 
 /**

--- a/packages/storage/__bench__/signed-url.bench.ts
+++ b/packages/storage/__bench__/signed-url.bench.ts
@@ -1,5 +1,6 @@
 import { beforeAll, bench, describe } from "vitest";
 
+import { fromBase64Url } from "../../../shared/base64";
 import { buildSignedUrl, verifySignedUrl } from "../src/signed-url";
 
 /**
@@ -22,19 +23,10 @@ const textEncoder = new TextEncoder();
 const importUncached = async (secret: string): Promise<CryptoKey> =>
     crypto.subtle.importKey("raw", textEncoder.encode(secret), { hash: "SHA-256", name: "HMAC" }, false, ["sign", "verify"]);
 
-// Reproduce verify's canonicalize + fromBase64Url inline for the uncached
-// baseline so the only difference vs the cached path is the key import.
-const fromBase64Url = (input: string): Uint8Array => {
-    const padded = input.replaceAll("-", "+").replaceAll("_", "/") + "===".slice((input.length + 3) % 4);
-    const binary = atob(padded);
-    const bytes = new Uint8Array(binary.length);
-
-    for (let index = 0; index < binary.length; index += 1) {
-        bytes[index] = binary.codePointAt(index) ?? 0;
-    }
-
-    return bytes;
-};
+// Reproduce verify's canonicalize inline for the uncached baseline so the only
+// difference vs the cached path is the key import. The decode itself comes from
+// `shared/base64` — the same function verify uses, so the bench cannot drift
+// from it (an earlier inline copy outlived the implementation it mirrored).
 
 // Async state the benches close over — seeded in beforeAll (see below).
 let signedUrl: string;


### PR DESCRIPTION
Acts on a review of the five changes merged in the last wave (#493, #494, #495, #498, #499). One real defect, two false comments, an incomplete dedup, and a review blind spot.

## The defect: #495 changed what existing cursors mean

Making the implicit `id` tiebreak follow the sort direction did not change a cursor's bytes — it changed their **meaning**. A cursor is an opaque `[...sortValues, id]` tuple with no version tag, so nothing could distinguish the two readings.

It is reachable. `use-paginated-core.ts` keeps page boundaries in `useState` for the component's life and replays `{cursor, endCursor}` on every reactive re-run, so a deploy feeds pre-change cursors to the changed predicate. Reproduced on six rows sharing one `_creationTime`:

```
current order:                          f,e,d,c,b,a
page with pre-#495 boundaries (b..d) →  [a]        (old semantics: [c,d])
```

Not empty — it returns a row from the *previous* page and makes four rows unreachable, silently, shaped exactly like a correct page.

Cursors now carry a two-character marker outside the base64 alphabet; one without it is refused as the existing typed 400. A client resets the feed and recovers. Wrong rows presented as right ones do not.

**Three mint sites feed one reader** and only the first was obvious — the DO's row cursors, shard-engine's rank cursors, and `sql-store`'s rank cursors. The last two surfaced as test failures, which is why the marker lives on the package index rather than in one module.

Credit where due: CodeRabbit flagged this risk on #495 (*"cursors created before deployment may be incompatible during mixed-version rollouts"*) and it was merged without a response.

## Two comments asserted things that are false

The codegen bench claimed `beforeAll` runs in a different context from bench bodies under CodSpeed's instrumented runner. **It does not** — `AnalysisRunner` calls the suite's `beforeAll`/`afterAll` around the benchmarks in the same process, which I verified in the plugin source and with a probe. Left standing, that claim implies the 28 bench files using `beforeAll` are inert. They are fine. The lazy priming stays (it is still the better shape); its justification is now accurate.

`ctx-db.ts` still documented an `id ASC` tiebreak, and `ctx-db-migrations.ts` still described the mixed-direction shape as current — in the docblock that justifies the index sort keys.

## The dedup was one of four

`shared/base64.ts` calls itself the canonical base64url home. Three copies were still hand-rolling it (`connector-cdc`, `scheduler-do`, `notify/web`), and a storage bench inlined the exact decoder #498 deleted under a comment claiming it mirrors verify. All four now use the shared one.

## `shared/` was invisible to review

It matched no path filter in `.coderabbit.yaml`, so #494 and #498 were skipped in full — the tree holding the cache-key encoder and the signed-URL codec. One line.

## Smaller

- `tiebreakDirectionFor` reads one field off the last key, so demanding a full `OrderKey[]` made the `sql-store` caller allocate N objects to inspect one string. Widened; adapter deleted.
- The team-chat assertion sorted with `localeCompare`, depending on the runner's ICU build — the exact locale sensitivity the key encoder documents avoiding. Set comparison instead.
- `broadcastDelta`'s comment pinned numbers measured against a fake whose `deserializeAttachment` is a field read, where workerd does a structured-clone deserialize per socket. Numbers cut; the qualitative claim stands.

## Measured and not taken

A single-pass `fromBase64Url` to match the encoder: **1.61x faster at 32 bytes, but 1.14x and 1.77x slower at 64 bytes and 4 KB.** Native `atob` beats a JS loop once inputs grow — the opposite of the encode side, where three `replaceAll` passes were the cost. Reverted.

An earlier draft of it also *skipped* invalid characters where `atob` throws. `decodeUserIdHeader` turns a throw into "anonymous", so that would have let a malformed header decode to garbage bytes and yield a userId nobody sent. An existing test caught it — worth recording as the reason that function must keep throwing.

## Verification

Full suite `--no-cache`: **108/108 task groups green**. `api:check` clean across 54 snapshots (the two additions are in the diff), `lint:types` 75 projects, `lint:eslint` 58 projects, prettier clean.

The cursor-rejection test was checked for vacuity: a legacy cursor alone rejects even without the marker check (slicing unaligned base64 happens to break `JSON.parse`), so the test also feeds a real payload behind a *wrong* marker — which does pass through without the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioning to keyset cursors with a `~2` prefix.
  * Invalid or unrecognized cursor formats are now rejected with a clear bad-request error.
  * Exposed the cursor version prefix for integrations that need to identify supported cursor formats.

* **Compatibility**
  * Existing unprefixed cursors are no longer accepted and may need to be regenerated.

* **Documentation**
  * Clarified sorting and cursor behavior for descending queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->