### PR TITLE
fix(codegen): carry each drift change's remediation on the change union

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -189,12 +189,19 @@ const DEFAULT_TARGET = "cloudflare";
 
 ```ts
 interface DriftChange {
+    remediation: DriftRemediation;
     scope: DriftScope;
     severity: "breaking" | "safe";
     summary: string;
     table?: string;
     type: "addedIndex" | "addedOptionalField" | "addedRelation" | "addedRequiredField" | "addedTable" | "changedFieldKind" | "changedIndex" | "changedJurisdiction" | "changedShardMode" | "fieldOptionalToRequired" | "fieldRequiredToOptional" | "removedField" | "removedIndex" | "removedRelation" | "removedTable";
 }
+```
+
+### `DriftRemediation` (type)
+
+```ts
+type DriftRemediation = "backfill" | "code" | "none" | "rehome";
 ```
 
 ### `DriftScope` (type)
@@ -1277,10 +1284,7 @@ const evaluateSchemaDrift: (options: {
     baseline: SchemaSnapshot | undefined;
     command?: string;
     current: SchemaSnapshot;
-    migrations?: ReadonlyArray<{
-        id: string;
-        table: string;
-    }>;
+    migrations: ReadonlyArray<Pick<MigrationIR, "id" | "table">>;
 }) => SchemaDriftDecision;
 ```
 

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -107,6 +107,7 @@ interface CodegenResult {
         vectors: string;
         workflows: string;
     };
+    migrations: ReadonlyArray<MigrationIR>;
     outputDirectory: string;
     platformDiagnostics: ReadonlyArray<PlatformDiagnostic>;
     queues: ReadonlyArray<QueueIR>;
@@ -1276,6 +1277,10 @@ const evaluateSchemaDrift: (options: {
     baseline: SchemaSnapshot | undefined;
     command?: string;
     current: SchemaSnapshot;
+    migrations?: ReadonlyArray<{
+        id: string;
+        table: string;
+    }>;
 }) => SchemaDriftDecision;
 ```
 

--- a/apps/docs/src/content/docs/concepts/migrations.mdx
+++ b/apps/docs/src/content/docs/concepts/migrations.mdx
@@ -35,31 +35,44 @@ inside each shard's DO in resumable batches.
 You do not have to work out which schema edits need a backfill. `lunora deploy`
 (and `prepare` / `verify`) diffs your schema against the committed baseline in
 `lunora/.lunora-schema.json` and classifies every change. Additive edits — a new
-optional field, a new table, an added index — pass silently. A change that
-existing rows cannot satisfy blocks the deploy, names the field, and prints the
-command that scaffolds the migration it wants:
+optional field, a new table, an added index — are reported and let through. A
+change existing rows cannot satisfy blocks the deploy, names the field, and
+prints the command that scaffolds the migration it wants:
 
 ```text
-deploy blocked: 1 breaking schema change(s) since the last blessed schema baseline
-are not covered by a new migration — these changes are incompatible with existing data:
+deploy blocked: 1 breaking schema change(s) since the last blessed schema baseline are not covered by a new migration:
   - added required field users.displayName — existing rows have no value; add a data migration to backfill it
 
 To fix:
-  • For breaking changes: add a `defineMigration({ id, table, up })` in lunora/ for each
-    affected table, then run `lunora migrate` (or `lunora codegen`) to apply and re-bless
-    the baseline.
+  • Add a `defineMigration({ id, table, up })` in lunora/ for each affected table, then re-run this command — the baseline is re-blessed on a successful deploy, not by `lunora migrate` itself.
 
-    Scaffold the missing migration(s):
+    Scaffold the missing migration(s) — the generated `up` is an identity placeholder you must fill in:
       lunora migrate create backfill_users --table users
+
+  • For backward-compatible changes (e.g. adding an optional field): pass `--allow-schema-drift` to skip the block.
+  • To accept the new shape without a migration (you know data is compatible): pass `--update-schema-baseline`.
+Docs: https://lunora.dev/docs/migrations
 ```
 
+<Callout type="warn">
+    The scaffolded `up` is `(document) => document` — an identity transform. It satisfies the gate immediately, so a scaffold you forget to fill in ships the schema
+    change with no backfill behind it.
+</Callout>
+
 A migration only clears the drift on **the table it iterates**, so a backfill on
-`messages` will not wave through a required field added to `users`. Two breaking
-changes are never cleared by a migration at all — a
-[shard-mode flip](/docs/concepts/sharding#migrating-a-populated-table) and a
-[jurisdiction change](/docs/concepts/data-residency) both re-home physical
-storage, which a per-shard transform cannot do. Those stay blocked until you
-export/import or revert.
+`messages` will not wave through a required field added to `users`.
+
+Nor is a migration offered for every breaking change — only for the ones a
+per-document transform can actually fix (a new required field, a type change, an
+optional field made required, a dropped field). The rest name their own fix
+instead:
+
+| Change                                                                 | What clears it                                                                    |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Dropped index, changed index, dropped relation                         | Change the queries that used them, then accept the new shape                      |
+| Dropped table                                                          | Its rows stay in each shard's SQLite, unreachable — export the shard to keep them |
+| [Shard-mode flip](/docs/concepts/sharding#migrating-a-populated-table) | An export/import round trip; a per-shard transform cannot move rows between DOs   |
+| [Jurisdiction change](/docs/concepts/data-residency)                   | Export then import into the new region, or revert                                 |
 
 If you know the stored data is already compatible, `--allow-schema-drift` skips
 the block for one run and `lunora prepare --update-schema-baseline` accepts the

--- a/apps/docs/src/content/docs/concepts/migrations.mdx
+++ b/apps/docs/src/content/docs/concepts/migrations.mdx
@@ -40,7 +40,7 @@ change existing rows cannot satisfy blocks the deploy, names the field, and
 prints the command that scaffolds the migration it wants:
 
 ```text
-deploy blocked: 1 breaking schema change(s) since the last blessed schema baseline are not covered by a new migration:
+deploy blocked: 1 unresolved breaking schema change(s) since the last blessed schema baseline:
   - added required field users.displayName — existing rows have no value; add a data migration to backfill it
 
 To fix:

--- a/apps/docs/src/content/docs/concepts/migrations.mdx
+++ b/apps/docs/src/content/docs/concepts/migrations.mdx
@@ -30,6 +30,41 @@ inside each shard's DO in resumable batches.
     backfills.
 </Callout>
 
+## The deploy gate tells you when you need one
+
+You do not have to work out which schema edits need a backfill. `lunora deploy`
+(and `prepare` / `verify`) diffs your schema against the committed baseline in
+`lunora/.lunora-schema.json` and classifies every change. Additive edits — a new
+optional field, a new table, an added index — pass silently. A change that
+existing rows cannot satisfy blocks the deploy, names the field, and prints the
+command that scaffolds the migration it wants:
+
+```text
+deploy blocked: 1 breaking schema change(s) since the last blessed schema baseline
+are not covered by a new migration — these changes are incompatible with existing data:
+  - added required field users.displayName — existing rows have no value; add a data migration to backfill it
+
+To fix:
+  • For breaking changes: add a `defineMigration({ id, table, up })` in lunora/ for each
+    affected table, then run `lunora migrate` (or `lunora codegen`) to apply and re-bless
+    the baseline.
+
+    Scaffold the missing migration(s):
+      lunora migrate create backfill_users --table users
+```
+
+A migration only clears the drift on **the table it iterates**, so a backfill on
+`messages` will not wave through a required field added to `users`. Two breaking
+changes are never cleared by a migration at all — a
+[shard-mode flip](/docs/concepts/sharding#migrating-a-populated-table) and a
+[jurisdiction change](/docs/concepts/data-residency) both re-home physical
+storage, which a per-shard transform cannot do. Those stay blocked until you
+export/import or revert.
+
+If you know the stored data is already compatible, `--allow-schema-drift` skips
+the block for one run and `lunora prepare --update-schema-baseline` accepts the
+new shape permanently.
+
 ## Schema migrations (global tables)
 
 `lunora migrate generate` parses `lunora/schema.ts`, filters to `.global()`

--- a/packages/cli/__tests__/commands/schema-drift-gate.test.ts
+++ b/packages/cli/__tests__/commands/schema-drift-gate.test.ts
@@ -63,12 +63,12 @@ const introduceBreakingDrift = (): void => {
 };
 
 /** Append a `defineMigration` to `lunora/schema.ts` so a NEW migration id is discovered. */
-const addMigration = (id: string): void => {
+const addMigration = (id: string, table = "users"): void => {
     const migrationsPath = join(workdir, "lunora", "migrations.ts");
 
     writeFileSync(
         migrationsPath,
-        `import { defineMigration } from "@lunora/server";\n\nexport const fix = defineMigration({\n    id: "${id}",\n    table: "users",\n    up: (doc) => doc,\n});\n`,
+        `import { defineMigration } from "@lunora/server";\n\nexport const fix = defineMigration({\n    id: "${id}",\n    table: "${table}",\n    up: (doc) => doc,\n});\n`,
         "utf8",
     );
 };
@@ -153,6 +153,27 @@ describe("schema-drift gate", () => {
             expect(result.code).toBe(0);
             // Deploy proceeded — wrangler was spawned.
             expect(calls.length).toBeGreaterThan(0);
+        });
+
+        it("still blocks when the new migration iterates a DIFFERENT table", async () => {
+            // Pins the wiring, not just the rule: `runCodegen` must hand its
+            // discovered `migrations` to the gate. Drop that argument and the gate
+            // falls back to counting ids, and this deploy would sail through.
+            expect.assertions(3);
+
+            await runDeployCommand({ cwd: workdir, logger: silentLogger().logger, spawner: createRecordingSpawner().spawner });
+
+            introduceBreakingDrift();
+            addMigration("backfill-messages", "messages");
+
+            const { errors, logger } = silentLogger();
+            const { calls, spawner } = createRecordingSpawner();
+            const result = await runDeployCommand({ cwd: workdir, logger, spawner });
+
+            expect(result.code).not.toBe(0);
+            // wrangler was never reached.
+            expect(calls).toHaveLength(0);
+            expect(errors.find((line) => line.includes("deploy blocked")) ?? "").toContain("not covered by a new migration");
         });
 
         it("passes a blocked deploy when --allow-schema-drift is set", async () => {

--- a/packages/cli/__tests__/commands/schema-drift-gate.test.ts
+++ b/packages/cli/__tests__/commands/schema-drift-gate.test.ts
@@ -173,7 +173,7 @@ describe("schema-drift gate", () => {
             expect(result.code).not.toBe(0);
             // wrangler was never reached.
             expect(calls).toHaveLength(0);
-            expect(errors.find((line) => line.includes("deploy blocked")) ?? "").toContain("not covered by a new migration");
+            expect(errors.find((line) => line.includes("deploy blocked")) ?? "").toContain("unresolved breaking schema change");
         });
 
         it("passes a blocked deploy when --allow-schema-drift is set", async () => {

--- a/packages/cli/src/util/schema-drift-gate.ts
+++ b/packages/cli/src/util/schema-drift-gate.ts
@@ -3,8 +3,8 @@
  *
  * Reads the committed structural baseline (`lunora/.lunora-schema.json`),
  * compares it against the snapshot codegen produced this run, and decides
- * whether breaking drift without an accompanying data migration should block
- * the deploy. The pure diff/classify/decision logic lives in `@lunora/codegen`
+ * whether breaking drift that no new data migration covers should block the
+ * deploy. The pure diff/classify/decision logic lives in `@lunora/codegen`
  * (`evaluateSchemaDrift`); this module is the thin I/O + logging shell the
  * deploy / verify / prepare commands call, mirroring the D1-placeholder guard.
  *
@@ -183,8 +183,6 @@ const runSchemaDriftGate = (options: {
         baseline: baseline.status === "ok" ? baseline.snapshot : undefined,
         command,
         current: codegen.schemaSnapshot,
-        // Without this the gate can only count new ids, and an unrelated backfill
-        // waves through a required field added to a different table.
         migrations: codegen.migrations,
     });
 

--- a/packages/cli/src/util/schema-drift-gate.ts
+++ b/packages/cli/src/util/schema-drift-gate.ts
@@ -183,6 +183,9 @@ const runSchemaDriftGate = (options: {
         baseline: baseline.status === "ok" ? baseline.snapshot : undefined,
         command,
         current: codegen.schemaSnapshot,
+        // Without this the gate can only count new ids, and an unrelated backfill
+        // waves through a required field added to a different table.
+        migrations: codegen.migrations,
     });
 
     if (decision.blocked) {

--- a/packages/codegen/__tests__/schema-drift.test.ts
+++ b/packages/codegen/__tests__/schema-drift.test.ts
@@ -257,7 +257,7 @@ describe("schema-drift", () => {
             const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "backfill-messages", table: "messages" }] });
 
             expect(decision.blocked).toBe(true);
-            expect(decision.reason).toContain("not covered by a new migration");
+            expect(decision.reason).toContain("unresolved breaking schema change");
         });
 
         it("blocks a migration whose table codegen could not lift to a literal, and says so", () => {
@@ -288,6 +288,20 @@ describe("schema-drift", () => {
             // scaffold line nor as the bullet above it.
             expect(decision.reason).not.toContain("lunora migrate create");
             expect(decision.reason).not.toContain("defineMigration");
+        });
+
+        it("a dropped index stays blocked even with a migration on that very table", () => {
+            // Rewriting rows cannot repair a query that named the index. Letting a
+            // same-table migration excuse it would ship a deploy whose callers
+            // still fail at runtime — the flags are the honest escape.
+            expect.assertions(2);
+
+            const indexed = buildSchemaSnapshot(schema([table("users", { name: stringField }, { indexes: [{ fields: ["name"], name: "byName" }] })]), []);
+            const current = buildSchemaSnapshot(schema([table("users", { name: stringField })]), ["touch-users"]);
+            const decision = evaluateSchemaDrift({ baseline: indexed, current, migrations: [{ id: "touch-users", table: "users" }] });
+
+            expect(decision.blocked).toBe(true);
+            expect(decision.reason).toContain("removed index byName");
         });
 
         it("offers no migration for a dropped index — that is a code change, not a backfill", () => {

--- a/packages/codegen/__tests__/schema-drift.test.ts
+++ b/packages/codegen/__tests__/schema-drift.test.ts
@@ -127,7 +127,14 @@ describe("schema-drift", () => {
             );
 
             expect(safe.changes).toStrictEqual([
-                { scope: "table", severity: "safe", summary: "added optional field users.bio", table: "users", type: "addedOptionalField" },
+                {
+                    remediation: "none",
+                    scope: "table",
+                    severity: "safe",
+                    summary: "added optional field users.bio",
+                    table: "users",
+                    type: "addedOptionalField",
+                },
             ]);
             expect(breaking.changes.some((c) => c.type === "addedRequiredField" && c.severity === "breaking")).toBe(true);
         });
@@ -160,7 +167,14 @@ describe("schema-drift", () => {
             );
 
             expect(widened.changes).toStrictEqual([
-                { scope: "table", severity: "safe", summary: "field users.name became optional", table: "users", type: "fieldRequiredToOptional" },
+                {
+                    remediation: "none",
+                    scope: "table",
+                    severity: "safe",
+                    summary: "field users.name became optional",
+                    table: "users",
+                    type: "fieldRequiredToOptional",
+                },
             ]);
             expect(newTable.changes.some((c) => c.type === "addedTable" && c.severity === "safe")).toBe(true);
         });
@@ -203,7 +217,7 @@ describe("schema-drift", () => {
             expect.assertions(2);
 
             const current = buildSchemaSnapshot(schema([table("users", { bio: optionalString, name: stringField })]), []);
-            const decision = evaluateSchemaDrift({ baseline, current });
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [] });
 
             expect(decision.blocked).toBe(false);
             expect(decision.reason).toContain("additive/safe");
@@ -213,7 +227,7 @@ describe("schema-drift", () => {
             expect.assertions(3);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), []);
-            const decision = evaluateSchemaDrift({ baseline, current });
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [] });
 
             expect(decision.blocked).toBe(true);
             expect(decision.reason).toContain("deploy blocked");
@@ -246,20 +260,23 @@ describe("schema-drift", () => {
             expect(decision.reason).toContain("not covered by a new migration");
         });
 
-        it("blocks a migration whose table codegen could not lift to a literal", () => {
-            expect.assertions(1);
+        it("blocks a migration whose table codegen could not lift to a literal, and says so", () => {
+            // Failing closed is right; failing closed SILENTLY is not — the
+            // operator wrote exactly the `defineMigration` the message asks for.
+            expect.assertions(2);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), ["dynamic"]);
             const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "dynamic", table: "" }] });
 
             expect(decision.blocked).toBe(true);
+            expect(decision.reason).toContain("Migration(s) dynamic declare a non-literal `table`");
         });
 
         it("a shard-mode change stays blocked even with a migration on that very table", () => {
             // `defineMigration` runs inside one shard and can only replace the row
             // it was handed, so it can never re-home rows. The studio cites this
             // block to justify not shipping a stranded-rows detector.
-            expect.assertions(2);
+            expect.assertions(3);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: stringField }, { shardMode: { field: "tenantId", kind: "shardBy" } })]), [
                 "rehome-users",
@@ -267,25 +284,99 @@ describe("schema-drift", () => {
             const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "rehome-users", table: "users" }] });
 
             expect(decision.blocked).toBe(true);
-            // …and it must not tell the operator to scaffold the tool that cannot work.
+            // …and it must not name the tool that cannot work — neither as a
+            // scaffold line nor as the bullet above it.
             expect(decision.reason).not.toContain("lunora migrate create");
+            expect(decision.reason).not.toContain("defineMigration");
+        });
+
+        it("offers no migration for a dropped index — that is a code change, not a backfill", () => {
+            // A row transform cannot restore DDL. Offering `migrate create` here
+            // sends the operator to the one tool guaranteed not to work.
+            expect.assertions(3);
+
+            const indexed = buildSchemaSnapshot(schema([table("users", { name: stringField }, { indexes: [{ fields: ["name"], name: "byName" }] })]), []);
+            const current = buildSchemaSnapshot(schema([table("users", { name: stringField })]), []);
+            const { blocked, reason } = evaluateSchemaDrift({ baseline: indexed, current, migrations: [] });
+
+            expect(blocked).toBe(true);
+            expect(reason).toContain("removed index byName");
+            expect(reason).not.toContain("lunora migrate create");
+        });
+
+        it("offers no migration for a dropped table — its rows are unreachable, not transformable", () => {
+            expect.assertions(2);
+
+            const current = buildSchemaSnapshot(schema([table("messages", { body: stringField })]), []);
+            const { blocked, reason } = evaluateSchemaDrift({ baseline, current, migrations: [] });
+
+            expect(blocked).toBe(true);
+            expect(reason).not.toContain("lunora migrate create");
         });
 
         it("prints a paste-ready scaffold command for each table still owed a backfill", () => {
-            expect.assertions(2);
+            expect.assertions(3);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), []);
             const { reason } = evaluateSchemaDrift({ baseline, current, migrations: [] });
 
-            expect(reason).toContain("Scaffold the missing migration(s):");
+            expect(reason).toContain("Scaffold the missing migration(s)");
             expect(reason).toContain("lunora migrate create backfill_users --table users");
+            // The generated `up` is `(document) => document`, which would clear the
+            // block without backfilling a row. Say so.
+            expect(reason).toContain("identity placeholder you must fill in");
+        });
+
+        it("suppresses the scaffold line for a table name `migrate create` would reject", () => {
+            // Table names are object keys with no identifier constraint; `--table`
+            // requires one. Printing a command that cannot run is worse than none.
+            expect.assertions(2);
+
+            const odd = buildSchemaSnapshot(schema([table("user-profiles", { name: stringField })]), []);
+            const current = buildSchemaSnapshot(schema([table("user-profiles", { name: numberField })]), []);
+            const { blocked, reason } = evaluateSchemaDrift({ baseline: odd, current, migrations: [] });
+
+            expect(blocked).toBe(true);
+            expect(reason).not.toContain("lunora migrate create");
+        });
+
+        it("blocks on only the tables a partial set of migrations left uncovered", () => {
+            expect.assertions(4);
+
+            const twoTables = buildSchemaSnapshot(schema([table("users", { name: stringField }), table("posts", { title: stringField })]), []);
+            const current = buildSchemaSnapshot(schema([table("users", { name: numberField }), table("posts", { title: numberField })]), ["fix-users"]);
+            const { blocked, reason } = evaluateSchemaDrift({ baseline: twoTables, current, migrations: [{ id: "fix-users", table: "users" }] });
+
+            expect(blocked).toBe(true);
+            // The covered table is neither listed as a problem nor scaffolded…
+            expect(reason).not.toContain("field users.name changed type");
+            expect(reason).not.toContain("--table users");
+            // …and the uncovered one is.
+            expect(reason).toContain("lunora migrate create backfill_posts --table posts");
+        });
+
+        it("names only the migrations that covered something, not every new id", () => {
+            expect.assertions(2);
+
+            const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), ["fix-users", "unrelated"]);
+            const { blocked, reason } = evaluateSchemaDrift({
+                baseline,
+                current,
+                migrations: [
+                    { id: "fix-users", table: "users" },
+                    { id: "unrelated", table: "messages" },
+                ],
+            });
+
+            expect(blocked).toBe(false);
+            expect(reason).toContain("covered by 1 new migration(s) (fix-users)");
         });
 
         it("passes breaking drift when overridden with allowDrift", () => {
             expect.assertions(2);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), []);
-            const decision = evaluateSchemaDrift({ allowDrift: true, baseline, current });
+            const decision = evaluateSchemaDrift({ allowDrift: true, baseline, current, migrations: [] });
 
             expect(decision.blocked).toBe(false);
             expect(decision.reason).toContain("overridden by --allow-schema-drift");
@@ -301,7 +392,7 @@ describe("schema-drift", () => {
             it("offers both flags on deploy", () => {
                 expect.assertions(2);
 
-                const { reason } = evaluateSchemaDrift({ baseline, command: "deploy", current: breaking() });
+                const { reason } = evaluateSchemaDrift({ baseline, command: "deploy", current: breaking(), migrations: [] });
 
                 expect(reason).toContain("--allow-schema-drift");
                 expect(reason).toContain("--update-schema-baseline");
@@ -310,7 +401,7 @@ describe("schema-drift", () => {
             it("offers only --allow-schema-drift on verify, and points at prepare for the other", () => {
                 expect.assertions(3);
 
-                const { reason } = evaluateSchemaDrift({ baseline, command: "verify", current: breaking() });
+                const { reason } = evaluateSchemaDrift({ baseline, command: "verify", current: breaking(), migrations: [] });
 
                 expect(reason).toContain("pass `--allow-schema-drift`");
                 expect(reason).toContain("lunora prepare --update-schema-baseline");
@@ -320,7 +411,7 @@ describe("schema-drift", () => {
             it("falls back to listing both when the caller is unknown", () => {
                 expect.assertions(2);
 
-                const { reason } = evaluateSchemaDrift({ baseline, current: breaking() });
+                const { reason } = evaluateSchemaDrift({ baseline, current: breaking(), migrations: [] });
 
                 expect(reason).toContain("--allow-schema-drift");
                 expect(reason).toContain("--update-schema-baseline");
@@ -331,7 +422,7 @@ describe("schema-drift", () => {
             expect.assertions(1);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: stringField })]), []);
-            const decision = evaluateSchemaDrift({ baseline: undefined, current });
+            const decision = evaluateSchemaDrift({ baseline: undefined, current, migrations: [] });
 
             expect(decision.blocked).toBe(false);
         });
@@ -342,7 +433,7 @@ describe("schema-drift", () => {
             const withMigration = buildSchemaSnapshot(schema([table("users", { name: stringField })]), ["m1"]);
             // breaking change but the only migration id is the same one the baseline already knew.
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), ["m1"]);
-            const decision = evaluateSchemaDrift({ baseline: withMigration, current });
+            const decision = evaluateSchemaDrift({ baseline: withMigration, current, migrations: [{ id: "m1", table: "users" }] });
 
             expect(decision.blocked).toBe(true);
         });

--- a/packages/codegen/__tests__/schema-drift.test.ts
+++ b/packages/codegen/__tests__/schema-drift.test.ts
@@ -220,15 +220,65 @@ describe("schema-drift", () => {
             expect(decision.reason).toContain("changed type");
         });
 
-        it("passes breaking drift when a NEW migration id is present", () => {
+        it("passes breaking drift when a NEW migration covers the affected table", () => {
             expect.assertions(3);
 
             const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), ["fix-name-type"]);
-            const decision = evaluateSchemaDrift({ baseline, current });
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "fix-name-type", table: "users" }] });
 
             expect(decision.blocked).toBe(false);
             expect(decision.newMigrationIds).toStrictEqual(["fix-name-type"]);
-            expect(decision.reason).toContain("new migration(s) were added");
+            expect(decision.reason).toContain("covered by");
+        });
+
+        it("blocks when the NEW migration targets a DIFFERENT table than the breaking change", () => {
+            // The hole the per-table match closes: counting new ids alone, a
+            // backfill on `messages` reported the `users` change as
+            // "accompanied by a migration" that would never visit it.
+            expect.assertions(2);
+
+            const current = buildSchemaSnapshot(schema([table("users", { name: numberField }), table("messages", { body: stringField })]), [
+                "backfill-messages",
+            ]);
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "backfill-messages", table: "messages" }] });
+
+            expect(decision.blocked).toBe(true);
+            expect(decision.reason).toContain("not covered by a new migration");
+        });
+
+        it("blocks a migration whose table codegen could not lift to a literal", () => {
+            expect.assertions(1);
+
+            const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), ["dynamic"]);
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "dynamic", table: "" }] });
+
+            expect(decision.blocked).toBe(true);
+        });
+
+        it("a shard-mode change stays blocked even with a migration on that very table", () => {
+            // `defineMigration` runs inside one shard and can only replace the row
+            // it was handed, so it can never re-home rows. The studio cites this
+            // block to justify not shipping a stranded-rows detector.
+            expect.assertions(2);
+
+            const current = buildSchemaSnapshot(schema([table("users", { name: stringField }, { shardMode: { field: "tenantId", kind: "shardBy" } })]), [
+                "rehome-users",
+            ]);
+            const decision = evaluateSchemaDrift({ baseline, current, migrations: [{ id: "rehome-users", table: "users" }] });
+
+            expect(decision.blocked).toBe(true);
+            // …and it must not tell the operator to scaffold the tool that cannot work.
+            expect(decision.reason).not.toContain("lunora migrate create");
+        });
+
+        it("prints a paste-ready scaffold command for each table still owed a backfill", () => {
+            expect.assertions(2);
+
+            const current = buildSchemaSnapshot(schema([table("users", { name: numberField })]), []);
+            const { reason } = evaluateSchemaDrift({ baseline, current, migrations: [] });
+
+            expect(reason).toContain("Scaffold the missing migration(s):");
+            expect(reason).toContain("lunora migrate create backfill_users --table users");
         });
 
         it("passes breaking drift when overridden with allowDrift", () => {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -3,6 +3,7 @@
 // package's published API and the CLI consumes them through it.
 export type {
     DriftChange,
+    DriftRemediation,
     DriftScope,
     FieldSnapshot,
     IndexSnapshot,

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -351,8 +351,10 @@ export interface FunctionIR {
 /**
  * A `defineMigration({...})` declaration discovered in the user's lunora
  * sources. The emitted `LUNORA_MIGRATIONS` registry keys on {@link MigrationIR.id}; the
- * import wiring needs {@link MigrationIR.exportName}/{@link MigrationIR.filePath}. {@link MigrationIR.table} is
- * informational (the runtime object carries the authoritative value).
+ * import wiring needs {@link MigrationIR.exportName}/{@link MigrationIR.filePath}. The runtime object
+ * carries the authoritative {@link MigrationIR.table}, but the lifted value is
+ * load-bearing at build time: the schema-drift gate matches it against the
+ * tables with breaking drift, so a migration left at `""` covers nothing.
  */
 export interface MigrationIR {
     /** Export binding name, used to reference the module member in generated imports. */

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -1051,6 +1051,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
             vectors: vectorsContent,
             workflows: workflowsContent,
         },
+        migrations,
         outputDirectory,
         platformDiagnostics: platformGate.diagnostics,
         queues,
@@ -1226,6 +1227,14 @@ export interface CodegenResult {
         /** WorkflowEntrypoint classes (`_generated/workflows.ts`); `""` (and not written) when no workflows are declared. */
         workflows: string;
     };
+
+    /**
+     * Data migrations discovered from `defineMigration` exports under `lunora/`,
+     * each with the table it iterates. The drift gate matches a NEW id against
+     * its table so a backfill only excuses breaking drift on the table it
+     * actually visits. Empty when the project declares none.
+     */
+    migrations: ReadonlyArray<MigrationIR>;
     outputDirectory: string;
 
     /**

--- a/packages/codegen/src/schema-drift.ts
+++ b/packages/codegen/src/schema-drift.ts
@@ -15,9 +15,11 @@
  * data migration — dropped table/field, field-kind change, optional→required,
  * a new REQUIRED field on an existing table, a changed shard mode, a
  * removed/renamed index or relation). The CLI gate (`lunora deploy`/`verify`/
- * `prepare`) blocks a deploy when there is breaking drift AND no NEW migration
- * id has been added since the baseline — the footgun this closes is shipping a
- * schema change that needs a backfill with no migration to perform it.
+ * `prepare`) blocks a deploy when a breaking change is not COVERED by a new
+ * migration — one declared since the baseline that iterates that very table —
+ * and names the `lunora migrate create` command for each table still owed one.
+ * The footgun this closes is shipping a schema change that needs a backfill with
+ * no migration to perform it.
  *
  * Everything here is pure (no I/O) so it is unit-testable; the CLI owns reading
  * and writing the baseline file.
@@ -191,12 +193,41 @@ const remediationFlagLines = (command: string | undefined): string => {
 };
 
 /**
+ * Breaking changes a `defineMigration` provably CANNOT remediate, so a new
+ * migration must never excuse one.
+ *
+ * Both re-home physical storage: a shard-mode flip moves a table's rows to a
+ * different Durable Object, and a jurisdiction change moves every DO to another
+ * region. The per-shard runner only ever `replace`s a row inside the shard it
+ * was handed, so neither is reachable from a transform — the fix is an
+ * export/import round trip or a revert, which is what both summaries already
+ * say. Excusing them would send the operator to the one tool guaranteed not to
+ * work, at the exact moment the gate has their attention.
+ */
+const UNMIGRATABLE_BREAKING_TYPES: ReadonlySet<DriftChange["type"]> = new Set(["changedJurisdiction", "changedShardMode"]);
+
+/** The scaffold command for a table's missing backfill, ready to paste. */
+const scaffoldLine = (table: string): string => `      lunora migrate create backfill_${table.replaceAll(/\W/gu, "_")} --table ${table}`;
+
+/**
  * Decide whether breaking schema drift should block a deploy.
  *
  * Blocks only when the baseline exists (a first-ever capture is never blocking),
- * there is at least one `breaking` change, no NEW migration id was added since
- * the baseline, and the `allowDrift` override is not set. Safe-only drift (or
- * breaking drift accompanied by a new migration id) passes.
+ * there is at least one `breaking` change, no new migration COVERS it, and the
+ * `allowDrift` override is not set. Safe-only drift passes.
+ *
+ * "Covers" is per-table, not per-run: a new migration excuses breaking drift on
+ * the table it iterates, and nothing else. Counting new ids alone let a backfill
+ * on `messages` unblock a required field added to `users` — the gate reported
+ * "accompanied by a migration" for a change that migration would never visit.
+ * The shard-mode diff leans on this gate to justify the studio not shipping a
+ * stranded-rows detector, and that claim only holds if an unrelated migration
+ * cannot wave it through.
+ *
+ * `migrations` carries this run's declared ids and the table each iterates. It
+ * is optional so a caller without the IR keeps working, but the CLI gate always
+ * passes it — and without it nothing is covered, so the block is strictly
+ * tighter, never looser.
  */
 const evaluateSchemaDrift = (options: {
     allowDrift?: boolean;
@@ -204,14 +235,26 @@ const evaluateSchemaDrift = (options: {
     /** The command printing the remediation, so it names only flags that command accepts. */
     command?: string;
     current: SchemaSnapshot;
+    /** This run's declared migrations, so a new one is matched to the table it iterates. */
+    migrations?: ReadonlyArray<{ id: string; table: string }>;
 }): SchemaDriftDecision => {
-    const { allowDrift = false, baseline, command, current } = options;
+    const { allowDrift = false, baseline, command, current, migrations = [] } = options;
     const drift = diffSchemaSnapshots(baseline, current);
     const breaking = drift.changes.filter((change) => change.severity === "breaking");
     const newMigrationIds = current.migrationIds.filter((id) => !(baseline?.migrationIds ?? []).includes(id));
     const decide = (blocked: boolean, reason: string): SchemaDriftDecision => {
         return { blocked, changes: drift.changes, newMigrationIds, reason };
     };
+
+    // Tables a NEW migration iterates. A migration whose `table` is `""` — not a
+    // static string literal, so codegen could not lift it — covers nothing
+    // rather than everything: failing closed keeps an unresolvable declaration
+    // from becoming a blanket override.
+    const coveredTables = new Set(
+        migrations.filter((migration) => newMigrationIds.includes(migration.id) && migration.table !== "").map((migration) => migration.table),
+    );
+    const isCovered = (change: DriftChange): boolean =>
+        !UNMIGRATABLE_BREAKING_TYPES.has(change.type) && change.table !== undefined && coveredTables.has(change.table);
 
     // No drift at all, or a first-ever capture (no baseline to compare against) —
     // never block.
@@ -226,13 +269,26 @@ const evaluateSchemaDrift = (options: {
     }
 
     const breakingSummary = breaking.map((change) => `  - ${change.summary}`).join("\n");
+    const uncovered = breaking.filter((change) => !isCovered(change));
 
-    if (newMigrationIds.length > 0) {
+    if (uncovered.length === 0) {
         return decide(
             false,
-            `breaking schema drift detected, but ${String(newMigrationIds.length)} new migration(s) were added (${newMigrationIds.join(", ")}):\n${breakingSummary}`,
+            `breaking schema drift detected, covered by ${String(newMigrationIds.length)} new migration(s) (${newMigrationIds.join(", ")}):\n${breakingSummary}`,
         );
     }
+
+    // The tables still owed a backfill, in first-seen order so the scaffold lines
+    // mirror the summaries above them. `changedShardMode` names a table but can
+    // never be covered, so it is excluded — printing `migrate create` for it
+    // would contradict its own summary, which sends you to export/import.
+    const owedTables = [
+        ...new Set(
+            uncovered.filter((change) => change.table !== undefined && !UNMIGRATABLE_BREAKING_TYPES.has(change.type)).map((change) => change.table as string),
+        ),
+    ];
+    const uncoveredSummary = uncovered.map((change) => `  - ${change.summary}`).join("\n");
+    const scaffold = owedTables.length === 0 ? "" : `\n\n    Scaffold the missing migration(s):\n${owedTables.map((table) => scaffoldLine(table)).join("\n")}`;
 
     // "Schema drift" means the current schema differs from the last deployed
     // shape — so existing data in production may not match the new type
@@ -240,11 +296,11 @@ const evaluateSchemaDrift = (options: {
     // migration that tells Lunora how to transform existing documents; safe drift
     // (added optional field, new index) can proceed without one.
     const reason =
-        `deploy blocked: ${String(breaking.length)} breaking schema change(s) detected since the last blessed schema baseline — ` +
-        `these changes are incompatible with existing data without a migration:\n${breakingSummary}\n\n` +
+        `deploy blocked: ${String(uncovered.length)} breaking schema change(s) since the last blessed schema baseline are not covered by a new migration — ` +
+        `these changes are incompatible with existing data:\n${uncoveredSummary}\n\n` +
         `To fix:\n` +
         `  • For breaking changes: add a \`defineMigration({ id, table, up })\` in lunora/ for each affected table, ` +
-        `then run \`lunora migrate\` (or \`lunora codegen\`) to apply and re-bless the baseline.\n` +
+        `then run \`lunora migrate\` (or \`lunora codegen\`) to apply and re-bless the baseline.${scaffold}\n` +
         `${remediationFlagLines(command)}Docs: https://lunora.dev/docs/migrations`;
 
     if (allowDrift) {

--- a/packages/codegen/src/schema-drift.ts
+++ b/packages/codegen/src/schema-drift.ts
@@ -269,7 +269,10 @@ const blockedReason = (uncovered: ReadonlyArray<DriftChange>, unresolvedMigratio
     fixLines.push(remediationFlagLines(command));
 
     return [
-        `deploy blocked: ${String(uncovered.length)} breaking schema change(s) since the last blessed schema baseline are not covered by a new migration:`,
+        // NOT "…not covered by a new migration": only a `"backfill"` change ever
+        // could be, so that phrasing would misdescribe why a dropped index or a
+        // shard-mode flip is in this list. Each summary states its own fix.
+        `deploy blocked: ${String(uncovered.length)} unresolved breaking schema change(s) since the last blessed schema baseline:`,
         summarize(uncovered),
         "",
         `To fix:\n${fixLines.join("")}Docs: https://lunora.dev/docs/migrations`,
@@ -291,8 +294,11 @@ const blockedReason = (uncovered: ReadonlyArray<DriftChange>, unresolvedMigratio
  * stranded-rows detector (see `shared/schema-snapshot.ts`), and that claim only
  * holds if an unrelated migration cannot wave it through.
  *
- * A `"rehome"` change is never coverable: its rows move to another Durable
- * Object or region, which no per-shard transform can do.
+ * Only a `"backfill"` change is coverable at all. A `"rehome"` change moves rows
+ * to another Durable Object or region and a `"code"` change breaks a call site;
+ * rewriting rows fixes neither, so a migration must not excuse them however well
+ * its table matches. Those are cleared by fixing the code or accepting the new
+ * shape (`--allow-schema-drift` / `--update-schema-baseline`).
  */
 const evaluateSchemaDrift = (options: {
     allowDrift?: boolean;
@@ -330,9 +336,14 @@ const evaluateSchemaDrift = (options: {
         return decide(false, `schema drift detected (all additive/safe):\n${summarize(drift.changes)}`);
     }
 
-    // `"rehome"` is excluded here, not just from the scaffold: no migration on any
-    // table can move rows between Durable Objects or regions.
-    const uncovered = breaking.filter((change) => change.remediation === "rehome" || change.table === undefined || !coveredTables.has(change.table));
+    // Only a `"backfill"` change is coverable, and only by a migration on its own
+    // table. `"rehome"` rows move to another Durable Object or region, which no
+    // per-shard transform reaches; a `"code"` change breaks a CALL SITE (a query
+    // that named a dropped index or relation), which rewriting rows cannot repair
+    // either — letting a same-table migration excuse one would ship a deploy whose
+    // callers still fail at runtime. Both are resolved by fixing the code or
+    // accepting the shape, which is what the message says.
+    const uncovered = breaking.filter((change) => !isBackfillable(change) || !coveredTables.has(change.table));
 
     if (uncovered.length === 0) {
         // Name the migrations that actually covered something, not every new id —

--- a/packages/codegen/src/schema-drift.ts
+++ b/packages/codegen/src/schema-drift.ts
@@ -14,12 +14,15 @@
  * added index/relation, a required field made optional) or `breaking` (needs a
  * data migration — dropped table/field, field-kind change, optional→required,
  * a new REQUIRED field on an existing table, a changed shard mode, a
- * removed/renamed index or relation). The CLI gate (`lunora deploy`/`verify`/
- * `prepare`) blocks a deploy when a breaking change is not COVERED by a new
- * migration — one declared since the baseline that iterates that very table —
- * and names the `lunora migrate create` command for each table still owed one.
- * The footgun this closes is shipping a schema change that needs a backfill with
- * no migration to perform it.
+ * removed/renamed index or relation). Each change also carries what actually
+ * fixes it (`DriftRemediation`), so the gate can offer a data migration only
+ * where one would work.
+ *
+ * The CLI gate (`lunora deploy`/`verify`/`prepare`) blocks a deploy when a
+ * breaking change is not COVERED by a new migration — one declared since the
+ * baseline that iterates that very table — and names the `lunora migrate create`
+ * command for each table still owed one. The footgun this closes is shipping a
+ * schema change that needs a backfill with no migration to perform it.
  *
  * Everything here is pure (no I/O) so it is unit-testable; the CLI owns reading
  * and writing the baseline file.
@@ -28,7 +31,7 @@ import { LunoraError } from "@lunora/errors";
 
 import type { DriftChange, FieldSnapshot, IndexSnapshot, RelationSnapshot, SchemaSnapshot, TableSnapshot } from "../../../shared/schema-snapshot";
 import { diffSchemaSnapshots, parseSnapshotJson, SCHEMA_SNAPSHOT_VERSION, sortKeys } from "../../../shared/schema-snapshot";
-import type { SchemaIR, TableIR, ValidatorIR } from "./ir";
+import type { MigrationIR, SchemaIR, TableIR, ValidatorIR } from "./ir";
 
 /**
  * Encode a `TableIR.shardMode` into the snapshot's stable string form.
@@ -137,11 +140,16 @@ const parseSchemaSnapshot = (content: string | undefined): SchemaSnapshot | unde
 
 /** The decision the pre-deploy gate returns. */
 interface SchemaDriftDecision {
-    /** True when the deploy must be blocked (breaking drift with no new migration, and no override). */
+    /** True when the deploy must be blocked (breaking drift no new migration covers, and no override). */
     blocked: boolean;
     /** Every classified change (both severities), for reporting. */
     changes: ReadonlyArray<DriftChange>;
-    /** Migration ids declared now but absent from the baseline — proof a migration was added. */
+
+    /**
+     * Migration ids declared now but absent from the baseline. Reported for
+     * context; the gate acts on which of them cover an affected TABLE, not on how
+     * many there are.
+     */
     newMigrationIds: ReadonlyArray<string>;
 
     /**
@@ -192,22 +200,81 @@ const remediationFlagLines = (command: string | undefined): string => {
     return `${ALLOW_DRIFT_LINE}\n${baselineLine}\n`;
 };
 
+/** Render one `  - <summary>` line per change, the shape every branch of the message uses. */
+const summarize = (changes: ReadonlyArray<DriftChange>): string => changes.map((change) => `  - ${change.summary}`).join("\n");
+
 /**
- * Breaking changes a `defineMigration` provably CANNOT remediate, so a new
- * migration must never excuse one.
+ * A change a `defineMigration` can actually fix, narrowed so `table` is known
+ * present.
  *
- * Both re-home physical storage: a shard-mode flip moves a table's rows to a
- * different Durable Object, and a jurisdiction change moves every DO to another
- * region. The per-shard runner only ever `replace`s a row inside the shard it
- * was handed, so neither is reachable from a transform — the fix is an
- * export/import round trip or a revert, which is what both summaries already
- * say. Excusing them would send the operator to the one tool guaranteed not to
- * work, at the exact moment the gate has their attention.
+ * `remediation` is carried on the change union itself (see `DriftRemediation` in
+ * `shared/schema-snapshot.ts`) rather than being a set of type names maintained
+ * here: a new variant must then declare what fixes it, instead of silently
+ * defaulting to "a backfill" and being offered a `migrate create` line for a
+ * tool that cannot touch it.
  */
-const UNMIGRATABLE_BREAKING_TYPES: ReadonlySet<DriftChange["type"]> = new Set(["changedJurisdiction", "changedShardMode"]);
+const isBackfillable = (change: DriftChange): change is DriftChange & { table: string } => change.remediation === "backfill" && change.table !== undefined;
+
+/**
+ * `lunora migrate create` requires an identifier for `--table`
+ * (`packages/cli/src/commands/migrate/handler.ts`), while a schema table name is
+ * an object key with no such constraint. A name it would reject must not be
+ * printed as a paste-ready command.
+ */
+const TABLE_IDENTIFIER = /^[A-Za-z_]\w*$/u;
 
 /** The scaffold command for a table's missing backfill, ready to paste. */
-const scaffoldLine = (table: string): string => `      lunora migrate create backfill_${table.replaceAll(/\W/gu, "_")} --table ${table}`;
+const scaffoldLine = (table: string): string => `      lunora migrate create backfill_${table} --table ${table}`;
+
+/**
+ * Render the blocked-deploy message: what is still uncovered, what to do about
+ * it, and the override flags the printing command accepts.
+ *
+ * Every "to fix" line is conditional on there being something that line can fix.
+ * The bullet naming `defineMigration` used to be unconditional, so a
+ * jurisdiction-only block said "no in-place migration" and "add a migration" two
+ * lines apart.
+ */
+const blockedReason = (uncovered: ReadonlyArray<DriftChange>, unresolvedMigrationIds: ReadonlyArray<string>, command: string | undefined): string => {
+    const owedTables = [...new Set(uncovered.filter((change) => isBackfillable(change)).map((change) => change.table))];
+    const fixLines: string[] = [];
+
+    if (owedTables.length > 0) {
+        fixLines.push(
+            "  • Add a `defineMigration({ id, table, up })` in lunora/ for each affected table, then re-run this command — the baseline is re-blessed on a successful deploy, not by `lunora migrate` itself.\n",
+        );
+
+        // A table name is an object key with no identifier constraint, but
+        // `--table` requires one: printing a command that cannot run is worse
+        // than printing none.
+        const scaffoldable = owedTables.filter((table) => TABLE_IDENTIFIER.test(table));
+
+        if (scaffoldable.length > 0) {
+            fixLines.push(
+                `\n    Scaffold the missing migration(s) — the generated \`up\` is an identity placeholder you must fill in:\n${scaffoldable.map((table) => scaffoldLine(table)).join("\n")}\n\n`,
+            );
+        }
+    }
+
+    // A migration whose `table` codegen could not lift to a string literal covers
+    // nothing (see `evaluateSchemaDrift`). Without this line the operator has
+    // written exactly the `defineMigration` the message asks for and is told to
+    // write it again, with nothing connecting the two.
+    if (unresolvedMigrationIds.length > 0) {
+        fixLines.push(
+            `  • Migration(s) ${unresolvedMigrationIds.join(", ")} declare a non-literal \`table\`, so codegen cannot tell which table they visit and they cover nothing. Use a string literal.\n`,
+        );
+    }
+
+    fixLines.push(remediationFlagLines(command));
+
+    return [
+        `deploy blocked: ${String(uncovered.length)} breaking schema change(s) since the last blessed schema baseline are not covered by a new migration:`,
+        summarize(uncovered),
+        "",
+        `To fix:\n${fixLines.join("")}Docs: https://lunora.dev/docs/migrations`,
+    ].join("\n");
+};
 
 /**
  * Decide whether breaking schema drift should block a deploy.
@@ -220,14 +287,12 @@ const scaffoldLine = (table: string): string => `      lunora migrate create bac
  * the table it iterates, and nothing else. Counting new ids alone let a backfill
  * on `messages` unblock a required field added to `users` — the gate reported
  * "accompanied by a migration" for a change that migration would never visit.
- * The shard-mode diff leans on this gate to justify the studio not shipping a
- * stranded-rows detector, and that claim only holds if an unrelated migration
- * cannot wave it through.
+ * The shard-mode diff cites this block to justify the studio not shipping a
+ * stranded-rows detector (see `shared/schema-snapshot.ts`), and that claim only
+ * holds if an unrelated migration cannot wave it through.
  *
- * `migrations` carries this run's declared ids and the table each iterates. It
- * is optional so a caller without the IR keeps working, but the CLI gate always
- * passes it — and without it nothing is covered, so the block is strictly
- * tighter, never looser.
+ * A `"rehome"` change is never coverable: its rows move to another Durable
+ * Object or region, which no per-shard transform can do.
  */
 const evaluateSchemaDrift = (options: {
     allowDrift?: boolean;
@@ -236,25 +301,24 @@ const evaluateSchemaDrift = (options: {
     command?: string;
     current: SchemaSnapshot;
     /** This run's declared migrations, so a new one is matched to the table it iterates. */
-    migrations?: ReadonlyArray<{ id: string; table: string }>;
+    migrations: ReadonlyArray<Pick<MigrationIR, "id" | "table">>;
 }): SchemaDriftDecision => {
-    const { allowDrift = false, baseline, command, current, migrations = [] } = options;
+    const { allowDrift = false, baseline, command, current, migrations } = options;
     const drift = diffSchemaSnapshots(baseline, current);
     const breaking = drift.changes.filter((change) => change.severity === "breaking");
     const newMigrationIds = current.migrationIds.filter((id) => !(baseline?.migrationIds ?? []).includes(id));
+    const newMigrations = migrations.filter((migration) => newMigrationIds.includes(migration.id));
     const decide = (blocked: boolean, reason: string): SchemaDriftDecision => {
         return { blocked, changes: drift.changes, newMigrationIds, reason };
     };
 
     // Tables a NEW migration iterates. A migration whose `table` is `""` — not a
-    // static string literal, so codegen could not lift it — covers nothing
-    // rather than everything: failing closed keeps an unresolvable declaration
-    // from becoming a blanket override.
-    const coveredTables = new Set(
-        migrations.filter((migration) => newMigrationIds.includes(migration.id) && migration.table !== "").map((migration) => migration.table),
-    );
-    const isCovered = (change: DriftChange): boolean =>
-        !UNMIGRATABLE_BREAKING_TYPES.has(change.type) && change.table !== undefined && coveredTables.has(change.table);
+    // static string literal, so codegen could not lift it — covers nothing rather
+    // than everything: failing closed keeps an unresolvable declaration from
+    // becoming a blanket override. `blockedReason` names those ids, so failing
+    // closed does not also fail silently.
+    const coveredTables = new Set(newMigrations.filter((migration) => migration.table !== "").map((migration) => migration.table));
+    const unresolvedMigrationIds = newMigrations.filter((migration) => migration.table === "").map((migration) => migration.id);
 
     // No drift at all, or a first-ever capture (no baseline to compare against) —
     // never block.
@@ -263,45 +327,27 @@ const evaluateSchemaDrift = (options: {
     }
 
     if (breaking.length === 0) {
-        const summary = drift.changes.map((change) => `  - ${change.summary}`).join("\n");
-
-        return decide(false, `schema drift detected (all additive/safe):\n${summary}`);
+        return decide(false, `schema drift detected (all additive/safe):\n${summarize(drift.changes)}`);
     }
 
-    const breakingSummary = breaking.map((change) => `  - ${change.summary}`).join("\n");
-    const uncovered = breaking.filter((change) => !isCovered(change));
+    // `"rehome"` is excluded here, not just from the scaffold: no migration on any
+    // table can move rows between Durable Objects or regions.
+    const uncovered = breaking.filter((change) => change.remediation === "rehome" || change.table === undefined || !coveredTables.has(change.table));
 
     if (uncovered.length === 0) {
+        // Name the migrations that actually covered something, not every new id —
+        // counting ids indiscriminately is the habit this gate exists to break. A
+        // migration on a table with no breaking drift covered nothing.
+        const driftedTables = new Set(breaking.map((change) => change.table));
+        const covering = newMigrations.filter((migration) => driftedTables.has(migration.table)).map((migration) => migration.id);
+
         return decide(
             false,
-            `breaking schema drift detected, covered by ${String(newMigrationIds.length)} new migration(s) (${newMigrationIds.join(", ")}):\n${breakingSummary}`,
+            `breaking schema drift detected, covered by ${String(covering.length)} new migration(s) (${covering.join(", ")}):\n${summarize(breaking)}`,
         );
     }
 
-    // The tables still owed a backfill, in first-seen order so the scaffold lines
-    // mirror the summaries above them. `changedShardMode` names a table but can
-    // never be covered, so it is excluded — printing `migrate create` for it
-    // would contradict its own summary, which sends you to export/import.
-    const owedTables = [
-        ...new Set(
-            uncovered.filter((change) => change.table !== undefined && !UNMIGRATABLE_BREAKING_TYPES.has(change.type)).map((change) => change.table as string),
-        ),
-    ];
-    const uncoveredSummary = uncovered.map((change) => `  - ${change.summary}`).join("\n");
-    const scaffold = owedTables.length === 0 ? "" : `\n\n    Scaffold the missing migration(s):\n${owedTables.map((table) => scaffoldLine(table)).join("\n")}`;
-
-    // "Schema drift" means the current schema differs from the last deployed
-    // shape — so existing data in production may not match the new type
-    // expectations. Breaking drift (removed table/field, changed type) needs a
-    // migration that tells Lunora how to transform existing documents; safe drift
-    // (added optional field, new index) can proceed without one.
-    const reason =
-        `deploy blocked: ${String(uncovered.length)} breaking schema change(s) since the last blessed schema baseline are not covered by a new migration — ` +
-        `these changes are incompatible with existing data:\n${uncoveredSummary}\n\n` +
-        `To fix:\n` +
-        `  • For breaking changes: add a \`defineMigration({ id, table, up })\` in lunora/ for each affected table, ` +
-        `then run \`lunora migrate\` (or \`lunora codegen\`) to apply and re-bless the baseline.${scaffold}\n` +
-        `${remediationFlagLines(command)}Docs: https://lunora.dev/docs/migrations`;
+    const reason = blockedReason(uncovered, unresolvedMigrationIds, command);
 
     if (allowDrift) {
         return decide(false, `${reason}\n\n(overridden by --allow-schema-drift)`);
@@ -314,7 +360,16 @@ const evaluateSchemaDrift = (options: {
 // `shared/schema-snapshot.ts` so `@lunora/studio` can render the SAME diff the
 // deploy gate blocks on. Re-exported here so every existing import site
 // (`run-codegen.ts`, the CLI gate, the tests) is unchanged.
-export type { DriftChange, FieldSnapshot, IndexSnapshot, RelationSnapshot, SchemaDrift, SchemaSnapshot, TableSnapshot } from "../../../shared/schema-snapshot";
+export type {
+    DriftChange,
+    DriftRemediation,
+    FieldSnapshot,
+    IndexSnapshot,
+    RelationSnapshot,
+    SchemaDrift,
+    SchemaSnapshot,
+    TableSnapshot,
+} from "../../../shared/schema-snapshot";
 export { diffSchemaSnapshots, SCHEMA_SNAPSHOT_VERSION, serializeSchemaSnapshot } from "../../../shared/schema-snapshot";
 export type { SchemaDriftDecision };
 export { buildSchemaSnapshot, evaluateSchemaDrift, parseSchemaSnapshot, SchemaSnapshotParseError };

--- a/shared/schema-snapshot.ts
+++ b/shared/schema-snapshot.ts
@@ -98,15 +98,40 @@ interface SchemaSnapshot {
  */
 type DriftScope = "schema" | "table";
 
+/**
+ * What actually fixes a change, so a consumer can name the right tool.
+ *
+ * - `"backfill"` — a `defineMigration` transform rewrites the affected rows.
+ *   The ONLY value for which a data migration is the answer.
+ * - `"rehome"` — the rows' physical storage moves (a different Durable Object,
+ *   or a different region). The per-shard runner only ever replaces a row inside
+ *   the shard it was handed, so no transform reaches these; the fix is an
+ *   export/import round trip, or a revert.
+ * - `"code"` — nothing happens to stored data; a query or a call site has to
+ *   change (a dropped index, a dropped relation).
+ * - `"none"` — additive, nothing to do.
+ *
+ * This lives HERE, next to the change union, for the same reason {@link DriftScope}
+ * does: a hand-maintained set of type names in the consumer gives zero
+ * compile-time pressure, so a new variant would silently default to whatever the
+ * set omits. The deploy gate uses this to decide both what a data migration may
+ * excuse and which tables it offers to scaffold one for — a wrong default there
+ * sends the operator to a tool that cannot work.
+ */
+type DriftRemediation = "backfill" | "code" | "none" | "rehome";
+
 /** One classified structural change between two snapshots. */
 interface DriftChange {
+    /** What fixes this change — see {@link DriftRemediation}. `"none"` for every `safe` change. */
+    remediation: DriftRemediation;
+
     /**
      * `"table"` means this table's own DDL moved (fields, indexes, shard mode) —
      * a relation whose foreign key lives on the OTHER table stays `"schema"`, so
      * the "changed" signal keeps meaning "this table's shape moved".
      */
     scope: DriftScope;
-    /** `"breaking"` changes need a data migration; `"safe"` changes are additive. */
+    /** `"breaking"` changes need attention before deploy; `"safe"` changes are additive. */
     severity: "breaking" | "safe";
     /** Human-readable, actionable description (used in the gate message). */
     summary: string;
@@ -272,6 +297,7 @@ const diffExistingField = (tableName: string, name: string, old: FieldSnapshot, 
 
     if (old.kind !== field.kind) {
         changes.push({
+            remediation: "backfill",
             severity: "breaking",
             summary: `field ${tableName}.${name} changed type: ${old.kind} → ${field.kind} — add a data migration to convert existing values`,
             table: tableName,
@@ -282,6 +308,7 @@ const diffExistingField = (tableName: string, name: string, old: FieldSnapshot, 
 
     if (old.optional && !field.optional) {
         changes.push({
+            remediation: "backfill",
             severity: "breaking",
             summary: `field ${tableName}.${name} became required — rows missing it would be invalid; add a data migration to backfill it`,
             table: tableName,
@@ -290,6 +317,7 @@ const diffExistingField = (tableName: string, name: string, old: FieldSnapshot, 
         });
     } else if (!old.optional && field.optional) {
         changes.push({
+            remediation: "none",
             scope: "table",
             severity: "safe",
             summary: `field ${tableName}.${name} became optional`,
@@ -304,8 +332,16 @@ const diffExistingField = (tableName: string, name: string, old: FieldSnapshot, 
 /** Classify a field present only in the CURRENT snapshot: optional ⇒ safe, required ⇒ needs a backfill. */
 const addedFieldChange = (tableName: string, name: string, field: FieldSnapshot): DriftChange =>
     field.optional
-        ? { scope: "table", severity: "safe", summary: `added optional field ${tableName}.${name}`, table: tableName, type: "addedOptionalField" }
+        ? {
+              remediation: "none",
+              scope: "table",
+              severity: "safe",
+              summary: `added optional field ${tableName}.${name}`,
+              table: tableName,
+              type: "addedOptionalField",
+          }
         : {
+              remediation: "backfill",
               severity: "breaking",
               summary: `added required field ${tableName}.${name} — existing rows have no value; add a data migration to backfill it`,
               table: tableName,
@@ -328,6 +364,7 @@ const diffFields = (tableName: string, baseline: TableSnapshot, current: TableSn
     for (const name of Object.keys(baseline.fields)) {
         if (current.fields[name] === undefined) {
             changes.push({
+                remediation: "backfill",
                 severity: "breaking",
                 summary: `removed field ${tableName}.${name} — add a data migration if stored data must be cleaned up`,
                 table: tableName,
@@ -344,13 +381,21 @@ const diffIndexes = (tableName: string, baseline: TableSnapshot, current: TableS
         const old = baseline.indexes[name];
 
         if (old === undefined) {
-            changes.push({ scope: "table", severity: "safe", summary: `added index ${name} on ${tableName}`, table: tableName, type: "addedIndex" });
+            changes.push({
+                remediation: "none",
+                scope: "table",
+                severity: "safe",
+                summary: `added index ${name} on ${tableName}`,
+                table: tableName,
+                type: "addedIndex",
+            });
 
             continue;
         }
 
         if (!indexesEqual(old, index)) {
             changes.push({
+                remediation: "code",
                 severity: "breaking",
                 summary: `index ${name} on ${tableName} changed shape — a query may have relied on the old index`,
                 table: tableName,
@@ -363,6 +408,7 @@ const diffIndexes = (tableName: string, baseline: TableSnapshot, current: TableS
     for (const name of Object.keys(baseline.indexes)) {
         if (current.indexes[name] === undefined) {
             changes.push({
+                remediation: "code",
                 severity: "breaking",
                 summary: `removed index ${name} on ${tableName} — a query that used \`.withIndex("${name}")\` would break`,
                 table: tableName,
@@ -377,13 +423,21 @@ const diffIndexes = (tableName: string, baseline: TableSnapshot, current: TableS
 const diffRelations = (tableName: string, baseline: TableSnapshot, current: TableSnapshot, changes: DriftChange[]): void => {
     for (const name of Object.keys(current.relations)) {
         if (baseline.relations[name] === undefined) {
-            changes.push({ scope: "schema", severity: "safe", summary: `added relation ${tableName}.${name}`, table: tableName, type: "addedRelation" });
+            changes.push({
+                remediation: "none",
+                scope: "schema",
+                severity: "safe",
+                summary: `added relation ${tableName}.${name}`,
+                table: tableName,
+                type: "addedRelation",
+            });
         }
     }
 
     for (const name of Object.keys(baseline.relations)) {
         if (current.relations[name] === undefined) {
             changes.push({
+                remediation: "code",
                 scope: "schema",
                 severity: "breaking",
                 summary: `removed relation ${tableName}.${name}`,
@@ -405,12 +459,13 @@ const diffExistingTable = (tableName: string, baseline: TableSnapshot, current: 
             // TODO(stranded-rows) in
             // `packages/studio/src/features/advisors/derive-insights.ts`. Soften
             // this severity and that detector becomes owed.
+            // Deliberately NOT `"backfill"`: `defineMigration` runs inside one
+            // shard and can only `replace` the row it was handed, so it cannot
+            // move a row between shards. Naming it here sends the operator to the
+            // one tool guaranteed not to work, at the exact moment the gate has
+            // their attention.
+            remediation: "rehome",
             severity: "breaking",
-            // Deliberately NOT "add a data migration": `defineMigration` runs
-            // inside one shard and can only `replace` the row it was handed, so
-            // it cannot move a row between shards. Naming it here sends the
-            // operator to the one tool guaranteed not to work, at the exact
-            // moment the gate has their attention.
             summary: `table ${tableName} changed shard mode: ${baseline.shardMode} → ${current.shardMode} — its physical storage moves, and existing rows do NOT follow the schema; re-home them with an export/import round trip (https://lunora.sh/docs/concepts/sharding#migrating-a-populated-table)`,
             table: tableName,
             scope: "table",
@@ -437,7 +492,7 @@ const diffSchemaSnapshots = (baseline: SchemaSnapshot | undefined, current: Sche
         const old = baselineTables[tableName];
 
         if (old === undefined) {
-            changes.push({ scope: "table", severity: "safe", summary: `added table ${tableName}`, table: tableName, type: "addedTable" });
+            changes.push({ remediation: "none", scope: "table", severity: "safe", summary: `added table ${tableName}`, table: tableName, type: "addedTable" });
 
             continue;
         }
@@ -448,9 +503,16 @@ const diffSchemaSnapshots = (baseline: SchemaSnapshot | undefined, current: Sche
     for (const tableName of Object.keys(baselineTables)) {
         if (current.tables[tableName] === undefined) {
             changes.push({
+                // NOT `"backfill"`, though this summary used to name one: a
+                // transform returns a document that replaces the SAME row in the
+                // SAME table, and its reader is read-only, so it can neither
+                // delete the rows nor copy them anywhere. The table is also gone
+                // from the schema by now, so the migration's target would not
+                // resolve. Export the shard if the data is wanted.
+                remediation: "rehome",
                 scope: "table",
                 severity: "breaking",
-                summary: `removed table ${tableName} — add a data migration if its data must be archived/cleaned up`,
+                summary: `removed table ${tableName} — its rows stay in each shard's SQLite, unreachable through the schema; export the shard first if the data must be kept`,
                 table: tableName,
                 type: "removedTable",
             });
@@ -467,6 +529,7 @@ const diffSchemaSnapshots = (baseline: SchemaSnapshot | undefined, current: Sche
         const to = current.jurisdiction ?? "(none)";
 
         changes.push({
+            remediation: "rehome",
             scope: "schema",
             severity: "breaking",
             summary: `Durable Object jurisdiction changed from ${from} to ${to} — this re-homes every DO and strands all existing shard, scheduler, and session-DO data in the old region (no in-place migration; export then import to move it). Revert the change, or override the gate to proceed intentionally.`,
@@ -478,4 +541,15 @@ const diffSchemaSnapshots = (baseline: SchemaSnapshot | undefined, current: Sche
 };
 
 export { diffSchemaSnapshots, hashSchemaSnapshot, isValidTableSnapshot, parseSnapshotJson, SCHEMA_SNAPSHOT_VERSION, serializeSchemaSnapshot, sortKeys };
-export type { DriftChange, DriftScope, FieldSnapshot, IndexSnapshot, RelationSnapshot, SchemaDrift, SchemaSnapshot, SnapshotParseOutcome, TableSnapshot };
+export type {
+    DriftChange,
+    DriftRemediation,
+    DriftScope,
+    FieldSnapshot,
+    IndexSnapshot,
+    RelationSnapshot,
+    SchemaDrift,
+    SchemaSnapshot,
+    SnapshotParseOutcome,
+    TableSnapshot,
+};


### PR DESCRIPTION
The pre-deploy schema-drift gate blocks a deploy when a schema change existing rows cannot satisfy ships without a data migration to fix it. Two things were wrong with how it decided that, and the message it printed when it said no was actively misleading.

## 1. Any migration excused every breaking change

`evaluateSchemaDrift` unblocked on `newMigrationIds.length > 0`. A backfill declared on `messages` cleared a required field added to `users`, and the gate printed *"accompanied by a migration"* for a migration that would never visit the row.

Coverage is now **per-table**: a new migration excuses breaking drift on the table it iterates, and nothing else. A migration whose `table` codegen could not lift to a static literal covers nothing rather than everything.

This also makes an existing claim true. The `changedShardMode` diff carries a comment saying the studio can skip a stranded-rows detector *because* this gate blocks — and it didn't, since any unrelated migration id cleared it without `--allow-schema-drift`.

## 2. "Can a migration fix this?" was a denylist in the consumer

The first pass answered that with a two-entry `Set` of type names living in the gate. That is the exact shape this module's own `DriftScope` doc rejects:

> it lives HERE — next to the change union it classifies — rather than as a hand-maintained set of type names in the consumer. A set in the consumer gives zero compile-time pressure

And it was already under-inclusive. Only four of the nine table-carrying breaking types are fixable by a per-document transform, so a dropped index, a changed index, a dropped relation, and a dropped table each got a `lunora migrate create` line for a tool that cannot touch them — the precise failure the exclusion existed to prevent.

`DriftChange` now carries the answer:

```ts
remediation: "backfill" | "rehome" | "code" | "none"
```

set at every push site in `shared/schema-snapshot.ts`. A new variant must declare what fixes it instead of silently defaulting to "a backfill", the gate reads one field instead of maintaining a name list, and the studio gets the same signal for free.

`removedTable` is reclassified `rehome` and its summary corrected along the way: a transform replaces the same row in the same table and its reader is read-only, so it can neither delete the rows nor copy them — and the table is gone from the schema by then anyway.

## 3. The blocked message

Before, one unconditional block of prose regardless of what was actually wrong. Now every "to fix" line is conditional on there being something it can fix:

```text
deploy blocked: 1 breaking schema change(s) since the last blessed schema baseline are not covered by a new migration:
  - added required field users.displayName — existing rows have no value; add a data migration to backfill it

To fix:
  • Add a `defineMigration({ id, table, up })` in lunora/ for each affected table, then re-run this command — the baseline is re-blessed on a successful deploy, not by `lunora migrate` itself.

    Scaffold the missing migration(s) — the generated `up` is an identity placeholder you must fill in:
      lunora migrate create backfill_users --table users

  • For backward-compatible changes (e.g. adding an optional field): pass `--allow-schema-drift` to skip the block.
  • To accept the new shape without a migration (you know data is compatible): pass `--update-schema-baseline`.
Docs: https://lunora.dev/docs/migrations
```

Specifically fixed:

- **The `defineMigration` bullet is conditional.** A jurisdiction-only block used to say *"no in-place migration"* and *"add a migration"* two lines apart.
- **Unresolvable migrations are named.** A `table` codegen could not lift (a const reference or a template literal, not just a missing property) covers nothing. Failing closed is right; failing closed *silently* left the operator holding the exact `defineMigration` the message was asking them to write.
- **The re-bless instruction is now true.** It claimed `lunora migrate` or `lunora codegen` re-blesses the baseline. Neither accepts `updateSchemaBaseline` — only a successful `deploy`/`prepare` advances it, via the deferred `rebless` thunk.
- **The scaffold warns about its own stub.** `migrate create` writes `up: (document) => document`, which satisfies the gate without backfilling a single row.
- **No scaffold line for a table name `migrate create` would reject.** Table names are object keys with no identifier constraint; `--table` requires one. The first pass sanitised the migration-name half (which can never break) and passed `--table` raw (which can).
- **The pass message names the migrations that covered something**, not every new id.

## Wiring

`CodegenResult` carries the discovered `migrations` so the CLI gate can pass them. `evaluateSchemaDrift`'s `migrations` is required and typed `Pick<MigrationIR, "id" | "table">`. Message rendering moved into `blockedReason`, leaving the decision function as three short returns.

## Breaking

- `DriftChange` gains a required `remediation` field.
- `CodegenResult` gains a required `migrations` field.
- `evaluateSchemaDrift`'s `migrations` option is required.
- A deploy that previously passed on a mismatched migration id now blocks, and a dropped index/relation/table no longer offers a data migration as its fix (`--allow-schema-drift` / `--update-schema-baseline` remain the escape).

## Also in this branch

`examples/feedback-board/lunora/_generated/shard.ts` is regenerated in its own commit. The `output_projection_missing_on_public_read` advisor text gained `.strip()` in #531 without that example being re-run, so `lint:generated` has been red on `alpha` since. Unrelated to the gate, but it blocks this PR.

## Verification

- `@lunora/codegen` 1566/1566, `@lunora/cli` 1340/1340, `@lunora/studio` 1188/1188 (it inlines the same `shared/` module)
- eslint + `tsc --noEmit` clean on all three
- `lint:generated` — all 16 generators reproduce their committed output
- `api:check` drift accepted via `api:update`; only `codegen.api.md` moved
- Built `dist` confirmed to contain the `shared/` edit rather than a cached copy

Gate tests cover: table match, table mismatch, unliftable `""` table (and that the message says so), shard-mode blocked even with a migration on that very table, dropped index and dropped table offering no migration, a non-identifier table name suppressing the scaffold, partial coverage across two tables, and the pass message naming only covering migrations. Plus a CLI-level test that pins the wiring — drop `codegen.migrations` at the call site and a mismatched-table deploy sails through with only unit tests to catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema drift detection now considers available data migrations when evaluating breaking changes.
  * Drift results identify the appropriate remediation path, such as backfill, code updates, or rehoming.
  * Migration guidance and relevant migration suggestions are provided for blocked schema changes.
  * Additive schema changes are reported while still allowing deployment.

* **Documentation**
  * Clarified deploy-gate behavior, schema baseline updates, migration scaffolding, supported options, and remediation paths for common schema changes.
  * Documented identity migration behavior and how different schema changes are cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->