### PR TITLE
fix(cli): teach the linter about generated output from codegen, not just init

### DIFF
--- a/packages/cli/__tests__/commands/codegen.test.ts
+++ b/packages/cli/__tests__/commands/codegen.test.ts
@@ -337,6 +337,32 @@ describe("lunora codegen", () => {
             await expect(runExecute()).resolves.not.toMatch(/is not exported by the worker entry/u);
         });
 
+        it("teaches the project's linter to skip the generated output", async () => {
+            expect.assertions(2);
+
+            // `init` offers this and `add` re-applies it, which covers a project
+            // Lunora scaffolded. A project that adopted Lunora INTO an existing
+            // codebase never runs either, so nothing told its linter about
+            // `_generated/` and the first lint buried real findings under
+            // thousands of generated-file errors. Every project runs codegen.
+            seedWorkflow('import { createShardDO } from "../lunora/_generated/shard.js";\nexport const ShardDO = createShardDO();\n');
+            // A linter already configured, and nothing that ever ran `lunora init`
+            // to tell it about `_generated/` — what an existing codebase adopting
+            // Lunora looks like. Detected from the config file rather than a
+            // manifest, so this fixture does not also have to satisfy codegen's
+            // required-add-on check.
+            writeFileSync(join(workdir, ".prettierrc"), JSON.stringify({ semi: true }), "utf8");
+            writeFileSync(join(workdir, ".prettierignore"), "dist\n", "utf8");
+
+            await runExecute();
+
+            const ignored = readFileSync(join(workdir, ".prettierignore"), "utf8");
+
+            expect(ignored).toContain("_generated");
+            // Idempotent: the pre-existing entry is preserved, not replaced.
+            expect(ignored).toContain("dist");
+        });
+
         it("says so when the check itself could not run, instead of reading as clean", async () => {
             expect.assertions(2);
 

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -575,6 +575,16 @@ lunora codegen --api-spec both     # also emit openapi.json and openrpc.json
 lunora codegen --format json       # machine-readable output
 ```
 
+It also keeps your linter and formatter skipping what it just wrote. `lunora
+init` offers this and `lunora add` re-applies it, which covers a project Lunora
+scaffolded — but a codebase that adopted Lunora later runs neither, so nothing
+ever told its ESLint / Prettier / Biome / oxlint about `_generated/`, and the
+first lint after adoption buries the real findings under thousands of
+generated-file errors. Detection is driven by the tools already in the project,
+every writer is idempotent, and a config it cannot safely edit (an ESLint flat
+config is arbitrary JavaScript; a monorepo-root config belongs to the workspace)
+is printed for you to paste rather than rewritten.
+
 `--api-spec` selects which API description to emit alongside the generated
 modules: `openapi` (the default) writes `openapi.json`, `openrpc` writes
 `openrpc.json`, `both` writes both, and `none` writes neither.

--- a/packages/cli/src/commands/codegen/handler.ts
+++ b/packages/cli/src/commands/codegen/handler.ts
@@ -1,6 +1,6 @@
 import type { Finding } from "@lunora/codegen";
 import { runCodegen } from "@lunora/codegen";
-import { inferLunoraBindings } from "@lunora/config";
+import { applyLintIgnores, detectLintTools, inferLunoraBindings } from "@lunora/config";
 import type { ExportGap } from "@lunora/config/cloudflare";
 import { collectExportGaps, collectWranglerSecretVariables } from "@lunora/config/cloudflare";
 
@@ -10,6 +10,7 @@ import { parseApiSpec } from "../../util/api-spec";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import { resolveTargetOrError } from "../../util/deploy-target";
+import { reportLintIgnoreOutcomes } from "../../util/lint-ignore-report";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
 import reportPlatformDiagnostics from "../../util/platform-diagnostics";
@@ -204,6 +205,33 @@ const warnAboutExportGaps = async (projectRoot: string, logger: Logger): Promise
     }
 };
 
+/**
+ * Keep the project's linters and formatters skipping what codegen just wrote.
+ *
+ * `init` offers this and `add` re-applies it, which covers a project scaffolded
+ * by Lunora. It missed the projects that adopted Lunora INTO an existing
+ * codebase — they never run `init`, so nothing ever told their linter about
+ * `_generated/`, and the first `lint` after adoption buries the real findings
+ * under thousands of generated-file errors. Every such project runs codegen.
+ *
+ * Deliberately on the COMMAND, not in `runCodegen`: the dev watcher calls the
+ * library directly on every save, and re-reading four config files per keystroke
+ * to write nothing is not worth it. Once per explicit `lunora codegen` is.
+ *
+ * Detection-driven with no prompt, like `add`: the tools present in the project
+ * answer the question, and every writer is idempotent, so the common case is
+ * silent. Best-effort — a lint config this cannot safely edit is reported as
+ * something to paste, never a failed codegen.
+ */
+const syncLintIgnores = (projectRoot: string, logger: Logger): void => {
+    try {
+        reportLintIgnoreOutcomes(applyLintIgnores(projectRoot, detectLintTools(projectRoot)), logger);
+    } catch {
+        // Generated output is written and valid; a linter that could not be
+        // taught about it is not a reason to fail the run.
+    }
+};
+
 /** `lunora codegen` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<CodegenOptions> = defineHandler<CodegenOptions>(async ({ cwd, logger, options }) => {
     const result = runCodegenCommand({
@@ -226,7 +254,10 @@ const execute: CommandHandler<CodegenOptions> = defineHandler<CodegenOptions>(as
     // signal rather than `result.error`, which is also set for a platform
     // diagnostic raised AFTER a successful emit, where the warning still applies.
     if (result.outputDirectory !== "") {
-        await warnAboutExportGaps(cwd, loggerForFormat(options.format, logger));
+        const commandLogger = loggerForFormat(options.format, logger);
+
+        syncLintIgnores(cwd, commandLogger);
+        await warnAboutExportGaps(cwd, commandLogger);
     }
 
     return { code: result.error === undefined && result.failedAdvisories === 0 ? 0 : 1 };


### PR DESCRIPTION
Closes the residual left open when #516 was closed.

## The gap

`lunora init` offers the lint-ignore entries and `lunora add` re-applies them, which covers a project Lunora scaffolded. Projects that adopted Lunora **into an existing codebase** run neither — so nothing ever told their ESLint / Prettier / Biome / oxlint about `_generated/`, and the first lint after adoption buries the real findings under thousands of generated-file errors.

That is exactly the reporter's situation in #516: they excluded five paths by hand and observed that *"every consumer rediscovers the same five"*.

## Where it went, and why

`lunora codegen` — the command that creates the thing needing ignoring, and the one invocation every adopting project makes. It reuses `applyLintIgnores` + `detectLintTools` and the same `reportLintIgnoreOutcomes` both other callers use, rather than a fifth spelling of the same path list.

**On the command, not inside `runCodegen`.** `lunora dev`'s watcher calls the library directly on every save; re-reading four config files per keystroke to write nothing is not worth it. Once per explicit `lunora codegen` is.

**Not `lunora doctor`**, despite that being the obvious "preflight" home. Its own docstring calls it read-only twice, and its diagnostic codes are a public contract asserted against the docs table. Reporting the gap there without being able to close it would have been worse than either doing or not doing it.

Best-effort: generated output is written and valid, so a linter that could not be taught about it is not a reason to fail the run. A config that cannot be edited safely — an ESLint flat config is arbitrary JavaScript, a monorepo-root config belongs to the whole workspace — is still printed for you to paste, by the existing reporter.

## Verification

`@lunora/cli` 1339 tests pass, `lint:eslint`, `lint:types`, `api:check` green.

The new test seeds a `.prettierrc` + a `.prettierignore` carrying an unrelated entry, and asserts codegen adds `_generated` while preserving what was there. I checked it fails with the wiring removed.

One note on that fixture: it detects Prettier from a config file rather than a `package.json` dependency, because adding a manifest to the shared codegen fixture makes `assertRequiredPackages` fail the run — the schema declares `.global()` tables whose add-on packages a bare manifest does not list. Detection covers both routes; the config-file one leaves the fixture's other behaviour untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `lunora codegen` now automatically excludes generated `_generated/` files from supported ESLint, Prettier, Biome, and oxlint configurations.
  * Safely applies repeatable configuration updates and reports the results.
  * Provides manual setup instructions when automatic updates aren’t possible.

* **Documentation**
  * Updated codegen documentation to explain automatic lint and formatter exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->