### PR TITLE
fix(codegen): retarget an emitted qualifier onto a specifier that resolves

### DIFF
--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -499,7 +499,7 @@ describe("discoverFunctions", () => {
 
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
 
-            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/mydoc").Doc<"posts">');
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/mydoc.js").Doc<"posts">');
         });
 
         it("qualifies a PACKAGE type the handler imports — a module `.d.ts` is no more reachable than a user's own file (#509)", () => {
@@ -584,7 +584,7 @@ describe("discoverFunctions", () => {
 
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
 
-            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/badges").Badges');
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/badges.js").Badges');
         });
 
         it("keeps an alias for a UNION, rather than flattening it to its members", () => {
@@ -605,7 +605,7 @@ describe("discoverFunctions", () => {
 
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
 
-            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/result").Outcome');
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/result.js").Outcome');
         });
 
         it("declines a return whose member the wire cannot encode, imported or not", () => {
@@ -683,7 +683,7 @@ describe("discoverFunctions", () => {
 
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
 
-            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/boxed").default');
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('import("./lib/boxed.js").default');
         });
 
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2174,14 +2174,18 @@ export const get = query.input({}).query(async (): Promise<UIMessage> => ({ text
             }
         });
 
-        it("retargets a TypeScript-extension specifier onto the extension the generated file can name", () => {
-            expect.assertions(4);
+        it("retargets a TypeScript-extension specifier onto the extension its own family is emitted as", () => {
+            expect.assertions(6);
 
             // `./lib/shapes.ts` is legal in the app's own source, and illegal
             // wherever the flag permitting it is off — which includes a dedicated
             // strict config for generated output, the pattern this repo itself
             // ships. Written through verbatim it is a TS5097 in a file the user
-            // did not write; `.js` resolves under both.
+            // did not write.
+            //
+            // The replacement is per FAMILY, not a blanket `.js`: TypeScript
+            // substitutes `.js`→`.ts` and `.cjs`→`.cts` but never across the two,
+            // so a `.cts` module named `.js` is a TS2307 instead.
             writeFileSync(
                 join(workdir, "tsconfig.json"),
                 `{
@@ -2192,12 +2196,15 @@ export const get = query.input({}).query(async (): Promise<UIMessage> => ({ text
             );
             mkdirSync(join(workdir, "lunora", "lib"), { recursive: true });
             writeFileSync(join(workdir, "lunora", "lib", "shapes.ts"), `export interface Badge {\n    label: string;\n}\n`);
+            writeFileSync(join(workdir, "lunora", "lib", "legacy.cts"), `export interface Stamp {\n    at: number;\n}\n`);
             writeFileSync(
                 join(workdir, "lunora", "badges.ts"),
                 `import { query } from "./_generated/server.js";
 import type { Badge } from "./lib/shapes.ts";
+import type { Stamp } from "./lib/legacy.cts";
 
 export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "x" }));
+export const stamp = query.input({}).query(async (): Promise<Stamp> => ({ at: 1 }));
 `,
             );
 
@@ -2205,7 +2212,8 @@ export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "
 
             for (const rendered of [api, functions]) {
                 expect(rendered).toContain('import("../lib/shapes.js").Badge');
-                expect(rendered).not.toContain('import("../lib/shapes.ts")');
+                expect(rendered).toContain('import("../lib/legacy.cjs").Stamp');
+                expect(rendered).not.toMatch(/import\("\.\.\/lib\/(?:shapes|legacy)\.[cm]?ts"\)/u);
             }
         });
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2143,6 +2143,72 @@ export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "
             }
         });
 
+        it("names the index module when the handler imports the type through a DIRECTORY", () => {
+            expect.assertions(4);
+
+            // `emit.ts` appends `.js` to a rebased relative qualifier, because
+            // the generated files are consumed under NodeNext. Extension
+            // substitution covers a file — `./lib/shapes.js` finds
+            // `lib/shapes.ts` — but a directory has nothing to substitute, so
+            // `../agent/client.js` for `agent/client/index.ts` was a TS2307 in a
+            // file the user did not write and could not repair: `paths` does not
+            // apply to a relative specifier and no ambient declaration satisfies
+            // a qualified `import("…").T`.
+            mkdirSync(join(workdir, "lunora", "agent", "client"), { recursive: true });
+            writeFileSync(join(workdir, "lunora", "agent", "messages.ts"), `export interface UIMessage {\n    text: string;\n}\n`);
+            writeFileSync(join(workdir, "lunora", "agent", "client", "index.ts"), `export type { UIMessage } from "../messages";\n`);
+            writeFileSync(
+                join(workdir, "lunora", "chat.ts"),
+                `import { query } from "./_generated/server.js";
+import type { UIMessage } from "./agent/client";
+
+export const get = query.input({}).query(async (): Promise<UIMessage> => ({ text: "x" }));
+`,
+            );
+
+            const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
+
+            for (const rendered of [api, functions]) {
+                expect(rendered).toContain('import("../agent/client/index.js").UIMessage');
+                expect(rendered).not.toContain('import("../agent/client.js")');
+            }
+        });
+
+        it("retargets a TypeScript-extension specifier onto the extension the generated file can name", () => {
+            expect.assertions(4);
+
+            // `./lib/shapes.ts` is legal in the app's own source, and illegal
+            // wherever the flag permitting it is off — which includes a dedicated
+            // strict config for generated output, the pattern this repo itself
+            // ships. Written through verbatim it is a TS5097 in a file the user
+            // did not write; `.js` resolves under both.
+            writeFileSync(
+                join(workdir, "tsconfig.json"),
+                `{
+    "compilerOptions": { "moduleResolution": "bundler", "module": "ESNext", "target": "ES2022", "strict": true, "noEmit": true, "allowImportingTsExtensions": true },
+    "include": ["lunora/**/*"]
+}
+`,
+            );
+            mkdirSync(join(workdir, "lunora", "lib"), { recursive: true });
+            writeFileSync(join(workdir, "lunora", "lib", "shapes.ts"), `export interface Badge {\n    label: string;\n}\n`);
+            writeFileSync(
+                join(workdir, "lunora", "badges.ts"),
+                `import { query } from "./_generated/server.js";
+import type { Badge } from "./lib/shapes.ts";
+
+export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "x" }));
+`,
+            );
+
+            const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
+
+            for (const rendered of [api, functions]) {
+                expect(rendered).toContain('import("../lib/shapes.js").Badge');
+                expect(rendered).not.toContain('import("../lib/shapes.ts")');
+            }
+        });
+
         it("declines to name an imported type carrying a member the wire cannot encode", () => {
             expect.assertions(4);
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { ModuleKind, ModuleResolutionKind, Project, ScriptTarget } from "ts-morph";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { UMBRELLA_BASE_PACKAGES } from "../src/emit";
@@ -36,6 +37,64 @@ const ctxInterface = (server: string, name: "ActionCtx" | "MutationCtx" | "Query
     const close = server.indexOf("\n}", open);
 
     return server.slice(open, close);
+};
+
+/** Every relative `import("…")` qualifier the emitted text carries — the ones that must resolve from inside `_generated/`. */
+const RELATIVE_QUALIFIER_RE = /import\("(?<specifier>\.\.?\/[^"]+)"\)/gu;
+
+/** TS2307 unresolved module, TS2835 missing extension, TS5097 a `.ts` extension the config does not allow. */
+const UNRESOLVED_DIAGNOSTIC_CODES = new Set([2307, 2835, 5097]);
+
+/**
+ * Every relative qualifier in `rendered` that does not resolve from
+ * `lunora/_generated/`, asked of the compiler rather than of a path heuristic.
+ *
+ * Seven distinct compile errors have shipped inside generated output — each
+ * caught late, then pinned afterwards by a `toContain` on the one string that
+ * was wrong at the time. A qualifier is not a string though, it is a promise
+ * that a module exists, so this writes the qualifiers into a probe file beside
+ * the files that will carry them and lets TypeScript answer.
+ *
+ * Deliberately compiled under a config of its own rather than the app's: what
+ * makes these failures unrepairable is that the generated files are read
+ * elsewhere — by a sibling package, or under a dedicated strict config for
+ * generated output, the pattern this repo itself ships. A qualifier that needs
+ * the authoring project's own settings to resolve has already lost.
+ *
+ * Scoped to the probe file, so a fixture workdir with no `node_modules` does not
+ * drown the answer in unresolved `@lunora/*` imports from `api.ts` itself.
+ */
+const unresolvableQualifiers = (root: string, rendered: ReadonlyArray<string>): string[] => {
+    const specifiers = [...new Set(rendered.flatMap((text) => [...text.matchAll(RELATIVE_QUALIFIER_RE)].map((match) => match.groups?.specifier ?? "")))];
+
+    if (specifiers.length === 0) {
+        return [];
+    }
+
+    const probePath = join(root, "lunora", "_generated", "qualifier-probe.ts");
+
+    writeFileSync(probePath, specifiers.map((specifier, index) => `export type Probe${String(index)} = import("${specifier}");`).join("\n"));
+
+    const project = new Project({
+        compilerOptions: {
+            module: ModuleKind.NodeNext,
+            moduleResolution: ModuleResolutionKind.NodeNext,
+            noEmit: true,
+            strict: true,
+            target: ScriptTarget.ES2022,
+        },
+        skipAddingFilesFromTsConfig: true,
+        useInMemoryFileSystem: false,
+    });
+    const unresolved = project
+        .addSourceFileAtPath(probePath)
+        .getPreEmitDiagnostics()
+        .filter((diagnostic) => UNRESOLVED_DIAGNOSTIC_CODES.has(diagnostic.getCode()))
+        .map((diagnostic) => specifiers[(diagnostic.getSourceFile()?.getLineAndColumnAtPos(diagnostic.getStart() ?? 0).line ?? 1) - 1] ?? "");
+
+    rmSync(probePath, { force: true });
+
+    return unresolved;
 };
 
 let workdir: string;
@@ -2144,7 +2203,7 @@ export const get = query.input({}).query(async (): Promise<Badge> => ({ label: "
         });
 
         it("names the index module when the handler imports the type through a DIRECTORY", () => {
-            expect.assertions(4);
+            expect.assertions(5);
 
             // `emit.ts` appends `.js` to a rebased relative qualifier, because
             // the generated files are consumed under NodeNext. Extension
@@ -2172,10 +2231,68 @@ export const get = query.input({}).query(async (): Promise<UIMessage> => ({ text
                 expect(rendered).toContain('import("../agent/client/index.js").UIMessage');
                 expect(rendered).not.toContain('import("../agent/client.js")');
             }
+
+            expect(unresolvableQualifiers(workdir, [api, functions])).toStrictEqual([]);
+        });
+
+        it("names a directory module by the file it resolved to, whatever that file is called", () => {
+            expect.assertions(5);
+
+            // Every shape below reads as a FILE to a heuristic over the written
+            // string, and is a directory on disk — so each one emitted a
+            // confidently wrong specifier rather than declining:
+            //
+            // - `./here/index` where `here/index/` is itself a directory, and
+            //   `./at` where the directory is literally named `at`: an "already
+            //   ends in /index" test suppresses the append that was needed.
+            // - `./vendor`, resolved through its own `package.json` to a file
+            //   not called `index` at all: a "the index file is named index"
+            //   test never fires.
+            // - `./shim`, whose index is `index.d.ts`: ts-morph reports that
+            //   extension whole rather than as `.ts`, so a map of source
+            //   extensions misses it and the blanket `.js` suffix applies.
+            //
+            // None of them are questions about the string. Rebuilding the
+            // specifier from the resolved path answers all four at once.
+            const directories: ReadonlyArray<readonly [string, string, string]> = [
+                ["here/index", "index.ts", "Nested"],
+                ["at", "index.ts", "Named"],
+                ["shim", "index.d.ts", "Declared"],
+                ["vendor/src", "main.ts", "Manifest"],
+            ];
+
+            for (const [directory, file, exported] of directories) {
+                mkdirSync(join(workdir, "lunora", directory), { recursive: true });
+                writeFileSync(join(workdir, "lunora", directory, file), `export interface ${exported} {\n    a: string;\n}\n`);
+            }
+
+            writeFileSync(join(workdir, "lunora", "vendor", "package.json"), `{ "types": "./src/main.ts" }\n`);
+            writeFileSync(
+                join(workdir, "lunora", "shapes.ts"),
+                `import { query } from "./_generated/server.js";
+import type { Nested } from "./here/index";
+import type { Named } from "./at";
+import type { Declared } from "./shim";
+import type { Manifest } from "./vendor";
+
+export const nested = query.input({}).query(async (): Promise<Nested> => ({ a: "x" }));
+export const named = query.input({}).query(async (): Promise<Named> => ({ a: "x" }));
+export const declared = query.input({}).query(async (): Promise<Declared> => ({ a: "x" }));
+export const manifest = query.input({}).query(async (): Promise<Manifest> => ({ a: "x" }));
+`,
+            );
+
+            const { api, functions } = runCodegen({ projectRoot: workdir }).generated;
+
+            expect(api).toContain('import("../here/index/index.js").Nested');
+            expect(api).toContain('import("../at/index.js").Named');
+            expect(api).toContain('import("../shim/index.js").Declared');
+            expect(api).toContain('import("../vendor/src/main.js").Manifest');
+            expect(unresolvableQualifiers(workdir, [api, functions])).toStrictEqual([]);
         });
 
         it("retargets a TypeScript-extension specifier onto the extension its own family is emitted as", () => {
-            expect.assertions(6);
+            expect.assertions(7);
 
             // `./lib/shapes.ts` is legal in the app's own source, and illegal
             // wherever the flag permitting it is off — which includes a dedicated
@@ -2215,6 +2332,8 @@ export const stamp = query.input({}).query(async (): Promise<Stamp> => ({ at: 1 
                 expect(rendered).toContain('import("../lib/legacy.cjs").Stamp');
                 expect(rendered).not.toMatch(/import\("\.\.\/lib\/(?:shapes|legacy)\.[cm]?ts"\)/u);
             }
+
+            expect(unresolvableQualifiers(workdir, [api, functions])).toStrictEqual([]);
         });
 
         it("declines to name an imported type carrying a member the wire cannot encode", () => {

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -374,7 +374,7 @@ const isGloballyDeclared = (type: Type): boolean => {
 interface QualifiedImport {
     /** The name the module exports it under — `"default"` for a default export. */
     exportName: string;
-    /** The specifier verbatim as the user wrote it. */
+    /** The specifier as the user wrote it, except that a directory module is pointed at its `index` (see {@link resolveEmittedSpecifier}). */
     specifier: string;
 }
 
@@ -506,10 +506,81 @@ const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: N
     return target?.getDeclarations().includes(declaration) === true ? { exportName: name, specifier: importDeclaration.getModuleSpecifierValue() } : undefined;
 };
 
+/** A specifier resolved from the handler's own directory rather than from a package name. */
+const RELATIVE_SPECIFIER_RE = /^\.\.?(?:$|\/)/u;
+
+/** A specifier whose final segment already names the directory's index module, with or without an extension. */
+const INDEX_SEGMENT_RE = /(?:^|\/)index(?:\.\w+)?$/u;
+
+/** A written-out trailing slash, dropped so the appended `/index` does not double it. */
+const TRAILING_SLASH_RE = /\/$/u;
+
+/** A TypeScript source extension written into an import specifier — legal in the app's own source, not in generated output (see {@link resolveEmittedSpecifier}). */
+const TS_EXTENSION_RE = /\.(?<extension>[cm]?tsx?)$/u;
+
+/** What each TypeScript source extension is written as once emitted. */
+const EMITTED_EXTENSIONS = new Map([
+    ["cts", "cjs"],
+    ["mts", "mjs"],
+    ["ts", "js"],
+    ["tsx", "js"],
+]);
+
+/**
+ * Rewrite the specifier a handler wrote into one that also resolves from
+ * `_generated/`.
+ *
+ * The qualifier is the user's own import text, and there are two spellings that
+ * resolve where they were written and nowhere else. Both are TS2307/TS5097 in a
+ * file nobody wrote and nothing can repair from outside: `paths` does not apply
+ * to a relative specifier, and no ambient declaration satisfies a qualified
+ * `import("…").T`.
+ *
+ * A DIRECTORY module (`./agent/client` → `agent/client/index.ts`) is the first.
+ * `emit.ts` appends `.js` to a rebased relative qualifier, because the generated
+ * files are consumed under NodeNext where the extension is mandatory. Extension
+ * substitution answers that for a file — `./lib/types.js` finds `lib/types.ts` —
+ * but a directory has no extension to substitute, so `../agent/client.js`
+ * resolves to nothing. Naming the index module explicitly gives the suffix
+ * something to attach to. Asked of the RESOLVED source file rather than guessed
+ * from the shape of the string: `./agent/client` is spelled the same whether it
+ * is a file or a directory, and only the checker knows which one it found.
+ *
+ * A TS EXTENSION (`./lib/types.ts`) is the second. It is legal in the app's own
+ * source under `allowImportingTsExtensions`, and illegal everywhere that flag is
+ * off — which includes a dedicated strict config for generated output, the
+ * pattern this repo itself ships. The emitted extension resolves under both.
+ */
+const resolveEmittedSpecifier = (importDeclaration: ImportDeclaration, matched: QualifiedImport): QualifiedImport => {
+    if (!RELATIVE_SPECIFIER_RE.test(matched.specifier)) {
+        return matched;
+    }
+
+    const written = TS_EXTENSION_RE.exec(matched.specifier)?.groups?.extension;
+    const emitted = written === undefined ? undefined : EMITTED_EXTENSIONS.get(written);
+
+    // An extension means the specifier already names a file, so the directory
+    // question below is answered and `emit.ts` appends nothing either.
+    if (written !== undefined && emitted !== undefined) {
+        return { ...matched, specifier: `${matched.specifier.slice(0, -written.length)}${emitted}` };
+    }
+
+    if (INDEX_SEGMENT_RE.test(matched.specifier)) {
+        return matched;
+    }
+
+    const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
+
+    return moduleFile?.getBaseNameWithoutExtension() === "index"
+        ? { ...matched, specifier: `${matched.specifier.replace(TRAILING_SLASH_RE, "")}/index` }
+        : matched;
+};
+
 /**
  * The module specifier the handler's file imports `name` from, when that import
- * resolves to `declaration` — the literal string the user wrote, never a
- * resolved path. `undefined` when the module does not import it.
+ * resolves to `declaration` — the string the user wrote, never a resolved path,
+ * beyond the retargeting {@link resolveEmittedSpecifier} does.
+ * `undefined` when the module does not import it.
  *
  * This answers both questions the printing rule needs: whether the checker will
  * print the name BARE at `node` (it will, exactly when the module imports it),
@@ -542,7 +613,7 @@ const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: st
                 : matchesAmbientModule(importDeclaration, ambientSpecifier, name);
 
         if (matched !== undefined) {
-            return matched;
+            return resolveEmittedSpecifier(importDeclaration, matched);
         }
     }
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -509,71 +509,85 @@ const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: N
 /** A specifier resolved from the handler's own directory rather than from a package name. */
 const RELATIVE_SPECIFIER_RE = /^\.\.?(?:$|\/)/u;
 
-/** A specifier whose final segment already names the directory's index module, with or without an extension. */
-const INDEX_SEGMENT_RE = /(?:^|\/)index(?:\.\w+)?$/u;
-
 /** A written-out trailing slash, dropped so the appended `/index` does not double it. */
 const TRAILING_SLASH_RE = /\/$/u;
 
-/** A TypeScript source extension written into an import specifier — legal in the app's own source, not in generated output (see {@link resolveEmittedSpecifier}). */
-const TS_EXTENSION_RE = /\.(?<extension>[cm]?tsx?)$/u;
+/**
+ * A module extension written into an import specifier, in either family — the
+ * source one the app may name under `allowImportingTsExtensions`, or the emitted
+ * one NodeNext requires. Matched as a closed list so a dotted DIRECTORY name
+ * (`./lib/utils.core`) is not mistaken for an extension and truncated.
+ */
+const MODULE_EXTENSION_RE = /\.[cm]?[jt]sx?$/u;
 
-/** What each TypeScript source extension is written as once emitted. */
+/**
+ * The extension a module is written as once emitted, keyed by the extension its
+ * file has on disk. TypeScript's own resolution substitutes in this direction —
+ * `.js` finds `.ts`, `.mjs` finds `.mts` — and only within a family, which is
+ * why `.mts` and `.cts` cannot borrow the plain `.js` the other four use.
+ */
 const EMITTED_EXTENSIONS = new Map([
-    ["cts", "cjs"],
-    ["mts", "mjs"],
-    ["ts", "js"],
-    ["tsx", "js"],
+    [".cjs", "cjs"],
+    [".cts", "cjs"],
+    [".js", "js"],
+    [".jsx", "jsx"],
+    [".mjs", "mjs"],
+    [".mts", "mjs"],
+    [".ts", "js"],
+    [".tsx", "js"],
 ]);
 
 /**
- * Rewrite the specifier a handler wrote into one that also resolves from
- * `_generated/`.
+ * Name the module a handler imported from by the file it RESOLVED to, with the
+ * extension that file is emitted as.
  *
- * The qualifier is the user's own import text, and there are two spellings that
- * resolve where they were written and nowhere else. Both are TS2307/TS5097 in a
- * file nobody wrote and nothing can repair from outside: `paths` does not apply
- * to a relative specifier, and no ambient declaration satisfies a qualified
- * `import("…").T`.
+ * The qualifier `_generated/` gets is the user's own import text, and several
+ * spellings of it resolve where they were written and nowhere else — each a
+ * TS2307/TS5097 in a file nobody wrote and nothing can repair from outside:
+ * `paths` does not apply to a relative specifier, and no ambient declaration
+ * satisfies a qualified `import("…").T`.
  *
- * A DIRECTORY module (`./agent/client` → `agent/client/index.ts`) is the first.
- * `emit.ts` appends `.js` to a rebased relative qualifier, because the generated
- * files are consumed under NodeNext where the extension is mandatory. Extension
- * substitution answers that for a file — `./lib/types.js` finds `lib/types.ts` —
- * but a directory has no extension to substitute, so `../agent/client.js`
- * resolves to nothing. Naming the index module explicitly gives the suffix
- * something to attach to. Asked of the RESOLVED source file rather than guessed
- * from the shape of the string: `./agent/client` is spelled the same whether it
- * is a file or a directory, and only the checker knows which one it found.
+ * `emit.ts` rebases a relative qualifier out of `_generated/` and appends `.js`
+ * when it carries no extension, because the generated files are consumed under
+ * NodeNext where the extension is mandatory. That single suffix is right for
+ * exactly one case — a `.ts` file named without an extension — and wrong for the
+ * rest.
  *
- * A TS EXTENSION (`./lib/types.ts`) is the second. It is legal in the app's own
- * source under `allowImportingTsExtensions`, and illegal everywhere that flag is
- * off — which includes a dedicated strict config for generated output, the
- * pattern this repo itself ships. The emitted extension resolves under both.
+ * A DIRECTORY (`./agent/client` → `agent/client/index.ts`) has no extension to
+ * substitute, so `../agent/client.js` resolves to nothing. A `.mts`/`.cts` file
+ * is emitted as `.mjs`/`.cjs`, and substitution does not cross families, so
+ * `.js` misses it. A TS extension the app wrote itself (`./lib/types.ts`, legal
+ * under `allowImportingTsExtensions`) is kept verbatim and is illegal everywhere
+ * that flag is off — including a dedicated strict config for generated output,
+ * the pattern this repo itself ships.
+ *
+ * Rather than special-case each, name the resolved file: `./agent/client` is
+ * spelled the same whether it is a file or a directory, and only the checker
+ * knows which one it found. An unresolved import, or a file in no family we
+ * emit (a `.json` module), is left exactly as written.
  */
 const resolveEmittedSpecifier = (importDeclaration: ImportDeclaration, matched: QualifiedImport): QualifiedImport => {
     if (!RELATIVE_SPECIFIER_RE.test(matched.specifier)) {
         return matched;
     }
 
-    const written = TS_EXTENSION_RE.exec(matched.specifier)?.groups?.extension;
-    const emitted = written === undefined ? undefined : EMITTED_EXTENSIONS.get(written);
+    const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
+    const extension = moduleFile === undefined ? undefined : EMITTED_EXTENSIONS.get(moduleFile.getExtension());
 
-    // An extension means the specifier already names a file, so the directory
-    // question below is answered and `emit.ts` appends nothing either.
-    if (written !== undefined && emitted !== undefined) {
-        return { ...matched, specifier: `${matched.specifier.slice(0, -written.length)}${emitted}` };
-    }
-
-    if (INDEX_SEGMENT_RE.test(matched.specifier)) {
+    if (moduleFile === undefined || extension === undefined) {
         return matched;
     }
 
-    const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
+    const written = matched.specifier.replace(TRAILING_SLASH_RE, "");
 
-    return moduleFile?.getBaseNameWithoutExtension() === "index"
-        ? { ...matched, specifier: `${matched.specifier.replace(TRAILING_SLASH_RE, "")}/index` }
-        : matched;
+    // A directory names its index module explicitly; anything else replaces
+    // whichever extension the app wrote — including none — with the emitted one.
+    const base =
+        moduleFile.getBaseNameWithoutExtension() === "index" && !MODULE_EXTENSION_RE.test(written) && !written.endsWith("/index")
+            ? `${written}/index`
+            : written.replace(MODULE_EXTENSION_RE, "");
+
+    return { ...matched, specifier: `${base}.${extension}` };
 };
 
 /**

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -1,3 +1,5 @@
+import { posix } from "node:path";
+
 import type {
     ArrowFunction,
     CallExpression,
@@ -374,7 +376,7 @@ const isGloballyDeclared = (type: Type): boolean => {
 interface QualifiedImport {
     /** The name the module exports it under — `"default"` for a default export. */
     exportName: string;
-    /** The specifier as the user wrote it, except that a directory module is pointed at its `index` (see {@link resolveEmittedSpecifier}). */
+    /** The specifier a package was written with, or the resolved file a relative import names (see {@link emittedSpecifierFor}). */
     specifier: string;
 }
 
@@ -466,11 +468,8 @@ const bindsByName = (importDeclaration: ImportDeclaration, name: string): boolea
  * source file for `getModuleSpecifierSourceFile()` to resolve to — the symbol
  * identity check every other path uses has nothing to compare against here.
  */
-const matchesAmbientModule = (importDeclaration: ImportDeclaration, ambientSpecifier: string, name: string): QualifiedImport | undefined => {
-    const specifier = importDeclaration.getModuleSpecifierValue();
-
-    return specifier === ambientSpecifier && bindsByName(importDeclaration, name) ? { exportName: name, specifier } : undefined;
-};
+const matchesAmbientModule = (importDeclaration: ImportDeclaration, ambientSpecifier: string, name: string): string | undefined =>
+    importDeclaration.getModuleSpecifierValue() === ambientSpecifier && bindsByName(importDeclaration, name) ? name : undefined;
 
 /**
  * Whether `importDeclaration`'s DEFAULT binding resolves to `declaration`.
@@ -479,7 +478,7 @@ const matchesAmbientModule = (importDeclaration: ImportDeclaration, ambientSpeci
  * this matches by resolving the binding rather than by comparing names — and the
  * name it must be written under is `default`, whatever the local alias is.
  */
-const matchesDefaultImport = (importDeclaration: ImportDeclaration, declaration: Node): QualifiedImport | undefined => {
+const matchesDefaultImport = (importDeclaration: ImportDeclaration, declaration: Node): string | undefined => {
     const defaultImport = importDeclaration.getDefaultImport();
 
     if (defaultImport === undefined) {
@@ -488,13 +487,11 @@ const matchesDefaultImport = (importDeclaration: ImportDeclaration, declaration:
 
     const bound = defaultImport.getSymbol();
 
-    return (bound?.getAliasedSymbol() ?? bound)?.getDeclarations().includes(declaration) === true
-        ? { exportName: "default", specifier: importDeclaration.getModuleSpecifierValue() }
-        : undefined;
+    return (bound?.getAliasedSymbol() ?? bound)?.getDeclarations().includes(declaration) === true ? "default" : undefined;
 };
 
 /** Whether `importDeclaration` brings `name` in from the module that declares it, through any re-export chain. */
-const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: Node, name: string): QualifiedImport | undefined => {
+const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: Node, name: string): string | undefined => {
     if (!bindsByName(importDeclaration, name)) {
         return undefined;
     }
@@ -503,43 +500,39 @@ const matchesNamedImport = (importDeclaration: ImportDeclaration, declaration: N
     const exported = moduleFile === undefined ? undefined : moduleExport(moduleFile, name);
     const target = exported?.getAliasedSymbol() ?? exported;
 
-    return target?.getDeclarations().includes(declaration) === true ? { exportName: name, specifier: importDeclaration.getModuleSpecifierValue() } : undefined;
+    return target?.getDeclarations().includes(declaration) === true ? name : undefined;
 };
 
 /** A specifier resolved from the handler's own directory rather than from a package name. */
 const RELATIVE_SPECIFIER_RE = /^\.\.?(?:$|\/)/u;
 
-/** A written-out trailing slash, dropped so the appended `/index` does not double it. */
-const TRAILING_SLASH_RE = /\/$/u;
-
-/**
- * A module extension written into an import specifier, in either family — the
- * source one the app may name under `allowImportingTsExtensions`, or the emitted
- * one NodeNext requires. Matched as a closed list so a dotted DIRECTORY name
- * (`./lib/utils.core`) is not mistaken for an extension and truncated.
- */
-const MODULE_EXTENSION_RE = /\.[cm]?[jt]sx?$/u;
-
 /**
  * The extension a module is written as once emitted, keyed by the extension its
  * file has on disk. TypeScript's own resolution substitutes in this direction —
- * `.js` finds `.ts`, `.mjs` finds `.mts` — and only within a family, which is
- * why `.mts` and `.cts` cannot borrow the plain `.js` the other four use.
+ * `.js` finds `.ts`, `.mjs` finds `.mts` — and only within a family, which is why
+ * `.mts` and `.cts` cannot borrow the plain `.js` that `.ts`/`.tsx`/`.d.ts` use.
+ *
+ * `.d.ts` earns its own key because ts-morph reports it whole rather than as
+ * `.ts`, so a declaration file misses a map that lists only the four source
+ * extensions — and `index.d.ts` is a directory-index candidate under every
+ * resolution mode, which is how a hand-written shim directory used to slip
+ * through this with the blanket suffix still on it.
  */
 const EMITTED_EXTENSIONS = new Map([
-    [".cjs", "cjs"],
-    [".cts", "cjs"],
-    [".js", "js"],
-    [".jsx", "jsx"],
-    [".mjs", "mjs"],
-    [".mts", "mjs"],
-    [".ts", "js"],
-    [".tsx", "js"],
+    [".cjs", ".cjs"],
+    [".cts", ".cjs"],
+    [".d.ts", ".js"],
+    [".js", ".js"],
+    [".jsx", ".jsx"],
+    [".mjs", ".mjs"],
+    [".mts", ".mjs"],
+    [".ts", ".js"],
+    [".tsx", ".js"],
 ]);
 
 /**
- * Name the module a handler imported from by the file it RESOLVED to, with the
- * extension that file is emitted as.
+ * Name the module a handler imported from by the file it RESOLVED to, carrying
+ * the extension that file is emitted as.
  *
  * The qualifier `_generated/` gets is the user's own import text, and several
  * spellings of it resolve where they were written and nowhere else — each a
@@ -561,40 +554,46 @@ const EMITTED_EXTENSIONS = new Map([
  * that flag is off — including a dedicated strict config for generated output,
  * the pattern this repo itself ships.
  *
- * Rather than special-case each, name the resolved file: `./agent/client` is
- * spelled the same whether it is a file or a directory, and only the checker
- * knows which one it found. An unresolved import, or a file in no family we
- * emit (a `.json` module), is left exactly as written.
+ * None of those are questions to ask the written STRING, which is why this
+ * rebuilds the specifier from the resolved path instead of editing the text.
+ * Every shape a heuristic gets wrong — a directory named `index`, a directory
+ * reached as `./feature/index`, one resolved through its own `package.json`
+ * `types` to a file that is not called `index` at all, a dotted directory name
+ * that reads as an extension — is simply the path the checker already found,
+ * expressed from the handler's own directory.
+ *
+ * Left exactly as written: a package specifier (correct from any directory
+ * already), an unresolved or ambient import, and a file in no family we emit —
+ * a `.json` module, whose extension is part of its name rather than something
+ * substitution restores.
  */
-const resolveEmittedSpecifier = (importDeclaration: ImportDeclaration, matched: QualifiedImport): QualifiedImport => {
-    if (!RELATIVE_SPECIFIER_RE.test(matched.specifier)) {
-        return matched;
+const emittedSpecifierFor = (handlerFile: SourceFile, importDeclaration: ImportDeclaration): string | undefined => {
+    const written = importDeclaration.getModuleSpecifierValue();
+
+    if (!RELATIVE_SPECIFIER_RE.test(written)) {
+        return undefined;
     }
 
     const moduleFile = importDeclaration.getModuleSpecifierSourceFile();
     const extension = moduleFile === undefined ? undefined : EMITTED_EXTENSIONS.get(moduleFile.getExtension());
 
     if (moduleFile === undefined || extension === undefined) {
-        return matched;
+        return undefined;
     }
 
-    const written = matched.specifier.replace(TRAILING_SLASH_RE, "");
+    // ts-morph normalises every path it reports to forward slashes, so the POSIX
+    // helpers are the right ones here on Windows too.
+    const target = `${posix.join(moduleFile.getDirectoryPath(), moduleFile.getBaseNameWithoutExtension())}${extension}`;
+    const rebased = posix.relative(handlerFile.getDirectoryPath(), target);
 
-    // A directory names its index module explicitly; anything else replaces
-    // whichever extension the app wrote — including none — with the emitted one.
-    const base =
-        moduleFile.getBaseNameWithoutExtension() === "index" && !MODULE_EXTENSION_RE.test(written) && !written.endsWith("/index")
-            ? `${written}/index`
-            : written.replace(MODULE_EXTENSION_RE, "");
-
-    return { ...matched, specifier: `${base}.${extension}` };
+    return rebased.startsWith(".") ? rebased : `./${rebased}`;
 };
 
 /**
  * The module specifier the handler's file imports `name` from, when that import
- * resolves to `declaration` — the string the user wrote, never a resolved path,
- * beyond the retargeting {@link resolveEmittedSpecifier} does.
- * `undefined` when the module does not import it.
+ * resolves to `declaration` — a package specifier exactly as the user wrote it,
+ * a relative one rewritten by {@link emittedSpecifierFor} to name the file it
+ * resolved to. `undefined` when the module does not import it.
  *
  * This answers both questions the printing rule needs: whether the checker will
  * print the name BARE at `node` (it will, exactly when the module imports it),
@@ -621,13 +620,15 @@ const importSpecifierFor = (handlerFile: SourceFile, declaration: Node, name: st
     const ambientSpecifier = ambientModuleSpecifier(declaration);
 
     for (const importDeclaration of handlerFile.getImportDeclarations()) {
-        const matched =
+        // The matchers answer only WHICH EXPORT was reached. The specifier is
+        // built once, here, so no matcher can be added later that forgets it.
+        const exportName =
             ambientSpecifier === undefined
                 ? (matchesDefaultImport(importDeclaration, declaration) ?? matchesNamedImport(importDeclaration, declaration, name))
                 : matchesAmbientModule(importDeclaration, ambientSpecifier, name);
 
-        if (matched !== undefined) {
-            return resolveEmittedSpecifier(importDeclaration, matched);
+        if (exportName !== undefined) {
+            return { exportName, specifier: emittedSpecifierFor(handlerFile, importDeclaration) ?? importDeclaration.getModuleSpecifierValue() };
         }
     }
 


### PR DESCRIPTION
Fixes #512.

An emitted `import("…").T` qualifier carries the specifier the handler wrote, and `emit.ts` appends `.js` to it when it carries no extension, because generated output is consumed under NodeNext where the extension is mandatory. That single suffix is right for exactly one case — a `.ts` file named without an extension — and wrong for the rest. Each wrong one lands in a file nobody wrote that nothing outside it can repair: `paths` does not apply to a relative specifier and no ambient declaration satisfies a qualified `import("…").T`, so the tree does not compile until the *source* stops spelling the import that way.

- **A directory** (the reported case). `./agent/client` → `agent/client/index.ts` has no extension to substitute, so `../agent/client.js` is a TS2307.
- **A `.mts` / `.cts` file.** Emitted as `.mjs` / `.cjs`; substitution does not cross families, so `.js` misses it.
- **A TypeScript extension the app wrote itself.** `./lib/types.ts` is legal under `allowImportingTsExtensions` and illegal everywhere that flag is off — including a dedicated strict config for generated output, the pattern this repo itself ships. Verbatim it is a TS5097.

Rather than special-case each, the fix applies the rule underneath them: **name the module the import resolved to, carrying the extension that file is emitted as.** `./agent/client` is spelled the same whether it names a file or a directory, and only the checker knows which one it found. A file in no family codegen emits — a `.json` module — is left exactly as written, and the extension list is closed so a dotted *directory* name (`./lib/utils.core`) is not truncated as though it carried one.

## Scope of the sweep

- The checker's own verbatim rendering was probed and already prints `../lib/box/index.js` — it names the declaration site with an extension, so it never produced any of these shapes. The qualify path added in #510 is the only one that copies a user's spelling, hence the single fix site.
- Every other `getModuleSpecifierValue()` read in codegen compares a specifier rather than emitting one.
- The two remaining `.js` appends emit a discovered file path (`import * as f from "../<filePath>.js"`), which is a real file by construction.
- A directory never resolves to `index.mts`/`index.cts` under any resolution mode, so that combination needs no branch — deriving the extension from the resolved file covers it anyway.

On the issue's option 2 (emit the declaring module): the checker's verbatim path already does that. The `qualify` path exists precisely for types the checker prints bare because the declaring module is not nameable from `_generated/`, so it has to use the handler's own import — the coupling is narrower than the report assumes, and this closes it.

## Tests

Two fixtures in `run-codegen.test.ts` — a procedure with no `.output()` whose return type arrives through a directory module, and one through `.ts` / `.cts` specifiers — both verified failing without the fix. Four discovery unit tests now expect the extension the IR carries; emitted output is unchanged for them, since `emit.ts` appended the same `.js` a step later.

`@lunora/codegen`: 1393 tests pass, `lint:types` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated import resolution for TypeScript handlers.
  - Relative imports now correctly map to emitted JavaScript modules across supported module formats.
  - Directory-based imports are correctly resolved through their index modules.
  - Preserved unsupported, unresolved, and non-relative import paths without changes.
  - Improved handling of declaration-based imports when generating JavaScript references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->