### PR TITLE
fix(codegen): generated output that resolves, from a cold tree, in one run

### DIFF
--- a/apps/playground/lunora/notes.ts
+++ b/apps/playground/lunora/notes.ts
@@ -49,15 +49,22 @@ export const list = query.use(notesReadRls).query(async ({ ctx }): Promise<Doc<"
  * Deliberately annotated with an imported PACKAGE alias and deliberately
  * without `.output()`: that is the exact shape whose inferred return type used
  * to reach `_generated/api.ts` as a bare, unimported `PaginationResult` —
- * TS2304 in generated output, invisible to every unit test because emitted code
- * is only ever compiled inside a real app. `tsconfig.generated.json` compiles
- * it here, so this procedure is the CI gate for that class (issue #509). Keep
- * the annotation, keep the import, and do not add `.output()`.
+ * TS2304 in generated output (issue #509).
+ *
+ * This is the INTEGRATION half of the gate for that class: `lint:types` compiles
+ * `lunora/_generated/**` under `tsconfig.generated.json`, against a real
+ * `node_modules`, so it also proves the umbrella rewrite actually resolves —
+ * which a sandboxed unit test cannot. The unit half lives where the emitter does
+ * (`packages/codegen/__tests__/run-codegen.test.ts`) and cannot be disarmed from
+ * here. Keep the annotation, keep the import, and do not add `.output()`.
  */
 export const listPage = query
     .input({
         cursor: v.optional(v.string().check((value) => value.length <= 512, { message: "must be at most 512 characters", schema: { maxLength: 512 } })),
-        numItems: v.number(),
+        numItems: v.number().check((value) => Number.isInteger(value) && value > 0 && value <= 200, {
+            message: "must be a whole number between 1 and 200",
+            schema: { maximum: 200, minimum: 1, type: "integer" },
+        }),
     })
     .use(notesReadRls)
     .query(

--- a/apps/playground/lunora/notes.ts
+++ b/apps/playground/lunora/notes.ts
@@ -1,6 +1,6 @@
 import type { RateLimitConfigMap } from "@lunora/ratelimit";
 import { dbRateLimit } from "@lunora/ratelimit";
-import type { Middleware } from "lunorash/server";
+import type { Middleware, PaginationResult } from "lunorash/server";
 import { definePolicies, definePolicy, rls } from "lunorash/server";
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- "Doc" is the generated dataModel type name; aliasing it breaks codegen
@@ -41,6 +41,29 @@ const notesWriteRls = rls(policies) as unknown as Middleware<MutationCtx, Mutati
  * to prove the policy (not the handler) is the isolation boundary.
  */
 export const list = query.use(notesReadRls).query(async ({ ctx }): Promise<Doc<"notes">[]> => ctx.db.query("notes").take(200));
+
+/**
+ * One page of the caller's notes, under the same RLS read policy as
+ * {@link list}.
+ *
+ * Deliberately annotated with an imported PACKAGE alias and deliberately
+ * without `.output()`: that is the exact shape whose inferred return type used
+ * to reach `_generated/api.ts` as a bare, unimported `PaginationResult` —
+ * TS2304 in generated output, invisible to every unit test because emitted code
+ * is only ever compiled inside a real app. `tsconfig.generated.json` compiles
+ * it here, so this procedure is the CI gate for that class (issue #509). Keep
+ * the annotation, keep the import, and do not add `.output()`.
+ */
+export const listPage = query
+    .input({
+        cursor: v.optional(v.string().check((value) => value.length <= 512, { message: "must be at most 512 characters", schema: { maxLength: 512 } })),
+        numItems: v.number(),
+    })
+    .use(notesReadRls)
+    .query(
+        async ({ args, ctx }): Promise<PaginationResult<Doc<"notes">>> =>
+            await ctx.db.query("notes").paginate({ cursor: args.cursor, numItems: args.numItems }),
+    );
 
 /**
  * Add a note owned by the caller. `createdAt` is stamped by the client so the

--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { Project } from "ts-morph";
+import { ModuleKind, ModuleResolutionKind, Project, ScriptTarget } from "ts-morph";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { discoverFunctions } from "../src/discover-functions";
@@ -474,15 +474,15 @@ describe("discoverFunctions", () => {
             expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("{ a: string; b: number }");
         });
 
-        it("expands a user's own `Doc` — the dataModel exemption is by declaration path, never by name", () => {
+        it("qualifies a user's own `Doc` — the dataModel exemption is by declaration path, never by name", () => {
             expect.assertions(1);
 
             // `Doc`/`Id` print correctly bare only because emit imports THOSE from
             // `./dataModel.js`. Exempting the NAME instead of the declaration path
-            // is worse than the leak it guards: `referencedDataModelImports`
-            // triggers on `\bDoc<`, so a user's own generic `Doc` would be emitted
-            // bare AND given the generated import — silently bound to a different
-            // type, with no compile error anywhere to show for it.
+            // is worse than the leak it guards: a user's own generic `Doc` would be
+            // emitted bare AND given the generated import — silently bound to a
+            // different type, with no compile error anywhere to show for it.
+            // Qualified by the user's own module, it can be neither.
             writeFunction("lib/mydoc.ts", `export type Doc<T extends string> = { table: T; body: string };`);
 
             writeFunction(
@@ -499,7 +499,67 @@ describe("discoverFunctions", () => {
 
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
 
-            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('{ table: "posts"; body: string }');
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/mydoc").Doc<"posts">');
+        });
+
+        it("qualifies a PACKAGE type the handler imports — a module `.d.ts` is no more reachable than a user's own file (#509)", () => {
+            expect.assertions(1);
+
+            // Every `.d.ts` and everything under `node_modules` used to be waved
+            // through as "prints correctly bare", on the reasoning that reached
+            // `Date` and the rest of `lib.*.d.ts`. But those are GLOBAL; a
+            // module-scoped declaration in a package is reachable only through an
+            // import, and `_generated/` has none — so a handler returning an
+            // imported `PaginationResult` (or `lunorash/server`'s own) wrote the
+            // bare name into `api.ts` as a TS2304 while `lunora codegen` exited 0.
+            writeFunction("node_modules/pkg/package.json", `{ "name": "pkg", "version": "1.0.0", "types": "index.d.ts" }`);
+            writeFunction("node_modules/pkg/index.d.ts", `export interface Page<T> { items: T[]; cursor: string | null }`);
+
+            writeFunction(
+                "feed.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Page } from "pkg";
+
+            declare const load: () => Promise<Page<string>>;
+
+            export const list = query({ args: {}, handler: async () => await load() });
+        `,
+            );
+
+            const project = new Project({
+                compilerOptions: { module: ModuleKind.ESNext, moduleResolution: ModuleResolutionKind.Bundler, strict: true, target: ScriptTarget.ES2022 },
+                skipAddingFilesFromTsConfig: true,
+                useInMemoryFileSystem: false,
+            });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("pkg").Page<string>');
+        });
+
+        it("leaves a GLOBAL declaration bare — `lib.*.d.ts` resolves from `_generated/` as well as it does from the handler", () => {
+            expect.assertions(1);
+
+            // The other side of the same rule, and the reason it is keyed on
+            // "script-mode file" rather than "`.d.ts` file": expanding `Date`
+            // structurally would be wrong (it is a class instance, so the walk
+            // declines outright and the return collapses to `unknown`), and
+            // qualifying it is impossible — there is no module to name.
+            writeFunction(
+                "clock.ts",
+                `
+            import { query } from "@lunora/server";
+
+            export const now = query({ args: {}, handler: async () => ({ at: new Date(), raw: new Uint8Array() }) });
+        `,
+            );
+
+            const project = new Project({
+                compilerOptions: { module: ModuleKind.ESNext, moduleResolution: ModuleResolutionKind.Bundler, strict: true, target: ScriptTarget.ES2022 },
+                skipAddingFilesFromTsConfig: true,
+                useInMemoryFileSystem: false,
+            });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("{ at: Date; raw: Uint8Array<ArrayBuffer>; }");
         });
 
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {

--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -562,6 +562,77 @@ describe("discoverFunctions", () => {
             expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("{ at: Date; raw: Uint8Array<ArrayBuffer>; }");
         });
 
+        it("keeps an alias for an ARRAY — qualifying runs ahead of the structural branches on purpose", () => {
+            expect.assertions(1);
+
+            // `type Badges = Badge[]` is a reference the checker prints by name.
+            // Expanding it would emit `import("./lib/badges").Badge[]` and throw
+            // the alias away for nothing; worse, an alias for a union whose member
+            // cannot be reproduced would decline to `unknown` when naming it would
+            // have worked. That is the whole reason the qualifier sits above
+            // `isArray`/`isUnion`, and nothing but this test enforces the order.
+            writeFunction("lib/badges.ts", `export interface Badge { label: string }\nexport type Badges = Badge[];\n`);
+            writeFunction(
+                "badges.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Badges } from "./lib/badges";
+
+            export const list = query({ args: {}, handler: async (): Promise<Badges> => [] });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/badges").Badges');
+        });
+
+        it("keeps an alias for a UNION, rather than flattening it to its members", () => {
+            expect.assertions(1);
+
+            // The other half of the ordering rule. Moving the qualifier back below
+            // `isUnion` still passes every other test in this file.
+            writeFunction("lib/result.ts", `export type Outcome = { kind: "ok"; value: string } | { kind: "err"; reason: string };\n`);
+            writeFunction(
+                "outcome.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Outcome } from "./lib/result";
+
+            export const get = query({ args: {}, handler: async (): Promise<Outcome> => ({ kind: "ok", value: "x" }) });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/result").Outcome');
+        });
+
+        it("declines a return whose member the wire cannot encode, imported or not", () => {
+            expect.assertions(1);
+
+            // `encodeWire` throws on a class instance at the send site, so naming
+            // one types a call that can never complete. The handler imports only
+            // `Envelope` here — `Money` is therefore NOT bare-nameable, the
+            // reachability walk waves it through, and the checker prints it fully
+            // qualified. Catching that needs a gate on the whole return type, not
+            // a branch inside the expansion.
+            writeFunction("lib/money.ts", `export class Money { format(): string { return "x"; } }\nexport interface Envelope { at: Money; label: string }\n`);
+            writeFunction(
+                "wallet.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Envelope } from "./lib/money";
+
+            export const get = query({ args: {}, handler: async (): Promise<Envelope> => null as never });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("unknown");
+        });
+
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {
             expect.hasAssertions();
 

--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -633,6 +633,59 @@ describe("discoverFunctions", () => {
             expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("unknown");
         });
 
+        it("qualifies a type from an ambient `declare module` — a script-mode file is not automatically global (#511)", () => {
+            expect.assertions(1);
+
+            // The bare-name exemption is keyed on the file having no module
+            // symbol, because that is what a global looks like. A script-mode
+            // `.d.ts` can still carry `declare module "spec" { … }`, whose members
+            // are module-scoped and reachable only through an import — the
+            // ordinary packaging of `declare module "*.svg"` and of a shim for an
+            // untyped dependency. Those went out bare.
+            //
+            // The specifier has to be matched as TEXT here: an ambient module
+            // declaration has no source file for the import to resolve to, so the
+            // symbol-identity check every other path uses has nothing to compare.
+            writeFunction("amb.d.ts", `declare module "virtual:thing" {\n    export interface Badge { label: string }\n}\n`);
+            writeFunction(
+                "badges.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Badge } from "virtual:thing";
+
+            export const get = query({ args: {}, handler: async (): Promise<Badge> => ({ label: "x" }) });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("virtual:thing").Badge');
+        });
+
+        it("qualifies a DEFAULT-imported type under `default`, not under its local alias (#511)", () => {
+            expect.assertions(1);
+
+            // A default import's local name is an alias the exporting module never
+            // agreed to, so `import("./lib/boxed").Boxed` would not resolve even
+            // though `Boxed` is what the handler calls it. Matching resolves the
+            // binding rather than comparing names, and the export is written under
+            // the name the module actually publishes.
+            writeFunction("lib/boxed.ts", `interface Boxed { v: number }\nexport default Boxed;\n`);
+            writeFunction(
+                "boxed.ts",
+                `
+            import { query } from "@lunora/server";
+            import type Renamed from "./lib/boxed";
+
+            export const get = query({ args: {}, handler: async (): Promise<Renamed> => ({ v: 1 }) });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/boxed").default');
+        });
+
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {
             expect.hasAssertions();
 

--- a/packages/codegen/__tests__/emit-api.test.ts
+++ b/packages/codegen/__tests__/emit-api.test.ts
@@ -741,4 +741,28 @@ describe("emitFunctions Caller types", () => {
 
         expect(rendered).toContain("list: (args?: {}) => Promise<string>;");
     });
+
+    it("draws the dataModel import for a BARE `Doc<…>` and not for a qualified one", () => {
+        expect.assertions(4);
+
+        // The generated files import `Doc`/`Id` from `./dataModel.js` only when a
+        // rendered body actually references them, because an unused import fails
+        // the emitted file under `noUnusedLocals`. A handler may import its own
+        // generic `Doc` from its own module, which renders as
+        // `import("../lib/mydoc.js").Doc<"posts">` — that names its own module and
+        // needs nothing from here, so counting it would emit an import nobody uses
+        // and break the very file it was added to help.
+        const bare: ReadonlyArray<FunctionIR> = [{ args: {}, exportName: "get", filePath: "posts", kind: "query", returnType: 'Doc<"posts">' }];
+        const qualified: ReadonlyArray<FunctionIR> = [
+            { args: {}, exportName: "get", filePath: "posts", kind: "query", returnType: 'import("../lib/mydoc.js").Doc<"posts">' },
+        ];
+
+        for (const rendered of [emitApi({ functions: bare }), emitFunctions({ functions: bare })]) {
+            expect(rendered).toContain('import type { Doc } from "./dataModel.js";');
+        }
+
+        for (const rendered of [emitApi({ functions: qualified }), emitFunctions({ functions: qualified })]) {
+            expect(rendered).not.toContain('from "./dataModel.js"');
+        }
+    });
 });

--- a/packages/codegen/__tests__/run-codegen-cold-start.test.ts
+++ b/packages/codegen/__tests__/run-codegen-cold-start.test.ts
@@ -70,6 +70,40 @@ describe("runCodegen — cold-start reproducibility (#283)", () => {
         expect(result.generated.api).toContain('getNote: FunctionReference<"query", {}, import("./dataModel.js").Doc_notes | null>;');
     });
 
+    it("does not collapse a return inferred THROUGH api.ts on the very first pass", () => {
+        expect.assertions(2);
+
+        // The other missing declaration. `dataModel.ts`/`server.ts` can be
+        // rendered before inference because nothing in them depends on it;
+        // `api.ts` cannot, because its content IS the inference result. So a
+        // handler whose own return type reads back through the api surface — the
+        // ordinary `ctx.runQuery(api.x.y)` shape — still collapsed on a cold run
+        // and was written out collapsed, which is the half of #283 that kept
+        // consumers looping the CLI until a hash of `_generated/` stopped moving.
+        //
+        // Indexed through `keyof` rather than a `FunctionReference` so the
+        // assertion holds in this suite's checker-degraded sandbox, where
+        // `@lunora/server` does not resolve: the dependency on `api.ts` EXISTING
+        // is the same either way.
+        writeFileSync(
+            join(workdir, "lunora", "relay.ts"),
+            `import type { ApiTypes } from "./_generated/api";
+import { query } from "@lunora/server";
+
+export const names = query({
+    args: {},
+    handler: async (): Promise<keyof ApiTypes["notes"]> => "getNote",
+});
+`,
+            "utf8",
+        );
+
+        const result = runCodegen({ lint: false, projectRoot: workdir });
+
+        expect(result.generated.api).not.toContain('names: FunctionReference<"query", {}, unknown>');
+        expect(result.generated.api).toContain('names: FunctionReference<"query", {}, "getNote">;');
+    });
+
     it("first-pass functions.ts/api.ts output equals a second pass's (fixpoint from pass 1)", () => {
         expect.assertions(2);
 

--- a/packages/codegen/__tests__/run-codegen-cold-start.test.ts
+++ b/packages/codegen/__tests__/run-codegen-cold-start.test.ts
@@ -104,6 +104,34 @@ export const names = query({
         expect(result.generated.api).toContain('names: FunctionReference<"query", {}, "getNote">;');
     });
 
+    it("does not collapse a STREAMING route's chunk type on the first pass", () => {
+        expect.assertions(2);
+
+        // `route.chunkType` goes through the same `unwrapHandlerReturn` as a
+        // function return (`discover-http-routes.ts`), so `discoverHttpRoutes` has
+        // to sit inside the fixpoint alongside `discoverFunctions` and
+        // `discoverMutators`. Left outside it, a streaming route was discovered
+        // once against a cold project and never re-inferred — #283 with a smaller
+        // blast radius, and invisible because no fixpoint fixture had a route in
+        // it.
+        writeFileSync(
+            join(workdir, "lunora", "feed.ts"),
+            `import type { ApiTypes } from "./_generated/api";
+import { httpRoute } from "@lunora/server";
+
+export const feed = httpRoute.get("/api/feed").stream(async function* () {
+    yield null as unknown as keyof ApiTypes["notes"];
+});
+`,
+            "utf8",
+        );
+
+        const result = runCodegen({ lint: false, projectRoot: workdir });
+
+        expect(result.generated.api).not.toContain("HttpStreamRef<unknown");
+        expect(result.generated.api).toContain('HttpStreamRef<"getNote"');
+    });
+
     it("first-pass functions.ts/api.ts output equals a second pass's (fixpoint from pass 1)", () => {
         expect.assertions(2);
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2139,7 +2139,88 @@ export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "
                 // Qualified and rebased one level out of `_generated/`, so it
                 // resolves without an import statement of its own.
                 expect(rendered).toContain('import("../lib/shapes.js").Badge');
-                expect(rendered).not.toMatch(/[^.]\bBadge\b/u);
+                expect(rendered).not.toMatch(/(?<![.\w])Badge\b/u);
+            }
+        });
+
+        it("declines to name an imported type carrying a member the wire cannot encode", () => {
+            expect.assertions(4);
+
+            // Naming a type publishes every member of it. `Money` is a class, so
+            // `encodeWire` throws on the value at the send site
+            // (`shared/wire-codec.ts`) — but `import("../lib/money.js").Envelope`
+            // would type `result.at.format()` for every caller, a runtime
+            // TypeError with no compile error anywhere. Structural expansion
+            // already declined a bare class for exactly this reason; qualifying
+            // must not become the way around it.
+            mkdirSync(join(workdir, "lunora", "lib"), { recursive: true });
+            writeFileSync(
+                join(workdir, "lunora", "lib", "money.ts"),
+                `export class Money {
+    format(): string {
+        return "x";
+    }
+}
+
+export interface Envelope {
+    at: Money;
+    label: string;
+}
+`,
+            );
+            writeFileSync(
+                join(workdir, "lunora", "wallet.ts"),
+                `import { query } from "./_generated/server.js";
+import type { Envelope } from "./lib/money";
+
+export const get = query.input({}).query(async (): Promise<Envelope> => null as never);
+`,
+            );
+
+            const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
+
+            expect(api).toContain('get: FunctionReference<"query", {}, unknown>');
+            expect(functions).toContain("Promise<unknown>");
+
+            for (const rendered of [api, functions]) {
+                expect(rendered).not.toMatch(/Envelope|Money/u);
+            }
+        });
+
+        it("declines a tsconfig `paths` alias — it resolves under the app's config and nowhere else", () => {
+            expect.assertions(4);
+
+            // The emitted qualifier is the specifier the USER wrote, and none of
+            // emit.ts's three rebasers touch an alias. Written out verbatim it
+            // resolves under the authoring project's own tsconfig and fails from a
+            // sibling package or under a dedicated strict config for generated
+            // output — which is the pattern this repo itself ships. Falling back
+            // to structural expansion is what the type got before qualifying
+            // existed, and it always resolves.
+            writeFileSync(
+                join(workdir, "tsconfig.json"),
+                `{
+    "compilerOptions": { "moduleResolution": "bundler", "module": "ESNext", "target": "ES2022", "strict": true, "baseUrl": ".", "paths": { "~/*": ["./lunora/lib/*"] } },
+    "include": ["lunora/**/*"]
+}
+`,
+            );
+            mkdirSync(join(workdir, "lunora", "lib"), { recursive: true });
+            writeFileSync(join(workdir, "lunora", "lib", "aliased.ts"), `export interface Badge {\n    label: string;\n}\n`);
+            writeFileSync(
+                join(workdir, "lunora", "aliased.ts"),
+                `import { query } from "./_generated/server.js";
+import type { Badge } from "~/aliased";
+
+export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "x" }));
+`,
+            );
+
+            const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
+
+            for (const rendered of [api, functions]) {
+                expect(rendered).not.toContain('import("~/aliased")');
+                expect(rendered).toContain("{ label: string }");
             }
         });
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2102,7 +2102,7 @@ export const run = query.input({ tool: v.from(toolSchema) }).query(async () => 1
             }
         });
 
-        it("expands a type IMPORTED into the handler's module instead of leaking a bare name", () => {
+        it("qualifies a type IMPORTED into the handler's module instead of leaking a bare name", () => {
             expect.assertions(4);
 
             // The other half of the same leak. When the handler DOES import the
@@ -2112,6 +2112,10 @@ export const run = query.input({ tool: v.from(toolSchema) }).query(async () => 1
             // reachability guard only covered types declared in the handler's OWN
             // file, so a shared `./lib/types` interface — the ordinary way to
             // write one — leaked straight through.
+            //
+            // The handler's own `import` names the module, so the alias survives
+            // as an `import("…")` qualifier rebased out of `_generated/`, rather
+            // than being flattened to its members.
             mkdirSync(join(workdir, "lunora", "lib"), { recursive: true });
             writeFileSync(
                 join(workdir, "lunora", "lib", "shapes.ts"),
@@ -2132,9 +2136,10 @@ export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "
             const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
 
             for (const rendered of [api, functions]) {
-                // Expanded structurally, so it resolves with no import at all.
-                expect(rendered).toContain("{ label: string }");
-                expect(rendered).not.toMatch(/,\s*Badge>/u);
+                // Qualified and rebased one level out of `_generated/`, so it
+                // resolves without an import statement of its own.
+                expect(rendered).toContain('import("../lib/shapes.js").Badge');
+                expect(rendered).not.toMatch(/[^.]\bBadge\b/u);
             }
         });
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -550,6 +550,54 @@ const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: st
 };
 
 /**
+ * Whether `specifier` is one the emitted file cannot resolve.
+ *
+ * A `tsconfig` `paths` alias (`~/lib/types`, `@/types`) resolves under the
+ * AUTHORING project's own config and nowhere else — not from a sibling package
+ * that imports `_generated/api.ts`, and not under a dedicated strict config for
+ * generated output, which is the pattern this repo itself ships
+ * (`apps/playground/tsconfig.generated.json` declares no `paths`). None of
+ * `emit.ts`'s three rebasers touch it, so the alias would be written out
+ * verbatim and fail to resolve exactly where `relocateUserRelativeImports`
+ * exists to stop that happening.
+ *
+ * Matched against the project's CONFIGURED patterns rather than guessed from the
+ * shape of the string, because an alias can be spelled anything. Declining sends
+ * the type back to structural expansion, which is what it got before qualifying
+ * existed.
+ */
+const isUnresolvableSpecifier = (specifier: string, node: Node): boolean =>
+    Object.keys(node.getProject().getCompilerOptions().paths ?? {}).some((pattern) => {
+        const star = pattern.indexOf("*");
+
+        return star === -1 ? specifier === pattern : specifier.startsWith(pattern.slice(0, star)) && specifier.endsWith(pattern.slice(star + 1));
+    });
+
+/**
+ * How `_generated/` can name a declaration the handler refers to.
+ *
+ * One question, asked once, with three answers — because there are exactly three
+ * things the emitter can do with a name.
+ *
+ * `verbatim` prints what the checker printed: either the name resolves from
+ * anywhere (a global, or `Doc`/`Id`, which the generated files import), or the
+ * checker already rendered it as a self-contained `import("…")` qualifier
+ * because it is not in scope at the handler either.
+ *
+ * `qualify` means the checker prints it BARE, which does not resolve from
+ * `_generated/`, but the handler's own import says which module to name it from,
+ * so it can be rewritten as `import("<specifier>").<export>`.
+ *
+ * `expand` means it prints bare and no specifier can reach it — declared in the
+ * handler's own module, or behind a `paths` alias that resolves nowhere else.
+ * Only its structure can be reproduced.
+ */
+type NameRendering = { kind: "expand" } | { kind: "qualify"; qualified: QualifiedImport } | { kind: "verbatim" };
+
+const VERBATIM: NameRendering = { kind: "verbatim" };
+const EXPAND: NameRendering = { kind: "expand" };
+
+/**
  * Every declaration kind the checker prints as a BARE name. Interfaces and type
  * aliases were the whole list once, which left `class` and `enum` — two ordinary
  * ways to declare a return type — printing as undeclared identifiers in
@@ -557,9 +605,7 @@ const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: st
  * reaches the rule as its MEMBER declarations (`Status.Done` is an enum-literal
  * type), so the member is listed alongside the enum itself.
  *
- * Detecting a kind here only says "this would print bare, so do not print it".
- * Whether it can then be reproduced structurally is
- * {@link expandUnreachableType}'s decision, and for a class the answer is no.
+ * Anything else the checker renders structurally already, so it needs no name.
  */
 const BARE_NAMEABLE_KINDS: ReadonlySet<SyntaxKind> = new Set([
     SyntaxKind.ClassDeclaration,
@@ -570,24 +616,11 @@ const BARE_NAMEABLE_KINDS: ReadonlySet<SyntaxKind> = new Set([
 ]);
 
 /**
- * True when `declaration` names a type the checker prints BARE at `node` AND
- * that bare name does not resolve from `_generated/`.
- *
- * Both halves matter, and the first guard below is the second half: a GLOBAL
- * declaration also prints bare, and resolves — so it is not this rule's
- * business, even though it would pass a pure printing test.
- *
- * Two ways a name comes out bare, and both must be caught. One: the type is
- * declared in the handler's own module (`handlerFilePath`), at any nesting depth.
- * Two: the type is declared elsewhere in user code but IMPORTED into the
- * handler's module, which makes it equally nameable there. That second half was
- * missing once, so a shared `./lib/types` interface — the ordinary way to write
- * one — leaked into `api.ts`/`functions.ts` unimported.
- *
- * Exported declarations are included — being nameable from the handler is the
- * whole trigger, and `export` does not change that.
+ * Classify one declaration. {@link classifyType} lifts this to a type and
+ * {@link annotationRendering} to a syntactic annotation; both defer here so the
+ * rule has one statement rather than three that must agree.
  */
-const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string): boolean => {
+const classifyDeclaration = (declaration: Node, node: Node, handlerFilePath: string): NameRendering => {
     const declarationFile = declaration.getSourceFile();
 
     // A GLOBAL declaration prints bare AND resolves bare from anywhere — `Date`,
@@ -599,24 +632,18 @@ const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string):
     // `_generated/` than a user's own interface is. A handler importing
     // `PaginationResult` from `lunorash/server` — or any package type at all —
     // had the name written into `api.ts` unimported, a TS2304 in generated
-    // output while `lunora codegen` exited 0.
+    // output while `lunora codegen` exited 0 (issue #509).
     //
     // Script-mode files are ALMOST exactly the globals, and the exception is why
     // this is two tests rather than one: a script-mode `.d.ts` may still carry
     // `declare module "spec" { … }` blocks, whose members are module-scoped and
-    // need an import like any other.
+    // need an import like any other (issue #511).
     if (declarationFile.getSymbol() === undefined && ambientModuleSpecifier(declaration) === undefined) {
-        return false;
+        return VERBATIM;
     }
 
-    // Every declaration kind the checker prints as a BARE name. Interfaces and
-    // type aliases were the whole list once, which left `class` and `enum` — two
-    // ordinary ways to declare a return type — printing as undeclared identifiers
-    // in `api.ts`/`functions.ts` (TS2304) while `lunora codegen` exited 0. An enum
-    // reaches here as its MEMBER declarations (`Status.Done` is an enum-literal
-    // type), so the member is listed alongside the enum itself.
     if (!BARE_NAMEABLE_KINDS.has(declaration.getKind())) {
-        return false;
+        return VERBATIM;
     }
 
     const declarationPath = declarationFile.getFilePath();
@@ -624,49 +651,71 @@ const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string):
     // `Doc`/`Id` and friends: the generated files import these by name, so the
     // bare rendering is correct there. Expanding them instead would discard a
     // branded `Id` (not an expandable object) and fall all the way back to
-    // `unknown` — measured as every `Doc`/`Id`-shaped return type in the
-    // example apps collapsing at once. Keyed on the declaration PATH, never on
-    // the name: a user's own `Doc`/`Id` is a different type, and exempting it by
-    // name let `referencedDataModelImports` bind it to the generated one — a
-    // wrong type with no compile error anywhere.
+    // `unknown` — measured as every `Doc`/`Id`-shaped return type in the example
+    // apps collapsing at once. Keyed on the declaration PATH, never on the name:
+    // a user's own `Doc`/`Id` is a different type, and exempting it by name let
+    // `referencedDataModelImports` bind it to the generated one — a wrong type
+    // with no compile error anywhere.
     if (declarationPath.includes(GENERATED_DIRECTORY_SEGMENT)) {
-        return false;
+        return VERBATIM;
     }
 
+    // Declared in the handler's own module, at any nesting depth. Nameable there
+    // and nowhere else — no import exists to borrow a specifier from.
     if (declarationPath === handlerFilePath) {
-        return true;
+        return EXPAND;
     }
 
-    // An enum member is imported under its ENUM's name, never its own.
-    if (Node.isEnumMember(declaration)) {
-        const enumDeclaration = declaration.getParent();
+    // An enum member is imported under its ENUM's name, never its own. A nameless
+    // `export default class {}` has no name to ask about at all.
+    const named = Node.isEnumMember(declaration) ? declaration.getParent() : declaration;
 
-        return importSpecifierFor(node.getSourceFile(), enumDeclaration, enumDeclaration.getName()) !== undefined;
+    if (!Node.hasName(named)) {
+        return EXPAND;
     }
 
-    // A nameless `export default class {}` has nothing to ask
-    // `importSpecifierFor` about, and is unreachable by name from anywhere.
-    return Node.hasName(declaration) && importSpecifierFor(node.getSourceFile(), declaration, declaration.getName()) !== undefined;
+    const qualified = importSpecifierFor(node.getSourceFile(), named, named.getName());
+
+    // Not imported here either, so the checker prints it as its own `import("…")`
+    // qualifier — already self-contained.
+    if (qualified === undefined) {
+        return VERBATIM;
+    }
+
+    return isUnresolvableSpecifier(qualified.specifier, node) ? EXPAND : { kind: "qualify", qualified };
 };
 
 /**
- * True when the checker will print this user-land named type as a BARE name at
- * `node`.
+ * Classify a type by the declarations behind it.
  *
- * `_generated/api.ts` does not import the handler's modules; codegen only emits
- * an import for a qualifier the checker itself rendered as `import("…")` (plus
- * the fixed `dataModel` one, excluded above). So a bare name must be expanded
- * structurally rather than printed, or it lands in the generated file as an
- * undeclared identifier (TS2304).
+ * A `qualify` counts only from the symbol the checker actually PRINTS — the
+ * alias when there is one, since that is the syntax that reaches the output.
+ * Reachability is judged across both symbols, because either can drag in a name
+ * that does not resolve.
  */
-const printsAsUnimportedName = (type: Type, node: Node, handlerFilePath: string): boolean =>
-    [type.getSymbol(), type.getAliasSymbol()]
-        .flatMap((candidate) => candidate?.getDeclarations() ?? [])
-        .some((declaration) => isBareNameable(declaration, node, handlerFilePath));
+const classifyType = (type: Type, node: Node, handlerFilePath: string): NameRendering => {
+    const aliasSymbol = type.getAliasSymbol();
+    const symbol = type.getSymbol();
+    const printedDeclarations = new Set<Node>((aliasSymbol ?? symbol)?.getDeclarations());
+
+    let needsRenaming = false;
+
+    for (const declaration of [symbol, aliasSymbol].flatMap((candidate) => candidate?.getDeclarations() ?? [])) {
+        const rendering = classifyDeclaration(declaration, node, handlerFilePath);
+
+        if (rendering.kind === "qualify" && printedDeclarations.has(declaration)) {
+            return rendering;
+        }
+
+        needsRenaming ||= rendering.kind !== "verbatim";
+    }
+
+    return needsRenaming ? EXPAND : VERBATIM;
+};
 
 /**
- * True when a declaration's type ANNOTATION names something that would print
- * bare — the half of the printing rule that the resolved type cannot reveal.
+ * Classify a declaration's type ANNOTATION — the half of the printing rule that
+ * the resolved type cannot reveal.
  *
  * TypeScript's node builder reuses the syntax of a declared annotation whenever
  * that syntax resolves at the printing location, so `{ action: AuditAction }`
@@ -681,26 +730,35 @@ const printsAsUnimportedName = (type: Type, node: Node, handlerFilePath: string)
  * that gap; it does not replace the resolved walk, because an inferred return
  * with no annotation anywhere still has to be caught by the type.
  */
-const annotationPrintsAsUnimportedName = (declaration: Node, node: Node, handlerFilePath: string): boolean => {
+const annotationRendering = (declaration: Node, node: Node, handlerFilePath: string): NameRendering => {
     const annotation = Node.isPropertySignature(declaration) || Node.isPropertyDeclaration(declaration) ? declaration.getTypeNode() : undefined;
 
     if (annotation === undefined) {
-        return false;
+        return VERBATIM;
     }
 
-    return [annotation, ...annotation.getDescendantsOfKind(SyntaxKind.TypeReference)]
-        .filter((candidate) => Node.isTypeReference(candidate))
-        .flatMap((reference) => {
-            // Resolved through `getAliasedSymbol()` for an `import type { X }`,
-            // exactly as `resolveValidatorAlias` does — otherwise the symbol is
-            // the `ImportSpecifier`, which is neither an interface nor a type
-            // alias, so every imported name read as reachable and the leak this
-            // walk exists to catch stayed open for the commonest spelling of it.
-            const symbol = reference.getTypeName().getSymbol();
+    let needsRenaming = false;
 
-            return (symbol?.getAliasedSymbol() ?? symbol)?.getDeclarations() ?? [];
-        })
-        .some((referenced) => isBareNameable(referenced, node, handlerFilePath));
+    for (const reference of [annotation, ...annotation.getDescendantsOfKind(SyntaxKind.TypeReference)].filter((candidate) => Node.isTypeReference(candidate))) {
+        // Resolved through `getAliasedSymbol()` for an `import type { X }`,
+        // exactly as `resolveValidatorAlias` does — otherwise the symbol is the
+        // `ImportSpecifier`, which is neither an interface nor a type alias, so
+        // every imported name read as reachable and the leak this walk exists to
+        // catch stayed open for the commonest spelling of it.
+        const symbol = reference.getTypeName().getSymbol();
+
+        for (const referenced of (symbol?.getAliasedSymbol() ?? symbol)?.getDeclarations() ?? []) {
+            const rendering = classifyDeclaration(referenced, node, handlerFilePath);
+
+            if (rendering.kind === "qualify") {
+                return rendering;
+            }
+
+            needsRenaming ||= rendering.kind !== "verbatim";
+        }
+    }
+
+    return needsRenaming ? EXPAND : VERBATIM;
 };
 
 /** Composite child types of `type` (type arguments + union/intersection members) to recurse into. */
@@ -736,11 +794,12 @@ const isExpandableObject = (type: Type): boolean => {
 };
 
 /**
- * Type-tree walker: returns true if any reachable symbol's declaration lives in
- * the handler's own source file but isn't exported (so it cannot be referenced
- * by name from `_generated/`). Descends type arguments, union/intersection
- * members, **and** object property types — the last so an anonymous object that
- * embeds an unreachable interface (`{ post: PostDoc }`) isn't mistaken for safe.
+ * Whether any name inside `type` needs renaming before it can go into
+ * `_generated/` — i.e. anything in it classifies as other than `verbatim`.
+ *
+ * Descends type arguments, union/intersection members, **and** object property
+ * types — the last so an anonymous object that embeds an unreachable interface
+ * (`{ post: PostDoc }`) isn't mistaken for safe.
  */
 const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath: string, seen = new Set<Type>()): boolean => {
     if (seen.has(type)) {
@@ -749,7 +808,7 @@ const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath:
 
     seen.add(type);
 
-    if (printsAsUnimportedName(type, node, handlerFilePath)) {
+    if (classifyType(type, node, handlerFilePath).kind !== "verbatim") {
         return true;
     }
 
@@ -764,7 +823,7 @@ const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath:
     return type.getProperties().some((property) => {
         // The annotation first: it is the syntax the printer reuses, and the
         // resolved type below has already lost the alias by the time we see it.
-        if (property.getDeclarations().some((declaration) => annotationPrintsAsUnimportedName(declaration, node, handlerFilePath))) {
+        if (property.getDeclarations().some((declaration) => annotationRendering(declaration, node, handlerFilePath).kind !== "verbatim")) {
             return true;
         }
 
@@ -956,31 +1015,7 @@ const containsUnencodableMember = (type: Type, node: Node, depth: number, seen: 
 };
 
 /**
- * Whether `specifier` is one the emitted file cannot resolve.
- *
- * A `tsconfig` `paths` alias (`~/lib/types`, `@/types`) resolves under the
- * AUTHORING project's own config and nowhere else — not from a sibling package
- * that imports `_generated/api.ts`, and not under a dedicated strict config for
- * generated output, which is the pattern this repo itself ships
- * (`apps/playground/tsconfig.generated.json` declares no `paths`). None of
- * `emit.ts`'s three rebasers touch it, so the alias would be written out
- * verbatim and fail to resolve exactly where `relocateUserRelativeImports`
- * exists to stop that happening.
- *
- * Matched against the project's CONFIGURED patterns rather than guessed from the
- * shape of the string, because an alias can be spelled anything. Declining sends
- * the type back to structural expansion, which is what it got before qualifying
- * existed.
- */
-const isUnresolvableSpecifier = (specifier: string, node: Node): boolean =>
-    Object.keys(node.getProject().getCompilerOptions().paths ?? {}).some((pattern) => {
-        const star = pattern.indexOf("*");
-
-        return star === -1 ? specifier === pattern : specifier.startsWith(pattern.slice(0, star)) && specifier.endsWith(pattern.slice(star + 1));
-    });
-
-/**
- * Render a type the checker would print BARE as `import("<specifier>").Name<…>`.
+ * Render `qualified` as `import("<specifier>").<export><…type arguments>`.
  *
  * Only the bare NAME is unreachable from `_generated/`; the type itself is
  * perfectly nameable, and the handler's own `import` declaration says which
@@ -991,43 +1026,20 @@ const isUnresolvableSpecifier = (specifier: string, node: Node): boolean =>
  * unresolved) off the `unknown` fallback it would otherwise land on.
  *
  * Type arguments go back through `expand`, so one unreachable argument still
- * decides the outcome for the whole reference. Returns `undefined` when the
- * name is not imported into the handler's module — a type declared in that
- * module itself has no specifier to name it by, and the caller expands instead.
+ * decides the outcome for the whole reference.
  */
-const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, depth: number, seen: Set<Type>, expand: ExpandFunction): string | undefined => {
-    const aliasSymbol = type.getAliasSymbol();
-    const symbol = aliasSymbol ?? type.getSymbol();
-    const name = symbol?.getName();
-
-    // An anonymous object/function type has no name to qualify — the checker
-    // spells those out structurally already.
-    if (symbol === undefined || name === undefined || name.startsWith("__")) {
-        return undefined;
-    }
-
-    // An `enum` is deliberately NOT qualified. What crosses the wire is the
-    // member's VALUE, and an enum type is NOMINAL — a caller comparing
-    // `result.status === "done"` does not typecheck against `Status`, and a
-    // caller without the enum installed cannot name it at all. The union of wire
-    // values the branches below produce is the honest rendering.
-    if (symbol.getDeclarations().some((declaration) => Node.isEnumDeclaration(declaration) || Node.isEnumMember(declaration))) {
-        return undefined;
-    }
-
-    const handlerFile = node.getSourceFile();
-    const qualified = symbol
-        .getDeclarations()
-        .map((declaration) => importSpecifierFor(handlerFile, declaration, name))
-        .find((candidate) => candidate !== undefined);
-
-    if (qualified === undefined || isUnresolvableSpecifier(qualified.specifier, node)) {
-        return undefined;
-    }
-
+const qualifiedImportText = (
+    qualified: QualifiedImport,
+    type: Type,
+    node: Node,
+    handlerFilePath: string,
+    depth: number,
+    seen: Set<Type>,
+    expand: ExpandFunction,
+): string | undefined => {
     const rendered: string[] = [];
 
-    for (const argument of aliasSymbol ? type.getAliasTypeArguments() : type.getTypeArguments()) {
+    for (const argument of type.getAliasSymbol() === undefined ? type.getTypeArguments() : type.getAliasTypeArguments()) {
         const text = expand(argument, node, handlerFilePath, depth + 1, seen);
 
         if (text === undefined) {
@@ -1039,6 +1051,12 @@ const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, de
 
     return `import("${qualified.specifier}").${qualified.exportName}${rendered.length > 0 ? `<${rendered.join(", ")}>` : ""}`;
 };
+
+/** Whether `type` is an `enum` or one of its members — the one named type deliberately rendered by VALUE rather than by name. */
+const isEnumDeclared = (type: Type): boolean =>
+    [type.getSymbol(), type.getAliasSymbol()]
+        .flatMap((candidate) => candidate?.getDeclarations() ?? [])
+        .some((declaration) => Node.isEnumDeclaration(declaration) || Node.isEnumMember(declaration));
 
 /**
  * Structurally expand a return type that references a non-exported local type,
@@ -1054,8 +1072,13 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
         return undefined;
     }
 
-    // Reachable types already print correctly by name — leave them verbatim.
-    if (!referencesUnreachableLocalType(type, node, handlerFilePath)) {
+    const rendering = classifyType(type, node, handlerFilePath);
+
+    // Reachable types already print correctly by name — leave them verbatim. The
+    // type's OWN rendering gates the walk rather than the other way round: it is
+    // the cheap half, it is implied by the walk anyway, and checking it first
+    // means a type that already needs renaming never pays for the recursion.
+    if (rendering.kind === "verbatim" && !referencesUnreachableLocalType(type, node, handlerFilePath)) {
         return type.getText(node);
     }
 
@@ -1076,10 +1099,12 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
         return undefined;
     }
 
-    // The member's VALUE is what crosses the wire, so that is both the honest
-    // rendering and a nameable one. (`qualifiedImportText` carries its own enum
-    // guard for the union-of-members case that reaches `isUnion` below — this
-    // branch does not rely on running first.)
+    // An `enum` is the one named type rendered by VALUE rather than by name. The
+    // value is what crosses the wire, and the type is NOMINAL — a caller
+    // comparing `result.status === "done"` does not typecheck against `Status`,
+    // and a caller without the enum installed cannot name it at all. A single
+    // member answers here; a whole enum falls through to the union branch, which
+    // expands each member the same way.
     if (type.isEnumLiteral()) {
         return expandEnumLiteralType(type);
     }
@@ -1088,11 +1113,15 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
     // imports it from. Ahead of the structural branches because an alias for an
     // array or a union (`type Ids = Id<"x">[]`, `type Status = A | B`) is a
     // reference the checker prints by name, and expanding it loses the alias for
-    // no gain — or declines outright on a member it cannot reproduce.
-    const qualified = qualifiedImportText(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
+    // no gain — or declines outright on a member it cannot reproduce. Nothing but
+    // `discover-functions.test.ts`'s alias-of-array and alias-of-union cases
+    // enforces that order.
+    if (rendering.kind === "qualify" && !isEnumDeclared(type)) {
+        const qualified = qualifiedImportText(rendering.qualified, type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
 
-    if (qualified !== undefined) {
-        return qualified;
+        if (qualified !== undefined) {
+            return qualified;
+        }
     }
 
     if (type.isArray()) {

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -3,6 +3,7 @@ import type {
     CallExpression,
     FunctionExpression,
     Identifier,
+    ImportDeclaration,
     ObjectLiteralExpression,
     Project,
     SourceFile,
@@ -363,6 +364,56 @@ const isGloballyDeclared = (type: Type): boolean => {
 };
 
 /**
+ * How `_generated/` can name a type the checker would print bare: the module
+ * specifier to qualify it with, and the name that module exports it under.
+ *
+ * The two differ for a DEFAULT import, where the local binding is an alias the
+ * exporting module never agreed to — `import Boxed from "./def"` has to be
+ * written `import("./def").default`, not `import("./def").Boxed`.
+ */
+interface QualifiedImport {
+    /** The name the module exports it under — `"default"` for a default export. */
+    exportName: string;
+    /** The specifier verbatim as the user wrote it. */
+    specifier: string;
+}
+
+/**
+ * `ModuleDeclaration.getName()` keeps the quotes for a string-literal module
+ * name (`"virtual:thing"`), which is what distinguishes an ambient MODULE from a
+ * `declare global` / namespace block.
+ */
+const AMBIENT_MODULE_NAME_RE = /^(?<quote>["'])(?<specifier>.*)\k<quote>$/su;
+
+/**
+ * The specifier of the ambient `declare module "…"` block `declaration` sits
+ * inside, or `undefined` when it is not in one.
+ *
+ * A script-mode `.d.ts` normally declares globals — which is why one is exempt
+ * from the bare-name rule — but it can also carry `declare module "spec" { … }`
+ * blocks whose members are MODULE-scoped and reachable only through an import.
+ * That is the ordinary packaging of `declare module "*.svg"`, of a hand-written
+ * shim for an untyped dependency, and of older DefinitelyTyped layouts, so the
+ * file-level test alone let those names out bare (issue #511).
+ *
+ * Nearest ancestor wins, and a `declare global` block is skipped by the quoting
+ * rule rather than by name — `global` is an identifier there, never a literal.
+ */
+const ambientModuleSpecifier = (declaration: Node): string | undefined => {
+    for (const ancestor of declaration.getAncestors()) {
+        if (Node.isModuleDeclaration(ancestor)) {
+            const match = AMBIENT_MODULE_NAME_RE.exec(ancestor.getName());
+
+            if (match?.groups?.specifier !== undefined) {
+                return match.groups.specifier;
+            }
+        }
+    }
+
+    return undefined;
+};
+
+/**
  * Per-module export lookup, memoised.
  *
  * `getExport` reads the module symbol's OWN export table, which does not list an
@@ -403,6 +454,58 @@ const moduleExport = (moduleFile: SourceFile, name: string): TsSymbol | undefine
     return byName.get(name);
 };
 
+/** Whether `importDeclaration` reaches `name` by name — named, or through a namespace alias `_generated/` does not have either. */
+const bindsByName = (importDeclaration: ImportDeclaration, name: string): boolean =>
+    importDeclaration.getNamespaceImport() !== undefined || importDeclaration.getNamedImports().some((entry) => entry.getName() === name);
+
+/**
+ * Whether `importDeclaration` brings `name` in from an ambient
+ * `declare module "…"` block.
+ *
+ * Matched on the specifier TEXT, because an ambient module declaration has no
+ * source file for `getModuleSpecifierSourceFile()` to resolve to — the symbol
+ * identity check every other path uses has nothing to compare against here.
+ */
+const matchesAmbientModule = (importDeclaration: ImportDeclaration, ambientSpecifier: string, name: string): QualifiedImport | undefined => {
+    const specifier = importDeclaration.getModuleSpecifierValue();
+
+    return specifier === ambientSpecifier && bindsByName(importDeclaration, name) ? { exportName: name, specifier } : undefined;
+};
+
+/**
+ * Whether `importDeclaration`'s DEFAULT binding resolves to `declaration`.
+ *
+ * A default import's local name says nothing about the export it came from, so
+ * this matches by resolving the binding rather than by comparing names — and the
+ * name it must be written under is `default`, whatever the local alias is.
+ */
+const matchesDefaultImport = (importDeclaration: ImportDeclaration, declaration: Node): QualifiedImport | undefined => {
+    const defaultImport = importDeclaration.getDefaultImport();
+
+    if (defaultImport === undefined) {
+        return undefined;
+    }
+
+    const bound = defaultImport.getSymbol();
+
+    return (bound?.getAliasedSymbol() ?? bound)?.getDeclarations().includes(declaration) === true
+        ? { exportName: "default", specifier: importDeclaration.getModuleSpecifierValue() }
+        : undefined;
+};
+
+/** Whether `importDeclaration` brings `name` in from the module that declares it, through any re-export chain. */
+const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: Node, name: string): QualifiedImport | undefined => {
+    if (!bindsByName(importDeclaration, name)) {
+        return undefined;
+    }
+
+    const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
+    const exported = moduleFile === undefined ? undefined : moduleExport(moduleFile, name);
+    const target = exported?.getAliasedSymbol() ?? exported;
+
+    return target?.getDeclarations().includes(declaration) === true ? { exportName: name, specifier: importDeclaration.getModuleSpecifierValue() } : undefined;
+};
+
 /**
  * The module specifier the handler's file imports `name` from, when that import
  * resolves to `declaration` — the literal string the user wrote, never a
@@ -429,25 +532,17 @@ const moduleExport = (moduleFile: SourceFile, name: string): TsSymbol | undefine
  * deep. Asking the module directly is depth-independent, because the recursion
  * visits each type on its own.
  */
-const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: string): string | undefined => {
+const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: string): QualifiedImport | undefined => {
+    const ambientSpecifier = ambientModuleSpecifier(declaration);
+
     for (const importDeclaration of handlerFile.getImportDeclarations()) {
-        // A namespace import (`import * as t`) makes every exported name
-        // reachable, but only as `t.Bar` — which the checker prints qualified by
-        // a local alias `_generated/` does not have either, so it counts exactly
-        // like a named import.
-        const importsIt =
-            importDeclaration.getNamespaceImport() !== undefined || importDeclaration.getNamedImports().some((specifier) => specifier.getName() === name);
+        const matched =
+            ambientSpecifier === undefined
+                ? (matchesDefaultImport(importDeclaration, declaration) ?? matchesNamedImport(importDeclaration, declaration, name))
+                : matchesAmbientModule(importDeclaration, ambientSpecifier, name);
 
-        if (!importsIt) {
-            continue;
-        }
-
-        const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
-        const exported = moduleFile === undefined ? undefined : moduleExport(moduleFile, name);
-        const target = exported?.getAliasedSymbol() ?? exported;
-
-        if (target?.getDeclarations().includes(declaration) === true) {
-            return importDeclaration.getModuleSpecifierValue();
+        if (matched !== undefined) {
+            return matched;
         }
     }
 
@@ -497,8 +592,7 @@ const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string):
 
     // A GLOBAL declaration prints bare AND resolves bare from anywhere — `Date`,
     // `Uint8Array`, the whole `lib.*.d.ts` surface, an app's own ambient
-    // `declare global`. Script-mode files (the ones with no module symbol) are
-    // exactly those, so that is the test.
+    // `declare global`.
     //
     // Skipping every `.d.ts`/`node_modules` file instead was wrong by a wide
     // margin: a MODULE-scoped declaration there is no more reachable from
@@ -506,7 +600,12 @@ const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string):
     // `PaginationResult` from `lunorash/server` — or any package type at all —
     // had the name written into `api.ts` unimported, a TS2304 in generated
     // output while `lunora codegen` exited 0.
-    if (declarationFile.getSymbol() === undefined) {
+    //
+    // Script-mode files are ALMOST exactly the globals, and the exception is why
+    // this is two tests rather than one: a script-mode `.d.ts` may still carry
+    // `declare module "spec" { … }` blocks, whose members are module-scoped and
+    // need an import like any other.
+    if (declarationFile.getSymbol() === undefined && ambientModuleSpecifier(declaration) === undefined) {
         return false;
     }
 
@@ -917,12 +1016,12 @@ const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, de
     }
 
     const handlerFile = node.getSourceFile();
-    const specifier = symbol
+    const qualified = symbol
         .getDeclarations()
         .map((declaration) => importSpecifierFor(handlerFile, declaration, name))
         .find((candidate) => candidate !== undefined);
 
-    if (specifier === undefined || isUnresolvableSpecifier(specifier, node)) {
+    if (qualified === undefined || isUnresolvableSpecifier(qualified.specifier, node)) {
         return undefined;
     }
 
@@ -938,7 +1037,7 @@ const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, de
         rendered.push(text);
     }
 
-    return `import("${specifier}").${name}${rendered.length > 0 ? `<${rendered.join(", ")}>` : ""}`;
+    return `import("${qualified.specifier}").${qualified.exportName}${rendered.length > 0 ? `<${rendered.join(", ")}>` : ""}`;
 };
 
 /**

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -348,6 +348,62 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 const GENERATED_DIRECTORY_SEGMENT = "/_generated/";
 
 /**
+ * Whether every declaration of `type` lives in a script-mode file — i.e. the
+ * name is GLOBAL, resolving from anywhere without an import. `lib.*.d.ts` and an
+ * app's own ambient `declare global` are the whole population.
+ *
+ * A file with a module symbol declares module-scoped names, so a `.d.ts` inside
+ * `node_modules` is emphatically not global. Assuming otherwise is what put
+ * unimported package types into `_generated/` as TS2304 (issue #509).
+ */
+const isGloballyDeclared = (type: Type): boolean => {
+    const declarations = [type.getSymbol(), type.getAliasSymbol()].flatMap((candidate) => candidate?.getDeclarations() ?? []);
+
+    return declarations.length > 0 && declarations.every((declaration) => declaration.getSourceFile().getSymbol() === undefined);
+};
+
+/**
+ * Per-module export lookup, memoised.
+ *
+ * `getExport` reads the module symbol's OWN export table, which does not list an
+ * `export * from "…"` re-export — and a star re-export is exactly how the
+ * umbrella republishes `@lunora/server`, so for the commonest spelling the cheap
+ * lookup always misses. `getExportSymbols` asks the checker instead and sees
+ * through it, at the cost of materialising every export of the module.
+ *
+ * That is why this is cached rather than merely guarded. The caller's
+ * already-imported check does not bound it: a namespace import (`import * as t`)
+ * makes the check unconditionally true, so without a cache every candidate name
+ * would rebuild `lunorash/server`'s whole export table, inside a per-property
+ * recursion, once per inference pass.
+ *
+ * Keyed on the module's compiler symbol, which is replaced wholesale when a file
+ * is re-parsed — so a stale entry cannot outlive the program it was read from.
+ */
+const MODULE_EXPORT_CACHE = new WeakMap<object, Map<string, TsSymbol | undefined>>();
+
+const moduleExport = (moduleFile: SourceFile, name: string): TsSymbol | undefined => {
+    const moduleSymbol = moduleFile.getSymbol();
+
+    if (moduleSymbol === undefined) {
+        return undefined;
+    }
+
+    let byName = MODULE_EXPORT_CACHE.get(moduleSymbol.compilerSymbol);
+
+    if (byName === undefined) {
+        byName = new Map<string, TsSymbol | undefined>();
+        MODULE_EXPORT_CACHE.set(moduleSymbol.compilerSymbol, byName);
+    }
+
+    if (!byName.has(name)) {
+        byName.set(name, moduleSymbol.getExport(name) ?? moduleFile.getExportSymbols().find((symbol) => symbol.getName() === name));
+    }
+
+    return byName.get(name);
+};
+
+/**
  * The module specifier the handler's file imports `name` from, when that import
  * resolves to `declaration` — the literal string the user wrote, never a
  * resolved path. `undefined` when the module does not import it.
@@ -387,13 +443,7 @@ const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: st
         }
 
         const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
-        // `getExport` reads the module symbol's OWN export table, which does not
-        // list a `export * from "…"` re-export — and a star re-export is exactly
-        // how the umbrella republishes `@lunora/server`. `getExportSymbols` asks
-        // the checker instead and sees through it; it costs an array of every
-        // export, so it stays behind the cheap lookup and behind the
-        // already-imported guard above.
-        const exported = moduleFile?.getSymbol()?.getExport(name) ?? moduleFile?.getExportSymbols().find((symbol) => symbol.getName() === name);
+        const exported = moduleFile === undefined ? undefined : moduleExport(moduleFile, name);
         const target = exported?.getAliasedSymbol() ?? exported;
 
         if (target?.getDeclarations().includes(declaration) === true) {
@@ -425,8 +475,12 @@ const BARE_NAMEABLE_KINDS: ReadonlySet<SyntaxKind> = new Set([
 ]);
 
 /**
- * True when `declaration` names a user-land type the checker can print BARE at
- * `node` — the case that does not resolve from `_generated/`.
+ * True when `declaration` names a type the checker prints BARE at `node` AND
+ * that bare name does not resolve from `_generated/`.
+ *
+ * Both halves matter, and the first guard below is the second half: a GLOBAL
+ * declaration also prints bare, and resolves — so it is not this rule's
+ * business, even though it would pass a pure printing test.
  *
  * Two ways a name comes out bare, and both must be caught. One: the type is
  * declared in the handler's own module (`handlerFilePath`), at any nesting depth.
@@ -730,6 +784,103 @@ const isClassInstance = (type: Type): boolean =>
         .some((declaration) => Node.isClassDeclaration(declaration) || Node.isClassExpression(declaration));
 
 /**
+ * Whether `type` reaches a value `encodeWire` refuses — a user-land class
+ * instance or anything with a call signature — at any depth.
+ *
+ * {@link expandUnreachableType} declines a class instance outright, and the
+ * reasoning there (a method or a `#private` field is absent from the serialized
+ * value, so a `result.format(...)` typed off one is a runtime TypeError with no
+ * compile error anywhere) applies just as much when the class is a MEMBER of the
+ * type being named. Printing `import("./money").Envelope` publishes
+ * `at.format()` to every caller for a value that cannot cross the wire at all —
+ * `shared/wire-codec.ts` throws on it at the send site.
+ *
+ * Keyed on the same script-mode test the global exemption uses, so the built-ins
+ * that DO round-trip (`Date`, `URL`, `Map`, `Set`, the typed arrays) are not
+ * caught by it — they are declared in `lib.*.d.ts` and are exactly the set
+ * `encodeWire` supports.
+ *
+ * An index signature is deliberately NOT a refusal: a `Record`-shaped return
+ * encodes fine, and declining one is the collapse-to-`unknown` this whole path
+ * exists to avoid.
+ */
+const containsUnencodableMember = (type: Type, node: Node, depth: number, seen: Set<Type>): boolean => {
+    if (depth > MAX_EXPANSION_DEPTH || seen.has(type)) {
+        return false;
+    }
+
+    const nextSeen = new Set(seen).add(type);
+
+    // Type arguments and union/intersection members first, so a supported
+    // container carrying an unsupported payload (`Map<string, Money>`, an array
+    // of them) is still caught — the container encodes, its contents do not.
+    if (childTypes(type).some((child) => containsUnencodableMember(child, node, depth + 1, nextSeen))) {
+        return true;
+    }
+
+    const element = type.getArrayElementType();
+
+    if (element !== undefined) {
+        return containsUnencodableMember(element, node, depth + 1, nextSeen);
+    }
+
+    // A GLOBAL type is trusted and NOT descended into. The globals a return type
+    // realistically names are the built-ins `encodeWire` supports (`Date`, `Map`,
+    // `Set`, `URL`, the typed arrays), and every one of them carries prototype
+    // methods — walking their members would report `Date` itself as unencodable
+    // on the strength of `getTime()`. Same script-mode test as the bare-name
+    // exemption uses, for the same reason.
+    if (isGloballyDeclared(type)) {
+        return false;
+    }
+
+    // A function/callable is not a plain object, so `encodeWire` throws on it.
+    if (type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0) {
+        return true;
+    }
+
+    const isUserLandClass = [type.getSymbol(), type.getAliasSymbol()]
+        .flatMap((candidate) => candidate?.getDeclarations() ?? [])
+        .some((declaration) => Node.isClassDeclaration(declaration) || Node.isClassExpression(declaration));
+
+    if (isUserLandClass) {
+        return true;
+    }
+
+    // Members are walked only for shapes structural expansion would itself walk —
+    // which excludes arrays, tuples, and anything carrying call or index
+    // signatures, so a prototype method never reaches the callable test above.
+    return (
+        isExpandableObject(type) &&
+        type.getProperties().some((property) => containsUnencodableMember(property.getTypeAtLocation(node), node, depth + 1, nextSeen))
+    );
+};
+
+/**
+ * Whether `specifier` is one the emitted file cannot resolve.
+ *
+ * A `tsconfig` `paths` alias (`~/lib/types`, `@/types`) resolves under the
+ * AUTHORING project's own config and nowhere else — not from a sibling package
+ * that imports `_generated/api.ts`, and not under a dedicated strict config for
+ * generated output, which is the pattern this repo itself ships
+ * (`apps/playground/tsconfig.generated.json` declares no `paths`). None of
+ * `emit.ts`'s three rebasers touch it, so the alias would be written out
+ * verbatim and fail to resolve exactly where `relocateUserRelativeImports`
+ * exists to stop that happening.
+ *
+ * Matched against the project's CONFIGURED patterns rather than guessed from the
+ * shape of the string, because an alias can be spelled anything. Declining sends
+ * the type back to structural expansion, which is what it got before qualifying
+ * existed.
+ */
+const isUnresolvableSpecifier = (specifier: string, node: Node): boolean =>
+    Object.keys(node.getProject().getCompilerOptions().paths ?? {}).some((pattern) => {
+        const star = pattern.indexOf("*");
+
+        return star === -1 ? specifier === pattern : specifier.startsWith(pattern.slice(0, star)) && specifier.endsWith(pattern.slice(star + 1));
+    });
+
+/**
  * Render a type the checker would print BARE as `import("<specifier>").Name<…>`.
  *
  * Only the bare NAME is unreachable from `_generated/`; the type itself is
@@ -771,7 +922,7 @@ const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, de
         .map((declaration) => importSpecifierFor(handlerFile, declaration, name))
         .find((candidate) => candidate !== undefined);
 
-    if (specifier === undefined) {
+    if (specifier === undefined || isUnresolvableSpecifier(specifier, node)) {
         return undefined;
     }
 
@@ -812,7 +963,8 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
     const nextSeen = new Set(seen).add(type);
 
     // A CLASS INSTANCE is not reproducible, and expanding it would be worse than
-    // declining. `encodeWire` refuses a class instance outright (`shared/wire-codec.ts`
+    // declining. Answered before every branch below — including the qualifier —
+    // so no path can publish one. `encodeWire` refuses a class instance outright (`shared/wire-codec.ts`
     // — only plain objects and the supported built-ins round-trip), so no such value
     // ever reaches a caller; and the structural expansion would describe one wrongly
     // in three directions at once: methods and getters live on the prototype and are
@@ -825,9 +977,10 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
         return undefined;
     }
 
-    // An enum-literal member is imported under its ENUM's name, so the qualifier
-    // below would name the wrong thing; its VALUE is what crosses the wire and
-    // is answered first.
+    // The member's VALUE is what crosses the wire, so that is both the honest
+    // rendering and a nameable one. (`qualifiedImportText` carries its own enum
+    // guard for the union-of-members case that reaches `isUnion` below — this
+    // branch does not rely on running first.)
     if (type.isEnumLiteral()) {
         return expandEnumLiteralType(type);
     }
@@ -899,6 +1052,22 @@ const unwrapHandlerReturn = (handler: Node): string => {
     // wiring to resolve `@lunora/server`/`@lunora/values`. Surfacing such
     // partial types would mislead users; fall back to `unknown` instead.
     if (ANY_TOKEN_RE.test(rendered.replaceAll(STRING_LITERAL_SPAN_RE, ""))) {
+        return "unknown";
+    }
+
+    // A value `encodeWire` refuses never reaches a caller — it throws at the send
+    // site (`shared/wire-codec.ts`: only plain objects, arrays, and the supported
+    // built-ins round-trip). Naming one in the contract types a call that can
+    // never complete: `result.at.format()` compiles and is a runtime TypeError,
+    // and `private`/`#private` members get published to clients besides.
+    //
+    // {@link expandUnreachableType} already declined a class it was asked to
+    // expand, but that only covers the types it walks. A class the handler does
+    // NOT import is not bare-nameable, so the checker prints it fully qualified
+    // and the reachability walk waves it through — `{ at: import("./money").Money }`
+    // reached `api.ts` intact. Every return type funnels through here, so this is
+    // the one place the rule holds for all of them.
+    if (containsUnencodableMember(returnType, handler, 0, new Set<Type>())) {
         return "unknown";
     }
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -348,28 +348,61 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 const GENERATED_DIRECTORY_SEGMENT = "/_generated/";
 
 /**
- * Whether the module at `node` imports `name` from `declarationFile` — the
- * precise form of "the checker will print this bare".
+ * The module specifier the handler's file imports `name` from, when that import
+ * resolves to `declaration` — the literal string the user wrote, never a
+ * resolved path. `undefined` when the module does not import it.
+ *
+ * This answers both questions the printing rule needs: whether the checker will
+ * print the name BARE at `node` (it will, exactly when the module imports it),
+ * and — since a bare name does not resolve from `_generated/` — which specifier
+ * to qualify it with instead. `emit.ts` takes it from there: a relative
+ * qualifier is rebased out of the source directory, an `@lunora/*` one is mapped
+ * onto the umbrella, and a bare package specifier is already correct from any
+ * directory.
+ *
+ * Resolved through the checker's ALIAS CHAIN, not by comparing source files.
+ * `lunorash/server` re-exports `@lunora/server`, which re-exports its own
+ * `types.d.ts`, so the file an import declaration resolves to is almost never
+ * the file the interface is DECLARED in — and comparing the two answered "not
+ * imported" for every umbrella type, which is the commonest spelling there is.
  *
  * Deliberately NOT `type.getText(node).includes("import(")`: that renders the
  * WHOLE type, type arguments and all, so an imported `Wrapper` wrapping an
  * out-of-scope `Bar` renders text containing `import(` and the wrapper is
  * wrongly cleared — printed bare into `_generated/` as a TS2304, one generic
- * deep. Asking the source file directly is depth-independent, because the
- * recursion visits each type on its own.
+ * deep. Asking the module directly is depth-independent, because the recursion
+ * visits each type on its own.
  */
-const importsName = (handlerFile: SourceFile, declarationFile: SourceFile, name: string): boolean =>
-    handlerFile.getImportDeclarations().some((declaration) => {
-        if (declaration.getModuleSpecifierSourceFile() !== declarationFile) {
-            return false;
+const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: string): string | undefined => {
+    for (const importDeclaration of handlerFile.getImportDeclarations()) {
+        // A namespace import (`import * as t`) makes every exported name
+        // reachable, but only as `t.Bar` — which the checker prints qualified by
+        // a local alias `_generated/` does not have either, so it counts exactly
+        // like a named import.
+        const importsIt =
+            importDeclaration.getNamespaceImport() !== undefined || importDeclaration.getNamedImports().some((specifier) => specifier.getName() === name);
+
+        if (!importsIt) {
+            continue;
         }
 
-        // A namespace import (`import * as t`) makes every exported name
-        // reachable, but only as `t.Bar` — which the checker prints qualified
-        // by a local alias that `_generated/` does not have either, so it
-        // counts as bare-nameable exactly like a named import.
-        return declaration.getNamespaceImport() !== undefined || declaration.getNamedImports().some((specifier) => specifier.getName() === name);
-    });
+        const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
+        // `getExport` reads the module symbol's OWN export table, which does not
+        // list a `export * from "…"` re-export — and a star re-export is exactly
+        // how the umbrella republishes `@lunora/server`. `getExportSymbols` asks
+        // the checker instead and sees through it; it costs an array of every
+        // export, so it stays behind the cheap lookup and behind the
+        // already-imported guard above.
+        const exported = moduleFile?.getSymbol()?.getExport(name) ?? moduleFile?.getExportSymbols().find((symbol) => symbol.getName() === name);
+        const target = exported?.getAliasedSymbol() ?? exported;
+
+        if (target?.getDeclarations().includes(declaration) === true) {
+            return importDeclaration.getModuleSpecifierValue();
+        }
+    }
+
+    return undefined;
+};
 
 /**
  * Every declaration kind the checker prints as a BARE name. Interfaces and type
@@ -408,7 +441,18 @@ const BARE_NAMEABLE_KINDS: ReadonlySet<SyntaxKind> = new Set([
 const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string): boolean => {
     const declarationFile = declaration.getSourceFile();
 
-    if (declarationFile.isInNodeModules() || declarationFile.isDeclarationFile()) {
+    // A GLOBAL declaration prints bare AND resolves bare from anywhere — `Date`,
+    // `Uint8Array`, the whole `lib.*.d.ts` surface, an app's own ambient
+    // `declare global`. Script-mode files (the ones with no module symbol) are
+    // exactly those, so that is the test.
+    //
+    // Skipping every `.d.ts`/`node_modules` file instead was wrong by a wide
+    // margin: a MODULE-scoped declaration there is no more reachable from
+    // `_generated/` than a user's own interface is. A handler importing
+    // `PaginationResult` from `lunorash/server` — or any package type at all —
+    // had the name written into `api.ts` unimported, a TS2304 in generated
+    // output while `lunora codegen` exited 0.
+    if (declarationFile.getSymbol() === undefined) {
         return false;
     }
 
@@ -442,12 +486,14 @@ const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string):
 
     // An enum member is imported under its ENUM's name, never its own.
     if (Node.isEnumMember(declaration)) {
-        return importsName(node.getSourceFile(), declarationFile, declaration.getParent().getName());
+        const enumDeclaration = declaration.getParent();
+
+        return importSpecifierFor(node.getSourceFile(), enumDeclaration, enumDeclaration.getName()) !== undefined;
     }
 
-    // A nameless `export default class {}` has nothing to ask `importsName`
-    // about, and is unreachable by name from anywhere.
-    return Node.hasName(declaration) && importsName(node.getSourceFile(), declarationFile, declaration.getName());
+    // A nameless `export default class {}` has nothing to ask
+    // `importSpecifierFor` about, and is unreachable by name from anywhere.
+    return Node.hasName(declaration) && importSpecifierFor(node.getSourceFile(), declaration, declaration.getName()) !== undefined;
 };
 
 /**
@@ -684,6 +730,67 @@ const isClassInstance = (type: Type): boolean =>
         .some((declaration) => Node.isClassDeclaration(declaration) || Node.isClassExpression(declaration));
 
 /**
+ * Render a type the checker would print BARE as `import("<specifier>").Name<…>`.
+ *
+ * Only the bare NAME is unreachable from `_generated/`; the type itself is
+ * perfectly nameable, and the handler's own `import` declaration says which
+ * module to name it from. Emitting the qualifier keeps the alias intact — a
+ * paginated page of `Doc`s stays that, rather than becoming the flattened record
+ * structural expansion produces — and keeps a type expansion cannot reproduce at
+ * all (an index signature, a call signature, a generic the checker left
+ * unresolved) off the `unknown` fallback it would otherwise land on.
+ *
+ * Type arguments go back through `expand`, so one unreachable argument still
+ * decides the outcome for the whole reference. Returns `undefined` when the
+ * name is not imported into the handler's module — a type declared in that
+ * module itself has no specifier to name it by, and the caller expands instead.
+ */
+const qualifiedImportText = (type: Type, node: Node, handlerFilePath: string, depth: number, seen: Set<Type>, expand: ExpandFunction): string | undefined => {
+    const aliasSymbol = type.getAliasSymbol();
+    const symbol = aliasSymbol ?? type.getSymbol();
+    const name = symbol?.getName();
+
+    // An anonymous object/function type has no name to qualify — the checker
+    // spells those out structurally already.
+    if (symbol === undefined || name === undefined || name.startsWith("__")) {
+        return undefined;
+    }
+
+    // An `enum` is deliberately NOT qualified. What crosses the wire is the
+    // member's VALUE, and an enum type is NOMINAL — a caller comparing
+    // `result.status === "done"` does not typecheck against `Status`, and a
+    // caller without the enum installed cannot name it at all. The union of wire
+    // values the branches below produce is the honest rendering.
+    if (symbol.getDeclarations().some((declaration) => Node.isEnumDeclaration(declaration) || Node.isEnumMember(declaration))) {
+        return undefined;
+    }
+
+    const handlerFile = node.getSourceFile();
+    const specifier = symbol
+        .getDeclarations()
+        .map((declaration) => importSpecifierFor(handlerFile, declaration, name))
+        .find((candidate) => candidate !== undefined);
+
+    if (specifier === undefined) {
+        return undefined;
+    }
+
+    const rendered: string[] = [];
+
+    for (const argument of aliasSymbol ? type.getAliasTypeArguments() : type.getTypeArguments()) {
+        const text = expand(argument, node, handlerFilePath, depth + 1, seen);
+
+        if (text === undefined) {
+            return undefined;
+        }
+
+        rendered.push(text);
+    }
+
+    return `import("${specifier}").${name}${rendered.length > 0 ? `<${rendered.join(", ")}>` : ""}`;
+};
+
+/**
  * Structurally expand a return type that references a non-exported local type,
  * so the generated `FunctionReference` carries the real shape (`PostDoc[]` →
  * `{ _id: Id<"posts">; … }[]`) instead of erasing to `unknown`. Reachable names
@@ -704,18 +811,6 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
 
     const nextSeen = new Set(seen).add(type);
 
-    if (type.isArray()) {
-        return expandArrayType(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
-    }
-
-    if (type.isUnion()) {
-        return expandUnionType(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
-    }
-
-    if (type.isEnumLiteral()) {
-        return expandEnumLiteralType(type);
-    }
-
     // A CLASS INSTANCE is not reproducible, and expanding it would be worse than
     // declining. `encodeWire` refuses a class instance outright (`shared/wire-codec.ts`
     // — only plain objects and the supported built-ins round-trip), so no such value
@@ -728,6 +823,32 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
     // function opens with, and the only answer that is never wrong.
     if (isClassInstance(type)) {
         return undefined;
+    }
+
+    // An enum-literal member is imported under its ENUM's name, so the qualifier
+    // below would name the wrong thing; its VALUE is what crosses the wire and
+    // is answered first.
+    if (type.isEnumLiteral()) {
+        return expandEnumLiteralType(type);
+    }
+
+    // Nameable, just not BARE-nameable — qualify it with the module the handler
+    // imports it from. Ahead of the structural branches because an alias for an
+    // array or a union (`type Ids = Id<"x">[]`, `type Status = A | B`) is a
+    // reference the checker prints by name, and expanding it loses the alias for
+    // no gain — or declines outright on a member it cannot reproduce.
+    const qualified = qualifiedImportText(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
+
+    if (qualified !== undefined) {
+        return qualified;
+    }
+
+    if (type.isArray()) {
+        return expandArrayType(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
+    }
+
+    if (type.isUnion()) {
+        return expandUnionType(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);
     }
 
     return expandObjectType(type, node, handlerFilePath, depth, nextSeen, expandUnreachableType);

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -787,7 +787,12 @@ const relocateBaseQualifiers = (rendered: string, useUmbrella: boolean): string 
  * `emitFunctions` so the selection rule stays in one place.
  */
 const referencedDataModelImports = (body: string): ReadonlyArray<"Doc" | "Id"> =>
-    (["Doc", "Id"] as const).filter((name) => new RegExp(String.raw`\b${name}<`, "u").test(body));
+    // A QUALIFIED occurrence does not count. A handler may import its own
+    // `Doc`/`Id` from its own module, which renders as
+    // `import("../lib/mydoc.js").Doc<"posts">` — that names its own module and
+    // needs no import here, so counting it would emit an unused
+    // `import type { Doc }` and fail the generated file under `noUnusedLocals`.
+    (["Doc", "Id"] as const).filter((name) => new RegExp(String.raw`(?<![.$\w])${name}<`, "u").test(body));
 
 /**
  * The `Return` a `FunctionReference` should carry.

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -331,6 +331,18 @@ const syncProjectFile = (project: Project, filePath: string, content: string): v
     existing.replaceWithText(content);
 };
 
+/** Whether `project` already holds `filePath` with exactly `content`. */
+const projectFileMatches = (project: Project, filePath: string, content: string): boolean => project.getSourceFile(filePath)?.getFullText() === content;
+
+/**
+ * Ceiling on the infer → render → re-infer loop that bootstraps `api.ts` /
+ * `functions.ts` (issue #283). A cold 92-table backend was measured converging
+ * on the fourth pass, so the cap sits above that with room, and it exists only
+ * so a schema that would not converge ends the run with its last output instead
+ * of spinning.
+ */
+const MAX_INFERENCE_PASSES = 8;
+
 /**
  * Construct the ts-morph `Project` codegen discovers over. Prefers the user's
  * `tsconfig.json` (when one is found walking up from `lunoraDirectory`) so
@@ -497,6 +509,8 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     const outputDirectory = join(lunoraDirectory, "_generated");
     const dataModelPath = join(outputDirectory, "dataModel.ts");
     const serverPath = join(outputDirectory, "server.ts");
+    const apiPath = join(outputDirectory, "api.ts");
+    const generatedFunctionsPath = join(outputDirectory, "functions.ts");
 
     // In MEMORY only — the disk write waits for the write phase with everything
     // else. `discoverFunctions` infers against the ts-morph `Project`, not the
@@ -512,7 +526,6 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     syncProjectFile(project, dataModelPath, dataModelContent);
     syncProjectFile(project, serverPath, serverContent);
 
-    const functions = discoverFunctions(project, lunoraDirectory);
     const httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
     const migrations = discoverMigrations(project, lunoraDirectory);
 
@@ -523,7 +536,51 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // `isCustomMutator` push-protocol override. Both return `[]` when their file
     // is absent, so a project without them emits byte-identical generated code.
     const shapes = discoverShapes(project, lunoraDirectory);
-    const mutators = discoverMutators(project, lunoraDirectory);
+
+    // Inference reads `api.ts`/`functions.ts` too: a handler doing
+    // `ctx.runQuery(api.messages.list)` gets its own return type FROM the
+    // `FunctionReference` those files declare. On a cold `_generated/` they do
+    // not exist, so `api` resolves to nothing, every return inferred through one
+    // collapses, and the collapse is written out — the tree only converges on a
+    // later run, which is what pushed projects into wrapping the CLI in a
+    // run-until-the-hash-stops-changing loop (issue #283). `dataModel.ts` and
+    // `server.ts` are seeded above precisely so they cannot do this; these two
+    // cannot be, because their content IS the inference result.
+    //
+    // So iterate instead: infer, render, feed the render back, re-infer. The
+    // loop exits as soon as a pass's output matches what inference already saw,
+    // which is the FIRST pass on any warm tree — `syncProjectFile` leaves an
+    // identical file alone, so nothing is re-inferred and a converged project
+    // costs exactly what it did before. The cap turns a hypothetical
+    // non-converging schema into a bounded run with the last output rather than
+    // a spin.
+    let functions = discoverFunctions(project, lunoraDirectory);
+    let mutators = discoverMutators(project, lunoraDirectory);
+
+    let converged = false;
+
+    for (let pass = 1; pass <= MAX_INFERENCE_PASSES && !converged; pass += 1) {
+        const previewApi = emitApi({ agents, functions, httpRoutes, mutators, useUmbrella, workflows });
+        const previewFunctions = emitFunctions({ agents, functions, migrations, mutators, shapes, useUmbrella, usesSandbox });
+
+        converged = projectFileMatches(project, apiPath, previewApi) && projectFileMatches(project, generatedFunctionsPath, previewFunctions);
+
+        if (!converged) {
+            syncProjectFile(project, apiPath, previewApi);
+            syncProjectFile(project, generatedFunctionsPath, previewFunctions);
+
+            functions = discoverFunctions(project, lunoraDirectory);
+            mutators = discoverMutators(project, lunoraDirectory);
+        }
+    }
+
+    if (!converged) {
+        throw new LunoraError(
+            "CODEGEN_DIAGNOSTIC",
+            `Codegen did not reach a stable api.ts/functions.ts within ${String(MAX_INFERENCE_PASSES)} inference passes. That is a generator bug, not a project one — please report it with your schema size and the handlers whose return types keep moving.`,
+            { status: 500 },
+        );
+    }
 
     const crons = discoverCrons(project, lunoraDirectory, workflows, agents);
 

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -85,7 +85,19 @@ import {
     emitWranglerCronTriggers,
 } from "./emit";
 import { emitApp } from "./emit-app";
-import type { AgentIR, ContainerIR, MaskMetadataIR, QueueIR, ShapeIR, WorkflowIR, WranglerVariableIR } from "./ir";
+import type {
+    AgentIR,
+    ContainerIR,
+    FunctionIR,
+    HttpRouteIR,
+    MaskMetadataIR,
+    MigrationIR,
+    MutatorIR,
+    QueueIR,
+    ShapeIR,
+    WorkflowIR,
+    WranglerVariableIR,
+} from "./ir";
 import { buildOpenApiDocument, emitOpenApiModule } from "./openapi";
 import { buildOpenRpcDocument, emitOpenRpcModule } from "./openrpc";
 import { setStandardTypeResolver } from "./parse-validator";
@@ -335,13 +347,95 @@ const syncProjectFile = (project: Project, filePath: string, content: string): v
 const projectFileMatches = (project: Project, filePath: string, content: string): boolean => project.getSourceFile(filePath)?.getFullText() === content;
 
 /**
- * Ceiling on the infer → render → re-infer loop that bootstraps `api.ts` /
- * `functions.ts` (issue #283). A cold 92-table backend was measured converging
- * on the fourth pass, so the cap sits above that with room, and it exists only
- * so a schema that would not converge ends the run with its last output instead
- * of spinning.
+ * Ceiling on the infer → render → re-infer loop below. Cold trees were measured
+ * converging on the fourth pass, so the cap sits above that with room. It is a spin guard, not a correctness guarantee — see
+ * {@link inferToFixpoint} for what happens when it is reached.
  */
 const MAX_INFERENCE_PASSES = 8;
+
+/**
+ * Infer every handler's return type against a project that already contains the
+ * `api.ts` / `functions.ts` those types are read back through.
+ *
+ * `dataModel.ts` and `server.ts` are rendered into the project before any
+ * inference happens, precisely so a cold tree cannot collapse the types that
+ * depend on them. These two cannot be seeded that way, because their content IS
+ * the inference result: a handler doing `ctx.runQuery(api.messages.list)` — or a
+ * streaming route whose chunk type comes back through one — infers against a
+ * module that does not exist yet on a cold `_generated/`, collapses, and the
+ * collapse is written out. The tree then converges only on a later invocation,
+ * which is what pushes projects into wrapping the CLI in a
+ * run-until-the-hash-stops-changing loop (issue #283).
+ *
+ * So iterate: infer, render, feed the render back, re-infer. The loop returns as
+ * soon as a pass's render matches what inference already saw — the first pass on
+ * any warm tree, where `syncProjectFile` leaves an identical file alone and
+ * nothing is re-inferred, so a converged project pays one extra render and no
+ * extra inference.
+ *
+ * The render that matched is RETURNED rather than recomputed by the caller. Two
+ * call sites building the same emit arguments 150 lines apart is how the
+ * convergence check silently starts comparing something other than what gets
+ * written.
+ *
+ * **Reaching the cap is not an error.** A handler that embeds its own result —
+ * `{ deeper: await createCaller(ctx).grow.grow() }`, the shape of any
+ * self-referential tree query — grows its inferred type by one level per pass
+ * and has no fixpoint to reach. Throwing there would turn a project that
+ * previously built (with that one return typed `unknown`) into one that produces
+ * no `_generated/` at all. So the last render wins, exactly as it did before this
+ * loop existed: never worse than one run's output, usually better.
+ */
+const inferToFixpoint = (options: {
+    agents: ReadonlyArray<AgentIR>;
+    apiPath: string;
+    generatedFunctionsPath: string;
+    lunoraDirectory: string;
+    migrations: ReadonlyArray<MigrationIR>;
+    project: Project;
+    shapes: ReadonlyArray<ShapeIR>;
+    usesSandbox: boolean;
+    useUmbrella: boolean;
+    workflows: ReadonlyArray<WorkflowIR>;
+}): {
+    apiContent: string;
+    functions: ReadonlyArray<FunctionIR>;
+    functionsContent: string;
+    httpRoutes: ReadonlyArray<HttpRouteIR>;
+    mutators: ReadonlyArray<MutatorIR>;
+} => {
+    const { agents, apiPath, generatedFunctionsPath, lunoraDirectory, migrations, project, shapes, usesSandbox, useUmbrella, workflows } = options;
+
+    // The three discoverers that read an inferred return type through
+    // `unwrapHandlerReturn`, and therefore the three that have to be re-run when
+    // the files those types resolve against change. Everything else in the
+    // pipeline reads syntax, not inference, and stays outside.
+    let functions = discoverFunctions(project, lunoraDirectory);
+    let mutators = discoverMutators(project, lunoraDirectory);
+    let httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
+
+    for (let pass = 1; ; pass += 1) {
+        const apiContent = emitApi({ agents, functions, httpRoutes, mutators, useUmbrella, workflows });
+        const functionsContent = emitFunctions({ agents, functions, migrations, mutators, shapes, useUmbrella, usesSandbox });
+
+        // Converged, or out of budget — either way this render is the answer, and
+        // the budget check sits HERE so the final pass's re-inference is never
+        // computed and then discarded.
+        if (
+            pass >= MAX_INFERENCE_PASSES ||
+            (projectFileMatches(project, apiPath, apiContent) && projectFileMatches(project, generatedFunctionsPath, functionsContent))
+        ) {
+            return { apiContent, functions, functionsContent, httpRoutes, mutators };
+        }
+
+        syncProjectFile(project, apiPath, apiContent);
+        syncProjectFile(project, generatedFunctionsPath, functionsContent);
+
+        functions = discoverFunctions(project, lunoraDirectory);
+        mutators = discoverMutators(project, lunoraDirectory);
+        httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
+    }
+};
 
 /**
  * Construct the ts-morph `Project` codegen discovers over. Prefers the user's
@@ -526,7 +620,6 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     syncProjectFile(project, dataModelPath, dataModelContent);
     syncProjectFile(project, serverPath, serverContent);
 
-    const httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
     const migrations = discoverMigrations(project, lunoraDirectory);
 
     // Local-first sync engine (Phase 7): replication shapes (`lunora/shapes.ts`)
@@ -535,52 +628,22 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // mutators register into `LUNORA_FUNCTIONS` (transaction-wrapped) and the
     // `isCustomMutator` push-protocol override. Both return `[]` when their file
     // is absent, so a project without them emits byte-identical generated code.
+    // Neither reads a handler's inferred return type, so both sit outside the
+    // fixpoint below — unlike `discoverHttpRoutes`, which does.
     const shapes = discoverShapes(project, lunoraDirectory);
 
-    // Inference reads `api.ts`/`functions.ts` too: a handler doing
-    // `ctx.runQuery(api.messages.list)` gets its own return type FROM the
-    // `FunctionReference` those files declare. On a cold `_generated/` they do
-    // not exist, so `api` resolves to nothing, every return inferred through one
-    // collapses, and the collapse is written out — the tree only converges on a
-    // later run, which is what pushed projects into wrapping the CLI in a
-    // run-until-the-hash-stops-changing loop (issue #283). `dataModel.ts` and
-    // `server.ts` are seeded above precisely so they cannot do this; these two
-    // cannot be, because their content IS the inference result.
-    //
-    // So iterate instead: infer, render, feed the render back, re-infer. The
-    // loop exits as soon as a pass's output matches what inference already saw,
-    // which is the FIRST pass on any warm tree — `syncProjectFile` leaves an
-    // identical file alone, so nothing is re-inferred and a converged project
-    // costs exactly what it did before. The cap turns a hypothetical
-    // non-converging schema into a bounded run with the last output rather than
-    // a spin.
-    let functions = discoverFunctions(project, lunoraDirectory);
-    let mutators = discoverMutators(project, lunoraDirectory);
-
-    let converged = false;
-
-    for (let pass = 1; pass <= MAX_INFERENCE_PASSES && !converged; pass += 1) {
-        const previewApi = emitApi({ agents, functions, httpRoutes, mutators, useUmbrella, workflows });
-        const previewFunctions = emitFunctions({ agents, functions, migrations, mutators, shapes, useUmbrella, usesSandbox });
-
-        converged = projectFileMatches(project, apiPath, previewApi) && projectFileMatches(project, generatedFunctionsPath, previewFunctions);
-
-        if (!converged) {
-            syncProjectFile(project, apiPath, previewApi);
-            syncProjectFile(project, generatedFunctionsPath, previewFunctions);
-
-            functions = discoverFunctions(project, lunoraDirectory);
-            mutators = discoverMutators(project, lunoraDirectory);
-        }
-    }
-
-    if (!converged) {
-        throw new LunoraError(
-            "CODEGEN_DIAGNOSTIC",
-            `Codegen did not reach a stable api.ts/functions.ts within ${String(MAX_INFERENCE_PASSES)} inference passes. That is a generator bug, not a project one — please report it with your schema size and the handlers whose return types keep moving.`,
-            { status: 500 },
-        );
-    }
+    const { apiContent, functions, functionsContent, httpRoutes, mutators } = inferToFixpoint({
+        agents,
+        apiPath,
+        generatedFunctionsPath,
+        lunoraDirectory,
+        migrations,
+        project,
+        shapes,
+        useUmbrella,
+        usesSandbox,
+        workflows,
+    });
 
     const crons = discoverCrons(project, lunoraDirectory, workflows, agents);
 
@@ -724,8 +787,6 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // a throw between here and there leaves `_generated/` untouched.
     const emitStartedAt = timingEnabled ? performance.now() : 0;
 
-    const apiContent = emitApi({ agents, functions, httpRoutes, mutators, useUmbrella, workflows });
-    const functionsContent = emitFunctions({ agents, functions, migrations, mutators, shapes, useUmbrella, usesSandbox });
     // Structural schema snapshot for the pre-deploy drift gate. Built from the
     // discovered schema + the declared migration ids; the CLI gate diffs the
     // CURRENT snapshot against the committed baseline. Always computed (cheap,


### PR DESCRIPTION
Closes #509 and #283. Both are about `_generated/` output that does not compile on a consumer's own `tsconfig.json`, and both were reported twice.

## #509 — inferred return types emitted by name with no import

`isBareNameable` treated every `.d.ts` and everything under `node_modules` as "prints correctly bare". That holds for `lib.*.d.ts` globals and fails for a module-scoped declaration in a package — `_generated/api.ts` imports nothing from the user's modules, so a handler returning an imported `PaginationResult` had the bare name written out. TS2304 in generated output, `lunora codegen` exit 0. The test is now whether the declaring file is script-mode (no module symbol), which is exactly the global case.

Reclassifying those types alone would route them into structural expansion, which flattens the alias and declines outright on an index or call signature. So the handler's own `import` is used instead: the type is emitted as `import("<specifier>").Name<…>`, a form `emit.ts`'s existing qualifier rebasers already resolve from inside `_generated/`.

Matching that import has to resolve through the checker's alias chain, not by source-file identity. `lunorash/server` star-re-exports `@lunora/server`, so the file an import declaration resolves to is almost never the file the interface is declared in — comparing the two answers "not imported" for every umbrella type, which is the commonest spelling there is. That was the difference between the first cut and a working one.

An `enum` is deliberately not qualified: the wire carries the member's value and an enum type is nominal, so the union of values stays the honest rendering.

Two follow-ons fall out. A qualified `Doc<…>`/`Id<…>` no longer counts as a bare reference, so a user's own generic `Doc` cannot draw an unused generated import and fail `noUnusedLocals`. And the drizzle half of the report is already closed on `alpha` — `renderDrizzleFile` emits `import type { Id } from "./dataModel.js"` behind `needsId`, type-only, so no cycle.

## #283 — not reproducible from a cold `_generated/`

`dataModel.ts` and `server.ts` are rendered into the ts-morph project before inference precisely so a cold tree cannot collapse what depends on them. `api.ts`/`functions.ts` cannot be seeded that way, because their content **is** the inference result — so a handler reading its own return type back through the api surface (`ctx.runQuery(api.x.y)`) still inferred against a missing module on pass 1, and the collapse was written out.

`runCodegen` now iterates: infer, render, feed the render back, re-infer. It exits as soon as a pass's output matches what inference already saw — the first pass on any warm tree, where `syncProjectFile` leaves an identical file alone and nothing is re-inferred, so a converged project costs what it did before. Failing to settle within eight passes throws rather than writing output that needs another run to be correct.

## The gate this class never had

Emitted code is only ever compiled inside a real app, so every unit test here asserts on substrings of a string. `apps/playground` already strict-typechecks `lunora/_generated/**` via `tsconfig.generated.json` in CI — nothing exercised the failing shape. `notes.listPage` now returns an imported `PaginationResult<Doc<"notes">>` with **no `.output()`**, which is that shape.

Verified it bites: forcing the bare name back into the generated files reproduces the report's own error.

```
lunora/_generated/api.ts(37,85): error TS2552: Cannot find name 'PaginationResult'.
lunora/_generated/functions.ts(201,76): error TS2552: Cannot find name 'PaginationResult'.
```

Keep the annotation and keep the import — that procedure is the regression gate, not decoration.

## Verification

- `@lunora/codegen` 1382, `@lunora/cli` 1314, `@lunora/vite` 200, `@lunora/playground` 6 — all pass
- `pnpm run api:check` — 54 snapshots match
- `apps/playground` `lint:types` (app **and** strict `_generated`) passes
- golden fixtures and all four `examples/*` regenerate byte-identical
- prettier + eslint clean on every changed file

Three existing tests asserted the old "expand everything" contract and now assert the qualified form; the enum case is unchanged by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination for retrieving notes.

* **Bug Fixes**
  * Improved generated type imports, including support for re-exported types and qualified references.
  * Prevented unnecessary generated imports that could cause compilation errors.
  * Improved code generation so inferred API and function types converge reliably on a fresh setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 2

Two thermo passes plus CodeRabbit ran against the first two commits. Everything actionable is fixed in `3273611d3` and `303142d57`; the notable ones changed behaviour rather than wording.

**The pass cap no longer throws.** A handler that embeds its own result — `{ deeper: await createCaller(ctx).grow.grow() }`, the shape of any self-referential tree query — grows its inferred type by one level per pass and has no fixpoint. Throwing there turned a project that previously built, with that one return typed `unknown`, into one that produced no `_generated/` at all. The last render wins instead. Two comments already described that behaviour and the code now matches them.

**#283 was still open for streaming routes.** `route.chunkType` reads a handler return through the same `unwrapHandlerReturn`, so `discoverHttpRoutes` belonged inside the fixpoint and was outside it. Invisible because no fixpoint fixture had a route in it; one does now.

**A named type could smuggle a value the wire refuses.** Naming a type publishes every member of it, so `import("./money").Envelope` typed `result.at.format()` for a value `encodeWire` throws on at the send site. The guard now sits in `unwrapHandlerReturn`, where every return type funnels through — which also closes the older half of the same hole, where a class the handler does *not* import is not bare-nameable, so the checker printed it fully qualified and the reachability walk waved it through. Globals are trusted rather than walked; descending into `Date` reports it unencodable on the strength of `getTime()`.

**A tsconfig `paths` alias is no longer emitted.** The qualifier is the specifier the user wrote, and none of `emit.ts`'s three rebasers touch an alias, so it resolved under the authoring project's config and nowhere else — including under a strict config for generated output, which is the pattern this repo ships. Matched against the project's configured patterns and declined back to structural expansion.

The fixpoint is extracted into `inferToFixpoint`, so the render that satisfied the convergence check is the render that gets written rather than one rebuilt from a duplicate argument list 150 lines away; the budget check sits ahead of the re-inference it would otherwise discard; and the module-export lookup is memoised, because the caller's already-imported guard does not bound it — a namespace import makes that guard always true.

`303142d57` then closes #511, filed during the review as out of scope and since asked for: a type from an ambient `declare module "spec"` block, and a default-imported type, both of which still went out bare.

Tests added for the two ordering rules that were comment-only (alias-of-array, alias-of-union), the `Doc<…>` import selection carrying half the original fix, both new declines, the streaming-route fixpoint, and both #511 shapes. Each was checked by reverting its guard and watching it fail.

**Not done:** consolidating the seven reachability predicates behind one classifier returning a tagged union. It is the right shape and I would take it, but not stacked on eight behaviour fixes in one PR — the concrete harm it was raised for (`importSpecifierFor` computed twice per type) is gone via the memo.

Verification after round 2: `@lunora/codegen` 1391, `@lunora/cli` 1314, `@lunora/vite` 200, `@lunora/playground` 6; `api:check` 54 snapshots; `apps/playground` `lint:types` app-side and strict-generated; golden fixtures and all four `examples/*` byte-identical; warm codegen unchanged at 2.24-2.26s.
