### PR TITLE
fix(team-chat): say goodbye on pagehide, not on every effect teardown

### DIFF
--- a/examples/team-chat/src/client/Channel.tsx
+++ b/examples/team-chat/src/client/Channel.tsx
@@ -57,9 +57,34 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
 
         const timer = globalThis.setInterval(beat, HEARTBEAT_MS);
 
+        // `leave` says goodbye for the TAB, so it hangs off `pagehide` rather than
+        // off this effect's cleanup.
+        //
+        // Cleanup runs on every re-run of the effect, not only when the tab goes
+        // away — and under StrictMode React deliberately runs mount, cleanup, mount
+        // back to back. Wired to cleanup, that issued heartbeat, leave, heartbeat as
+        // three separate RPCs over `POST /_lunora/rpc`, which carries no ordering
+        // guarantee between requests. Whenever the leave landed last it deleted the
+        // row the second heartbeat had just written, and that member vanished from
+        // the roster until the next beat 15 seconds later.
+        //
+        // That is what made the presence assertion in the team-chat e2e fail
+        // intermittently, seeing 0 or 1 of 2 members while the messages those same
+        // members had just exchanged rendered fine.
+        //
+        // On `pagehide` there is no remount to race. Switching channels no longer
+        // sends an explicit goodbye and ages out of the old roster via
+        // PRESENCE_TTL_MS instead — which is what that TTL is for, and why the
+        // staleness cut already lives on the client.
+        const goodbye = (): void => {
+            void leave({ channelId, sessionId }, { shardKey: channelId });
+        };
+
+        globalThis.addEventListener("pagehide", goodbye);
+
         return () => {
             globalThis.clearInterval(timer);
-            void leave({ channelId, sessionId }, { shardKey: channelId });
+            globalThis.removeEventListener("pagehide", goodbye);
         };
     }, [channelId, displayName, heartbeat, leave, sessionId]);
 


### PR DESCRIPTION
Fixes the team-chat e2e flake — and the reason it flaked is a real defect in the example, not test timing.

## The symptom

`team-chat.spec.ts:30` asserts the presence roster shows 2 members. It has failed on two unrelated PRs (#502, #503), seeing **1 of 2** once and **0 of 2** the next time, while the messages those same members had just exchanged rendered fine in the same run.

A varying count with working message delivery is not a broken assertion. It is a roster that loses people.

## The cause

`leave` is documented as *"Best-effort goodbye on tab close"* — but it was wired to the heartbeat effect's **cleanup**. Cleanup runs on every re-run of that effect, not only when the tab goes away, and under StrictMode React deliberately runs **mount → cleanup → mount** back to back.

Both halves hold here: the app is wrapped in `<StrictMode>` (`src/client/main.tsx`), and the e2e serves it from the **Vite dev server** (`globalSetup.ts`). So that path ran on every channel open.

The effect therefore issued three separate RPCs:

```
beat()    → heartbeat   (writes the presence row)
cleanup   → leave       (DELETES it)
beat()    → heartbeat   (writes it again)
```

These go over `POST /_lunora/rpc` as independent requests, which carries no ordering guarantee. Whenever the leave landed **last**, it deleted the row the second heartbeat had just written — and that member stayed missing until the next beat **15 seconds** later. The assertion gives up at 10.

A real user sees the same thing: open a channel, and someone can drop off the roster for 15 seconds.

## The fix

Move the goodbye to `pagehide`, where there is no remount to lose to. That removes the race rather than widening a timeout.

Switching channels no longer sends an explicit goodbye and ages out of the old roster via `PRESENCE_TTL_MS` instead — which is exactly what that TTL is for, and why the staleness cut already lives on the client rather than in the query.

## What I ruled out first

So this is a diagnosis rather than a guess at the timing:

- **Missing initial heartbeat** — no: `beat()` runs on mount, not only on the interval.
- **TTL too tight against the beat** — no: 30s TTL against a 15s heartbeat is a 2x margin.
- **Effect thrashing on every render** — no: `mutate` is referentially stable via `useCallback`, and that hook's comment calls the memoization load-bearing "for consumers that place it in effect deps", which is this exact case.

## Verification

`@lunora-example/team-chat` 7 passing, `lint:types` clean, eslint clean, prettier clean.

**I could not run the e2e suite locally to reproduce it**: its inspector port (9230) is held by an unrelated project on this machine, and the config pins it. So CI is the check on this one — the honest position is that the mechanism is evidenced and the fix follows from it, but the before/after has not been observed end to end.

If it recurs after this, the next thing I would look at is presence propagation latency versus the 10s assertion window, which is the remaining candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fJuLhuqLNnWwP1F9zqmPc
