### PR TITLE
fix(client,codegen,sql-store): address four review findings from #522

### DIFF
--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -443,6 +443,62 @@ describe("tabCoordinator — subscription-data/subscription-settled wire frames 
         follower.stop();
     });
 
+    it("stamps a broadcast subscription error with the identity it was raised under, not one an onError callback switched to", async () => {
+        expect.assertions(2);
+
+        // `fanSubscriptionError` runs subscriber `onError` callbacks
+        // synchronously, and signing out/in is a natural reaction to an
+        // auth-shaped rejection. Reading the fingerprint after that fan stamps
+        // the frame with the identity that REPLACED the one the error was raised
+        // under — and `identity` is exactly what a follower trusts to decide the
+        // frame is theirs, so tabs on the new identity would accept a rejection
+        // belonging to the old session.
+        const stamped: (string | null | undefined)[] = [];
+        const spy = vi
+            .spyOn(TabCoordinator.prototype, "broadcastSubscriptionError")
+            .mockImplementation((_key: string, _error: SubscriptionError, identity?: string | null) => {
+                stamped.push(identity);
+            });
+
+        vi.spyOn(TabCoordinator.prototype, "isLeader").mockReturnValue(true);
+
+        const constructed: string[] = [];
+        const client = new LunoraClient({
+            crossTabSync: true,
+            fetch: vi.fn<typeof fetch>(async () => jsonResponse({ value: null })),
+            url: TEST_URL,
+            WebSocket: createMockWebSocket(constructed),
+        });
+
+        try {
+            client.setAuthToken("token-1", "user-1");
+
+            const before = client.currentIdentity();
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, {
+                onError: () => {
+                    // The switch that used to win the race.
+                    client.setAuthToken("token-2", "user-2");
+                },
+            });
+
+            // Drive a server-side subscription rejection into the client.
+            const internals = client as unknown as {
+                handleErrorMessage: (message: { id?: string; message?: string; type: "error" }) => void;
+                subscriptions: { all: () => { id: string }[] };
+            };
+
+            internals.handleErrorMessage({ id: internals.subscriptions.all()[0]?.id, message: "rls denied", type: "error" });
+
+            expect(client.currentIdentity()).not.toBe(before);
+            expect(stamped).toStrictEqual([before]);
+        } finally {
+            spy.mockRestore();
+            vi.restoreAllMocks();
+            client.close();
+        }
+    });
+
     it("broadcastSubscriptionData/broadcastSubscriptionSettled carry cursor/epoch on the wire when supplied, and omit them when not", async () => {
         expect.assertions(4);
 

--- a/packages/client/__tests__/stream.test.ts
+++ b/packages/client/__tests__/stream.test.ts
@@ -421,6 +421,50 @@ describe("stream", () => {
             client.close();
         });
 
+        it("queues the unsubscribe when a started durable stream is cancelled while disconnected", async () => {
+            expect.assertions(3);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+            const iterable = client.stream(fnRef<number>("chat:answer"), {});
+
+            const first = latestSocket();
+
+            first.open();
+
+            const { id } = first.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>).find((f) => f.type === "stream") as { id: string };
+
+            // A seq-bearing chunk marks the run durable — it now outlives the
+            // socket, and the server keeps producing and persisting it.
+            first.receive({ data: 1, generation: 1234, id, seq: 1, type: "chunk" });
+
+            // Socket drops. The disconnect path queues a resume frame.
+            first.close();
+
+            // Consumer gives up while still disconnected. Dropping the cancel here
+            // is right for an ephemeral run but leaks a durable one: the resume
+            // frame is removed and nothing else ever tells the server to stop.
+            iterable.cancel();
+
+            vi.runOnlyPendingTimers();
+
+            const second = latestSocket();
+
+            second.open();
+
+            const frames = second.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+            const unsubscribeAt = frames.findIndex((f) => f.type === "unsubscribe" && f.id === id);
+
+            expect(unsubscribeAt).toBeGreaterThanOrEqual(0);
+            // And no resume may be sent for a run we just cancelled.
+            expect(frames.some((f) => f.type === "stream" && f.id === id)).toBe(false);
+            // Teardown has to precede anything that could restart it.
+            expect(frames.slice(0, unsubscribeAt).some((f) => f.type === "stream")).toBe(false);
+
+            client.close();
+        });
+
         it("buffers the start frame while the socket is connecting and flushes it on open", async () => {
             expect.assertions(2);
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -1013,7 +1013,22 @@ class LunoraClient {
      */
     private readonly streams = new Map<
         string,
-        { durable: boolean; generation: number | undefined; handle: StreamHandle; lastSeq: number; message: ClientMessage; shardKey: string | undefined }
+        {
+            durable: boolean;
+            generation: number | undefined;
+            handle: StreamHandle;
+            lastSeq: number;
+            message: ClientMessage;
+            shardKey: string | undefined;
+
+            /**
+             * Whether the start frame ever reached the server. Distinguishes "the
+             * run exists server-side and must be told to stop" from "the frame is
+             * still queued locally and can simply be dropped" — which is the whole
+             * question on the cancel path when the socket is down.
+             */
+            started: boolean;
+        }
     >();
 
     /** Live shape subscriptions (partial replication), keyed by their wire id. */
@@ -3364,26 +3379,7 @@ class LunoraClient {
         const { handle, iterable } = createStream<ReturnOf<F>>({
             maxBuffer: options.maxBuffer,
             onCancel: () => {
-                // Send the cancel frame on the matching connection (if any).
-                // If the socket is down we drop the cancel: the DO has already
-                // lost its handle on close, so there's nothing to abort.
-                const conn = this.getConnection(shardKey);
-
-                if (conn) {
-                    // Drop a start frame still waiting on the socket. Without
-                    // this the cancelled stream was sent anyway on the next open:
-                    // the server opened an iterator nobody consumes, its chunks
-                    // arrived for an id no longer in `this.streams` (a silent
-                    // no-op), and no `unsubscribe` ever followed because the
-                    // consumer had already gone. `handleDisconnect` knows to
-                    // filter `pendingStreams` by id; that knowledge just never
-                    // reached the cancel path.
-                    conn.pendingStreams = conn.pendingStreams?.filter((pending) => (pending as { id?: string }).id !== id);
-
-                    sendOn(conn, { id, type: "unsubscribe" });
-                }
-
-                this.streams.delete(id);
+                this.cancelStream(id, shardKey);
             },
         });
 
@@ -3410,7 +3406,17 @@ class LunoraClient {
         // `durable` starts from the caller's intent and is corrected by the first
         // `seq`-bearing chunk; a server that did not declare the procedure durable
         // never sends one, so the stream stays non-resumable.
-        this.streams.set(id, { durable: options.durable === true, generation: undefined, handle: handle as StreamHandle, lastSeq: 0, message, shardKey });
+        const record = {
+            durable: options.durable === true,
+            generation: undefined as number | undefined,
+            handle: handle as StreamHandle,
+            lastSeq: 0,
+            message,
+            shardKey,
+            started: false,
+        };
+
+        this.streams.set(id, record);
 
         // Fast path: socket is open, try to send immediately. `sendOn` can still
         // return `false` if the socket closed between the `wsState` check and the
@@ -3418,6 +3424,10 @@ class LunoraClient {
         // delivered, so fall through to the bounded pending-queue path below so it
         // rides the next reconnect instead of leaking a forever-hanging consumer.
         const sentImmediately = conn?.wsState === "open" && sendOn(conn, message);
+
+        // Once the frame lands the server owns a run for this id, so a later
+        // cancel has to reach it rather than just dropping the local record.
+        record.started = sentImmediately;
 
         if (!sentImmediately && conn === undefined) {
             // No connection at all, so there is nothing to send on AND nothing to
@@ -4930,16 +4940,7 @@ class LunoraClient {
                 // Reconnect-after-close: in-flight streams have already torn down
                 // on the server, so the only entries here are brand-new ones that
                 // raced the connect.
-                if (conn.pendingStreams && conn.pendingStreams.length > 0) {
-                    const pending = conn.pendingStreams;
-
-                    // eslint-disable-next-line no-param-reassign -- mutate the shared ShardConnection state machine in place
-                    conn.pendingStreams = [];
-
-                    for (const message of pending) {
-                        sendOn(conn, message);
-                    }
-                }
+                this.flushPendingStreams(conn);
 
                 // Rejoin every whisper topic registered for this shard so ephemeral
                 // channels survive a socket bounce.
@@ -4954,6 +4955,66 @@ class LunoraClient {
                 this.flushOfflineQueue(shardKey).catch(() => undefined);
             },
         });
+    }
+
+    /**
+     * Send the stream-start frames queued while the socket was (re)connecting,
+     * marking each one that lands as started on the server.
+     */
+    private flushPendingStreams(conn: ShardConnection): void {
+        if (!conn.pendingStreams || conn.pendingStreams.length === 0) {
+            return;
+        }
+
+        const pending = conn.pendingStreams;
+
+        // eslint-disable-next-line no-param-reassign -- mutate the shared ShardConnection state machine in place
+        conn.pendingStreams = [];
+
+        for (const message of pending) {
+            // Reaching the server is what makes a later cancel owe it an
+            // unsubscribe rather than a silent local delete.
+            const stream = sendOn(conn, message) ? this.streams.get(String((message as { id?: string }).id)) : undefined;
+
+            if (stream) {
+                stream.started = true;
+            }
+        }
+    }
+
+    /**
+     * Tear down a stream the consumer cancelled, telling the server when the
+     * server is the one still holding it.
+     */
+    private cancelStream(id: string, shardKey: string | undefined): void {
+        const conn = this.getConnection(shardKey);
+        const stream = this.streams.get(id);
+
+        if (conn) {
+            // Drop a start frame still waiting on the socket. Without this the
+            // cancelled stream was sent anyway on the next open: the server opened
+            // an iterator nobody consumes, its chunks arrived for an id no longer
+            // in `this.streams` (a silent no-op), and no `unsubscribe` ever
+            // followed because the consumer had already gone. `handleDisconnect`
+            // knows to filter `pendingStreams` by id; that knowledge just never
+            // reached the cancel path.
+            conn.pendingStreams = conn.pendingStreams?.filter((pending) => (pending as { id?: string }).id !== id);
+
+            // Dropping the cancel when the socket is down is right only for an
+            // EPHEMERAL run: the DO lost its handle on close, so there is nothing
+            // left to abort. A DURABLE run is the opposite — it outlives the
+            // socket by design, and the line above just removed the resume frame
+            // that would have carried us back to it. Without queueing the
+            // unsubscribe the server keeps producing and persisting a run no one
+            // will ever read, and nothing later says stop. `pendingUnsubscribes`
+            // already flushes ahead of `pendingStreams` on open, so the teardown
+            // lands before any resume that races it.
+            if (!sendOn(conn, { id, type: "unsubscribe" }) && stream?.durable === true && stream.started) {
+                conn.pendingUnsubscribes.push({ id, type: "unsubscribe" });
+            }
+        }
+
+        this.streams.delete(id);
     }
 
     private handleDisconnect(conn: ShardConnection): void {
@@ -5319,6 +5380,21 @@ class LunoraClient {
         if (state) {
             const subscriptionError = buildSubscriptionError(message);
 
+            // Snapshot the identity and key BEFORE fanning. `fanSubscriptionError`
+            // runs subscriber `onError` callbacks synchronously, and one of them
+            // may call `setAuthToken` — signing out and back in is a natural
+            // reaction to an auth-shaped rejection. Reading the fingerprint
+            // afterwards stamps this frame with the identity that replaced the one
+            // the error was raised under, and the `identity` field is exactly what
+            // followers trust to decide the frame is theirs: tabs on the NEW
+            // identity would accept a rejection belonging to the OLD session.
+            //
+            // Stamping the captured identity is the whole fix — followers still on
+            // that identity accept it (correct) and everyone else drops it
+            // (correct), so there is no need to also suppress the broadcast.
+            const identity = this.identityFingerprint();
+            const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
+
             fanSubscriptionError(state.errorCallbacks, subscriptionError);
 
             // Fan it to follower tabs too. `broadcastSubscriptionError` existed
@@ -5329,11 +5405,7 @@ class LunoraClient {
             // like its `data` and `settled` siblings — only the leader holds the
             // socket that produced this frame.
             if (this.tabCoordinator?.isLeader()) {
-                this.tabCoordinator.broadcastSubscriptionError(
-                    SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey),
-                    subscriptionError,
-                    this.identityFingerprint(),
-                );
+                this.tabCoordinator.broadcastSubscriptionError(key, subscriptionError, identity);
             }
 
             return;

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -961,7 +961,7 @@ export interface WorkflowReference<Params = Record<string, unknown>> {
         const objectMembers = sorted
             .map(
                 (workflow) =>
-                    `    ${workflow.exportName}: { isLunoraWorkflow: true, binding: ${JSON.stringify(workflow.bindingName)}, name: ${JSON.stringify(workflow.exportName)} },`,
+                    `    ${renderObjectKey(workflow.exportName)}: { isLunoraWorkflow: true, binding: ${JSON.stringify(workflow.bindingName)}, name: ${JSON.stringify(workflow.exportName)} },`,
             )
             .join("\n");
 
@@ -984,7 +984,7 @@ ${objectMembers}
         const objectMembers = sorted
             .map(
                 (agent) =>
-                    `    ${agent.exportName}: { isLunoraWorkflow: true, binding: ${JSON.stringify(agent.bindingName)}, name: ${JSON.stringify(agent.name)} },`,
+                    `    ${renderObjectKey(agent.exportName)}: { isLunoraWorkflow: true, binding: ${JSON.stringify(agent.bindingName)}, name: ${JSON.stringify(agent.name)} },`,
             )
             .join("\n");
 
@@ -1769,7 +1769,10 @@ const renderCaller = (functions: ReadonlyArray<FunctionIR>): { implementation: s
         .map(([file, list]) => {
             const namespace = sanitizeNamespace(file);
             const leaves = list
-                .map((definition) => `        ${definition.exportName}: (args) => callRegistered(context, "${namespace}:${definition.exportName}", args),`)
+                .map(
+                    (definition) =>
+                        `        ${renderObjectKey(definition.exportName)}: (args) => callRegistered(context, "${namespace}:${definition.exportName}", args),`,
+                )
                 .join("\n");
 
             // The object key is quoted when `namespace` isn't a bare identifier

--- a/packages/sql-store/__tests__/value-codec.test.ts
+++ b/packages/sql-store/__tests__/value-codec.test.ts
@@ -27,6 +27,38 @@ describe("nested wire-typed values", () => {
         // stored form and still read back unchanged.
         expect(sqliteEncode({ a: 1, b: [true, "x"], c: null })).toBe(JSON.stringify({ a: 1, b: [true, "x"], c: null }));
     });
+
+    it.each(["array", "object", "record", "any", "union"])("returns a legacy %s row that looks wire-encoded unchanged", (kind) => {
+        expect.assertions(1);
+
+        // Legitimate app data that happens to be shaped like a wire payload, and
+        // written before this path existed — so it never passed through
+        // `encodeWire`'s `"arr"` escape. Sniffing the content for the tag decodes
+        // it as `42n`, and the next patch/replace persists that corruption. Only
+        // the explicit prefix that `sqliteEncode` writes marks a wire value.
+        const legacy = ["$lunora.wire$", "bigint", "42"];
+
+        expect(sqliteDecode(JSON.stringify(legacy), kind)).toStrictEqual(legacy);
+    });
+
+    it("still round-trips that same array when it is written through the encoder", () => {
+        expect.assertions(2);
+
+        // The escape hatch has to keep working: written through `sqliteEncode` the
+        // array is escaped, marked, and must come back as itself — not as `42n`.
+        const hostile = ["$lunora.wire$", "bigint", "42"];
+        const stored = sqliteEncode(hostile) as string;
+
+        expect(stored.startsWith("$lunora.wire$")).toBe(true);
+        expect(sqliteDecode(stored, "array")).toStrictEqual(hostile);
+    });
+
+    it("marks a genuinely wire-encoded value and leaves ordinary JSON unmarked", () => {
+        expect.assertions(2);
+
+        expect(sqliteEncode({ n: 1n }) as string).toMatch(/^\$lunora\.wire\$/);
+        expect(sqliteEncode({ n: 1 }) as string).not.toMatch(/^\$lunora\.wire\$/);
+    });
 });
 
 describe("sqliteEncode", () => {

--- a/packages/sql-store/src/value-codec.ts
+++ b/packages/sql-store/src/value-codec.ts
@@ -17,26 +17,31 @@ import { effectiveKind } from "../../../shared/effective-kind";
 import { decodeWire, encodeWire, needsWireEncoding, WIRE_TAG } from "../../../shared/wire-codec";
 
 /**
- * Walk a decoded JSON column for wire tags only when one can be present.
- *
- * `decodeWire` is identity for pure JSON but still walks and rebuilds the whole
- * structure to prove it — pure overhead for the ordinary document carrying no
- * `bigint`/bytes leaf, which is the common case on the per-column path of every
- * global read. Decoding unconditionally measured ~1.3x on an object column and
- * ~1.25x on a 100-row page against a plain parse; this gate recovers about three
- * quarters of that.
- *
- * A tagged value is a JSON array whose first element is exactly {@link WIRE_TAG},
- * so a tag cannot survive `JSON.stringify` without appearing verbatim in the
- * text. Testing the raw string is therefore sound in the direction that matters:
- * a false negative is impossible, and a false positive (app data that happens to
- * contain the sentinel) merely takes the slow path and still decodes correctly.
- *
- * Takes the already-parsed value rather than parsing itself so it depends only on
- * imports: `import/exports-last` wants a non-exported helper above the exports,
- * and calling `tryJsonParse` from there would trip `no-use-before-define`.
+ * Marks a stored column as wire-encoded. Reuses {@link WIRE_TAG} rather than
+ * minting a second sentinel — as a *prefix* it cannot be confused with the tag
+ * appearing *inside* a value, because `JSON.stringify` output always starts with
+ * `{`, `[`, `"`, a digit, `-`, `t`, `f`, or `n`, never `$`.
  */
-const decodeWireIfTagged = (raw: string, parsed: unknown): unknown => (raw.includes(WIRE_TAG) ? decodeWire(parsed) : parsed);
+const WIRE_PREFIX = WIRE_TAG;
+
+/**
+ * Decode a stored JSON column, honouring the wire marker written by
+ * {@link sqliteEncode}.
+ *
+ * Testing an explicit prefix rather than sniffing for the tag anywhere in the
+ * text is what makes this unambiguous: a legacy row that merely *contains* an
+ * array shaped like a wire payload is ordinary data and is returned as parsed,
+ * where a content sniff would decode it and the next write would persist the
+ * corruption.
+ *
+ * It is also the cheaper test. `decodeWire` is identity for pure JSON but still
+ * walks and rebuilds the whole structure to prove it — pure overhead on the
+ * per-column path of every global read, measuring ~1.3x on an object column and
+ * ~1.25x on a 100-row page. A `startsWith` is O(1) against the O(n) scan a
+ * content sniff needs.
+ */
+const decodeJsonColumn = (raw: string, parse: (text: string) => unknown): unknown =>
+    raw.startsWith(WIRE_PREFIX) ? decodeWire(parse(raw.slice(WIRE_PREFIX.length))) : parse(raw);
 
 /** Map a JS value onto its SQLite storage form — SQLite has no boolean, so true/false → 1/0. */
 export const sqliteEncode = (value: unknown): unknown => {
@@ -66,11 +71,21 @@ export const sqliteEncode = (value: unknown): unknown => {
     // Wire-encode a composite so a nested `bigint`/bytes leaf survives. A bare
     // `JSON.stringify` threw an untyped `TypeError` on `{ n: 1n }` (surfacing as
     // an opaque 500) and silently flattened `{ b: <ArrayBuffer> }` to `{"b":{}}`
-    // — data destroyed with no error at all. `encodeWire` is identity for pure
-    // JSON, so an ordinary document stores byte-identically to before and
-    // existing rows still read back unchanged.
+    // — data destroyed with no error at all.
+    //
+    // Only a value that actually needs it is wire-encoded, and that form is
+    // marked with a leading `WIRE_PREFIX` so the reader can tell it apart from
+    // ordinary JSON with certainty rather than by sniffing the content. Without
+    // the marker, a row already holding the array `["$lunora.wire$","bigint","42"]`
+    // — legitimate app data, written before this path existed and so never passed
+    // through `encodeWire`'s `"arr"` escape — decodes as `42n`, and the next
+    // `patch`/`replace` persists that corruption. `encodeWire` escapes such an
+    // array on the way in, so only pre-existing rows are exposed; the marker
+    // closes them too.
+    //
+    // An ordinary document is untouched: no prefix, byte-identical to before.
     try {
-        return needsWireEncoding(value) ? JSON.stringify(encodeWire(value)) : JSON.stringify(value);
+        return needsWireEncoding(value) ? WIRE_PREFIX + JSON.stringify(encodeWire(value)) : JSON.stringify(value);
     } catch (error: unknown) {
         // `encodeWire` throws a bare `TypeError` for a non-plain object and a
         // `RangeError` past its depth cap; re-thrown typed so the writer names
@@ -148,12 +163,17 @@ export const sqliteDecode = (raw: unknown, kind: string | undefined): unknown =>
         case "any":
         case "from":
         case "union": {
-            return typeof raw === "string" && (raw.startsWith("{") || raw.startsWith("[")) ? decodeWireIfTagged(raw, tryJsonParse(raw)) : raw;
+            // The wire marker joins `{`/`[` as a shape this branch must decode —
+            // a marked value is not raw JSON, so it would otherwise fall through
+            // and be returned as its own storage string.
+            return typeof raw === "string" && (raw.startsWith("{") || raw.startsWith("[") || raw.startsWith(WIRE_PREFIX))
+                ? decodeJsonColumn(raw, tryJsonParse)
+                : raw;
         }
         case "array":
         case "object":
         case "record": {
-            return typeof raw === "string" ? decodeWireIfTagged(raw, tryJsonParse(raw)) : raw;
+            return typeof raw === "string" ? decodeJsonColumn(raw, tryJsonParse) : raw;
         }
         case "bigint": {
             return decodeBigint(raw);


### PR DESCRIPTION
Follow-up to #522. Those four review findings were still open when #522 merged, so they land here on top of `alpha`.

Each was verified against the current code before fixing — one was confirmed by experiment first, and the two behavioural ones were confirmed by reverting the fix and watching the new test go red.

## `sql-store` — a legacy row shaped like a wire value was decoded as one

Sniffing the parsed value for the tag cannot tell an encoded value from app data that merely looks like one. A row already holding `["$lunora.wire$","bigint","42"]` — legitimate data, written before this path existed and so never passed through `encodeWire`'s `"arr"` escape — decoded as `42n`, and the next `patch`/`replace` persisted that corruption.

`sqliteEncode` now marks a wire-encoded value with a leading prefix and the reader tests only that, so an unmarked row is returned exactly as parsed. An ordinary document is unchanged and still stores byte-identically.

It is also **faster** than the content scan it replaces (`startsWith` is O(1) against O(n)), which puts the decode back within ~1% of the pre-wire baseline instead of ~5–10%:

| benchmark | alpha ref | this PR | `includes` scan |
| --- | --- | --- | --- |
| `object (JSON text)` | 3,760,743 | 3,728,428 | 3,560,477 |
| `union (non-scalar)` | 10,628,568 | 10,656,690 | 9,937,030 |
| `100-row page` | 14,712 | 14,278 | 13,829 |

## `client` — a cancelled durable stream left the server producing forever

A durable run outlives the socket by design. Cancelling while disconnected removed the queued resume frame, failed to send the unsubscribe on the dead socket, and dropped the local record — so nothing ever told the server to stop, and it kept producing and persisting a run no one would read.

The unsubscribe is now queued on `pendingUnsubscribes`, which already flushes ahead of `pendingStreams`, so teardown lands before any resume that races it. A `started` flag distinguishes this from a frame that never reached the server, which is still just dropped.

## `client` — an error broadcast could be stamped with the wrong identity

`fanSubscriptionError` runs subscriber `onError` callbacks synchronously, and signing out/in is a natural reaction to an auth-shaped rejection. Reading the fingerprint after the fan stamped the frame with the identity that *replaced* the one the error was raised under — and `identity` is exactly what followers trust to decide a frame is theirs, so tabs on the new identity accepted a rejection belonging to the old session.

Captured before the fan. Also suppressing the broadcast was considered and rejected: the captured stamp is already correct for every recipient, and dropping it would lose a legitimate delivery.

## `codegen` — three more `__proto__` value positions

The index-entry site was already fixed in #522; the caller-object leaf and the workflow/agent reference objects still emitted a raw key, where `__proto__:` is a prototype setter rather than an own property, so the entry silently vanishes. Type positions are deliberately left alone — an interface member named `__proto__` is an ordinary declaration.

## Verification

`tsc`, ESLint, and tests green for all three packages (761 / 1557 / 122), plus `lint:generated` (16 generators reproduce committed output) and `api:check` (54 snapshots, no public surface change). Rebuilt and re-run against current `alpha`, not the merged branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ