### PR TITLE
fix(values,server)!: reject undeclared keys on the way out, and refuse output on a stream

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -7519,6 +7519,14 @@ Re-exported from `@lunora/values` — signature tracked at its source.
 
 Re-exported from `@lunora/values` — signature tracked at its source.
 
+### `ObjectColumnValidator` (interface)
+
+Re-exported from `@lunora/values` — signature tracked at its source.
+
+### `ParseOptions` (interface)
+
+Re-exported from `@lunora/values` — signature tracked at its source.
+
 ### `SchemaNodeReader` (interface)
 
 Re-exported from `@lunora/values` — signature tracked at its source.

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -1579,11 +1579,15 @@ interface QueryBuilder<Context, Args extends ArgsValidator, Output = undefined> 
         args: InferArgs<Args>;
         ctx: Context;
     }) => Output | Promise<Output>) => RegisteredQuery<Args, Output>;
-    stream: <R>(handler: (options: {
+    stream: [
+        Output
+    ] extends [
+        undefined
+    ] ? <R>(handler: (options: {
         args: InferArgs<Args>;
         ctx: Context;
         signal: AbortSignal;
-    }) => AsyncGenerator<R, void, void> | AsyncIterable<R>, options?: StreamOptions) => RegisteredStream<Args, R>;
+    }) => AsyncGenerator<R, void, void> | AsyncIterable<R>, options?: StreamOptions) => RegisteredStream<Args, R> : never;
     use: <ContextOut>(middleware: Middleware<Context, ContextOut>) => QueryBuilder<ContextOut, Args, Output>;
     x402: (config: X402ProcedureConfig) => QueryBuilder<Context, Args, Output>;
 }

--- a/api-snapshots/values.api.md
+++ b/api-snapshots/values.api.md
@@ -180,6 +180,22 @@ interface NumberColumnValidator extends ColumnValidator<number, number> {
 }
 ```
 
+### `ObjectColumnValidator` (interface)
+
+```ts
+interface ObjectColumnValidator<T> extends ColumnValidator<T, T> {
+    strip: () => ObjectColumnValidator<T>;
+}
+```
+
+### `ParseOptions` (interface)
+
+```ts
+interface ParseOptions {
+    rejectUnknownKeys?: boolean;
+}
+```
+
 ### `SchemaNodeReader` (interface)
 
 ```ts
@@ -265,8 +281,8 @@ interface Validator<T = unknown> extends StandardSchemaV1<T, T> {
     check: (predicate: (value: T) => boolean, options?: CheckOptions | string) => Validator<T>;
     readonly kind: ValidatorKind;
     meta: (options: MetaOptions) => Validator<T>;
-    parse: (value: unknown) => T;
-    safeParse: (value: unknown) => {
+    parse: (value: unknown, options?: ParseOptions) => T;
+    safeParse: (value: unknown, options?: ParseOptions) => {
         error: ValidationError;
         ok: false;
     } | {

--- a/apps/docs/src/content/docs/concepts/validation.mdx
+++ b/apps/docs/src/content/docs/concepts/validation.mdx
@@ -102,16 +102,47 @@ export const getProfile = query
     });
 ```
 
-<Callout type="info">
-    `.output()` does not apply to streaming/subscription chunks: each chunk is yielded as-is. Use it for the single resolved value of a `query` / `mutation` /
-    `action`.
-</Callout>
+### Returning more than you declared
+
+On the way **in**, `v.object` drops keys it does not declare — that is what stops
+an over-posted field reaching your handler. On the way **out**, the same
+behaviour would delete a field the server meant to send, so `.output()` rejects
+undeclared keys instead:
+
+```ts
+.output(v.object({ id: v.id("users"), name: v.string() }))
+.query(async ({ ctx, args }) => {
+    const user = await ctx.db.get(args.userId);
+
+    return user; // ← 500: "object has 3 undeclared key(s): email, createdAt, …"
+});
+```
+
+The error names the keys, so the fix is either adding them to the validator or
+saying you meant to drop them.
+
+#### Narrowing on purpose: `.strip()`
+
+Trimming an internal field off a row before it reaches a client is a real use of
+`.output()`. Mark it and it works exactly as before:
+
+```ts
+.output(v.object({ id: v.id("users"), name: v.string() }).strip())
+.query(async ({ ctx, args }) => ctx.db.get(args.userId)); // email, passwordHash dropped
+```
+
+`.strip()` returns a **new** validator, so calling it on a shared const does not
+change what other procedures using that const enforce.
 
 <Callout type="warn">
-    `v.object(...)` **strips** keys it does not declare rather than rejecting them, and `.output()` is enforced at runtime. So a column that exists in your
-    schema but is missing from a hand-written output validator disappears from every response that function serves, with no error anywhere. Derive output
-    validators from the table shape where you can, or test them against it. (`.stream()` is the exception noted above — it never parses chunks, so nothing is
-    stripped there either.)
+    This is the one asymmetry worth remembering: **input strips, output rejects.** Without it, a column present in your table and missing from a hand-written
+    output validator vanished from every response that function served, with no error anywhere — a schema mistake turning into silent data loss. `.strip()`
+    keeps the narrowing available and makes it visible in review.
+</Callout>
+
+<Callout type="info">
+    **`.output()` and `.stream()` cannot be combined** — it is a type error. Stream chunks are yielded as-is with no per-chunk validation, so accepting an
+    output validator there would promise something it never did. Validate inside the handler, or return the whole payload from `.query()`.
 </Callout>
 
 ## Return-type inference to the client
@@ -136,7 +167,7 @@ second schema to keep in sync: the validator is the contract on both ends.
 | `v.id(table)`          | `Id<table>`                   | Branded foreign-key id                   |
 | `v.literal(value)`     | exact `value`                 | String / number / boolean / null literal |
 | `v.array(inner)`       | `Array<Infer<inner>>`         | Homogeneous array                        |
-| `v.object(shape)`      | `{ ...shape }`                | Undeclared keys are **stripped**         |
+| `v.object(shape)`      | `{ ...shape }`                | Extra keys: stripped in, rejected out    |
 | `v.union(a, b, ...)`   | any member                    | Discriminated by `kind` when present     |
 | `v.record(key, value)` | `Record<key, value>`          | Map-style object                         |
 | `v.optional(inner)`    | `Infer<inner>` \| `undefined` | Makes a field optional                   |
@@ -173,9 +204,10 @@ than at compile time.
   what the database writes when a field is absent on insert; it does **not**
   fill a missing value in during `parse`. Reading a defaulted field out of
   `args` gives `undefined`.
-- **`v.object` strips undeclared keys.** There is no `.strict()`, and a
-  `.check()` cannot restore rejection because the predicate receives the
-  already-stripped value.
+- **`v.object` strips undeclared keys on input, and rejects them on output.**
+  There is no `.strict()`: input stripping is not configurable, and `.output()`
+  is strict for you. A `.check()` cannot restore rejection on the input side,
+  because the predicate receives the already-stripped value.
 
 Genuinely absent: there is no `v.enum` (spell it as
 `v.union(v.literal("a"), v.literal("b"))`), no `.extend()`, and no loose-object

--- a/packages/advisor/src/lints/static/output-projection-missing-on-public-read.ts
+++ b/packages/advisor/src/lints/static/output-projection-missing-on-public-read.ts
@@ -10,7 +10,7 @@ import { isPiiColumn } from "../helpers";
  * A public query is reachable by any client. Returning a table row verbatim ships
  * every column it holds — including PII the caller never needed — and silently
  * widens the exposed surface every time a column is added to the table later. An
- * explicit `.output(v.object({ … }))` projection (or a `.use(mask(...))` policy)
+ * explicit `.output(v.object({ … }).strip())` projection (or a `.use(mask(...))` policy)
  * makes the exposed shape intentional and stops the next-added column from leaking
  * by default. This is an INFO-level nudge, not a defect: the query may be perfectly
  * fine — it flags a place worth a deliberate projection decision.
@@ -33,7 +33,7 @@ const outputProjectionMissingOnPublicRead: Lint = {
     level: "INFO",
     name: "output_projection_missing_on_public_read",
     remediation:
-        "Add an explicit return projection to the public query — `.output(v.object({ … }))` listing only the fields a client needs — or apply a `.use(mask(...))` policy to the PII columns. This makes the exposed shape intentional and stops a newly-added column from leaking through this query by default.",
+        "Add an explicit return projection to the public query — `.output(v.object({ … }).strip())` listing only the fields a client needs — or apply a `.use(mask(...))` policy to the PII columns. This makes the exposed shape intentional and stops a newly-added column from leaking through this query by default.",
     run: (context) => {
         if (context.rawRowReturns === undefined) {
             return [];
@@ -66,7 +66,7 @@ const outputProjectionMissingOnPublicRead: Lint = {
             findings.push(
                 emit(outputProjectionMissingOnPublicRead, {
                     cacheKey: `output_projection_missing_on_public_read:${row.file}:${row.line.toString()}`,
-                    detail: `Public query \`${row.exportName}\` (${row.file}:${row.line.toString()}) returns raw \`${row.table}\` rows with no \`.output(...)\` projection — shipping PII column(s) ${piiColumns.join(", ")} to every caller, and any column added to \`${row.table}\` later leaks by default. Project the return with \`.output(v.object({ … }))\` or mask the PII columns.`,
+                    detail: `Public query \`${row.exportName}\` (${row.file}:${row.line.toString()}) returns raw \`${row.table}\` rows with no \`.output(...)\` projection — shipping PII column(s) ${piiColumns.join(", ")} to every caller, and any column added to \`${row.table}\` later leaks by default. Project the return with \`.output(v.object({ … }).strip())\` or mask the PII columns.`,
                     metadata: {
                         columns: piiColumns,
                         exportName: row.exportName,

--- a/packages/codegen/__tests__/validator-modifier-drift.test.ts
+++ b/packages/codegen/__tests__/validator-modifier-drift.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { Project } from "ts-morph";
 import { describe, expect, it } from "vitest";
 
-import { COLUMN_MODIFIERS, METADATA_MODIFIERS, REFINEMENT_MODIFIERS } from "../src/parse-validator";
+import { COLUMN_MODIFIERS, METADATA_MODIFIERS, PARSE_BEHAVIOR_MODIFIERS, REFINEMENT_MODIFIERS } from "../src/parse-validator";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const VALIDATOR_SOURCE = join(here, "..", "..", "values", "src", "v.ts");
@@ -62,7 +62,7 @@ describe("validator modifier drift", () => {
     it("knows every modifier `@lunora/values` publishes", () => {
         expect.assertions(1);
 
-        const known = new Set([...COLUMN_MODIFIERS, ...REFINEMENT_MODIFIERS, ...METADATA_MODIFIERS]);
+        const known = new Set([...COLUMN_MODIFIERS, ...REFINEMENT_MODIFIERS, ...METADATA_MODIFIERS, ...PARSE_BEHAVIOR_MODIFIERS]);
         const unknown = [...publishedModifiers()].filter((name) => !known.has(name)).toSorted((a, b) => a.localeCompare(b));
 
         // Anything listed here aborts `lunora codegen` the moment an app uses it.

--- a/packages/codegen/src/parse-validator.ts
+++ b/packages/codegen/src/parse-validator.ts
@@ -121,6 +121,24 @@ const REFINEMENT_MODIFIERS = new Set(["check", "email", "int", "length", "max", 
 const METADATA_MODIFIERS = new Set(["meta"]);
 
 /**
+ * Modifiers that change only how a value is PARSED at runtime, never the
+ * inferred type or the set of accepted values — so the IR passes through
+ * untouched, exactly like a metadata modifier, and the AOT compiler may still
+ * compile the node.
+ *
+ * `.strip()` marks an object as narrowing on purpose, which only has an effect
+ * under `.output()` (where undeclared keys are otherwise an error). Args
+ * validation — the only thing the AOT compiler emits — is unaffected either way,
+ * so there is nothing here for it to model.
+ *
+ * Kept separate from {@link METADATA_MODIFIERS} rather than folded in: that set
+ * is defined as attaching a JSON Schema fragment, and `.strip()` attaches
+ * nothing. Same handling, different reason — and the reason is what the next
+ * person needs.
+ */
+const PARSE_BEHAVIOR_MODIFIERS = new Set(["strip"]);
+
+/**
  * Identifiers currently being followed to their declaration, so a self- or
  * mutually-referential `const` (`const a = b; const b = a;`) terminates instead
  * of recursing forever. Parsing is synchronous and single-threaded, so one
@@ -440,7 +458,7 @@ const parseValidatorCall = (call: CallExpression): ValidatorIR => {
     // choosing which list it belongs in — a single `member === …` comparison
     // standing in for one of the sets is how the next addition silently gets the
     // wrong treatment.
-    if (COLUMN_MODIFIERS.has(member) || REFINEMENT_MODIFIERS.has(member) || METADATA_MODIFIERS.has(member)) {
+    if (COLUMN_MODIFIERS.has(member) || REFINEMENT_MODIFIERS.has(member) || METADATA_MODIFIERS.has(member) || PARSE_BEHAVIOR_MODIFIERS.has(member)) {
         const receiver = callee.getExpression();
         const base = Node.isExpression(receiver) ? parseValidator(receiver) : { kind: "any" };
 
@@ -454,5 +472,5 @@ const parseValidatorCall = (call: CallExpression): ValidatorIR => {
     return parseBuilderMember(member, args, call);
 };
 
-export { COLUMN_MODIFIERS, METADATA_MODIFIERS, parseObjectShape, parseValidator, REFINEMENT_MODIFIERS, setStandardTypeResolver };
+export { COLUMN_MODIFIERS, METADATA_MODIFIERS, PARSE_BEHAVIOR_MODIFIERS, parseObjectShape, parseValidator, REFINEMENT_MODIFIERS, setStandardTypeResolver };
 export type { StandardTypeResolver };

--- a/packages/server/__tests__/builder.test.ts
+++ b/packages/server/__tests__/builder.test.ts
@@ -303,12 +303,46 @@ describe("builder middleware", () => {
 });
 
 describe("builder output", () => {
-    it("parses the handler result through the .output() validator, stripping undeclared keys", async () => {
+    it("rejects a result carrying keys the .output() validator does not declare", async () => {
+        expect.assertions(2);
+
+        // This used to strip `extra` and return `{ count: 1 }`. That is how a
+        // column present in a row goes missing from every response the procedure
+        // serves, with no error anywhere — the failure this asymmetry exists to
+        // stop. On the way IN stripping is right; on the way OUT it deletes data
+        // the server meant to send.
+        const fn = c.query.output(v.object({ count: v.number() })).query(() => ({ count: 1, extra: "not declared" }) as { count: number });
+
+        await expect(fn.handler({}, {})).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+        // And it names the key, so the fix does not need a debugger.
+        await expect(fn.handler({}, {})).rejects.toThrow(/extra/u);
+    });
+
+    it("strips undeclared keys when .strip() says the narrowing is deliberate", async () => {
         expect.assertions(1);
 
-        const fn = c.query.output(v.object({ count: v.number() })).query(() => ({ count: 1, extra: "stripped" }) as { count: number });
+        // Trimming an internal field off a row before it reaches a client is a
+        // real use of `.output()`. It stays available — it just has to be said,
+        // so a reviewer can tell it apart from a forgotten column.
+        const fn = c.query.output(v.object({ count: v.number() }).strip()).query(() => ({ count: 1, passwordHash: "secret" }) as { count: number });
 
         await expect(fn.handler({}, {})).resolves.toEqual({ count: 1 });
+    });
+
+    it("leaves .strip() off the original validator when a shared const is narrowed", async () => {
+        expect.assertions(2);
+
+        // `.strip()` returns a new validator rather than mutating in place: the
+        // shape may be a const reused across procedures, and flipping it there
+        // would silently change what every other holder parses.
+        const shared = v.object({ count: v.number() });
+        const narrowed = shared.strip();
+
+        const strict = c.query.output(shared).query(() => ({ count: 1, extra: "x" }) as { count: number });
+        const lenient = c.query.output(narrowed).query(() => ({ count: 1, extra: "x" }) as { count: number });
+
+        await expect(strict.handler({}, {})).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+        await expect(lenient.handler({}, {})).resolves.toEqual({ count: 1 });
     });
 
     it("re-tags an .output() mismatch as an internal error, not a client 400", async () => {

--- a/packages/server/__tests__/http-route.test.ts
+++ b/packages/server/__tests__/http-route.test.ts
@@ -214,9 +214,28 @@ describe("httpRoute body", () => {
 });
 
 describe("httpRoute output", () => {
-    it("parses the result through .output(), stripping undeclared keys before serialization", async () => {
+    it("strips undeclared keys before serialization when .strip() says so", async () => {
         expect.assertions(1);
 
+        // The legitimate narrowing case, and why the escape hatch has to exist:
+        // trimming an internal field off a row before it reaches a client.
+        // `.strip()` makes that intent visible at the call site.
+        const route = httpRoute
+            .get("/api/me")
+            .output(v.object({ id: v.string() }).strip())
+            .handler(() => ({ id: "u1", secret: "leaked" }) as { id: string });
+
+        const response = await dispatch(route, "GET", "/api/me", new Request("https://x/api/me"));
+
+        await expect(response.json()).resolves.toEqual({ id: "u1" });
+    });
+
+    it("answers 500 when the result carries keys .output() does not declare", async () => {
+        expect.assertions(2);
+
+        // Without `.strip()` an undeclared key is a contract bug, not noise. The
+        // alternative is what this replaced: the field silently absent from every
+        // response the route serves.
         const route = httpRoute
             .get("/api/me")
             .output(v.object({ id: v.string() }))
@@ -224,7 +243,9 @@ describe("httpRoute output", () => {
 
         const response = await dispatch(route, "GET", "/api/me", new Request("https://x/api/me"));
 
-        await expect(response.json()).resolves.toEqual({ id: "u1" });
+        expect(response.status).toBe(500);
+        // Never the offending value — this path can carry server secrets.
+        await expect(response.text()).resolves.not.toContain("leaked");
     });
 
     it("a result that violates .output() surfaces as a 500, not a 400", async () => {

--- a/packages/server/src/apply-output.ts
+++ b/packages/server/src/apply-output.ts
@@ -12,7 +12,14 @@ import { LunoraError } from "./error";
  */
 const applyOutput = (output: Validator, result: unknown): unknown => {
     try {
-        return output.parse(result);
+        // `rejectUnknownKeys` — the asymmetry that makes this safe. Stripping is
+        // right on the way IN (it is what stops an over-posted field reaching a
+        // handler) and wrong on the way OUT, where the same behaviour deletes a
+        // field the server meant to send. A column present in the row and absent
+        // from the validator used to vanish from every response with no error
+        // anywhere; it is now a loud 500 naming the key. Narrowing on purpose
+        // stays available, and becomes visible, via `.strip()`.
+        return output.parse(result, { rejectUnknownKeys: true });
     } catch (error: unknown) {
         if (error instanceof ValidationError) {
             throw new LunoraError("INTERNAL_SERVER_ERROR", `Response did not match the declared output schema: ${error.message}`);

--- a/packages/server/src/builder/types.ts
+++ b/packages/server/src/builder/types.ts
@@ -92,8 +92,14 @@ export interface QueryBuilder<Context, Args extends ArgsValidator, Output = unde
      * async generator (or any function returning an `AsyncIterable<R>`) that
      * yields one chunk per server-pushed frame. The third `signal` argument is
      * tripped when the client cancels — break out of the loop or check
-     * `signal.aborted` between yields. `.output()` does not apply: per-chunk
-     * validation is opt-in via the handler itself.
+     * `signal.aborted` between yields.
+     *
+     * **Unavailable after `.output()`, deliberately.** Chunks are yielded as-is —
+     * there is no per-chunk validation — so `.output(...).stream(...)` used to
+     * compile and quietly enforce nothing, which is worse than not offering the
+     * combination: the author asked for validation and was told yes. Declaring an
+     * output on a stream is now a type error rather than a false promise. Validate
+     * inside the handler, or return the whole payload from `.query()` instead.
      *
      * Pass `{ durable: true }` to make the run outlive the socket that opened
      * it: chunks are persisted as they are produced, so a reload resumes the
@@ -101,10 +107,12 @@ export interface QueryBuilder<Context, Args extends ArgsValidator, Output = unde
      * second client with the same arguments attaches to the same transcript.
      * That is what an LLM response wants; a progress ticker does not need it.
      */
-    stream: <R>(
-        handler: (options: { args: InferArgs<Args>; ctx: Context; signal: AbortSignal }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
-        options?: StreamOptions,
-    ) => RegisteredStream<Args, R>;
+    stream: [Output] extends [undefined]
+        ? <R>(
+              handler: (options: { args: InferArgs<Args>; ctx: Context; signal: AbortSignal }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
+              options?: StreamOptions,
+          ) => RegisteredStream<Args, R>
+        : never;
     use: <ContextOut>(middleware: Middleware<Context, ContextOut>) => QueryBuilder<ContextOut, Args, Output>;
 
     /**

--- a/packages/values/src/index.ts
+++ b/packages/values/src/index.ts
@@ -20,6 +20,8 @@ export type {
     JsonSchemaFragment,
     MetaOptions,
     NumberColumnValidator,
+    ObjectColumnValidator,
+    ParseOptions,
     SelectShape,
     ServerDefaultContext,
     StringColumnValidator,

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -107,9 +107,9 @@ interface Validator<T = unknown> extends StandardSchemaV1<T, T> {
      */
     meta: (options: MetaOptions) => Validator<T>;
 
-    parse: (value: unknown) => T;
+    parse: (value: unknown, options?: ParseOptions) => T;
 
-    safeParse: (value: unknown) => { error: ValidationError; ok: false } | { ok: true; value: T };
+    safeParse: (value: unknown, options?: ParseOptions) => { error: ValidationError; ok: false } | { ok: true; value: T };
 }
 
 /** Extract the TS type a validator describes (the **select** type). */
@@ -267,6 +267,21 @@ interface NumberColumnValidator extends ColumnValidator<number, number> {
 }
 
 /**
+ * A {@link ColumnValidator} for `v.object(...)`, carrying the `.strip()` opt-out.
+ */
+interface ObjectColumnValidator<T> extends ColumnValidator<T, T> {
+    /**
+     * Drop keys this shape does not declare, even under `.output()`.
+     *
+     * Only meaningful there — input parsing strips already. Say it when the
+     * narrowing is deliberate (trimming an internal field off a row before it
+     * reaches a client); without it, an undeclared key on the way OUT is an
+     * error, because the alternative is deleting server data silently.
+     */
+    strip: () => ObjectColumnValidator<T>;
+}
+
+/**
  * A {@link ColumnValidator} for `v.array(...)` with ergonomic length-refinement
  * shortcuts — see {@link StringColumnValidator} for the delegation pattern.
  */
@@ -299,6 +314,12 @@ type InsertShape<S extends Record<string, Validator>> = {
     [K in keyof S as undefined extends InferInsert<S[K]> ? never : K]: InferInsert<S[K]>;
 };
 
+/** Options for {@link Validator.parse} / {@link Validator.safeParse}. */
+interface ParseOptions {
+    /** See {@link ParseContext.rejectUnknownKeys}. */
+    rejectUnknownKeys?: boolean;
+}
+
 interface ParseContext {
     /**
      * Mutable path stack walked from the root to the value currently being
@@ -315,6 +336,18 @@ interface ParseContext {
      * real {@link ValidationError} — see that constant for why.
      */
     probe?: boolean;
+
+    /**
+     * Reject keys an object shape does not declare, instead of dropping them.
+     *
+     * Off for input, where stripping is what stops an over-posted field reaching
+     * a handler. On for `.output()`, where the same behaviour deletes a field the
+     * server meant to send: a column present in the row and missing from the
+     * validator vanished from every response with no error anywhere. An object
+     * that opts out with `.strip()` keeps stripping under this flag, so
+     * deliberate narrowing stays possible and — unlike before — visible.
+     */
+    rejectUnknownKeys?: boolean;
 }
 
 interface InternalValidator<T> extends Validator<T> {
@@ -497,13 +530,13 @@ const createValidator = <T>(
             return parser(value, context);
         },
         kind,
-        parse(value: unknown) {
-            return parser(value, { path: [] });
+        parse(value: unknown, options?: ParseOptions) {
+            return parser(value, { path: [], ...options });
         },
         /** @returns `{ ok: true, value }` on success or `{ ok: false, error }` on a validation failure. */
-        safeParse(value: unknown): { error: ValidationError; ok: false } | { ok: true; value: T } {
+        safeParse(value: unknown, options?: ParseOptions): { error: ValidationError; ok: false } | { ok: true; value: T } {
             try {
-                return { ok: true as const, value: parser(value, { path: [] }) };
+                return { ok: true as const, value: parser(value, { path: [], ...options }) };
             } catch (error: unknown) {
                 if (error instanceof ValidationError) {
                     return { error, ok: false as const };
@@ -909,7 +942,7 @@ type OptionalizeShape<M> = {
 type ObjectShape = Record<string, Validator>;
 type ObjectShapeType<S extends ObjectShape> = OptionalizeShape<{ [K in keyof S]: Infer<S[K]> }>;
 
-const objectValidator = <S extends ObjectShape>(shape: S): ColumnValidator<ObjectShapeType<S>, ObjectShapeType<S>> => {
+const objectValidator = <S extends ObjectShape>(shape: S, stripUnknown?: boolean): ObjectColumnValidator<ObjectShapeType<S>> => {
     // Precompute the key list, per-key internal validator, and the optional flag
     // once at construction time — the shape is fixed, so the per-parse hot path
     // never re-runs Object.keys (one array alloc) or re-casts each child.
@@ -933,7 +966,7 @@ const objectValidator = <S extends ObjectShape>(shape: S): ColumnValidator<Objec
         throw new LunoraError("INTERNAL", 'v.object: "__proto__" cannot be a declared field name — it collides with the Object.prototype accessor');
     }
 
-    return asColumn(
+    const validator = asColumn(
         createValidator<ObjectShapeType<S>>(
             "object",
             (value, context) => {
@@ -944,6 +977,27 @@ const objectValidator = <S extends ObjectShape>(shape: S): ColumnValidator<Objec
                 const input = value as Record<string, unknown>;
                 const out: Record<string, unknown> = {};
                 const { path } = context;
+
+                // Under `.output()` an undeclared key is a mistake, not noise:
+                // silently dropping it is how a column present in the row goes
+                // missing from every response. `.strip()` is the opt-out for a
+                // shape that is narrowing on purpose.
+                if (context.rejectUnknownKeys === true && stripUnknown !== true) {
+                    const declared = new Set(entries.map(({ key }) => key));
+                    const undeclared = Object.keys(input).filter((key) => !declared.has(key));
+
+                    if (undeclared.length > 0) {
+                        throw new ValidationError(
+                            `object has ${String(undeclared.length)} undeclared key(s): ${undeclared.join(", ")}. ` +
+                                `Add them to the validator, or call .strip() on it to drop them on purpose.`,
+                            {
+                                expected: `only the declared keys (${entries.map(({ key }) => key).join(", ")})`,
+                                path: [...path],
+                                received: undeclared.join(", "),
+                            },
+                        );
+                    }
+                }
 
                 for (const { child, isOptional, key } of entries) {
                     // Read via Object.hasOwn so a declared field whose name
@@ -972,7 +1026,15 @@ const objectValidator = <S extends ObjectShape>(shape: S): ColumnValidator<Objec
             },
             { shape },
         ),
-    );
+    ) as unknown as ObjectColumnValidator<ObjectShapeType<S>>;
+
+    // Rebuilt rather than mutated, so `.strip()` returns a NEW validator: the
+    // shape it is called on may already be a const shared across procedures, and
+    // flipping its behaviour in place would change what every other holder
+    // parses.
+    validator.strip = () => objectValidator(shape, true);
+
+    return validator;
 };
 
 const record = <K extends Validator<string>, V extends Validator>(
@@ -1450,7 +1512,9 @@ export type {
     JsonSchemaFragment,
     MetaOptions,
     NumberColumnValidator,
+    ObjectColumnValidator,
     OptionalizeShape,
+    ParseOptions,
     PartialShape,
     SelectShape,
     ServerDefaultContext,


### PR DESCRIPTION
Closes the third and last point of #517.

## Two silent traps, not one

Rechecking the issue turned up a second one the reporter had not hit yet.

**1. Stripping on the way out deleted server data.** `v.object` drops undeclared keys. That is *correct* for input — it is what stops an over-posted field reaching a handler. It is *wrong* for output, where the same behaviour removes a field the server meant to send. A column present in the row and missing from a hand-written output validator vanished from every response that procedure served, with no error anywhere. The reporter shipped that across six procedures and found it only with a hand-written drift test.

**2. `.output(...).stream(...)` compiled and enforced nothing.** `stream` stayed on the builder after `output`, and its handler type ignored `Output`. So an author who explicitly asked for chunk validation was told yes and got none — worse than not offering the combination at all.

## The fix

`.output()` parses with `rejectUnknownKeys`, so an undeclared key is a 500 that names it:

```
Response did not match the declared output schema: object has 3 undeclared
key(s): email, passwordHash, createdAt. Add them to the validator, or call
.strip() on it to drop them on purpose.
```

Deliberate narrowing stays available and becomes **visible**:

```ts
.output(v.object({ id: v.id("users"), name: v.string() }).strip())
.query(async ({ ctx, args }) => ctx.db.get(args.userId)); // email, passwordHash dropped
```

`.strip()` returns a *new* validator rather than mutating, since the shape may be a const shared across procedures — flipping it in place would change what every other holder enforces.

**Input is untouched.** It still strips, and that asymmetry is the whole design: *strips in, rejects out.*

For streams, `stream` is typed away once an output is declared. Chunks are yielded as-is by design, so a type error is the honest answer where a silent no-op was the previous one.

## Why this shape rather than the alternatives

The issue floated three options. Rejecting outright is the only one that is actually error-proof:

- A **codegen advisory** comparing output validators against the table shape is build-time and non-breaking, but heuristic — it cannot tell deliberate narrowing from a forgotten column, so it either misses cases or cries wolf.
- **Derived validators** (`v.doc`/`v.pick`) make the mistake unrepresentable for whole-doc returns, but do nothing for a hand-built shape, which is where the bug lives.

Rejecting converts a silent, ships-to-production data-loss bug into an immediate, self-describing failure during development, and leaves narrowing possible with one call that documents intent. TypeScript cannot catch this on its own: excess-property checks only fire on fresh object literals, so a handler returning a variable typed wider than the validator compiles cleanly today.

## Two repo guards earned their keep

Neither of these would have been caught by review:

- **Codegen's modifier-drift lock** failed the moment `.strip()` existed without being taught to `parse-validator`. An unknown modifier throws `Unsupported validator kind` and aborts the entire run — that lock is why this did not brick codegen for every app that adopted `.strip()`. It is registered as `PARSE_BEHAVIOR_MODIFIERS`, deliberately separate from `METADATA_MODIFIERS`: same pass-through handling, but that set is defined as attaching a JSON Schema fragment and `.strip()` attaches nothing.
- **The advisor lint** that tells users to add `.output(v.object({ … }))` as a PII projection was instructing them straight into the pattern that now throws. Its remediation now says `.strip()`.

## Scope check

The AOT-compiled validator is **args-only** (`compileArgsValidator`), so output validation runs through the interpreted parser alone and the compiled fast path cannot diverge from this.

## Verification

Whole repo: `pnpm run test`, `lint:eslint` (161 tasks), `lint:types` (54), `api:check` — all green. `@lunora/values` 179, `@lunora/server` 685, `@lunora/codegen` 1557, `@lunora/advisor` 512.

The two server tests that asserted silent stripping now assert both halves of the contract, including that a 500 never echoes the offending value (that path can carry secrets — the existing fixture literally narrows away `secret: "leaked"`).

Docs rewritten in `concepts/validation.mdx`: the strips-in/rejects-out asymmetry, `.strip()`, and the stream combination as a type error rather than the previous "does not apply".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae
