### PR TITLE
fix(vue): open the pinned page range on loadMore

### DIFF
--- a/api-snapshots/solid.api.md
+++ b/api-snapshots/solid.api.md
@@ -282,6 +282,7 @@ interface CreateAgentToolEventsResult {
 ```ts
 interface CreateInfiniteQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -290,6 +291,7 @@ interface CreateInfiniteQueryOptions {
 
 ```ts
 interface CreateInfiniteQueryResult<T> {
+    error: Accessor<SubscriptionError | undefined>;
     fetchNextPage: (numberItems?: number) => void;
     hasNextPage: Accessor<boolean>;
     isFetchingNextPage: Accessor<boolean>;
@@ -304,6 +306,7 @@ interface CreateInfiniteQueryResult<T> {
 ```ts
 interface CreatePaginatedQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -312,6 +315,7 @@ interface CreatePaginatedQueryOptions {
 
 ```ts
 interface CreatePaginatedQueryResult<T> {
+    error: Accessor<SubscriptionError | undefined>;
     isLoading: Accessor<boolean>;
     loadMore: (numberItems: number) => void;
     results: Accessor<T[]>;
@@ -748,7 +752,9 @@ const createVoiceAgent: (options: CreateVoiceAgentOptions) => CreateVoiceAgentRe
 ### `hydratePreloaded` (const)
 
 ```ts
-const hydratePreloaded: <T>(preloaded: Preloaded<T>) => Accessor<T>;
+const hydratePreloaded: <T>(preloaded: Preloaded<T>, options?: {
+    onError?: SubscriptionErrorCallback;
+}) => Accessor<T>;
 ```
 
 ### `useLunora` (const)

--- a/api-snapshots/svelte.api.md
+++ b/api-snapshots/svelte.api.md
@@ -87,6 +87,7 @@ interface AgentChatOptions {
     api: AgentChatApi;
     cancel?: FunctionReference<"mutation">;
     limit?: number;
+    onError?: SubscriptionErrorCallback;
     send: FunctionReference<"mutation">;
     sendArgs?: Record<string, unknown>;
     stream?: AgentTokenStreamReference;
@@ -119,6 +120,7 @@ type AgentLiveEvent = AgentProgressEvent | AgentTokenDelta;
 interface AgentOptions {
     api: AgentApi;
     cancel?: FunctionReference<"mutation">;
+    onError?: SubscriptionErrorCallback;
     run: FunctionReference<"mutation">;
     runArgs?: Record<string, unknown>;
     threadKey: string;
@@ -314,6 +316,7 @@ type HeartbeatReference = FunctionReference<"mutation", {
 
 ```ts
 interface InfiniteQueryHandle<T> {
+    error: Readable<SubscriptionError | undefined>;
     fetchNextPage: (numberItems?: number) => void;
     hasNextPage: Readable<boolean>;
     isFetchingNextPage: Readable<boolean>;
@@ -328,6 +331,7 @@ interface InfiniteQueryHandle<T> {
 ```ts
 interface InfiniteQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -398,6 +402,7 @@ type PaginatedArgs<F extends FunctionReference> = Omit<ArgsOf<F>, "paginationOpt
 
 ```ts
 interface PaginatedQueryHandle<T> {
+    error: Readable<SubscriptionError | undefined>;
     isLoading: Readable<boolean>;
     loadMore: (numberItems: number) => void;
     results: Readable<T[]>;
@@ -410,6 +415,7 @@ interface PaginatedQueryHandle<T> {
 ```ts
 interface PaginatedQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -678,7 +684,9 @@ const getLunoraClient: () => LunoraClient;
 ### `hydratePreloaded` (const)
 
 ```ts
-const hydratePreloaded: <T>(preloaded: Preloaded<T>, client?: LunoraClient) => Readable<T>;
+const hydratePreloaded: <T>(preloaded: Preloaded<T>, client?: LunoraClient, options?: {
+    onError?: SubscriptionErrorCallback;
+}) => Readable<T>;
 ```
 
 ### `infiniteQuery` (function)

--- a/api-snapshots/vue.api.md
+++ b/api-snapshots/vue.api.md
@@ -416,6 +416,7 @@ interface UseAuthResult {
 ```ts
 interface UseInfiniteQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -424,6 +425,7 @@ interface UseInfiniteQueryOptions {
 
 ```ts
 interface UseInfiniteQueryResult<T> {
+    error: Ref<SubscriptionError | undefined>;
     fetchNextPage: (numberItems?: number) => void;
     hasNextPage: Ref<boolean>;
     isFetchingNextPage: Ref<boolean>;
@@ -438,6 +440,7 @@ interface UseInfiniteQueryResult<T> {
 ```ts
 interface UsePaginatedQueryOptions {
     initialNumItems: number;
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 ```
@@ -446,6 +449,7 @@ interface UsePaginatedQueryOptions {
 
 ```ts
 interface UsePaginatedQueryResult<T> {
+    error: Ref<SubscriptionError | undefined>;
     isLoading: Ref<boolean>;
     loadMore: (numberItems: number) => void;
     results: Ref<T[]>;
@@ -611,7 +615,9 @@ const createLunora: (client: LunoraClient) => {
 ### `hydratePreloaded` (const)
 
 ```ts
-const hydratePreloaded: <T>(preloaded: Preloaded<T>) => Ref<T>;
+const hydratePreloaded: <T>(preloaded: Preloaded<T>, options?: {
+    onError?: SubscriptionErrorCallback;
+}) => Ref<T>;
 ```
 
 ### `provideLunora` (const)
@@ -624,6 +630,7 @@ const provideLunora: (client: LunoraClient) => void;
 
 ```ts
 const subscribeToQuery: <F extends FunctionReference, T = ReturnOf<F>>(client: LunoraClient, function_: F, args: ArgsOf<F>, options?: {
+    onError?: SubscriptionErrorCallback;
     seed?: T;
     shardKey?: string;
 }) => Ref<T | undefined>;

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -58,8 +58,8 @@ export class MessagesComponent {
 Pass `"skip"` as the args to short-circuit (no network call, no socket).
 
 Pass a function/`Signal` instead of a plain object to make the args reactive —
-each change tears the old subscription down and opens a fresh one for the new
-args:
+each change tears the old subscription down, resets the signal to `undefined`,
+and opens a fresh one for the new args:
 
 ```ts
 export class MessagesComponent {

--- a/packages/angular/__tests__/live-query.dom.test.ts
+++ b/packages/angular/__tests__/live-query.dom.test.ts
@@ -162,10 +162,13 @@ describe("liveQuery — reactive args (plan 340)", () => {
         expect(fake.subscriptions[1]?.unsubscribed).toBe(false);
         expect(fake.subscriptions[1]?.args).toStrictEqual({ channelId: "random" });
 
-        // A late frame from the torn-down subscription must not leak into the signal.
+        // The previous args' value does not survive the switch, and a late frame
+        // from the torn-down subscription must not leak into the signal.
+        expect(data()).toBeUndefined();
+
         fake.subscriptions[0]?.push({ messages: ["stale"] });
 
-        expect(data()).toStrictEqual({ messages: ["hi"] });
+        expect(data()).toBeUndefined();
 
         fake.subscriptions[1]?.push({ messages: ["fresh"] });
 

--- a/packages/angular/__tests__/paginated-query.dom.test.ts
+++ b/packages/angular/__tests__/paginated-query.dom.test.ts
@@ -1,6 +1,6 @@
 import { Injector, provideZonelessChangeDetection, signal } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionError } from "@lunora/client";
 import type { PaginationResult } from "@lunora/client/pagination";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -109,6 +109,56 @@ describe(paginatedQuery, () => {
         );
 
         expect(status()).toBe("Exhausted");
+    });
+
+    it("a page error surfaces on `error`, returns status to CanLoadMore, and lets loadMore retry", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const errors: SubscriptionError[] = [];
+
+        const { error, isLoading, loadMore, results, status } = paginatedQuery(
+            fn,
+            {},
+            {
+                client: fake.asClient,
+                destroyRef: destroy.asDestroyRef,
+                initialNumItems: NUM_ITEMS,
+                onError: (e) => errors.push(e),
+            },
+        );
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            { continueCursor: "cur-1", isDone: false, page: firstPageItems },
+        );
+
+        loadMore(NUM_ITEMS);
+
+        expect(status()).toBe("LoadingMore");
+
+        // An RLS denial on the new page: pending was cleared but the feed sat in
+        // `LoadingMore` forever with `isLoading` true and nothing surfaced.
+        const tailArgs = { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS };
+        const tail = fake.subscriptions.find((sub) => JSON.stringify(sub.args) === JSON.stringify({ paginationOpts: tailArgs }));
+
+        tail?.emitError({ code: "FORBIDDEN", message: "denied" });
+
+        expect(errors).toStrictEqual([{ code: "FORBIDDEN", message: "denied" }]);
+        expect(error()).toStrictEqual({ code: "FORBIDDEN", message: "denied" });
+        expect(status()).toBe("CanLoadMore");
+        expect(isLoading()).toBe(false);
+        expect(results()).toStrictEqual(firstPageItems);
+        expect(tail?.unsubscribed).toBe(true);
+
+        // The failed tail was dropped, so `loadMore` re-opens exactly that range.
+        const before = fake.subscriptions.length;
+
+        loadMore(NUM_ITEMS);
+
+        expect(error()).toBeUndefined();
+        expect(status()).toBe("LoadingMore");
+        expect(fake.subscriptions.slice(before).map((sub) => sub.args["paginationOpts"])).toStrictEqual([tailArgs]);
     });
 
     it("tears down all subscriptions on destroy", () => {

--- a/packages/angular/__tests__/subscription.dom.test.ts
+++ b/packages/angular/__tests__/subscription.dom.test.ts
@@ -172,10 +172,13 @@ describe("subscription — reactive args (plan 340)", () => {
         expect(fake.subscriptions[0]?.unsubscribed).toBe(true);
         expect(fake.subscriptions[1]?.unsubscribed).toBe(false);
 
-        // A late frame from the torn-down subscription must not leak into the signal.
+        // The previous args' value does not survive the switch, and a late frame
+        // from the torn-down subscription must not leak into the signal.
+        expect(data()).toBeUndefined();
+
         fake.subscriptions[0]?.push([{ id: "stale" }]);
 
-        expect(data()).toStrictEqual([{ id: "1" }]);
+        expect(data()).toBeUndefined();
 
         fake.subscriptions[1]?.push([{ id: "2" }]);
 

--- a/packages/angular/src/live-query.ts
+++ b/packages/angular/src/live-query.ts
@@ -73,7 +73,8 @@ export interface LiveQueryOptions {
  *
  * `args` also accepts a function/`Signal` — `() => ({ channelId: channelId() })`
  * — to make the subscription reactive: an args change tears the old
- * subscription down and opens a fresh one for the new args, mirroring
+ * subscription down, resets the signal to `undefined`, and opens a fresh one
+ * for the new args, mirroring
  * `@lunora/solid`'s `createQuery`/`@lunora/vue`'s `useQuery`. A static (plain
  * object) `args` resolves once and never re-runs — no `effect()` is created for
  * it, so it carries none of the reactive form's DI requirement.
@@ -91,6 +92,10 @@ export const liveQuery = <F extends FunctionReference>(
     const value = signal<ReturnOf<F> | undefined>(undefined);
 
     const open = (currentArgs: ArgsOf<F> | "skip", registerCleanup: (unsubscribe: () => void) => void): void => {
+        // The previous args' value must not render under the new args until the
+        // new subscription's first frame lands.
+        value.set(undefined);
+
         const unsubscribe = createQuerySubscription<F>(
             client,
             reference,

--- a/packages/angular/src/paginated-query.ts
+++ b/packages/angular/src/paginated-query.ts
@@ -1,6 +1,6 @@
 import type { Injector, Signal } from "@angular/core";
 import { computed, DestroyRef, inject, signal } from "@angular/core";
-import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionError, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
 import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
 
@@ -40,6 +40,7 @@ const buildPageArgs = (page: Page, baseArgs: Record<string, unknown>): Record<st
 
 /** The signal-backed handle {@link usePaginatedCore} returns. */
 interface PaginatedCore<F extends FunctionReference> {
+    error: Signal<SubscriptionError | undefined>;
     loadMore: (numberItems: number) => void;
     pageResults: Signal<(PaginationResult<PageItemOf<F>> | undefined)[]>;
     status: Signal<PaginationStatus>;
@@ -73,6 +74,7 @@ const usePaginatedCore = <F extends FunctionReference>(
     const pages = signal<Page[]>(initialPages(initialNumItems));
     const pageResults = signal<(PaginationResult<PageItemOf<F>> | undefined)[]>([]);
     const status = signal<PaginationStatus>("LoadingFirstPage");
+    const error = signal<SubscriptionError | undefined>(undefined);
 
     /**
      * Each active subscription entry, keyed in `activeSubs` by the page key it
@@ -168,6 +170,7 @@ const usePaginatedCore = <F extends FunctionReference>(
                 (value) => {
                     resultsByKey.set(entry.currentKey, value as PaginationResult<PageItemOf<F>>);
                     pendingPageKeys.delete(entry.currentKey);
+                    error.set(undefined);
 
                     doRebuildPageResults();
 
@@ -186,9 +189,25 @@ const usePaginatedCore = <F extends FunctionReference>(
                     }
                 },
                 {
-                    onError: () => {
-                        pendingPageKeys.delete(entry.currentKey);
+                    onError: (subscriptionError) => {
+                        pendingPageKeys.delete(key);
+                        error.set(subscriptionError);
+
+                        // A tail that fails before its first frame is dropped so
+                        // the feed leaves `LoadingMore` (status falls back to the
+                        // previous page's cursor) and `loadMore` can retry it. The
+                        // first page has nothing to fall back to and stays.
+                        const current = pages();
+                        const tail = current.at(-1);
+
+                        if (current.length > 1 && tail && !resultsByKey.has(key) && buildPageKey(functionPath, buildPageArgs(tail, narrowedArgs)) === key) {
+                            pages.set(current.slice(0, -1));
+                            // eslint-disable-next-line @typescript-eslint/no-use-before-define -- runs inside a deferred subscription callback, after syncSubscriptions is defined
+                            syncSubscriptions(pages());
+                        }
+
                         doRebuildPageResults();
+                        options.onError?.(subscriptionError);
                     },
                     shardKey,
                 },
@@ -305,12 +324,13 @@ const usePaginatedCore = <F extends FunctionReference>(
             }
         }
 
+        error.set(undefined);
         pages.set(next);
         syncSubscriptions(pages());
         doRebuildPageResults();
     };
 
-    return { loadMore, pageResults, status };
+    return { error, loadMore, pageResults, status };
 };
 
 /**
@@ -364,6 +384,7 @@ const useReactivePaginatedCore = <F extends FunctionReference>(
     }
 
     return {
+        error: computed(() => active()?.error()),
         loadMore: (numberItems: number) => {
             active()?.loadMore(numberItems);
         },
@@ -396,6 +417,9 @@ export interface PaginatedQueryOptions {
      */
     injector?: Injector;
 
+    /** Called when a page subscription reports an error (also surfaced on the `error` signal). */
+    onError?: SubscriptionErrorCallback;
+
     /** Route to a specific shard when the target function is `.shardBy(...)`-partitioned. */
     shardKey?: string;
 }
@@ -405,6 +429,14 @@ export interface PaginatedQueryOptions {
  * @experimental
  */
 export interface PaginatedQueryResult<T> {
+    /**
+     * The last page subscription error, or `undefined`. A tail page that fails
+     * before its first frame is dropped so `status` returns to `"CanLoadMore"`
+     * and `loadMore` can retry it; cleared by the next successful frame,
+     * `loadMore`, or an args change.
+     */
+    error: Signal<SubscriptionError | undefined>;
+
     /** `true` while the first page or a `loadMore` page is in flight. */
     isLoading: Signal<boolean>;
 
@@ -423,6 +455,9 @@ export interface PaginatedQueryResult<T> {
  * @experimental
  */
 export interface InfiniteQueryResult<T> {
+    /** The last page subscription error, or `undefined` — see `PaginatedQueryResult.error`. */
+    error: Signal<SubscriptionError | undefined>;
+
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
     fetchNextPage: (numberItems?: number) => void;
 
@@ -481,6 +516,7 @@ export const paginatedQuery = <F extends FunctionReference>(
     });
 
     return {
+        error: core.error,
         isLoading,
         loadMore: core.loadMore,
         results,
@@ -523,6 +559,7 @@ export const infiniteQuery = <F extends FunctionReference>(
     };
 
     return {
+        error: core.error,
         fetchNextPage,
         hasNextPage,
         isFetchingNextPage,

--- a/packages/angular/src/subscription.ts
+++ b/packages/angular/src/subscription.ts
@@ -86,16 +86,14 @@ export const subscription = <F extends FunctionReference>(
     const error = signal<SubscriptionError | undefined>(undefined);
 
     const open = (currentArgs: ArgsOf<F> | "skip", registerCleanup: (unsubscribe: () => void) => void): void => {
-        if (currentArgs === "skip") {
-            // Reset, don't just bail: under the reactive form args can move from
-            // real args to `"skip"`, and the effect's cleanup only closes the
-            // socket. Without this the consumer keeps rendering the last payload
-            // (or the last error) of a subscription that is no longer open.
-            // `liveQuery` gets this for free via `createQuerySubscription`'s
-            // `onReset` on its own SKIP branch.
-            data.set(undefined);
-            error.set(undefined);
+        // Reset first, don't just (re)open: under the reactive form the effect's
+        // cleanup only closes the socket. Without this the consumer keeps
+        // rendering the previous args' last payload (or error) under the new
+        // args — or, on a `"skip"` emission, as if the subscription were still open.
+        data.set(undefined);
+        error.set(undefined);
 
+        if (currentArgs === "skip") {
             return;
         }
 

--- a/packages/replica/README.md
+++ b/packages/replica/README.md
@@ -142,7 +142,9 @@ machine, and pushes the resulting diffs to the mirror:
 import { EventsSync } from "@lunora/replica";
 
 const sync = new EventsSync({
-    fetchEventsSince: (seq) => eventLogClient.getSince(seq),
+    // `getSince` answers ONE bounded page; EventsSync keeps calling with the
+    // advanced watermark until the log is exhausted.
+    fetchEventsSince: async (seq) => (await eventLogClient.getSince(seq)).entries,
     applyEvents: (events) => {
         /* feed events into your state machine */
     },
@@ -235,9 +237,10 @@ const client = new EventLogDOClient({
 const [entry] = await client.append([{ type: "order:placed", payload: { orderId: "123" } }]);
 
 // Read back by sequence number — the log is append-only and ordered, so
-// there is no filter-by-type query. `getSince(0)` is the whole log.
-const events = await client.getSince(entry.seq);
-const { entries, hasMore } = await client.getRange(0, 50);
+// there is no filter-by-type query. Every read is ONE bounded page (500
+// entries by default, 1000 max): walk `cursor` while `truncated` is true.
+const { entries, truncated, cursor } = await client.getSince(entry.seq);
+const page = await client.getSince(0, 50);
 const size = await client.getSize();
 ```
 

--- a/packages/replica/__tests__/event-log-do-client.test.ts
+++ b/packages/replica/__tests__/event-log-do-client.test.ts
@@ -294,6 +294,44 @@ describe("eventLogDOClient + MaterializerRuntime", () => {
         expect(counter.state).toEqual({ total: 2 });
     });
 
+    it("materializerRuntime initialize yields instead of chasing a log that keeps growing", async () => {
+        expect.assertions(2);
+
+        // A writer faster than the reader keeps `truncated` true on every page,
+        // so "walk until the log is exhausted" never terminates and startup
+        // never completes. The log stops growing here at 1500 only so an
+        // unbounded walk terminates and reports the overrun instead of hanging
+        // the suite.
+        const client = {
+            getSince: async (sinceSeq: number) => {
+                return {
+                    cursor: sinceSeq + 1,
+                    entries: [{ seq: sinceSeq, type: "increment", payload: {}, timestamp: sinceSeq }],
+                    truncated: sinceSeq < 1500,
+                };
+            },
+        } as unknown as EventLogDOClient;
+
+        const counter = defineMaterializer({
+            name: "counter",
+            initial: () => {
+                return { total: 0 };
+            },
+            handle: (state, entry) => {
+                if (entry.type === "increment") {
+                    return { total: state.total + 1 };
+                }
+                return state;
+            },
+        });
+
+        const runtime = new MaterializerRuntime([counter], { doClient: client });
+
+        await expect(runtime.initialize()).resolves.toBe(1000);
+        // The watermark carries the progress, so a later call resumes from here.
+        expect(runtime.appliedSeq).toBe(1000);
+    });
+
     it("appendEvent throws when no doClient configured", async () => {
         expect.assertions(1);
 

--- a/packages/replica/__tests__/event-log-do-client.test.ts
+++ b/packages/replica/__tests__/event-log-do-client.test.ts
@@ -70,12 +70,15 @@ const createMockSql = () => {
                     table = table.filter((r) => r.seq >= Number(params[0]));
                 }
 
-                const limitMatch = query.match(/LIMIT\s+(\d+)/i);
+                // ORDER BY seq ASC — before the limit, as SQLite does.
+                table.sort((a, b) => a.seq - b.seq);
+
+                // LIMIT ? (bound — the handlers' form) or LIMIT <n>
+                const limitMatch = query.match(/LIMIT\s+(\?|\d+)/i);
                 if (limitMatch) {
-                    table = table.slice(0, Number(limitMatch[1]));
+                    table = table.slice(0, limitMatch[1] === "?" ? Number(params.at(-1)) : Number(limitMatch[1]));
                 }
 
-                table.sort((a, b) => a.seq - b.seq);
                 return { toArray: () => table };
             }
 
@@ -121,13 +124,13 @@ describe("eventLogDOClient + MaterializerRuntime", () => {
 
         const since = await client.getSince(1);
 
-        expect(since).toHaveLength(1);
-        expect(since[0]!.seq).toBe(1);
-        expect(since[0]!.type).toBe("test.b");
+        expect(since.entries).toHaveLength(1);
+        expect(since.entries[0]!.seq).toBe(1);
+        expect(since.entries[0]!.type).toBe("test.b");
     });
 
-    it("paginates via getRange", async () => {
-        expect.assertions(7);
+    it("paginates via getSince", async () => {
+        expect.assertions(8);
 
         const do_ = createDO();
         const client = createClient(do_);
@@ -138,17 +141,18 @@ describe("eventLogDOClient + MaterializerRuntime", () => {
             { type: "c", payload: {} },
         ]);
 
-        const page1 = await client.getRange(0, 2);
+        const page1 = await client.getSince(0, 2);
 
         expect(page1.entries).toHaveLength(2);
-        expect(page1.hasMore).toBe(true);
+        expect(page1.truncated).toBe(true);
+        expect(page1.cursor).toBe(2);
         expect(page1.entries[0]!.seq).toBe(0);
         expect(page1.entries[1]!.seq).toBe(1);
 
-        const page2 = await client.getRange(2, 2);
+        const page2 = await client.getSince(page1.cursor!, 2);
 
         expect(page2.entries).toHaveLength(1);
-        expect(page2.hasMore).toBe(false);
+        expect(page2.truncated).toBe(false);
         expect(page2.entries[0]!.seq).toBe(2);
     });
 

--- a/packages/replica/__tests__/event-log-do.test.ts
+++ b/packages/replica/__tests__/event-log-do.test.ts
@@ -14,6 +14,13 @@ interface StoredRow {
     type: string;
 }
 
+/** Body of a `GET /since` response. */
+interface SincePage {
+    cursor?: number;
+    entries: { seq: number; type: string }[];
+    truncated: boolean;
+}
+
 const createMockSql = () => {
     const tables = new Map<string, StoredRow[]>([["events", []]]);
 
@@ -79,16 +86,15 @@ const createMockSql = () => {
                     table = table.filter((r) => r.seq >= since);
                 }
 
-                // ORDER BY seq ASC
-                // LIMIT
-                const limitMatch = query.match(/LIMIT\s+(\d+)/i);
+                // ORDER BY seq ASC — applied BEFORE the limit, as SQLite does.
+                table.sort((a, b) => a.seq - b.seq);
+
+                // LIMIT ? (bound — the handlers' form) or LIMIT <n>
+                const limitMatch = query.match(/LIMIT\s+(\?|\d+)/i);
                 if (limitMatch) {
-                    const limit = Number(limitMatch[1]);
+                    const limit = limitMatch[1] === "?" ? Number(params.at(-1)) : Number(limitMatch[1]);
                     table = table.slice(0, limit);
                 }
-
-                // ORDER BY seq ASC (default sort)
-                table.sort((a, b) => a.seq - b.seq);
 
                 return { toArray: () => table };
             }
@@ -208,8 +214,8 @@ describe(EventLogDO, () => {
         expect(data.entries[1]!.type).toBe("e.3");
     });
 
-    it("supports paginated range queries", async () => {
-        expect.assertions(11);
+    it("pages /since with an explicit limit", async () => {
+        expect.assertions(12);
 
         const do_ = createDO();
 
@@ -225,30 +231,65 @@ describe(EventLogDO, () => {
         });
 
         // Get first page of 2
-        const page1 = await doFetch(do_, "GET", "/range?from=0&limit=2");
-        const d1 = (await page1.json()) as { entries: { seq: number }[]; hasMore: boolean };
+        const page1 = await doFetch(do_, "GET", "/since?seq=0&limit=2");
+        const d1 = (await page1.json()) as SincePage;
 
         expect(d1.entries).toHaveLength(2);
         expect(d1.entries[0]!.seq).toBe(0);
         expect(d1.entries[1]!.seq).toBe(1);
-        expect(d1.hasMore).toBe(true);
+        expect(d1.truncated).toBe(true);
+        expect(d1.cursor).toBe(2);
 
-        // Get second page
-        const page2 = await doFetch(do_, "GET", "/range?from=2&limit=2");
-        const d2 = (await page2.json()) as { entries: { seq: number }[]; hasMore: boolean };
+        // Get second page from the cursor the first one handed back
+        const page2 = await doFetch(do_, "GET", `/since?seq=${String(d1.cursor)}&limit=2`);
+        const d2 = (await page2.json()) as SincePage;
 
         expect(d2.entries).toHaveLength(2);
         expect(d2.entries[0]!.seq).toBe(2);
-        expect(d2.entries[1]!.seq).toBe(3);
-        expect(d2.hasMore).toBe(true);
+        expect(d2.truncated).toBe(true);
+        expect(d2.cursor).toBe(4);
 
-        // Get last page (should have 1 entry, hasMore false)
-        const page3 = await doFetch(do_, "GET", "/range?from=4&limit=2");
-        const d3 = (await page3.json()) as { entries: { seq: number }[]; hasMore: boolean };
+        // Last page — one entry, and the walk ends here.
+        const page3 = await doFetch(do_, "GET", `/since?seq=${String(d2.cursor)}&limit=2`);
+        const d3 = (await page3.json()) as SincePage;
 
         expect(d3.entries).toHaveLength(1);
         expect(d3.entries[0]!.seq).toBe(4);
-        expect(d3.hasMore).toBe(false);
+        expect(d3.truncated).toBe(false);
+    });
+
+    it("bounds /since to 500 entries when no limit is given", async () => {
+        expect.assertions(4);
+
+        const do_ = createDO();
+
+        await doFetch(do_, "POST", "/append", {
+            events: Array.from({ length: 501 }, () => {
+                return { type: "e", payload: {} };
+            }),
+        });
+
+        // A catch-up from 0 must NOT serialize the whole log into one response.
+        const page1 = await doFetch(do_, "GET", "/since?seq=0");
+        const d1 = (await page1.json()) as SincePage;
+
+        expect(d1.entries).toHaveLength(500);
+        expect(d1.truncated).toBe(true);
+        expect(d1.cursor).toBe(500);
+
+        const page2 = await doFetch(do_, "GET", `/since?seq=${String(d1.cursor)}`);
+        const d2 = (await page2.json()) as SincePage;
+
+        expect(d2.entries).toHaveLength(1);
+    });
+
+    it("rejects an out-of-range /since limit", async () => {
+        expect.assertions(2);
+
+        const do_ = createDO();
+
+        await expect(doFetch(do_, "GET", "/since?seq=0&limit=0").then((r) => r.status)).resolves.toBe(400);
+        await expect(doFetch(do_, "GET", "/since?seq=0&limit=1001").then((r) => r.status)).resolves.toBe(400);
     });
 
     it("rejects append with empty events array", async () => {

--- a/packages/replica/__tests__/event-log-do.test.ts
+++ b/packages/replica/__tests__/event-log-do.test.ts
@@ -292,6 +292,18 @@ describe(EventLogDO, () => {
         await expect(doFetch(do_, "GET", "/since?seq=0&limit=1001").then((r) => r.status)).resolves.toBe(400);
     });
 
+    it("rejects non-integral /since pagination parameters", async () => {
+        expect.assertions(2);
+
+        const do_ = createDO();
+
+        // Both are finite, so the old range checks let them through: a fractional
+        // `limit` reaches SQLite's `LIMIT ?` as a 500, and a fractional `seq`
+        // silently shifts the `seq >= ?` boundary past a real entry.
+        await expect(doFetch(do_, "GET", "/since?seq=0&limit=1.5").then((r) => r.status)).resolves.toBe(400);
+        await expect(doFetch(do_, "GET", "/since?seq=1.5").then((r) => r.status)).resolves.toBe(400);
+    });
+
     it("rejects append with empty events array", async () => {
         expect.assertions(1);
 

--- a/packages/replica/__tests__/events-context.test.ts
+++ b/packages/replica/__tests__/events-context.test.ts
@@ -38,17 +38,14 @@ const createTestClient = (): EventLogDOClient => {
 
         if (url.pathname === "/since") {
             const seq = Number(url.searchParams.get("seq") ?? "0");
-            const since = entries.filter((e) => e.seq >= seq);
-            return Response.json({ entries: since });
-        }
-
-        if (url.pathname === "/range") {
-            const from = Number(url.searchParams.get("from") ?? "0");
-            const limit = Number(url.searchParams.get("limit") ?? "50");
-            const slice = entries.slice(from, from + limit);
+            const limit = Number(url.searchParams.get("limit") ?? "500");
+            const matching = entries.filter((e) => e.seq >= seq);
+            const page = matching.slice(0, limit);
+            const truncated = matching.length > page.length;
             return Response.json({
-                entries: slice,
-                hasMore: from + limit < entries.length,
+                cursor: truncated ? page[page.length - 1]!.seq + 1 : undefined,
+                entries: page,
+                truncated,
             });
         }
 
@@ -94,7 +91,7 @@ const createNext = (originalCtx: Record<string, unknown>): MockNext => {
 
 describe("eventsContext middleware", () => {
     it("attaches ctx.events with expected facade methods", async () => {
-        expect.assertions(6);
+        expect.assertions(5);
 
         const client = createTestClient();
         const middleware = eventsContext(client);
@@ -107,7 +104,6 @@ describe("eventsContext middleware", () => {
         expect(result).toHaveProperty("events");
         expect(result.events.append).toBeTypeOf("function");
         expect(result.events.getSince).toBeTypeOf("function");
-        expect(result.events.getRange).toBeTypeOf("function");
         expect(result.events.getSize).toBeTypeOf("function");
         expect(result.events.getState).toBeTypeOf("function");
     });
@@ -169,11 +165,11 @@ describe("eventsContext middleware", () => {
 
         const since = await events.getSince(1);
 
-        expect(since).toHaveLength(1);
-        expect(since[0]!.type).toBe("b");
+        expect(since.entries).toHaveLength(1);
+        expect(since.entries[0]!.type).toBe("b");
     });
 
-    it("ctx.events.getRange returns paginated results", async () => {
+    it("ctx.events.getSince pages through the log", async () => {
         expect.assertions(6);
 
         const client = createTestClient();
@@ -188,17 +184,17 @@ describe("eventsContext middleware", () => {
             await events.append([{ type: `e${i}`, payload: i }]);
         }
 
-        const page = await events.getRange(2, 2);
+        const page = await events.getSince(2, 2);
 
         expect(page.entries).toHaveLength(2);
         expect(page.entries[0]!.seq).toBe(2);
         expect(page.entries[1]!.seq).toBe(3);
-        expect(page.hasMore).toBe(true);
+        expect(page.truncated).toBe(true);
 
-        const last = await events.getRange(4, 2);
+        const last = await events.getSince(page.cursor!, 2);
 
         expect(last.entries).toHaveLength(1);
-        expect(last.hasMore).toBe(false);
+        expect(last.truncated).toBe(false);
     });
 
     it("ctx.events.getSize returns total count", async () => {

--- a/packages/replica/__tests__/integration.test.ts
+++ b/packages/replica/__tests__/integration.test.ts
@@ -425,6 +425,20 @@ describe(LocalMirror, () => {
         expect(result).toHaveLength(1);
         expect(result[0]!.name).toBe("alice");
     });
+
+    it("caps the event log by default, dropping the oldest entries", () => {
+        expect.assertions(2);
+
+        const mirror = new LocalMirror({ db: createTestAdapter(), tables: { users: { primaryKey: "id" } } });
+
+        for (let index = 0; index < 1005; index += 1) {
+            mirror.applyDiff(createTableDiff("users", [{ type: "insert", data: { id: String(index) } }]));
+        }
+
+        expect(mirror.eventLog.size).toBe(1000);
+        // Oldest-first eviction: seqs 0..4 are gone, 5 is the new floor.
+        expect(mirror.eventLog.getSince(0)[0]?.seq).toBe(5);
+    });
 });
 
 // ─── subscribeToMirror ─────────────────────────────────────────────────
@@ -477,6 +491,65 @@ describe(subscribeToMirror, () => {
 
         expect(rows).toHaveLength(1);
         expect(rows[0]!.text).toBe("hello");
+    });
+
+    it("repeating a frame writes nothing; a changed/removed row writes only that change", () => {
+        expect.assertions(8);
+
+        const adapter = createTestAdapter();
+        const statements: string[] = [];
+        const counting: SqliteAdapter = {
+            ...adapter,
+            exec(sql: string, params?: ReadonlyArray<unknown>): void {
+                statements.push(sql.replaceAll("`", "").trim().toUpperCase());
+                adapter.exec(sql, params);
+            },
+        };
+
+        const mirror = new LocalMirror({ db: counting });
+
+        let push: ((data: unknown) => void) | undefined;
+        const client: SubscriptionClient = {
+            subscribe(_fn: { __lunoraRef: string }, _args: Record<string, unknown>, cb: (data: unknown) => void) {
+                push = cb;
+                return vi.fn<() => void>();
+            },
+        };
+
+        subscribeToMirror(client, mirror, { __lunoraRef: "todos/list" }, {});
+
+        const rows = Array.from({ length: 50 }, (_, index) => {
+            return { id: String(index), text: "same" };
+        });
+
+        // 200 identical frames. Only the first carries any change: the rest are
+        // byte-identical snapshots, so nothing is applied, logged or bumped.
+        for (let frame = 0; frame < 200; frame += 1) {
+            push!(rows);
+        }
+
+        // The mirror's own meta table is written with the same statement kind,
+        // so count only the ones aimed at the mirrored table.
+        const upserts = () => statements.filter((sql) => sql.startsWith("INSERT OR REPLACE") && sql.includes("FN_TODOS_LIST")).length;
+
+        expect(mirror.eventLog.size).toBe(1);
+        expect(mirror.version).toBe(1);
+        expect(upserts()).toBe(50);
+
+        // One row edited, one row gone.
+        push!([{ id: "0", text: "edited" }, ...rows.slice(1, 49)]);
+
+        expect(mirror.eventLog.size).toBe(2);
+        expect(mirror.eventLog.getSince(1)[0]?.tableDiffs?.[0]?.changes).toStrictEqual([
+            { data: { id: "0", text: "edited" }, type: "insert" },
+            { id: "49", type: "delete" },
+        ]);
+        expect(upserts()).toBe(51);
+
+        const remaining = adapter.query<{ id: string; text: string }>("SELECT * FROM fn_todos_list");
+
+        expect(remaining).toHaveLength(49);
+        expect(remaining.filter((row) => row.text === "edited")).toHaveLength(1);
     });
 
     it("cleanup unsubs the client subscription", () => {

--- a/packages/replica/__tests__/runtime-edges.test.ts
+++ b/packages/replica/__tests__/runtime-edges.test.ts
@@ -36,29 +36,26 @@ describe("eventLogDOClient wire contract", () => {
         await expect(requests[0]?.json()).resolves.toStrictEqual({ events: [{ payload: { n: 1 }, type: "a" }] });
     });
 
-    it("getSince and getRange encode their cursor in the query string", async () => {
-        expect.assertions(3);
+    it("getSince encodes its cursor and limit in the query string", async () => {
+        expect.assertions(2);
 
-        const { client, requests } = clientWith(() => Response.json({ entries: [], hasMore: false }));
+        const { client, requests } = clientWith(() => Response.json({ entries: [], truncated: false }));
 
         await client.getSince(7);
-        await client.getRange(3, 25);
-        await client.getRange(0);
+        await client.getSince(3, 25);
 
+        // No `limit` → the DO's own default page size applies.
         expect(new URL(requests[0]?.url as string).search).toBe("?seq=7");
-        expect(new URL(requests[1]?.url as string).search).toBe("?from=3&limit=25");
-        // The default page size is 50.
-        expect(new URL(requests[2]?.url as string).search).toBe("?from=0&limit=50");
+        expect(new URL(requests[1]?.url as string).search).toBe("?seq=3&limit=25");
     });
 
     it("surfaces the DO's structured error message on a non-OK response", async () => {
-        expect.assertions(5);
+        expect.assertions(4);
 
         const { client } = clientWith(() => Response.json({ error: { code: "BAD_REQUEST", message: "events[] required" } }, { status: 400 }));
 
         await expect(client.append([])).rejects.toThrow("EventLogDO.append failed (400): events[] required");
         await expect(client.getSince(0)).rejects.toThrow("EventLogDO.getSince failed (400): events[] required");
-        await expect(client.getRange(0)).rejects.toThrow("EventLogDO.getRange failed (400): events[] required");
         await expect(client.getSize()).rejects.toThrow("EventLogDO.getSize failed (400): events[] required");
         await expect(client.getState()).rejects.toThrow("EventLogDO.getState failed (400): events[] required");
     });
@@ -312,7 +309,7 @@ interface MirrorDouble {
     registered: string[];
 }
 
-const mirrorDouble = (): MirrorDouble => {
+const mirrorDouble = (primaryKey: string = "id"): MirrorDouble => {
     const applied: TableDiff[] = [];
     const registered: string[] = [];
 
@@ -320,6 +317,7 @@ const mirrorDouble = (): MirrorDouble => {
         applyDiff: (diff: TableDiff) => {
             applied.push(diff);
         },
+        primaryKeyOf: () => primaryKey,
         registerTable: (name: string) => {
             registered.push(name);
         },
@@ -331,8 +329,8 @@ const mirrorDouble = (): MirrorDouble => {
 describe(subscribeToMirror, () => {
     const functionRef = { __lunoraRef: "todos/list" };
 
-    const wire = (): { double: MirrorDouble; push: (data: unknown) => void; unsubscribe: () => void; unsubscribed: () => boolean } => {
-        const double = mirrorDouble();
+    const wire = (primaryKey?: string): { double: MirrorDouble; push: (data: unknown) => void; unsubscribe: () => void; unsubscribed: () => boolean } => {
+        const double = mirrorDouble(primaryKey);
         let callback: ((data: unknown) => void) | undefined;
         let torn = false;
 
@@ -364,7 +362,7 @@ describe(subscribeToMirror, () => {
         expect(double.registered).toStrictEqual(["fn_todos_list"]);
     });
 
-    it("upserts every row of a frame and deletes rows that dropped out of the next frame", () => {
+    it("upserts every row of the first frame and only the changes of the next", () => {
         expect.assertions(4);
 
         const { double, push } = wire();
@@ -381,13 +379,59 @@ describe(subscribeToMirror, () => {
             { data: { id: "2", title: "b" }, type: "insert" },
         ]);
 
-        // Row "1" vanished from the server result — the snapshot pass deletes it.
+        // Row "1" vanished from the server result — the snapshot pass deletes
+        // it. Row "2" is byte-identical to the previous frame, so it is NOT
+        // re-upserted.
         push([{ id: "2", title: "b" }]);
 
-        expect(double.applied[1]?.changes).toStrictEqual([
-            { data: { id: "2", title: "b" }, type: "insert" },
-            { id: "1", type: "delete" },
+        expect(double.applied[1]?.changes).toStrictEqual([{ id: "1", type: "delete" }]);
+    });
+
+    it("emits nothing for a frame identical to the last one", () => {
+        expect.assertions(2);
+
+        const { double, push } = wire();
+
+        const rows = [
+            { id: "1", title: "a" },
+            { id: "2", title: "b" },
+        ];
+
+        push(rows);
+        // Same rows, fresh objects, keys in a different order — same content.
+        push([
+            { title: "b", id: "2" },
+            { title: "a", id: "1" },
         ]);
+        push(rows);
+
+        expect(double.applied).toHaveLength(1);
+
+        // …and a real edit still lands.
+        push([
+            { id: "1", title: "a" },
+            { id: "2", title: "B!" },
+        ]);
+
+        expect(double.applied[1]?.changes).toStrictEqual([{ data: { id: "2", title: "B!" }, type: "insert" }]);
+    });
+
+    it("diffs on the table's registered primary key, not a hard-coded `id`", () => {
+        expect.assertions(2);
+
+        // `registerTable(name, {})` must not erase a caller-supplied
+        // `primaryKey`; the mirror keeps answering `todoId` and the snapshot
+        // pass keys rows by it.
+        const { double, push } = wire("todoId");
+
+        push([{ title: "a", todoId: "t1" }]);
+        push([{ title: "a", todoId: "t1" }]);
+
+        expect(double.applied).toHaveLength(1);
+
+        push([]);
+
+        expect(double.applied[1]?.changes).toStrictEqual([{ id: "t1", type: "delete" }]);
     });
 
     it("treats a single-object frame as one row and numeric ids as strings", () => {
@@ -436,6 +480,7 @@ describe(subscribeToMirror, () => {
 
                 applied.push(diff);
             },
+            primaryKeyOf: () => "id",
             registerTable: () => undefined,
         } as unknown as LocalMirror;
 

--- a/packages/replica/__tests__/runtime-edges.test.ts
+++ b/packages/replica/__tests__/runtime-edges.test.ts
@@ -434,6 +434,28 @@ describe(subscribeToMirror, () => {
         expect(double.applied[1]?.changes).toStrictEqual([{ id: "t1", type: "delete" }]);
     });
 
+    it("tracks a bigint primary key like any other id", () => {
+        expect.assertions(3);
+
+        // An int64 column decodes off the wire as a `bigint`. Classified as
+        // un-keyed it was inserted every frame and never deleted.
+        const { double, push } = wire();
+
+        push([{ id: 1n, title: "a" }]);
+
+        expect(double.applied[0]?.changes).toStrictEqual([{ data: { id: 1n, title: "a" }, type: "insert" }]);
+
+        // Identical frame: no re-upsert.
+        push([{ id: 1n, title: "a" }]);
+
+        expect(double.applied).toHaveLength(1);
+
+        // …and the row is deletable once the server drops it.
+        push([]);
+
+        expect(double.applied[1]?.changes).toStrictEqual([{ id: "1", type: "delete" }]);
+    });
+
     it("treats a single-object frame as one row and numeric ids as strings", () => {
         expect.assertions(2);
 

--- a/packages/replica/__tests__/sync-events.test.ts
+++ b/packages/replica/__tests__/sync-events.test.ts
@@ -101,7 +101,68 @@ describe(EventsSync, () => {
         expect(applied[0]!.seq).toBe(0);
         expect(applied[1]!.seq).toBe(1);
         expect(sync.watermark).toBe(2); // seq 0 + 1 + 1
-        expect(callCount()).toBe(1);
+        // Two fetches: the batch, then the one that comes back empty and ends
+        // the catch-up walk.
+        expect(callCount()).toBe(2);
+    });
+
+    it("sync() walks every page of a log larger than one batch", async () => {
+        expect.assertions(4);
+
+        const { mirror } = createMockMirror();
+
+        const log: EventLogEntry[] = Array.from({ length: 5 }, (_, index) => {
+            return { seq: index, type: "e", payload: index, timestamp: 100 + index };
+        });
+
+        // A transport that answers a BOUNDED page, like `EventLogDOClient.getSince`.
+        const pageSize = 2;
+        const batches: number[][] = [];
+
+        const sync = new EventsSync({
+            fetchEventsSince: (sinceSeq) => Promise.resolve(log.filter((entry) => entry.seq >= sinceSeq).slice(0, pageSize)),
+            applyEvents: (events) => {
+                batches.push(events.map((entry) => entry.seq));
+            },
+            getTableDiffs: () => [],
+            mirror,
+        });
+
+        const count = await sync.sync();
+
+        expect(count).toBe(5);
+        expect(sync.watermark).toBe(5);
+        // Each page is applied as its own atom — never one 5-event batch.
+        expect(batches).toStrictEqual([[0, 1], [2, 3], [4]]);
+        await expect(sync.sync()).resolves.toBe(0);
+    });
+
+    it("sync() stops instead of spinning when a batch does not advance the watermark", async () => {
+        expect.assertions(2);
+
+        const { mirror } = createMockMirror();
+        let calls = 0;
+
+        const sync = new EventsSync({
+            // A broken transport: always the same entry, whatever the watermark.
+            fetchEventsSince: () => {
+                calls += 1;
+
+                return Promise.resolve([{ seq: 0, type: "stuck", payload: null, timestamp: 1 }]);
+            },
+            applyEvents: () => {},
+            getTableDiffs: () => [],
+            mirror,
+        });
+
+        await sync.sync();
+        await sync.sync();
+
+        expect(sync.watermark).toBe(1);
+        // Cycle 1: the batch, then one more fetch that returns the SAME entry —
+        // it ends at seq 0 < the watermark, so the walk stops. Cycle 2: one
+        // fetch, same verdict. Bounded, not spinning.
+        expect(calls).toBe(3);
     });
 
     it("sync() applies diffs to the mirror", async () => {
@@ -336,7 +397,7 @@ describe(EventsSync, () => {
     });
 
     it("callbacks are invoked with correct watermark progression", async () => {
-        expect.assertions(9);
+        expect.assertions(6);
 
         const { mirror, applied } = createMockMirror();
 
@@ -363,27 +424,20 @@ describe(EventsSync, () => {
             mirror,
         });
 
-        // First sync → events seq 0-1 → watermark 2. A CLEAN batch takes the
-        // fast path: ONE `getTableDiffs()` + ONE mirror fan-out for the whole
-        // batch (REPLICA-08 batched catch-up), so exactly ONE diff lands for
-        // this 2-event batch — not one per event.
+        // One sync walks BOTH pages (seq 0-1, then seq 2) and lands on
+        // watermark 3. A clean page takes the fast path: ONE `getTableDiffs()`
+        // + ONE mirror fan-out per page (REPLICA-08 batched catch-up), so two
+        // diffs land for three events — not one per event.
         const count1 = await sync.sync();
 
-        expect(count1).toBe(2);
-        expect(sync.watermark).toBe(2);
-        expect(applied).toHaveLength(1);
-
-        // Second sync → event seq 2 → watermark 3 → one more diff.
-        const count2 = await sync.sync();
-
-        expect(count2).toBe(1);
+        expect(count1).toBe(3);
         expect(sync.watermark).toBe(3);
         expect(applied).toHaveLength(2);
 
-        // Third sync → no new events
-        const count3 = await sync.sync();
+        // Second sync → no new events.
+        const count2 = await sync.sync();
 
-        expect(count3).toBe(0);
+        expect(count2).toBe(0);
         expect(sync.watermark).toBe(3);
         expect(applied).toHaveLength(2);
     });
@@ -571,6 +625,12 @@ describe(EventsSync, () => {
             fetchEventsSince: async () => {
                 fetchCalls += 1;
 
+                // The catch-up walk's terminating fetch — only the FIRST call
+                // is the one this test parks in flight.
+                if (fetchCalls > 1) {
+                    return [];
+                }
+
                 return new Promise<EventLogEntry[]>((resolve) => {
                     resolveFetch = resolve;
                 });
@@ -595,6 +655,8 @@ describe(EventsSync, () => {
         // Both callers observe the SAME outcome — the real result of the one
         // cycle that ran — not a synthetic `0`.
         expect(secondCount).toBe(1);
-        expect(fetchCalls).toBe(1);
+        // The parked fetch plus the walk's terminating one — the second
+        // `sync()` still started no cycle of its own.
+        expect(fetchCalls).toBe(2);
     });
 });

--- a/packages/replica/__tests__/sync-events.test.ts
+++ b/packages/replica/__tests__/sync-events.test.ts
@@ -614,6 +614,92 @@ describe(EventsSync, () => {
         expect(mirroredRows).toStrictEqual(["row0", "row1", "row2", "row3"]);
     });
 
+    it("does NOT replay a batch through applyEvents when only the mirror fan-out failed", async () => {
+        expect.assertions(4);
+
+        // The replay succeeded; the mirror threw afterwards. The watermark holds
+        // (correctly — the diffs are not mirrored yet), so the next poll re-fetches
+        // the same batch. Handing it to the state machine again applies the same
+        // events twice, and unlike `getTableDiffs`, `applyEvents` is not required
+        // to be idempotent and has nothing to roll back.
+        const applied: unknown[] = [];
+        const { fetchEventsSince } = createMockLog([
+            { seq: 0, type: "ok", payload: "a", timestamp: 10 },
+            { seq: 1, type: "ok", payload: "b", timestamp: 20 },
+        ]);
+
+        let failMirror = true;
+
+        const mirror = {
+            applyDiff: vi.fn<(diff: TableDiff) => void>(() => {
+                if (failMirror) {
+                    throw new Error("mirror write failed");
+                }
+            }),
+            onChange: vi.fn<() => () => void>(),
+            get eventLog(): EventLog {
+                return new EventLog();
+            },
+        } as unknown as LocalMirror;
+
+        const sync = new EventsSync({
+            fetchEventsSince,
+            applyEvents: (events) => {
+                for (const event of events) {
+                    applied.push(event.payload);
+                }
+            },
+            getTableDiffs: () => [createTableDiff("rows", [{ type: "insert", data: { id: "x" } }])],
+            mirror,
+            onError: () => {},
+        });
+
+        await sync.sync();
+
+        expect(applied).toStrictEqual(["a", "b"]);
+        expect(sync.watermark).toBe(0);
+
+        failMirror = false;
+
+        const count = await sync.sync();
+
+        // The retry re-derives the diffs (that is `getTableDiffs`' idempotency
+        // contract) but must not re-run the state machine over "a" and "b".
+        expect(applied).toStrictEqual(["a", "b"]);
+        expect(count).toBe(2);
+    });
+
+    it("yields a poll cycle instead of chasing a log that keeps growing", async () => {
+        expect.assertions(3);
+
+        const { mirror } = createMockMirror();
+
+        // A writer faster than the reader: every fetch answers with one more
+        // event, so the batch is never empty. Against a genuinely live log an
+        // unbounded cycle never returns at all — and `#inFlight`, which every
+        // concurrent `sync()` awaits, never settles. The writer stops here at
+        // 1500 only so an unbounded loop terminates and reports the overrun
+        // instead of hanging the suite.
+        const sync = new EventsSync({
+            fetchEventsSince: async (sinceSeq) => {
+                return sinceSeq >= 1500 ? [] : [{ seq: sinceSeq, type: "ok", payload: sinceSeq, timestamp: sinceSeq }];
+            },
+            applyEvents: () => {},
+            getTableDiffs: () => [],
+            mirror,
+            onError: () => {},
+        });
+
+        const count = await sync.sync();
+
+        expect(count).toBe(1000);
+        // The watermark carries the cycle's progress, so the next one resumes
+        // exactly where this stopped rather than repeating any of it.
+        expect(sync.watermark).toBe(1000);
+
+        await expect(sync.sync()).resolves.toBe(500);
+    });
+
     it("sync() awaits an in-flight poll instead of no-op'ing for a concurrent call", async () => {
         expect.assertions(4);
 

--- a/packages/replica/docs/getting-started.mdx
+++ b/packages/replica/docs/getting-started.mdx
@@ -115,7 +115,8 @@ import { mirror } from "./mirror";
 
 const source = new EventSource(initialState, reducer);
 const sync = new EventsSync({
-    fetchEventsSince: (seq) => eventLogClient.getSince(seq),
+    // One bounded page per call — EventsSync walks the pages for you.
+    fetchEventsSince: async (seq) => (await eventLogClient.getSince(seq)).entries,
     applyEvents: (events) => {
         for (const event of events) {
             source.applyEvent(event.type, event.payload);

--- a/packages/replica/docs/index.mdx
+++ b/packages/replica/docs/index.mdx
@@ -202,9 +202,11 @@ const client = new EventLogDOClient({
 const [entry] = await client.append([{ type: "order.placed", payload: { orderId: "123" } }], { batchId: "order-123" });
 
 // The log is append-only and ordered, so reads are by sequence number — there
-// is no filter-by-type query. `getSince(0)` returns the whole log.
-const since = await client.getSince(entry.seq);
-const { entries, hasMore } = await client.getRange(0, 50);
+// is no filter-by-type query. `getSince` returns ONE bounded page (500 entries
+// by default, 1000 max); keep passing the returned `cursor` back while
+// `truncated` is true to walk the whole log.
+const { entries, truncated, cursor } = await client.getSince(entry.seq);
+const page = await client.getSince(0, 50);
 const size = await client.getSize();
 ```
 

--- a/packages/replica/src/define-materializer.ts
+++ b/packages/replica/src/define-materializer.ts
@@ -364,33 +364,48 @@ class MaterializerRuntime {
      *
      * 1. Recover materialized state from snapshots (if a snapshotStore is
      * configured).
-     * 2. Fetch all entries since the MINIMUM per-materializer watermark from
+     * 2. Fetch entries since the MINIMUM per-materializer watermark from
      * the DO — not the maximum — so a materializer with no snapshot (or a
      * lower one) still receives every event it hasn't seen (REPLICA-04).
      * 3. Apply them through the materializers; `applyEntries` skips each
      * entry for any materializer already past it, so nothing is double-applied.
      *
+     * The DO answers one BOUNDED page per request, so step 2/3 walk pages until
+     * the log is exhausted — applying each page as it arrives, rather than
+     * holding the whole backlog in memory. Taking only the first page (and
+     * dropping `truncated`) would silently leave every materializer short of
+     * the log's head whenever the backlog exceeds a page.
+     *
      * Call this once on startup / after the DO binding is available.
      * @returns The number of entries applied during catch-up.
      */
     public async initialize(): Promise<number> {
-        if (!this.#doClient) {
+        const client = this.#doClient;
+
+        if (!client) {
             return 0;
         }
 
         // 1. Recover from snapshots — sets each materializer's own watermark.
         await this.recoverFromSnapshots();
 
-        // 2. Fetch entries since the LOWEST watermark across materializers.
-        const minWatermark = this.#watermarks.length > 0 ? Math.min(...this.#watermarks) : 0;
-        const entries = await this.#doClient.getSince(minWatermark);
+        // 2. Walk pages from the LOWEST watermark across materializers.
+        let sinceSeq = this.#watermarks.length > 0 ? Math.min(...this.#watermarks) : 0;
+        let applied = 0;
 
-        if (entries.length === 0) {
-            return 0;
+        for (;;) {
+            // eslint-disable-next-line no-await-in-loop -- each page's cursor comes from the previous page, so the round-trips are inherently sequential
+            const page = await client.getSince(sinceSeq);
+
+            // 3. Apply this page through the materializers.
+            applied += this.applyEntries(page.entries);
+
+            if (!page.truncated || page.cursor === undefined || page.cursor <= sinceSeq) {
+                return applied;
+            }
+
+            sinceSeq = page.cursor;
         }
-
-        // 3. Apply through materializers
-        return this.applyEntries(entries);
     }
 
     /**

--- a/packages/replica/src/define-materializer.ts
+++ b/packages/replica/src/define-materializer.ts
@@ -30,6 +30,14 @@ import type { AppendEventInput, EventLogDOClient } from "./event-log-do-client";
 import type { EventReducer, UnknownEventHandling } from "./event-source";
 import type { SnapshotStore } from "./snapshot-store";
 
+/**
+ * Pages {@link MaterializerRuntime.initialize} walks before yielding, however
+ * much log is left. A live writer keeps `truncated` true forever, so an
+ * unbounded walk never returns; the budget leaves the remainder to the next
+ * call, at the advanced watermark.
+ */
+const MAX_CATCHUP_PAGES = 1000;
+
 // ── Types ────────────────────────────────────────────────────────────────
 
 /**
@@ -376,6 +384,12 @@ class MaterializerRuntime {
      * dropping `truncated`) would silently leave every materializer short of
      * the log's head whenever the backlog exceeds a page.
      *
+     * The walk is bounded by {@link MAX_CATCHUP_PAGES}: against a log written
+     * faster than it is read, "until the log is exhausted" never arrives and
+     * startup would never finish. Hitting the budget returns what was applied
+     * with every materializer's watermark advanced, so a later `initialize()`
+     * (or the ordinary append path) picks up exactly where this left off.
+     *
      * Call this once on startup / after the DO binding is available.
      * @returns The number of entries applied during catch-up.
      */
@@ -393,7 +407,7 @@ class MaterializerRuntime {
         let sinceSeq = this.#watermarks.length > 0 ? Math.min(...this.#watermarks) : 0;
         let applied = 0;
 
-        for (;;) {
+        for (let pages = 0; pages < MAX_CATCHUP_PAGES; pages += 1) {
             // eslint-disable-next-line no-await-in-loop -- each page's cursor comes from the previous page, so the round-trips are inherently sequential
             const page = await client.getSince(sinceSeq);
 
@@ -406,6 +420,8 @@ class MaterializerRuntime {
 
             sinceSeq = page.cursor;
         }
+
+        return applied;
     }
 
     /**

--- a/packages/replica/src/event-log-do-client.ts
+++ b/packages/replica/src/event-log-do-client.ts
@@ -12,7 +12,7 @@
  *   fetch: (req) => env.EVENT_LOG_DO.get(id).fetch(req),
  * });
  *
- * const entries = await client.getSince(0);
+ * const { entries } = await client.getSince(0); // first page — see `getSince`
  * await client.append([{ type: "chat.messageSent", payload: { text: "hi" } }]);
  * ```
  */
@@ -108,23 +108,28 @@ export class EventLogDOClient {
     // ── Read / replay ───────────────────────────────────────────────────
 
     /**
-     * Fetch all entries with `seq >= sinceSeq`.
+     * Fetch ONE page of entries with `seq >= sinceSeq`.
      *
-     * Pass `sinceSeq = 0` to fetch the entire log.
+     * The DO bounds every page (500 entries unless `limit` says otherwise, 1000
+     * max), so `getSince(0)` is the START of the log, never all of it — a
+     * catch-up walks pages until `truncated` is `false`:
+     *
+     * ```ts
+     * let seq = 0;
+     * for (;;) {
+     *   const page = await client.getSince(seq);
+     *   apply(page.entries);
+     *   if (!page.truncated || page.cursor === undefined) break;
+     *   seq = page.cursor;
+     * }
+     * ```
+     * @returns `{ entries, truncated, cursor }` — `cursor` is the `sinceSeq`
+     * for the next page and is present exactly when `truncated` is `true`.
      */
-    public async getSince(sinceSeq: number): Promise<EventLogEntry[]> {
-        const data = await this.#get<{ entries: EventLogEntry[] }>(`/since?seq=${String(sinceSeq)}`, "getSince");
+    public async getSince(sinceSeq: number, limit?: number): Promise<{ cursor?: number; entries: EventLogEntry[]; truncated: boolean }> {
+        const limitQuery = limit === undefined ? "" : `&limit=${String(limit)}`;
 
-        return data.entries;
-    }
-
-    /**
-     * Fetch a paginated range of entries.
-     * @returns `{ entries, hasMore }` — `hasMore` is `true` when another
-     * page exists (i.e. the DO returned `limit + 1` rows).
-     */
-    public async getRange(fromSeq: number, limit: number = 50): Promise<{ entries: EventLogEntry[]; hasMore: boolean }> {
-        return this.#get(`/range?from=${String(fromSeq)}&limit=${String(limit)}`, "getRange");
+        return this.#get(`/since?seq=${String(sinceSeq)}${limitQuery}`, "getSince");
     }
 
     /**

--- a/packages/replica/src/event-log-do.ts
+++ b/packages/replica/src/event-log-do.ts
@@ -443,11 +443,15 @@ export class EventLogDO {
         const limitParameter = url.searchParams.get("limit");
         const limit = limitParameter === null ? DEFAULT_PAGE_SIZE : Number(limitParameter);
 
-        if (!Number.isFinite(sinceSeq) || sinceSeq < 0) {
+        // Integral, not merely finite: `seq` indexes rows, and a fractional one silently moves the
+        // `seq >= ?` boundary (`?seq=1.5` skips seq 1 while reporting the page it asked for), while a
+        // fractional `limit` reaches SQLite's `LIMIT ?` — which rejects it — and surfaces as an
+        // unexplained 500 rather than the 400 the request has earned.
+        if (!Number.isSafeInteger(sinceSeq) || sinceSeq < 0) {
             return errorResponse(400, "BAD_REQUEST", "invalid seq");
         }
 
-        if (!Number.isFinite(limit) || limit < 1 || limit > MAX_PAGE_SIZE) {
+        if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_PAGE_SIZE) {
             return errorResponse(400, "BAD_REQUEST", "invalid limit");
         }
 

--- a/packages/replica/src/event-log-do.ts
+++ b/packages/replica/src/event-log-do.ts
@@ -8,13 +8,12 @@
  *
  * ## RPC surface (fetch-like)
  *
- * | Method | Path               | Description                          |
- * |--------|--------------------|--------------------------------------|
- * | POST   | `/append`          | Insert events, return assigned seqs  |
- * | GET    | `/since?seq=N`     | Events with `seq >= N`               |
- * | GET    | `/range?from=N&limit=M` | Paginated read               |
- * | GET    | `/size`            | Number of stored events              |
- * | GET    | `/state`           | Full event log state (for recovery)  |
+ * | Method | Path                    | Description                          |
+ * |--------|-------------------------|--------------------------------------|
+ * | POST   | `/append`               | Insert events, return assigned seqs  |
+ * | GET    | `/since?seq=N&limit=M`  | ONE bounded page of `seq >= N`       |
+ * | GET    | `/size`                 | Number of stored events              |
+ * | GET    | `/state`                | Full event log state (for recovery)  |
  */
 
 import type { EventLogEntry } from "./event-log";
@@ -142,9 +141,24 @@ interface AppendResponse {
     entries: EventLogEntry[];
 }
 
-interface RangeResponse {
+/** Entries returned by `GET /since` when the caller names no `limit`. */
+const DEFAULT_PAGE_SIZE = 500;
+
+/** Largest `limit` a caller may ask `GET /since` for. */
+const MAX_PAGE_SIZE = 1000;
+
+/**
+ * `GET /since` body — ONE page of the log.
+ *
+ * `truncated` is `true` when the page stopped at the limit rather than at the
+ * end of the log, and `cursor` is then the `seq` to pass as the next request's
+ * `seq` (the last returned entry's `seq + 1`). A caller that ignores them reads
+ * a silently short log.
+ */
+interface SinceResponse {
+    cursor?: number;
     entries: EventLogEntry[];
-    hasMore: boolean;
+    truncated: boolean;
 }
 
 interface SqlRow {
@@ -229,9 +243,6 @@ export class EventLogDO {
             }
             if (request.method === "GET" && url.pathname === "/since") {
                 return this.#handleSince(url);
-            }
-            if (request.method === "GET" && url.pathname === "/range") {
-                return this.#handleRange(url);
             }
             if (request.method === "GET" && url.pathname === "/size") {
                 return this.#handleSize();
@@ -418,47 +429,42 @@ export class EventLogDO {
         return undefined;
     }
 
-    /** GET /since?seq=N — return entries with seq >= N. */
+    /**
+     * GET /since?seq=N&limit=M — ONE bounded page of entries with `seq >= N`.
+     *
+     * The page is bounded because a catch-up starts at seq 0: an unbounded
+     * response serialised the WHOLE log into one body (and the caller applied
+     * it as one atom), so log growth alone eventually broke every first sync.
+     * A caller walks the pages with `truncated`/`cursor`.
+     */
     #handleSince(url: URL): Response {
         const seqParameter = url.searchParams.get("seq");
         const sinceSeq = seqParameter === null ? 0 : Number(seqParameter);
+        const limitParameter = url.searchParams.get("limit");
+        const limit = limitParameter === null ? DEFAULT_PAGE_SIZE : Number(limitParameter);
 
         if (!Number.isFinite(sinceSeq) || sinceSeq < 0) {
             return errorResponse(400, "BAD_REQUEST", "invalid seq");
         }
 
-        const { sql } = this.state.storage;
-        const cursor = sql.exec(
-            "SELECT seq, type, payload, timestamp, client_id, session_id, parent_seq FROM events WHERE seq >= ? ORDER BY seq ASC",
-            sinceSeq,
-        ) as SqlCursor;
-
-        return json({ entries: rowsToEntries(cursor) });
-    }
-
-    /** GET /range?from=N&limit=M — paginated read (default limit 50). */
-    #handleRange(url: URL): Response {
-        const fromParameter = url.searchParams.get("from");
-        const fromSeq = fromParameter === null ? 0 : Number(fromParameter);
-        const limitParameter = url.searchParams.get("limit");
-        const limit = limitParameter === null ? 50 : Number(limitParameter);
-
-        if (!Number.isFinite(fromSeq) || fromSeq < 0 || !Number.isFinite(limit) || limit < 1 || limit > 1000) {
-            return errorResponse(400, "BAD_REQUEST", "invalid from/limit");
+        if (!Number.isFinite(limit) || limit < 1 || limit > MAX_PAGE_SIZE) {
+            return errorResponse(400, "BAD_REQUEST", "invalid limit");
         }
 
         const { sql } = this.state.storage;
         const cursor = sql.exec(
             "SELECT seq, type, payload, timestamp, client_id, session_id, parent_seq FROM events WHERE seq >= ? ORDER BY seq ASC LIMIT ?",
-            fromSeq,
-            limit + 1, // Fetch one extra to detect hasMore
+            sinceSeq,
+            limit + 1, // One extra row: its presence is what `truncated` reports.
         ) as SqlCursor;
 
-        const allRows = rowsToEntries(cursor);
-        const hasMore = allRows.length > limit;
-        const entries = hasMore ? allRows.slice(0, limit) : allRows;
+        const rows = rowsToEntries(cursor);
+        const truncated = rows.length > limit;
+        const entries = truncated ? rows.slice(0, limit) : rows;
+        const last = entries.at(-1);
 
-        const response: RangeResponse = { entries, hasMore };
+        const response: SinceResponse = truncated && last !== undefined ? { entries, truncated: true, cursor: last.seq + 1 } : { entries, truncated: false };
+
         return json(response);
     }
 

--- a/packages/replica/src/events-context.ts
+++ b/packages/replica/src/events-context.ts
@@ -44,18 +44,11 @@ export interface EventsFacade {
     append: (events: { payload: unknown; timestamp?: number; type: string }[]) => Promise<EventLogEntry[]>;
 
     /**
-     * Fetch a paginated range of entries.
-     * @returns `{ entries, hasMore }` — `hasMore` is `true` when another
-     * page exists.
+     * Fetch ONE bounded page of entries with `seq >= sinceSeq`.
+     * @returns `{ entries, truncated, cursor }` — pass `cursor` back as
+     * `sinceSeq` while `truncated` is `true` to walk the whole log.
      */
-    getRange: (fromSeq: number, limit?: number) => Promise<{ entries: EventLogEntry[]; hasMore: boolean }>;
-
-    /**
-     * Fetch all entries with `seq >= sinceSeq`.
-     *
-     * Pass `sinceSeq = 0` to fetch the entire log.
-     */
-    getSince: (sinceSeq: number) => Promise<EventLogEntry[]>;
+    getSince: (sinceSeq: number, limit?: number) => Promise<{ cursor?: number; entries: EventLogEntry[]; truncated: boolean }>;
 
     /** Return the total number of entries currently in the log. */
     getSize: () => Promise<number>;
@@ -79,7 +72,7 @@ export interface EventsContextOutput {
  * Create a middleware that attaches a typed `ctx.events` facade backed by
  * the given {@link EventLogDOClient}.
  *
- * The facade surfaces `append`, `getSince`, `getRange`, `getSize`, and
+ * The facade surfaces `append`, `getSince`, `getSize`, and
  * `getState` — every method the DO client exposes — so handlers can read
  * and write the event log without reaching for the DO stub directly.
  *

--- a/packages/replica/src/local-mirror.ts
+++ b/packages/replica/src/local-mirror.ts
@@ -23,15 +23,18 @@ interface LocalMirrorOptions {
     readonly db: SqliteAdapter;
 
     /**
-     * Cap the mirror's internal {@link EventLog} to this many entries
-     * (REPLICA-06). Every applied diff is recorded in the log — with no cap,
-     * a long-running client accumulates one entry per diff forever.
+     * Cap the mirror's internal {@link EventLog} to this many entries.
+     * Every applied diff is recorded in the log, so an uncapped log grows by
+     * one entry (holding every changed row) per diff for the life of the
+     * mirror — a leak by construction on a long-lived client.
      *
-     * `undefined` (the default) preserves unbounded retention. Set this when
-     * catch-up replication only ever needs a bounded recent window; older
-     * entries are silently evicted (oldest-first) once the cap is exceeded.
-     * See {@link EventLog#truncateBelow} for caller-driven truncation tied to
-     * a snapshot instead.
+     * Defaults to {@link DEFAULT_MAX_EVENT_LOG_ENTRIES}. On overflow the
+     * OLDEST entries are dropped; nothing in the mirror replays its own log,
+     * so a drop loses nothing the mirror needs. A consumer that does replay
+     * it (`eventLog.getSince(watermark)` from another tab / service worker)
+     * detects a gap when the first returned entry's `seq` is above its
+     * watermark, and should re-seed from the mirror's rows (`query`) instead
+     * of applying the partial window.
      */
     readonly maxEventLogEntries?: number;
 
@@ -47,6 +50,9 @@ interface LocalMirrorOptions {
 }
 
 // ── LocalMirror ──────────────────────────────────────────────────────────
+
+/** Default {@link LocalMirrorOptions.maxEventLogEntries}. */
+const DEFAULT_MAX_EVENT_LOG_ENTRIES = 1000;
 
 // Bookkeeping table for mirror-wide state — currently just the schema
 // version (see `MIRROR_SCHEMA_VERSION` below). Created on construction.
@@ -190,7 +196,7 @@ class LocalMirror {
     public constructor(options: LocalMirrorOptions) {
         this.#db = options.db;
         this.#tables = { ...options.tables };
-        this.#eventLog = new EventLog({ maxEntries: options.maxEventLogEntries });
+        this.#eventLog = new EventLog({ maxEntries: options.maxEventLogEntries ?? DEFAULT_MAX_EVENT_LOG_ENTRIES });
 
         ensureMetaTable(this.#db);
         this.#reconcileSchemaVersion();
@@ -248,11 +254,9 @@ class LocalMirror {
             return;
         }
 
-        const pkColumn = this.#tables[diff.table]?.primaryKey ?? "id";
-
         this.#ensureTableSchema(diff);
 
-        applyDiffToDatabase(this.#db, diff, pkColumn);
+        applyDiffToDatabase(this.#db, diff, this.primaryKeyOf(diff.table));
 
         this.#eventLog.append("table-diff", diff, [diff]);
         this.#notifyChange();
@@ -320,10 +324,18 @@ class LocalMirror {
 
     /**
      * Register a table schema so the mirror can create the table on
-     * first use.
+     * first use. Merges into any definition already registered for `name`
+     * (from the constructor's `tables` or an earlier call), so a helper that
+     * registers `{}` just to make the table known does not erase a
+     * user-supplied `primaryKey`.
      */
     public registerTable(name: string, definition: MirrorTableDef): void {
-        this.#tables[name] = definition;
+        this.#tables[name] = { ...this.#tables[name], ...definition };
+    }
+
+    /** The primary-key column of a mirrored table (`"id"` unless registered otherwise). */
+    public primaryKeyOf(table: string): string {
+        return this.#tables[table]?.primaryKey ?? "id";
     }
 
     /**
@@ -477,7 +489,7 @@ class LocalMirror {
      * - If the table already exists, ALTER TABLE ADD COLUMN for any keys in the diff that don't have a corresponding column yet (schema evolution), with the same inferred affinity.
      */
     #ensureTableSchema(diff: TableDiff): void {
-        const pk = this.#tables[diff.table]?.primaryKey ?? "id";
+        const pk = this.primaryKeyOf(diff.table);
 
         // Derive required columns from the UNION of keys across every non-delete change
         const requiredColumns = LocalMirror.#collectDiffColumns(diff, pk);

--- a/packages/replica/src/subscribe-mirror.ts
+++ b/packages/replica/src/subscribe-mirror.ts
@@ -1,3 +1,4 @@
+import { stableWireKey } from "../../../shared/wire-key";
 import type { LocalMirror } from "./local-mirror";
 import type { RowChange } from "./table-diff";
 
@@ -38,12 +39,16 @@ export interface SubscriptionClient {
  * is applied to the local SQLite store.
  *
  * Each frame from a Lunora live query is the FULL current result set, so the
- * callback treats it as a snapshot: it upserts every row present and emits a
- * `delete` for any id that was mirrored on a previous frame but is absent now —
- * otherwise rows that drop out of the server result would linger stale in the
- * local mirror. Rows are keyed by their `id` field (the mirror's default primary
- * key); a row without an `id` can't be reconciled on removal, and — because the
- * mirror table's `id` column is `NOT NULL` — will fail the insert.
+ * callback diffs it against the previous frame: a row that is new or whose
+ * content changed is upserted, a row that dropped out is deleted, and an
+ * unchanged row produces nothing. A frame identical to the last one therefore
+ * applies no diff — no event-log entry, no `version` bump, no re-query for the
+ * hooks subscribed to the mirror.
+ *
+ * Rows are keyed by the table's primary key (`id` unless the table was
+ * registered with another `primaryKey`); a row without one can't be diffed or
+ * reconciled on removal, and — because the mirror's key column is `NOT NULL` —
+ * will fail the insert.
  *
  * The mirror table name is derived from the function ref alone (not `args`), so
  * do NOT mirror two subscriptions to the same function with different `args`
@@ -70,55 +75,66 @@ const subscribeToMirror = (
     // Derive a table name from the function path (e.g. "todos/list" → "fn_todos_list")
     const tableName = deriveTableName(functionRef.__lunoraRef);
 
-    // Register the table so the mirror creates it on first diff
+    // Register the table so the mirror creates it on first diff (merges into a
+    // pre-registered definition, so a user-supplied `primaryKey` survives).
     mirror.registerTable(tableName, {});
 
-    // Ids mirrored by the previous frame, so the next frame can delete the ones
-    // that dropped out of the result set (full-snapshot reconciliation).
-    let knownIds = new Set<string>();
+    const pk = mirror.primaryKeyOf(tableName);
+
+    // The last APPLIED frame: primary key → stable encoding of the row. Holding
+    // the encoding (not the row) keeps this O(rows) and makes "changed?" one
+    // string compare. `stableWireKey` covers every value a decoded wire row can
+    // carry (bigint, Date, bytes, …), which plain JSON would throw on or alias.
+    let known = new Map<string, string>();
 
     return client.subscribe(
         functionRef,
         args,
         (data: unknown) => {
-            const rows = asRowArray(data);
-            const nextIds = new Set<string>();
+            const next = new Map<string, string>();
             const changes: RowChange[] = [];
 
-            for (const row of rows) {
+            for (const row of asRowArray(data)) {
                 const record = row as Record<string, unknown>;
-                const rawId = record.id;
+                const rawId = record[pk];
 
-                if (typeof rawId === "string" || typeof rawId === "number") {
-                    nextIds.add(String(rawId));
+                if (typeof rawId !== "string" && typeof rawId !== "number") {
+                    // Un-keyed row: cannot be diffed; let the mirror's NOT NULL
+                    // constraint surface it, as documented above.
+                    changes.push({ type: "insert", data: record });
+
+                    continue;
                 }
 
-                changes.push({ type: "insert", data: record });
+                const id = String(rawId);
+                const encoded = stableWireKey(record);
+
+                next.set(id, encoded);
+
+                // A changed row is upserted (`insert` → INSERT OR REPLACE), not
+                // `update`d: a snapshot row is the WHOLE row, and UPDATE would
+                // leave a column the server dropped at its stale value.
+                if (known.get(id) !== encoded) {
+                    changes.push({ type: "insert", data: record });
+                }
             }
 
             // Delete rows present last frame but gone now.
-            for (const id of knownIds) {
-                if (!nextIds.has(id)) {
+            for (const id of known.keys()) {
+                if (!next.has(id)) {
                     changes.push({ type: "delete", id });
                 }
             }
 
-            if (changes.length === 0) {
-                knownIds = nextIds;
-
-                return;
+            if (changes.length > 0) {
+                mirror.applyDiff({ table: tableName, changes, timestamp: Date.now() });
             }
 
-            mirror.applyDiff({ table: tableName, changes, timestamp: Date.now() });
-
-            // Advance ONLY on a successful apply. `applyDiff` throws — an id-less
-            // row fails the `NOT NULL` insert (see above) — and advancing first
-            // meant a single throwing frame dropped the ids this frame should have
-            // deleted from `knownIds` while their rows were still in the mirror.
-            // Nothing ever emits those deletes again, so the rows are orphaned for
-            // the life of the subscription. Leaving `knownIds` on the last APPLIED
-            // frame lets the next frame re-derive them.
-            knownIds = nextIds;
+            // Reached only after a successful apply (or a no-op frame). A throw
+            // above — an un-keyed row failing the NOT NULL insert — leaves `known`
+            // on the last applied frame, so the deletes this frame owed are
+            // re-derived by the next one instead of being orphaned forever.
+            known = next;
         },
         { shardKey },
     );

--- a/packages/replica/src/subscribe-mirror.ts
+++ b/packages/replica/src/subscribe-mirror.ts
@@ -98,7 +98,14 @@ const subscribeToMirror = (
                 const record = row as Record<string, unknown>;
                 const rawId = record[pk];
 
-                if (typeof rawId !== "string" && typeof rawId !== "number") {
+                // `bigint` belongs here with the other two: it is what the wire
+                // decoder hands back for an int64 column, so an id-typed primary
+                // key arrives as one. Rejecting it as un-keyed made every frame
+                // re-insert every row (never recorded in `known`, so never
+                // "unchanged") and made removal undetectable (never in `known`,
+                // so never deleted). `String()` keys them consistently — 1n and 1
+                // are the same row id, which is what the mirror stores.
+                if (typeof rawId !== "string" && typeof rawId !== "number" && typeof rawId !== "bigint") {
                     // Un-keyed row: cannot be diffed; let the mirror's NOT NULL
                     // constraint surface it, as documented above.
                     changes.push({ type: "insert", data: record });

--- a/packages/replica/src/sync-events.ts
+++ b/packages/replica/src/sync-events.ts
@@ -61,6 +61,17 @@ import type { EventLogEntry } from "./event-log";
 import type { LocalMirror } from "./local-mirror";
 import type { TableDiff } from "./table-diff";
 
+/**
+ * Batches one poll cycle will drive before yielding, however much log is left.
+ *
+ * A catch-up loop that runs until a fetch comes back empty never terminates
+ * against a log being written faster than it is read. Bounding the cycle leaves
+ * the remainder to the next one, at the advanced watermark, so progress is
+ * unaffected and a busy log cannot pin the cycle open (or its `#inFlight`
+ * promise, which every concurrent `sync()` awaits).
+ */
+const MAX_BATCHES_PER_CYCLE = 1000;
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 /**
@@ -158,6 +169,14 @@ export class EventsSync {
     readonly #options: EventsSyncOptions;
     /** The highest `seq + 1` that has been applied. Starts at `0`. */
     #watermark = 0;
+
+    /**
+     * The highest `seq + 1` already handed to `applyEvents`. Runs AHEAD of
+     * `#watermark` between a successful replay and the mirror fan-out that
+     * commits it, which is exactly the interval a retry must not replay through
+     * the state machine a second time.
+     */
+    #appliedSeq = 0;
     #timer: ReturnType<typeof setInterval> | undefined;
 
     /**
@@ -294,7 +313,7 @@ export class EventsSync {
         let total = 0;
 
         try {
-            for (;;) {
+            for (let batches = 0; batches < MAX_BATCHES_PER_CYCLE; batches += 1) {
                 // eslint-disable-next-line no-await-in-loop -- each batch is fetched from the watermark the previous one advanced, so the round-trips are inherently sequential
                 const events = await this.#options.fetchEventsSince(this.#watermark);
 
@@ -307,7 +326,22 @@ export class EventsSync {
                 // catch: the watermark stays put and the next poll re-fetches
                 // and (via the idempotent getTableDiffs) re-derives the missing
                 // diffs.
-                this.#options.applyEvents(events);
+                //
+                // Only the events this sync has not already replayed reach
+                // `applyEvents`. A batch whose replay SUCCEEDED and then failed
+                // downstream (`getTableDiffs`, or a `mirror.applyDiff` partway
+                // through the fan-out) is re-fetched from the unmoved watermark,
+                // and handing it to the state machine a second time would apply
+                // the same events twice — only `getTableDiffs` is required to be
+                // idempotent, `applyEvents` is not, and it has no rollback. A
+                // replay that THREW is not recorded, so that batch is still
+                // retried whole (the state machine's own atomicity, unchanged).
+                const fresh = events.filter((event) => event.seq >= this.#appliedSeq);
+
+                if (fresh.length > 0) {
+                    this.#options.applyEvents(fresh);
+                    this.#appliedSeq = (fresh[fresh.length - 1] as EventLogEntry).seq + 1;
+                }
 
                 const diffs = this.#options.getTableDiffs();
 
@@ -332,6 +366,13 @@ export class EventsSync {
 
                 this.#watermark = next;
             }
+
+            // The page budget ran out. A log with a writer faster than this
+            // sync never returns an empty batch, so an unbounded loop would
+            // never finish — and `#inFlight` would never settle, hanging every
+            // later `sync()` on it. The watermark is where the last completed
+            // batch left it, so the next cycle picks up exactly there.
+            return total;
         } catch (error: unknown) {
             // eslint-disable-next-line no-console -- fallback for a caller that supplied no `onError`; swallowing the failure silently is the worse default
             const onError = this.#options.onError ?? console.error;

--- a/packages/replica/src/sync-events.ts
+++ b/packages/replica/src/sync-events.ts
@@ -33,8 +33,10 @@
  * const source = new EventSource(initialState, reducer);
  *
  * const sync = new EventsSync({
- *   // Transport: fetch events since last known seq
- *   fetchEventsSince: (sinceSeq) => client.getSince(sinceSeq),
+ *   // Transport: fetch the next batch of events after the last known seq.
+ *   // `getSince` answers one bounded page; EventsSync keeps calling until the
+ *   // log is exhausted.
+ *   fetchEventsSince: async (sinceSeq) => (await client.getSince(sinceSeq)).entries,
  *
  *   // Replay events through the EventSource
  *   applyEvents: (events) => {
@@ -77,12 +79,15 @@ export interface EventsSyncOptions {
     applyEvents: (events: ReadonlyArray<EventLogEntry>) => void;
 
     /**
-     * Fetch all events whose `seq >= sinceSeq`.
+     * Fetch the next batch of events whose `seq >= sinceSeq`.
      *
-     * In a server-side context, this typically wraps
-     * {@link import("@lunora/replica").EventLogDOClient.getSince |
-     * EventLogDOClient.getSince()}.
-     * In a client context it could call a Lunora action that proxies to the
+     * It does NOT have to return the whole backlog: a bounded batch is
+     * preferred and is what the DO-backed transport gives you
+     * ({@link import("@lunora/replica").EventLogDOClient.getSince |
+     * EventLogDOClient.getSince()} answers one page). {@link EventsSync} keeps
+     * calling with the advanced watermark until a call returns nothing, so the
+     * whole log is applied either way — one bounded atom at a time.
+     * In a client context this could call a Lunora action that proxies to the
      * event log, or read from an IndexedDB cache.
      *
      * Return an empty array when there are no new events.
@@ -244,27 +249,37 @@ export class EventsSync {
     }
 
     /**
-     * One poll cycle: fetch the whole batch since the watermark, then drive it
-     * through the pipeline as ONE atom — `applyEvents` → `getTableDiffs` →
-     * mirror fan-out → advance the watermark.
+     * One poll cycle: drive every batch available since the watermark through
+     * the pipeline — `applyEvents` → `getTableDiffs` → mirror fan-out →
+     * advance the watermark — one batch at a time until a fetch comes back
+     * empty.
      *
-     * ## Whole batch as one atom
+     * ## One batch at a time, but a whole batch as one atom
      *
-     * A returning-from-offline client with a large backlog drives the WHOLE
-     * fetched batch through the pipeline once: a single `applyEvents(events)`,
-     * a single `getTableDiffs()`, and a single mirror fan-out. A 500-event
-     * catch-up therefore computes ONE aggregate diff and issues ONE mirror
-     * round, not 500 of each. The watermark advances past the last event **only
-     * after** every diff has been mirrored — it is the LAST statement in the
-     * try, reached only on full success.
+     * `fetchEventsSince` answers with whatever the transport is willing to
+     * return in one call — for the DO-backed transport that is ONE bounded page
+     * (`EventLogDOClient.getSince`), so a returning-from-offline client with a
+     * 10k-event backlog never materialises 10k events, and never asks the
+     * server to serialise them into one response. Each batch is driven through
+     * the pipeline exactly once: a single `applyEvents(events)`, a single
+     * `getTableDiffs()`, and a single mirror fan-out — 500 events per page
+     * compute ONE aggregate diff, not 500 of them. The loop then re-fetches
+     * from the advanced watermark and repeats; the cycle ends when a fetch
+     * returns nothing (or when the batch failed to move the watermark forward,
+     * which would otherwise spin).
+     *
+     * The watermark advances past a batch's last event **only after** every
+     * diff for that batch has been mirrored — it is the last statement of the
+     * iteration, reached only on full success.
      *
      * ## Atomicity on failure — retry the whole batch from a clean state
      *
      * If any stage throws (`applyEvents`, `getTableDiffs`, or a
      * `mirror.applyDiff` partway through the fan-out), control falls to the
-     * catch: the error is surfaced via `onError` and the watermark is left
-     * exactly where it was. The next poll therefore re-fetches the SAME batch
-     * from the same watermark and re-derives the still-missing diffs.
+     * catch: the error is surfaced via `onError`, the cycle stops, and the
+     * watermark is left exactly where the last fully-mirrored batch put it. The
+     * next poll therefore re-fetches the SAME batch from the same watermark and
+     * re-derives the still-missing diffs.
      *
      * This is safe — and lossless — precisely because `getTableDiffs` is
      * required to be idempotent (recompute-from-current-mirror-state, no
@@ -276,40 +291,57 @@ export class EventsSync {
      * advances past a diff the mirror never received.
      */
     async #pollOnce(): Promise<number> {
+        let total = 0;
+
         try {
-            const events = await this.#options.fetchEventsSince(this.#watermark);
+            for (;;) {
+                // eslint-disable-next-line no-await-in-loop -- each batch is fetched from the watermark the previous one advanced, so the round-trips are inherently sequential
+                const events = await this.#options.fetchEventsSince(this.#watermark);
 
-            if (events.length === 0) {
-                return 0;
+                if (events.length === 0) {
+                    return total;
+                }
+
+                // ── Whole batch as ONE atom ───────────────────────────────
+                // Any throw below skips the watermark advance and lands in the
+                // catch: the watermark stays put and the next poll re-fetches
+                // and (via the idempotent getTableDiffs) re-derives the missing
+                // diffs.
+                this.#options.applyEvents(events);
+
+                const diffs = this.#options.getTableDiffs();
+
+                for (const diff of diffs) {
+                    this.#options.mirror.applyDiff(diff);
+                }
+
+                total += events.length;
+
+                // Every stage succeeded for this batch — advance past its last
+                // event. This is the last statement of the iteration, so it is
+                // reached only when every diff above has been mirrored.
+                const lastEvent = events[events.length - 1] as EventLogEntry;
+                const next = lastEvent.seq + 1;
+
+                if (next <= this.#watermark) {
+                    // The transport handed back a batch that ends at or before
+                    // the watermark it was given: re-fetching would return the
+                    // same batch forever. Stop instead of spinning.
+                    return total;
+                }
+
+                this.#watermark = next;
             }
-
-            // ── Whole batch as ONE atom ───────────────────────────────────
-            // Any throw below skips the watermark advance and lands in the
-            // catch: the watermark stays put and the next poll re-fetches and
-            // (via the idempotent getTableDiffs) re-derives the missing diffs.
-            this.#options.applyEvents(events);
-
-            const diffs = this.#options.getTableDiffs();
-
-            for (const diff of diffs) {
-                this.#options.mirror.applyDiff(diff);
-            }
-
-            // Every stage succeeded for the whole batch — advance past the last
-            // event in one step. This is the last statement, so it is reached
-            // only when every diff above has been mirrored.
-            const lastEvent = events[events.length - 1] as EventLogEntry;
-
-            this.#watermark = lastEvent.seq + 1;
-
-            return events.length;
         } catch (error: unknown) {
             // eslint-disable-next-line no-console -- fallback for a caller that supplied no `onError`; swallowing the failure silently is the worse default
             const onError = this.#options.onError ?? console.error;
 
             onError(error);
 
-            return 0;
+            // The batches that DID complete before the failure are already
+            // mirrored and past the watermark — report them rather than
+            // claiming the whole cycle did nothing.
+            return total;
         }
     }
 }

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -95,25 +95,25 @@ render(
 
 ## API
 
-| Primitive                                           | React equivalent      | Description                                                                      |
-| --------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------- |
-| `LunoraProvider`                                    | `LunoraProvider`      | Context component — wraps your app tree with the `LunoraClient`.                 |
-| `useLunora`                                         | `useLunora`           | Read the ambient `LunoraClient` from the nearest `LunoraProvider`.               |
-| `createQuery`                                       | `useQuery`            | Live query signal — returns `() => T \| undefined`, re-subscribes on arg change. |
-| `createMutation`                                    | `useMutation`         | Optimistic mutation handle (`data`, `error`, `pending`, `mutate`, `reset`).      |
-| `createSubscription`                                | `useSubscription`     | Raw subscription signal — unbounded live stream.                                 |
-| `createPaginatedQuery`                              | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, and `results` signals.         |
-| `createInfiniteQuery`                               | `useInfiniteQuery`    | Infinite-scroll variant of `createPaginatedQuery`.                               |
-| `createAuth`                                        | `useAuth`             | Reactive auth state (`token`, `user` signals + `setToken`).                      |
-| `Authenticated` / `AuthLoading` / `Unauthenticated` | —                     | Auth-gate components rendering `children` per identity state.                    |
-| `createPresence`                                    | `usePresence`         | Collaborative-awareness — heartbeat + live present-members signal.               |
-| `createFlag`                                        | `useFlag`             | Live OpenFeature flag accessor — returns `default` until the server answers.     |
-| `createFlags`                                       | `useFlags`            | Batch variant — an accessor of one value per key in the defaults map.            |
-| `createRateLimit`                                   | `useRateLimit`        | Client-side rate-limit mirror — `ok`, `disabled`, `retryAfter` as signals.       |
-| `createConnectionStatus`                            | `useConnectionStatus` | Reactive connection state signal.                                                |
-| `hydratePreloaded`                                  | `usePreloadedQuery`   | Seed a query synchronously from an SSR `Preloaded` token, then go live.          |
-| `createAgentToolEvents`                             | `useAgentToolEvents`  | One agent thread's tool lifecycle as an `Accessor` of discriminated events.      |
-| `createVoiceAgent`                                  | `useVoiceAgent`       | Full-duplex voice call — accessors for status/transcript/level + call controls.  |
+| Primitive                                           | React equivalent      | Description                                                                       |
+| --------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------- |
+| `LunoraProvider`                                    | `LunoraProvider`      | Context component — wraps your app tree with the `LunoraClient`.                  |
+| `useLunora`                                         | `useLunora`           | Read the ambient `LunoraClient` from the nearest `LunoraProvider`.                |
+| `createQuery`                                       | `useQuery`            | Live query signal — returns `() => T \| undefined`, re-subscribes on arg change.  |
+| `createMutation`                                    | `useMutation`         | Optimistic mutation handle (`data`, `error`, `pending`, `mutate`, `reset`).       |
+| `createSubscription`                                | `useSubscription`     | Raw subscription signal — unbounded live stream.                                  |
+| `createPaginatedQuery`                              | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, `results`, and `error` signals. |
+| `createInfiniteQuery`                               | `useInfiniteQuery`    | Infinite-scroll variant of `createPaginatedQuery`.                                |
+| `createAuth`                                        | `useAuth`             | Reactive auth state (`token`, `user` signals + `setToken`).                       |
+| `Authenticated` / `AuthLoading` / `Unauthenticated` | —                     | Auth-gate components rendering `children` per identity state.                     |
+| `createPresence`                                    | `usePresence`         | Collaborative-awareness — heartbeat + live present-members signal.                |
+| `createFlag`                                        | `useFlag`             | Live OpenFeature flag accessor — returns `default` until the server answers.      |
+| `createFlags`                                       | `useFlags`            | Batch variant — an accessor of one value per key in the defaults map.             |
+| `createRateLimit`                                   | `useRateLimit`        | Client-side rate-limit mirror — `ok`, `disabled`, `retryAfter` as signals.        |
+| `createConnectionStatus`                            | `useConnectionStatus` | Reactive connection state signal.                                                 |
+| `hydratePreloaded`                                  | `usePreloadedQuery`   | Seed a query synchronously from an SSR `Preloaded` token, then go live.           |
+| `createAgentToolEvents`                             | `useAgentToolEvents`  | One agent thread's tool lifecycle as an `Accessor` of discriminated events.       |
+| `createVoiceAgent`                                  | `useVoiceAgent`       | Full-duplex voice call — accessors for status/transcript/level + call controls.   |
 
 `createVoiceAgent` opens nothing until `startCall()` — that call is what requests the microphone, so it must run from a user gesture. `endCall()` releases the socket, the mic tracks and the Web Audio graph, and `onCleanup` runs it for you when the owning root is disposed.
 

--- a/packages/solid/__tests__/create-paginated-query.test.tsx
+++ b/packages/solid/__tests__/create-paginated-query.test.tsx
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionError } from "@lunora/client";
 import { render } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
 
@@ -139,6 +139,56 @@ describe("createPaginatedQuery (Solid)", () => {
         await flushAsync();
 
         expect(capturedStatus!()).toBe("Exhausted");
+    });
+});
+
+describe("createPaginatedQuery page errors", () => {
+    it("a page error surfaces on `error`, returns status to CanLoadMore, and lets loadMore retry", async () => {
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+        let api: ReturnType<typeof createPaginatedQuery> | undefined;
+
+        render(
+            () => {
+                api = createPaginatedQuery(fn, {}, { initialNumItems: NUM_ITEMS, onError: (error) => errors.push(error) });
+
+                return <pre>{api.status()}</pre>;
+            },
+            { wrapper: (props) => <LunoraProvider client={fake.asClient}>{props.children}</LunoraProvider> },
+        );
+
+        const find = (opts: Record<string, unknown>) => fake.subscriptions.find((s) => JSON.stringify(s.args) === JSON.stringify({ paginationOpts: opts }));
+
+        find({ cursor: null, endCursor: null, numItems: NUM_ITEMS })?.push({ continueCursor: "cur-1", isDone: false, page: firstPageItems });
+        await flushAsync();
+
+        api!.loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(api!.status()).toBe("LoadingMore");
+
+        // An RLS denial on the new page: without an error channel the feed sat
+        // in `LoadingMore` forever with `isLoading` true and nothing surfaced.
+        const tailArgs = { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS };
+
+        find(tailArgs)?.error({ code: "FORBIDDEN", message: "denied" });
+        await flushAsync();
+
+        expect(errors).toStrictEqual([{ code: "FORBIDDEN", message: "denied" }]);
+        expect(api!.error()).toStrictEqual({ code: "FORBIDDEN", message: "denied" });
+        expect(api!.status()).toBe("CanLoadMore");
+        expect(api!.isLoading()).toBe(false);
+        expect(api!.results()).toStrictEqual(firstPageItems);
+
+        // The failed tail was dropped, so `loadMore` re-opens exactly that range.
+        const before = fake.subscriptions.length;
+
+        api!.loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(api!.error()).toBeUndefined();
+        expect(api!.status()).toBe("LoadingMore");
+        expect(fake.subscriptions.slice(before).map((s) => s.args["paginationOpts"])).toStrictEqual([tailArgs]);
     });
 });
 

--- a/packages/solid/__tests__/create-query.test.tsx
+++ b/packages/solid/__tests__/create-query.test.tsx
@@ -50,7 +50,7 @@ describe(createQuery, () => {
         const fake = createFakeClient();
         const [channelId, setChannelId] = createSignal("channel:a");
 
-        render(
+        const { container } = render(
             () => {
                 const data = createQuery(listRef, () => {
                     return { channelId: channelId() };
@@ -65,9 +65,16 @@ describe(createQuery, () => {
         expect(fake.subscriptions[0]?.args).toStrictEqual({ channelId: "channel:a" });
         expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
 
+        fake.subscriptions[0]?.push(["from-a"]);
+
+        expect(container.textContent).toBe(JSON.stringify(["from-a"]));
+
         // Change the reactive args: the old subscription must be torn down and a
-        // fresh one opened for the new args.
+        // fresh one opened for the new args — and the old args' value must not
+        // render under the new args until the new subscription's first frame.
         setChannelId("channel:b");
+
+        expect(container.textContent).toBe("loading");
 
         expect(fake.subscriptions).toHaveLength(2);
         expect(fake.subscriptions[0]?.unsubscribed).toBe(true);

--- a/packages/solid/__tests__/create-subscription.test.tsx
+++ b/packages/solid/__tests__/create-subscription.test.tsx
@@ -63,7 +63,7 @@ describe(createSubscription, () => {
         const fake = createFakeClient();
         const [channelId, setChannelId] = createSignal("c1");
 
-        render(
+        const { container } = render(
             () => {
                 const { data } = createSubscription(msgRef, () => {
                     return { channelId: channelId() };
@@ -77,7 +77,14 @@ describe(createSubscription, () => {
         expect(fake.subscriptions).toHaveLength(1);
         expect(fake.subscriptions[0]?.args).toStrictEqual({ channelId: "c1" });
 
+        fake.subscriptions[0]?.push("from-c1");
+
+        expect(container.textContent).toBe("from-c1");
+
         setChannelId("c2");
+
+        // The previous args' value does not survive the switch.
+        expect(container.textContent).toBe("undefined");
 
         expect(fake.subscriptions).toHaveLength(2);
         expect(fake.subscriptions[0]?.unsubscribed).toBe(true);

--- a/packages/solid/__tests__/hydrate-preloaded.test.tsx
+++ b/packages/solid/__tests__/hydrate-preloaded.test.tsx
@@ -1,4 +1,4 @@
-import type { Preloaded } from "@lunora/client";
+import type { Preloaded, SubscriptionError } from "@lunora/client";
 import { render } from "@solidjs/testing-library";
 import { describe, expect, it } from "vitest";
 
@@ -58,6 +58,27 @@ describe(hydratePreloaded, () => {
         fake.subscriptions[0]?.push({ messages: ["seeded", "live"] });
 
         expect(container.textContent).toBe(JSON.stringify({ messages: ["seeded", "live"] }));
+    });
+
+    it("forwards onError so a server-pushed subscription error reaches the caller", () => {
+        // Regression: the live subscription behind the SSR seed had no error
+        // channel, so a session expiry after hydration was fanned to nobody and
+        // the snapshot kept rendering as if it were live.
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+
+        render(
+            () => {
+                const data = hydratePreloaded(makePreloaded("seed"), { onError: (error) => errors.push(error) });
+
+                return <pre>{data()}</pre>;
+            },
+            { wrapper: (props) => <LunoraProvider client={fake.asClient}>{props.children}</LunoraProvider> },
+        );
+
+        fake.subscriptions[0]?.error({ code: "UNAUTHORIZED", message: "session expired" });
+
+        expect(errors).toStrictEqual([{ code: "UNAUTHORIZED", message: "session expired" }]);
     });
 
     it("tears down the subscription when the owner is disposed", () => {

--- a/packages/solid/docs/index.mdx
+++ b/packages/solid/docs/index.mdx
@@ -63,7 +63,7 @@ render(
 | `createAction`                                      | primitive | Action handle: `{ data, error, pending, call, reset }` accessors. No optimistic options.         |
 | `createActionForClient`                             | primitive | Build an action handle bound to an explicit client (test/internal seam).                         |
 | `createSubscription`                                | primitive | Raw live stream as `{ data, error }` accessors. `"skip"` tears down.                             |
-| `createPaginatedQuery`                              | primitive | Cursor pagination: `{ results, status, isLoading, loadMore }`.                                   |
+| `createPaginatedQuery`                              | primitive | Cursor pagination: `{ results, status, isLoading, loadMore, error }`.                            |
 | `createInfiniteQuery`                               | primitive | Infinite-scroll variant: `{ pages, status, hasNextPage, fetchNextPage, ... }`.                   |
 | `createAuth`                                        | primitive | Identity plumbing: `{ token, user }` signals + `setToken`.                                       |
 | `Authenticated` / `AuthLoading` / `Unauthenticated` | component | Render `children` per identity state (signed-in / resolving / signed-out).                       |
@@ -100,7 +100,8 @@ every delta the WebSocket pushes.
 
 `args` may be a plain value or an accessor. Passing an accessor makes the
 subscription reactive: when the args change the previous subscription is torn
-down (via `onCleanup`) and a fresh one opens for the new args. Pass `"skip"` (or
+down (via `onCleanup`), the accessor resets to `undefined`, and a fresh one opens
+for the new args. Pass `"skip"` (or
 an accessor returning `"skip"`) to short-circuit: no network call, no socket.
 
 ```tsx
@@ -233,6 +234,11 @@ during hydration returns the server-rendered value with no loading flash and no
 `Suspense` fallback (unlike `createResource`, which always starts pending). After
 mount, a WebSocket subscription attaches in an effect and every subsequent delta
 flows into the same signal, so the UI goes live with zero refetch.
+
+Pass `{ onError }` as the second argument to observe a subscription-scoped error
+the server pushes after hydration (a session expiry, an RLS denial). Without it
+such an error is dropped and the accessor keeps rendering the SSR snapshot as if
+it were live.
 
 Internally `hydratePreloaded` is a default export, but the package barrel
 re-publishes it as a named binding, so import it from `@lunora/solid` directly:

--- a/packages/solid/src/create-paginated-query.ts
+++ b/packages/solid/src/create-paginated-query.ts
@@ -1,4 +1,4 @@
-import type { ArgsOf, FunctionReference, ReturnOf, Unsubscribe } from "@lunora/client";
+import type { ArgsOf, FunctionReference, ReturnOf, SubscriptionError, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
 import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
 import type { Accessor } from "solid-js";
@@ -17,10 +17,19 @@ type PageItemOf<F extends FunctionReference> = ReturnOf<F> extends { page: (infe
 interface CreatePaginatedQueryOptions {
     /** Page size for the first page (and the default for `loadMore`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` accessor). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface CreatePaginatedQueryResult<T> {
+    /**
+     * The last page subscription error, or `undefined`. A tail page that fails
+     * before its first frame is dropped so `status` returns to `"CanLoadMore"`
+     * and `loadMore` can retry it; cleared by the next successful frame,
+     * `loadMore`, or an args change.
+     */
+    error: Accessor<SubscriptionError | undefined>;
     /** `true` while the first page or a `loadMore` page is in flight. */
     isLoading: Accessor<boolean>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
@@ -33,10 +42,14 @@ interface CreatePaginatedQueryResult<T> {
 interface CreateInfiniteQueryOptions {
     /** Page size for the first page (and the default for `fetchNextPage`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` accessor). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface CreateInfiniteQueryResult<T> {
+    /** The last page subscription error, or `undefined` — see `CreatePaginatedQueryResult.error`. */
+    error: Accessor<SubscriptionError | undefined>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
     fetchNextPage: (numberItems?: number) => void;
     /** `true` when the loaded tail reports it can load another page. */
@@ -75,10 +88,15 @@ const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): 
 const createPaginatedCore = <T>(
     function_: FunctionReference,
     args: "skip" | Accessor<"skip" | Record<string, unknown>> | Record<string, unknown>,
-    options: { initialNumItems: number; shardKey?: string },
-): { loadMore: (n: number) => void; pageResults: Accessor<(PaginationResult<T> | undefined)[]>; status: Accessor<PaginationStatus> } => {
+    options: { initialNumItems: number; onError?: SubscriptionErrorCallback; shardKey?: string },
+): {
+    error: Accessor<SubscriptionError | undefined>;
+    loadMore: (n: number) => void;
+    pageResults: Accessor<(PaginationResult<T> | undefined)[]>;
+    status: Accessor<PaginationStatus>;
+} => {
     const client = useLunora();
-    const { initialNumItems, shardKey } = options;
+    const { initialNumItems, onError, shardKey } = options;
 
     const resolveArgs = (): "skip" | Record<string, unknown> => (typeof args === "function" ? args() : args);
 
@@ -88,6 +106,7 @@ const createPaginatedCore = <T>(
     const resultsByKey = new Map<string, PaginationResult<T>>();
 
     const [pageResults, setPageResults] = createSignal<(PaginationResult<T> | undefined)[]>([]);
+    const [error, setError] = createSignal<SubscriptionError | undefined>(undefined);
 
     // Active subscriptions keyed by pageKey.
     const activeSubs = new Map<string, Unsubscribe>();
@@ -182,6 +201,7 @@ const createPaginatedCore = <T>(
 
                     // This page has resolved; remove from the pending set.
                     pendingPageKeys.delete(key);
+                    setError(undefined);
 
                     const currentArgs = resolveArgs();
 
@@ -209,7 +229,31 @@ const createPaginatedCore = <T>(
                         }
                     }
                 },
-                { shardKey },
+                {
+                    onError: (subscriptionError) => {
+                        pendingPageKeys.delete(key);
+                        setError(subscriptionError);
+
+                        // A tail that fails before its first frame is dropped so
+                        // the feed leaves `LoadingMore` (status falls back to the
+                        // previous page's cursor) and `loadMore` can retry it. The
+                        // first page has nothing to fall back to and stays.
+                        const current = pages();
+                        const tail = current.at(-1);
+
+                        if (
+                            current.length > 1 &&
+                            tail &&
+                            !resultsByKey.has(key) &&
+                            buildPageKey(function_["__lunoraRef"], buildPageArgs(tail, baseArgs)) === key
+                        ) {
+                            setPages(current.slice(0, -1));
+                        }
+
+                        onError?.(subscriptionError);
+                    },
+                    shardKey,
+                },
             );
 
             activeSubs.set(key, unsub);
@@ -280,6 +324,7 @@ const createPaginatedCore = <T>(
         teardownAll();
         setPages(initialPages(initialNumItems));
         setPageResults([]);
+        setError(undefined);
 
         if (current !== "skip") {
             syncSubscriptions(pages(), current);
@@ -350,10 +395,11 @@ const createPaginatedCore = <T>(
             }
         }
 
+        setError(undefined);
         setPages(next);
     };
 
-    return { loadMore, pageResults, status };
+    return { error, loadMore, pageResults, status };
 };
 
 /**
@@ -371,13 +417,13 @@ const createPaginatedQuery = <F extends FunctionReference>(
     args: "skip" | Accessor<"skip" | PaginatedArgs<F>> | PaginatedArgs<F>,
     options: CreatePaginatedQueryOptions,
 ): CreatePaginatedQueryResult<PageItemOf<F>> => {
-    const { loadMore, pageResults, status } = createPaginatedCore<PageItemOf<F>>(function_, args, options);
+    const { error, loadMore, pageResults, status } = createPaginatedCore<PageItemOf<F>>(function_, args, options);
 
     const results = createMemo<PageItemOf<F>[]>(() => pageResults().flatMap((page) => page?.page ?? []));
 
     const isLoading = createMemo<boolean>(() => status() === "LoadingFirstPage" || status() === "LoadingMore");
 
-    return { isLoading, loadMore, results, status };
+    return { error, isLoading, loadMore, results, status };
 };
 
 /**
@@ -394,7 +440,7 @@ const createInfiniteQuery = <F extends FunctionReference>(
     options: CreateInfiniteQueryOptions,
 ): CreateInfiniteQueryResult<PageItemOf<F>> => {
     const { initialNumItems } = options;
-    const { loadMore, pageResults, status } = createPaginatedCore<PageItemOf<F>>(function_, args, options);
+    const { error, loadMore, pageResults, status } = createPaginatedCore<PageItemOf<F>>(function_, args, options);
 
     const pages = createMemo<PageItemOf<F>[][]>(() => pageResults().flatMap((page) => (page ? [page.page] : [])));
 
@@ -406,7 +452,7 @@ const createInfiniteQuery = <F extends FunctionReference>(
         loadMore(numberItems ?? initialNumItems);
     };
 
-    return { fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
+    return { error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
 };
 
 export type { CreateInfiniteQueryOptions, CreateInfiniteQueryResult, CreatePaginatedQueryOptions, CreatePaginatedQueryResult, PageItemOf, PaginatedArgs };

--- a/packages/solid/src/create-query.ts
+++ b/packages/solid/src/create-query.ts
@@ -28,7 +28,8 @@ export interface CreateQueryOptions {
  *
  * `args` may be a plain value or an accessor; passing an accessor makes the
  * subscription reactive — when the args change the old subscription is torn down
- * (via `onCleanup`) and a fresh one opens for the new args. Pass `"skip"` (or an
+ * (via `onCleanup`), the accessor resets to `undefined`, and a fresh one opens for
+ * the new args. Pass `"skip"` (or an
  * accessor returning `"skip"`) to short-circuit: no network call, no socket.
  *
  * ```tsx
@@ -60,6 +61,10 @@ export const createQuery = <F extends FunctionReference>(
     // a Solid signal. The `() => …` setter forms keep Solid from mistaking a
     // function-valued server result for an updater.
     trackedEffect(resolveArgs, (current) => {
+        // The previous args' value must not render under the new args until the
+        // new subscription's first frame lands.
+        setValue(() => undefined as ReturnOf<F> | undefined);
+
         const unsubscribe = createQuerySubscription<F>(
             client,
             function_,

--- a/packages/solid/src/create-subscription.ts
+++ b/packages/solid/src/create-subscription.ts
@@ -30,10 +30,12 @@ const createSubscription = <F extends FunctionReference>(
     const resolveArgs = typeof args === "function" ? (args as Accessor<ArgsOf<F> | "skip">) : () => args;
 
     trackedEffect(resolveArgs, (currentArgs) => {
-        if (currentArgs === "skip") {
-            setData(() => undefined);
-            setError(() => undefined);
+        // Each args generation starts clean: the previous args' value must not
+        // render under the new args until the new subscription's first frame.
+        setData(() => undefined);
+        setError(() => undefined);
 
+        if (currentArgs === "skip") {
             return undefined;
         }
 

--- a/packages/solid/src/hydrate-preloaded.ts
+++ b/packages/solid/src/hydrate-preloaded.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, Preloaded } from "@lunora/client";
+import type { FunctionReference, Preloaded, SubscriptionErrorCallback } from "@lunora/client";
 import type { Accessor } from "solid-js";
 import { createSignal } from "solid-js";
 
@@ -26,8 +26,12 @@ import { onMounted } from "./solid-compat";
  * Mount callbacks do not run on the server during SSR (both Solid majors defer
  * them until after hydration), so the subscription is strictly client-side —
  * the seed is the only value the server render ever sees.
+ *
+ * Pass `onError` to surface a subscription-scoped error the server pushes (a
+ * session expiry, an RLS denial). Without it such an error is dropped and the
+ * accessor keeps rendering the SSR snapshot as if it were live.
  */
-const hydratePreloaded = <T>(preloaded: Preloaded<T>): Accessor<T> => {
+const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: { onError?: SubscriptionErrorCallback } = {}): Accessor<T> => {
     const client = useLunora();
 
     const { args, functionPath, shardKey, value } = preloaded;
@@ -38,7 +42,7 @@ const hydratePreloaded = <T>(preloaded: Preloaded<T>): Accessor<T> => {
 
     const functionRef: FunctionReference = { __lunoraRef: functionPath };
 
-    onMounted(() => client.subscribe(functionRef, args, (next) => setData(() => next as T), { shardKey }));
+    onMounted(() => client.subscribe(functionRef, args, (next) => setData(() => next as T), { onError: options.onError, shardKey }));
 
     return data;
 };

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -104,7 +104,7 @@ All functions that require a component lifecycle (presence, rate-limit) return a
 | `query`            | `useQuery`            | Live readable store — updates on every server delta.                                   |
 | `mutation`         | `useMutation`         | Optimistic mutation handle (`data`, `error`, `pending`, `mutate`, `reset` stores).     |
 | `subscription`     | `useSubscription`     | Raw subscription readable — unbounded live stream.                                     |
-| `paginatedQuery`   | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, and `results` stores.                |
+| `paginatedQuery`   | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, `results`, and `error` stores.       |
 | `infiniteQuery`    | `useInfiniteQuery`    | Infinite-scroll variant of `paginatedQuery`.                                           |
 | `auth`             | `useAuth`             | Reactive auth stores (`user`, `token`) plus `setToken`.                                |
 | `presence`         | `usePresence`         | Collaborative-awareness — heartbeat + live present-members readable + `teardown`.      |

--- a/packages/svelte/__tests__/agent-chat.test.ts
+++ b/packages/svelte/__tests__/agent-chat.test.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference } from "@lunora/client";
+import type { FunctionReference, SubscriptionError } from "@lunora/client";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -69,6 +69,26 @@ describe(agentChat, () => {
         handle.teardown();
 
         expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("forwards onError so a history or thread subscription error reaches the caller", () => {
+        // Without an error channel a session expiry left `messages` / `status`
+        // frozen at their last value with nothing surfaced.
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+
+        agentChat(fake.client, {
+            api: buildApi(),
+            onError: (error) => errors.push(error),
+            send: makeRef(SEND_REF) as FunctionReference<"mutation">,
+            threadKey: "t1",
+        });
+
+        for (const call of fake.subscribeCalls) {
+            call.options.onError?.({ code: "UNAUTHORIZED", message: `expired:${call.functionPath}` });
+        }
+
+        expect(errors.map((error) => error.message).toSorted((a, b) => a.localeCompare(b))).toStrictEqual([`expired:${MESSAGES_REF}`, `expired:${THREAD_REF}`]);
     });
 
     it("accumulates in-flight token deltas into streamingText, then clears once the turn persists", async () => {

--- a/packages/svelte/__tests__/agent.test.ts
+++ b/packages/svelte/__tests__/agent.test.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionError } from "@lunora/client";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,6 +17,7 @@ interface SubscribeCall {
     args: { key: string };
     callback: (value: unknown) => void;
     functionPath: string;
+    onError?: (error: SubscriptionError) => void;
 }
 
 const buildApi = (): AgentApi =>
@@ -33,13 +34,18 @@ const createFakeClient = () => {
         return { resolved: true };
     });
 
-    const subscribe = vi.fn<(function_: FunctionReference, args: SubscribeCall["args"], callback: (value: unknown) => void) => () => void>(
-        (function_, args, callback) => {
-            subscribeCalls.push({ args, callback, functionPath: function_["__lunoraRef"] });
+    const subscribe = vi.fn<
+        (
+            function_: FunctionReference,
+            args: SubscribeCall["args"],
+            callback: (value: unknown) => void,
+            options?: { onError?: (error: SubscriptionError) => void },
+        ) => () => void
+    >((function_, args, callback, options) => {
+        subscribeCalls.push({ args, callback, functionPath: function_["__lunoraRef"], onError: options?.onError });
 
-            return unsubscribeSpy;
-        },
-    );
+        return unsubscribeSpy;
+    });
 
     const client = { mutation: mutationSpy, subscribe } as unknown as LunoraClient;
 
@@ -95,6 +101,24 @@ describe(agent, () => {
         handle.teardown();
 
         expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards onError so a thread subscription error reaches the caller", () => {
+        // Without an error channel a session expiry left `thread` / `status`
+        // frozen at their last value with nothing surfaced.
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+
+        agent(fake.client, {
+            api: buildApi(),
+            onError: (error) => errors.push(error),
+            run: makeRef(RUN_REF) as FunctionReference<"mutation">,
+            threadKey: "t1",
+        });
+
+        fake.subscribeCalls[0]?.onError?.({ code: "UNAUTHORIZED", message: "session expired" });
+
+        expect(errors).toStrictEqual([{ code: "UNAUTHORIZED", message: "session expired" }]);
     });
 
     it("fires the run mutation with the input, thread key, and merged run args", async () => {

--- a/packages/svelte/__tests__/hydrate-preloaded.test.ts
+++ b/packages/svelte/__tests__/hydrate-preloaded.test.ts
@@ -1,4 +1,4 @@
-import type { LunoraClient, Preloaded } from "@lunora/client";
+import type { LunoraClient, Preloaded, SubscriptionError } from "@lunora/client";
 import { get } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,20 +11,28 @@ import { hydratePreloaded } from "../src/hydrate-preloaded";
 const createFakeClient = () => {
     const unsubscribe = vi.fn<() => void>();
     let lastCallback: ((value: unknown) => void) | undefined;
+    let lastOnError: ((error: SubscriptionError) => void) | undefined;
 
-    const subscribe = vi.fn<(function_: unknown, args: unknown, callback: (value: unknown) => void, options?: { shardKey?: string }) => () => void>(
-        (_function, _args, callback) => {
-            lastCallback = callback;
+    const subscribe = vi.fn<
+        (
+            function_: unknown,
+            args: unknown,
+            callback: (value: unknown) => void,
+            options?: { onError?: (error: SubscriptionError) => void; shardKey?: string },
+        ) => () => void
+    >((_function, _args, callback, options) => {
+        lastCallback = callback;
+        lastOnError = options?.onError;
 
-            return unsubscribe;
-        },
-    );
+        return unsubscribe;
+    });
 
     const client = { subscribe } as unknown as LunoraClient;
 
     return {
         client,
         emit: (value: unknown) => lastCallback?.(value),
+        emitError: (error: SubscriptionError) => lastOnError?.(error),
         subscribe,
         unsubscribe,
     };
@@ -84,5 +92,22 @@ describe(hydratePreloaded, () => {
         stop();
 
         expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards onError so a server-pushed subscription error reaches the caller", () => {
+        // Regression: the live subscription behind the SSR seed had no error
+        // channel, so a session expiry after hydration was fanned to nobody and
+        // the snapshot kept rendering as if it were live.
+        const { client, emitError } = createFakeClient();
+        const errors: SubscriptionError[] = [];
+        const store = hydratePreloaded(makePreloaded("seed"), client, { onError: (error) => errors.push(error) });
+
+        const stop = store.subscribe(() => {});
+
+        emitError({ code: "UNAUTHORIZED", message: "session expired" });
+
+        expect(errors).toStrictEqual([{ code: "UNAUTHORIZED", message: "session expired" }]);
+
+        stop();
     });
 });

--- a/packages/svelte/__tests__/paginated-query.test.ts
+++ b/packages/svelte/__tests__/paginated-query.test.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionError, Unsubscribe } from "@lunora/client";
 import type { PaginationResult } from "@lunora/client/pagination";
 import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
@@ -159,6 +159,66 @@ describe("paginatedQuery (Svelte)", () => {
         expect(get(status)).toBe("Exhausted");
 
         stopStatus();
+    });
+});
+
+describe("paginatedQuery page errors", () => {
+    it("a page error surfaces on `error`, returns status to CanLoadMore, and lets loadMore retry", async () => {
+        const subscribeCalls: { args: Record<string, unknown>; callback: (data: unknown) => void; onError?: (error: SubscriptionError) => void }[] = [];
+
+        const client = {
+            subscribe: (
+                _fn: FunctionReference,
+                args: Record<string, unknown>,
+                callback: (data: unknown) => void,
+                options?: { onError?: (error: SubscriptionError) => void },
+            ) => {
+                subscribeCalls.push({ args, callback, onError: options?.onError });
+
+                return () => undefined;
+            },
+        } as unknown as LunoraClient;
+
+        const errors: SubscriptionError[] = [];
+        const { error, isLoading, loadMore, results, status } = paginatedQuery(client, fn, {}, { initialNumItems: NUM_ITEMS, onError: (e) => errors.push(e) });
+
+        const stops = [results.subscribe(() => {}), status.subscribe(() => {}), error.subscribe(() => {}), isLoading.subscribe(() => {})];
+        const find = (opts: Record<string, unknown>) => subscribeCalls.find((c) => JSON.stringify(c.args) === JSON.stringify({ paginationOpts: opts }));
+
+        find({ cursor: null, endCursor: null, numItems: NUM_ITEMS })?.callback({ continueCursor: "cur-1", isDone: false, page: firstPageItems });
+        await flushAsync();
+
+        loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(get(status)).toBe("LoadingMore");
+
+        // An RLS denial on the new page: without an error channel the feed sat
+        // in `LoadingMore` forever with `isLoading` true and nothing surfaced.
+        const tailArgs = { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS };
+
+        find(tailArgs)?.onError?.({ code: "FORBIDDEN", message: "denied" });
+        await flushAsync();
+
+        expect(errors).toStrictEqual([{ code: "FORBIDDEN", message: "denied" }]);
+        expect(get(error)).toStrictEqual({ code: "FORBIDDEN", message: "denied" });
+        expect(get(status)).toBe("CanLoadMore");
+        expect(get(isLoading)).toBe(false);
+        expect(get(results)).toStrictEqual(firstPageItems);
+
+        // The failed tail was dropped, so `loadMore` re-opens exactly that range.
+        const before = subscribeCalls.length;
+
+        loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(get(error)).toBeUndefined();
+        expect(get(status)).toBe("LoadingMore");
+        expect(subscribeCalls.slice(before).map((c) => c.args["paginationOpts"])).toStrictEqual([tailArgs]);
+
+        for (const stop of stops) {
+            stop();
+        }
     });
 });
 

--- a/packages/svelte/__tests__/query.test.ts
+++ b/packages/svelte/__tests__/query.test.ts
@@ -111,7 +111,7 @@ describe("query store", () => {
 
 describe("query store with reactive args", () => {
     it("re-subscribes with the new args when the args store emits", () => {
-        const { client, subscribe, unsubscribe } = createFakeClient();
+        const { client, emit, subscribe, unsubscribe } = createFakeClient();
         const argsStore = writable<unknown>({ room: "general" });
         const store = query(client, fnRef, argsStore);
 
@@ -120,7 +120,15 @@ describe("query store with reactive args", () => {
         expect(subscribe).toHaveBeenCalledTimes(1);
         expect(subscribe.mock.calls[0]?.[1]).toStrictEqual({ room: "general" });
 
+        emit([{ id: 1 }]);
+
+        expect(get(store)).toStrictEqual([{ id: 1 }]);
+
         argsStore.set({ room: "random" });
+
+        // The previous args' value does not survive the switch: the store reads
+        // `undefined` until the new subscription's first frame lands.
+        expect(get(store)).toBeUndefined();
 
         // The previous subscription is torn down before the new one opens.
         expect(unsubscribe).toHaveBeenCalledTimes(1);

--- a/packages/svelte/__tests__/subscription.test.ts
+++ b/packages/svelte/__tests__/subscription.test.ts
@@ -1,4 +1,5 @@
 import type { FunctionReference, LunoraClient } from "@lunora/client";
+import { LunoraError } from "@lunora/errors";
 import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
@@ -10,10 +11,15 @@ const args = { channelId: "c1" } as unknown;
 const createFakeClient = () => {
     const unsubscribeSpy = vi.fn<() => void>();
     let lastCallback: ((value: unknown) => void) | undefined;
-    let lastOnError: ((error: { message: string }) => void) | undefined;
+    let lastOnError: ((error: { code?: string; message: string }) => void) | undefined;
 
     const subscribeSpy = vi.fn<
-        (function_: unknown, args: unknown, callback: (value: unknown) => void, options?: { onError?: (error: { message: string }) => void }) => () => void
+        (
+            function_: unknown,
+            args: unknown,
+            callback: (value: unknown) => void,
+            options?: { onError?: (error: { code?: string; message: string }) => void },
+        ) => () => void
     >((_fn, _args, callback, options) => {
         lastCallback = callback;
         lastOnError = options?.onError;
@@ -26,7 +32,7 @@ const createFakeClient = () => {
     return {
         client,
         emit: (value: unknown) => lastCallback?.(value),
-        emitError: (message: string) => lastOnError?.({ message }),
+        emitError: (message: string, code?: string) => lastOnError?.(code === undefined ? { message } : { code, message }),
         subscribeSpy,
         unsubscribeSpy,
     };
@@ -107,6 +113,25 @@ describe("subscription store", () => {
         stopError();
     });
 
+    it("preserves the server-supplied code on the error store as a LunoraError", () => {
+        // Sibling gap: Vue/Solid's subscription primitives keep `code` so a
+        // consumer can branch on UNAUTHORIZED vs NOT_FOUND; a bare `Error` lost it.
+        const { client, emitError } = createFakeClient();
+        const { data, error } = subscription(client, fnRef, args);
+
+        const stop = data.subscribe(() => {});
+
+        emitError("denied", "FORBIDDEN");
+
+        const captured = get(error);
+
+        expect(captured).toBeInstanceOf(LunoraError);
+        expect((captured as LunoraError).code).toBe("FORBIDDEN");
+        expect(captured?.message).toBe("denied");
+
+        stop();
+    });
+
     it("clears the error store once a healthy value arrives after an error", () => {
         const { client, emit, emitError } = createFakeClient();
         const { data, error } = subscription(client, fnRef, args);
@@ -150,7 +175,7 @@ describe("subscription store", () => {
 
 describe("subscription store with reactive args", () => {
     it("re-subscribes with the new args when the args store emits", () => {
-        const { client, subscribeSpy, unsubscribeSpy } = createFakeClient();
+        const { client, emit, subscribeSpy, unsubscribeSpy } = createFakeClient();
         const argsStore = writable<unknown>({ channelId: "c1" });
         const { data } = subscription(client, fnRef, argsStore);
 
@@ -159,7 +184,14 @@ describe("subscription store with reactive args", () => {
         expect(subscribeSpy).toHaveBeenCalledTimes(1);
         expect(subscribeSpy.mock.calls[0]?.[1]).toStrictEqual({ channelId: "c1" });
 
+        emit([{ id: "1" }]);
+
+        expect(get(data)).toStrictEqual([{ id: "1" }]);
+
         argsStore.set({ channelId: "c2" });
+
+        // The previous args' value does not survive the switch.
+        expect(get(data)).toBeUndefined();
 
         // The previous subscription is torn down before the new one opens.
         expect(unsubscribeSpy).toHaveBeenCalledTimes(1);

--- a/packages/svelte/docs/index.mdx
+++ b/packages/svelte/docs/index.mdx
@@ -233,6 +233,11 @@ hydration mismatch. When the store gains its first subscriber on the client, a
 live WS subscription attaches and every subsequent delta re-emits, exactly like a
 plain `query` store.
 
+Pass `{ onError }` as the third argument (after the optional `client`) to observe
+a subscription-scoped error the server pushes after hydration (a session expiry,
+an RLS denial). Without it such an error is dropped and the store keeps
+rendering the SSR snapshot as if it were live.
+
 ```svelte
 <script lang="ts">
     import { hydratePreloaded } from "@lunora/svelte";
@@ -304,7 +309,8 @@ listener (`presence`, `rateLimit`) return a `teardown()`; call it from
 
 A raw live subscription as a pair of readable stores, `{ data, error }`. `data`
 holds the latest server push (`undefined` until the first), `error` holds the
-last subscription error. Pass `"skip"` as `args` to keep the handle but leave the
+last subscription error (a `LunoraError` carrying the server `code` when one was
+sent). Pass `"skip"` as `args` to keep the handle but leave the
 subscription dormant. Options: `{ shardKey, onError }`.
 
 ```svelte
@@ -319,14 +325,17 @@ subscription dormant. Options: `{ shardKey, onError }`.
 {#each $data ?? [] as m (m._id)}<li>{m.text}</li>{/each}
 ```
 
-### `paginatedQuery(fn, args, { initialNumItems })`
+### `paginatedQuery(fn, args, { initialNumItems, shardKey?, onError? })`
 
 A cursor-paginated live query. `args` is the function's args minus
 `paginationOpts` (the framework supplies the cursor), or `"skip"`. The handle is
-`{ results, status, isLoading, loadMore }`: `results` is the flattened items
+`{ results, status, isLoading, loadMore, error }`: `results` is the flattened items
 across every loaded page; `status` is `"LoadingFirstPage" | "LoadingMore" |
 "CanLoadMore" | "Exhausted"`; `loadMore(n)` appends the next page (a no-op unless
-`status === "CanLoadMore"`).
+`status === "CanLoadMore"`); `error` holds the last page subscription error
+(`undefined` when healthy) — a page that fails before its first frame is dropped,
+`status` returns to `"CanLoadMore"`, and `loadMore(n)` retries it. `onError` is
+called with the same error.
 
 ```svelte
 <script lang="ts">
@@ -341,7 +350,7 @@ across every loaded page; `status` is `"LoadingFirstPage" | "LoadingMore" |
 ```
 
 `infiniteQuery` is the TanStack-Query-shaped variant: `{ pages, status,
-isLoading, hasNextPage, isFetchingNextPage, fetchNextPage }`, where `pages` keeps
+isLoading, hasNextPage, isFetchingNextPage, fetchNextPage, error }`, where `pages` keeps
 each loaded page as its own inner array.
 
 ### `presence(roomId, options)`

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient, OptimisticMessage } from "@lunora/client";
+import type { FunctionReference, LunoraClient, OptimisticMessage, SubscriptionErrorCallback } from "@lunora/client";
 import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
@@ -123,6 +123,13 @@ interface AgentChatOptions {
     limit?: number;
 
     /**
+     * Called when the live history or thread subscription reports an error (a
+     * session expiry, an RLS denial). Without it such an error is dropped and
+     * `messages` / `status` freeze at their last value.
+     */
+    onError?: SubscriptionErrorCallback;
+
+    /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
      * `ctx.agents[name].run(...)`. Called with `{ threadKey, input }` merged with
      * {@link AgentChatOptions.sendArgs} and the per-call args.
@@ -182,7 +189,7 @@ interface AgentChatHandle {
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions): AgentChatHandle => {
-    const { api, cancel: cancelReference, limit, send: sendReference, sendArgs, stream: streamReference, threadKey } = options;
+    const { api, cancel: cancelReference, limit, onError, send: sendReference, sendArgs, stream: streamReference, threadKey } = options;
 
     const sendMutation = mutation(client, sendReference);
     const cancelMutation = mutation(client, cancelReference ?? NO_MUTATION_REF);
@@ -275,17 +282,27 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
 
     const historyArgs = limit === undefined ? { key: threadKey } : { key: threadKey, limit };
     const unsubscribeHistory = isBrowser()
-        ? client.subscribe(api.agents.agentMessages, historyArgs, (value) => {
-              durable = value as unknown as ReadonlyArray<AgentChatMessage>;
-              recompute();
-              recomputeStreamingText();
-          })
+        ? client.subscribe(
+              api.agents.agentMessages,
+              historyArgs,
+              (value) => {
+                  durable = value as unknown as ReadonlyArray<AgentChatMessage>;
+                  recompute();
+                  recomputeStreamingText();
+              },
+              { onError },
+          )
         : (): void => undefined;
     const unsubscribeThread = isBrowser()
-        ? client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
-              latestThread = value as AgentThreadRecord | undefined;
-              statusStore.set(latestThread?.status);
-          })
+        ? client.subscribe(
+              api.agents.agentThread,
+              { key: threadKey },
+              (value) => {
+                  latestThread = value as AgentThreadRecord | undefined;
+                  statusStore.set(latestThread?.status);
+              },
+              { onError },
+          )
         : (): void => undefined;
 
     const send = async (input: string, arguments_?: Record<string, unknown>): Promise<void> => {

--- a/packages/svelte/src/agent.ts
+++ b/packages/svelte/src/agent.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, SubscriptionErrorCallback } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
@@ -59,6 +59,13 @@ interface AgentOptions {
     cancel?: FunctionReference<"mutation">;
 
     /**
+     * Called when the live thread subscription reports an error (a session
+     * expiry, an RLS denial). Without it such an error is dropped and `thread` /
+     * `status` freeze at their last value.
+     */
+    onError?: SubscriptionErrorCallback;
+
+    /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
      * `ctx.agents[name].run(...)`. Called with `{ threadKey, input }` merged with
      * {@link AgentOptions.runArgs} and the per-call args.
@@ -105,7 +112,7 @@ const isClient = (value: unknown): value is LunoraClient =>
     typeof value === "object" && value !== null && typeof (value as { subscribe?: unknown }).subscribe === "function";
 
 const createAgentHandle = (client: LunoraClient, options: AgentOptions): AgentHandle => {
-    const { api, cancel: cancelReference, run: runReference, runArgs, threadKey } = options;
+    const { api, cancel: cancelReference, onError, run: runReference, runArgs, threadKey } = options;
 
     const runMutation = mutation(client, runReference);
     const cancelMutation = mutation(client, cancelReference ?? NO_MUTATION_REF);
@@ -123,11 +130,16 @@ const createAgentHandle = (client: LunoraClient, options: AgentOptions): AgentHa
     // `presence.ts`/`agent-chat.ts` guard). Skip it server-side; `thread`/
     // `status` stay at their inert initial values until the component hydrates.
     const unsubscribe = isBrowser()
-        ? client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
-              latestThread = value as AgentThreadRecord | undefined;
-              threadStore.set(latestThread);
-              statusStore.set(latestThread?.status);
-          })
+        ? client.subscribe(
+              api.agents.agentThread,
+              { key: threadKey },
+              (value) => {
+                  latestThread = value as AgentThreadRecord | undefined;
+                  threadStore.set(latestThread);
+                  statusStore.set(latestThread?.status);
+              },
+              { onError },
+          )
         : (): void => undefined;
 
     const run = async (input: string, arguments_?: Record<string, unknown>): Promise<void> => {

--- a/packages/svelte/src/hydrate-preloaded.ts
+++ b/packages/svelte/src/hydrate-preloaded.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, LunoraClient, Preloaded } from "@lunora/client";
+import type { FunctionReference, LunoraClient, Preloaded, SubscriptionErrorCallback } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { readable } from "svelte/store";
 
@@ -17,7 +17,9 @@ import { getLunoraClient } from "./context";
  * `usePreloadedQuery`.
  *
  * Pass `client` explicitly, or omit it to resolve the ambient client published
- * by `setLunoraClient`.
+ * by `setLunoraClient`. Pass `onError` to surface a subscription-scoped error the
+ * server pushes (a session expiry, an RLS denial); without it such an error is
+ * dropped and the store keeps rendering the SSR snapshot as if it were live.
  *
  * Note on SSR: `readable`'s start callback only runs when the store is actually
  * subscribed (the browser), so on the server the store simply holds the seeded
@@ -25,7 +27,7 @@ import { getLunoraClient } from "./context";
  * for the first paint either way.
  */
 // eslint-disable-next-line import/prefer-default-export -- the package barrel re-exports every store by name; a default here would break the `import { hydratePreloaded } from "@lunora/svelte"` surface.
-export const hydratePreloaded = <T>(preloaded: Preloaded<T>, client?: LunoraClient): Readable<T> => {
+export const hydratePreloaded = <T>(preloaded: Preloaded<T>, client?: LunoraClient, options: { onError?: SubscriptionErrorCallback } = {}): Readable<T> => {
     const resolvedClient = client ?? getLunoraClient();
     const { args, functionPath, shardKey, value } = preloaded;
     const functionRef: FunctionReference = { __lunoraRef: functionPath };
@@ -40,7 +42,7 @@ export const hydratePreloaded = <T>(preloaded: Preloaded<T>, client?: LunoraClie
             (next: unknown) => {
                 set(next as T);
             },
-            { shardKey },
+            { onError: options.onError, shardKey },
         ),
     );
 };

--- a/packages/svelte/src/paginated-query.ts
+++ b/packages/svelte/src/paginated-query.ts
@@ -1,4 +1,4 @@
-import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, Unsubscribe } from "@lunora/client";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, SubscriptionError, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
 import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
 import type { Readable } from "svelte/store";
@@ -22,10 +22,19 @@ type PageItemOf<F extends FunctionReference> = ReturnOf<F> extends { page: (infe
 interface PaginatedQueryOptions {
     /** Page size for the first page (and the default for `loadMore`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` store). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface PaginatedQueryHandle<T> {
+    /**
+     * The last page subscription error, or `undefined`. A tail page that fails
+     * before its first frame is dropped so `status` returns to `"CanLoadMore"`
+     * and `loadMore` can retry it; cleared by the next successful frame,
+     * `loadMore`, or an args emission.
+     */
+    error: Readable<SubscriptionError | undefined>;
     /** `true` while the first page or a `loadMore` page is in flight. */
     isLoading: Readable<boolean>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
@@ -38,10 +47,14 @@ interface PaginatedQueryHandle<T> {
 interface InfiniteQueryOptions {
     /** Page size for the first page (and the default for `fetchNextPage`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` store). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface InfiniteQueryHandle<T> {
+    /** The last page subscription error, or `undefined` — see `PaginatedQueryHandle.error`. */
+    error: Readable<SubscriptionError | undefined>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
     fetchNextPage: (numberItems?: number) => void;
     /** `true` when the loaded tail reports it can load another page. */
@@ -84,15 +97,17 @@ const createPaginatedEngine = <T>(
     client: LunoraClient,
     function_: FunctionReference,
     baseArgs: "skip" | Record<string, unknown> | Readable<"skip" | Record<string, unknown>>,
-    options: { initialNumItems: number; shardKey?: string },
+    options: { initialNumItems: number; onError?: SubscriptionErrorCallback; shardKey?: string },
 ): {
+    error: Readable<SubscriptionError | undefined>;
     loadMore: (numberItems: number) => void;
     pageResults: Readable<(PaginationResult<T> | undefined)[]>;
     status: Readable<PaginationStatus>;
 } => {
-    const { initialNumItems, shardKey } = options;
+    const { initialNumItems, onError, shardKey } = options;
 
     const pagesStore = writable<Page[]>(initialPages(initialNumItems));
+    const errorStore = writable<SubscriptionError | undefined>();
     // pageResultsStore is a writable used as the source; pageResults is the
     // public Readable that the lazy start/stop callback wires up.
     const pageResultsInternal = writable<(PaginationResult<T> | undefined)[]>([]);
@@ -222,6 +237,7 @@ const createPaginatedEngine = <T>(
 
                     // This page has resolved; remove from the pending set.
                     pendingPageKeys.delete(key);
+                    errorStore.set(undefined);
 
                     rebuildPageResults();
 
@@ -245,7 +261,34 @@ const createPaginatedEngine = <T>(
                         }
                     }
                 },
-                { shardKey },
+                {
+                    onError: (subscriptionError) => {
+                        pendingPageKeys.delete(key);
+                        errorStore.set(subscriptionError);
+
+                        // A tail that fails before its first frame is dropped so
+                        // the feed leaves `LoadingMore` (status falls back to the
+                        // previous page's cursor) and `loadMore` can retry it. The
+                        // first page has nothing to fall back to and stays.
+                        const current = get(pagesStore);
+                        const tail = current.at(-1);
+
+                        if (
+                            current.length > 1 &&
+                            tail &&
+                            !resultsByKey.has(key) &&
+                            buildPageKey(function_["__lunoraRef"], buildPageArgs(tail, baseArgsRecord)) === key
+                        ) {
+                            pagesStore.set(current.slice(0, -1));
+                            // eslint-disable-next-line @typescript-eslint/no-use-before-define -- runs inside a deferred subscription callback, after syncSubscriptions is defined
+                            syncSubscriptions();
+                            rebuildPageResults();
+                        }
+
+                        onError?.(subscriptionError);
+                    },
+                    shardKey,
+                },
             );
 
             activeSubs.set(key, unsub);
@@ -315,6 +358,7 @@ const createPaginatedEngine = <T>(
             return () => {
                 teardownAll();
                 pagesStore.set(initialPages(initialNumItems));
+                errorStore.set(undefined);
             };
         });
 
@@ -373,12 +417,13 @@ const createPaginatedEngine = <T>(
             }
         }
 
+        errorStore.set(undefined);
         pagesStore.set(next);
         syncSubscriptions();
         rebuildPageResults();
     };
 
-    return { loadMore, pageResults, status };
+    return { error: { subscribe: errorStore.subscribe }, loadMore, pageResults, status };
 };
 
 /**
@@ -416,7 +461,7 @@ export function paginatedQuery<F extends FunctionReference>(
     const args = (hasExplicitClient ? argumentsOrOptions : functionOrArguments) as ReactivePaginatedArgs<F>;
     const options = (hasExplicitClient ? maybeOptions : argumentsOrOptions) as PaginatedQueryOptions;
 
-    const { loadMore, pageResults, status } = createPaginatedEngine<PageItemOf<F>>(client, functionRef, args, options);
+    const { error, loadMore, pageResults, status } = createPaginatedEngine<PageItemOf<F>>(client, functionRef, args, options);
 
     const results = derived<Readable<(PaginationResult<PageItemOf<F>> | undefined)[]>, PageItemOf<F>[]>(pageResults, (currentResults) =>
         currentResults.flatMap((page) => page?.page ?? []),
@@ -427,7 +472,7 @@ export function paginatedQuery<F extends FunctionReference>(
         (currentStatus) => currentStatus === "LoadingFirstPage" || currentStatus === "LoadingMore",
     );
 
-    return { isLoading, loadMore, results, status };
+    return { error, isLoading, loadMore, results, status };
 }
 
 /**
@@ -461,7 +506,7 @@ export function infiniteQuery<F extends FunctionReference>(
     const options = (hasExplicitClient ? maybeOptions : argumentsOrOptions) as InfiniteQueryOptions;
     const { initialNumItems } = options;
 
-    const { loadMore, pageResults, status } = createPaginatedEngine<PageItemOf<F>>(client, functionRef, args, options);
+    const { error, loadMore, pageResults, status } = createPaginatedEngine<PageItemOf<F>>(client, functionRef, args, options);
 
     const pages = derived<Readable<(PaginationResult<PageItemOf<F>> | undefined)[]>, PageItemOf<F>[][]>(pageResults, (currentResults) =>
         currentResults.flatMap((page) => (page ? [page.page] : [])),
@@ -475,7 +520,7 @@ export function infiniteQuery<F extends FunctionReference>(
         loadMore(numberItems ?? initialNumItems);
     };
 
-    return { fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
+    return { error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
 }
 
 export type { InfiniteQueryHandle, InfiniteQueryOptions, PageItemOf, PaginatedArgs, PaginatedQueryHandle, PaginatedQueryOptions, ReactivePaginatedArgs };

--- a/packages/svelte/src/query.ts
+++ b/packages/svelte/src/query.ts
@@ -47,9 +47,9 @@ export type QueryStore<F extends FunctionReference> = Readable<ReturnOf<F> | und
  * before this runs).
  *
  * `args` may also be a `Readable` store (wrap runes state with `toStore` or
- * `derived`): each emission tears down the previous subscription and opens a
- * fresh one against the new args — the Svelte counterpart of Vue's
- * `MaybeRefOrGetter` args. An emission of `"skip"` tears down without
+ * `derived`): each emission tears down the previous subscription, resets the
+ * value to `undefined`, and opens a fresh one against the new args — the Svelte
+ * counterpart of Vue's `MaybeRefOrGetter` args. An emission of `"skip"` tears down without
  * re-opening and resets the value to `undefined`.
  */
 export function query<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: QueryStoreOptions): QueryStore<F>;
@@ -75,8 +75,12 @@ export function query<F extends FunctionReference>(
         // pushes every subsequent delta into the store, and its returned teardown
         // is the store's stop callback, so the WS subscription closes when the
         // last `$`-reader detaches.
-        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe =>
-            createQuerySubscription<F>(
+        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe => {
+            // The previous args' value must not render under the new args until
+            // the new subscription's first frame lands.
+            set(undefined);
+
+            return createQuerySubscription<F>(
                 client,
                 functionRef,
                 resolved,
@@ -94,6 +98,7 @@ export function query<F extends FunctionReference>(
                 },
                 { shardKey: options.shardKey },
             );
+        };
 
         return subscribeReactiveArgs<ArgsOf<F> | "skip">(args, open);
     });

--- a/packages/svelte/src/subscription.ts
+++ b/packages/svelte/src/subscription.ts
@@ -1,5 +1,6 @@
 import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, Unsubscribe } from "@lunora/client";
 import { createQuerySubscription } from "@lunora/client/query";
+import { LunoraError } from "@lunora/errors";
 import type { Readable } from "svelte/store";
 import { readable, writable } from "svelte/store";
 
@@ -31,8 +32,8 @@ interface SubscriptionHandle<T> {
  * argument to bypass the ambient context (useful in tests).
  *
  * `args` may also be a `Readable` store: each emission tears down the previous
- * subscription and opens a fresh one; a `"skip"` emission tears down without
- * re-opening and resets `data` to `undefined`.
+ * subscription, resets `data` to `undefined`, and opens a fresh one; a `"skip"`
+ * emission tears down without re-opening.
  */
 function subscription<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
 function subscription<F extends FunctionReference>(
@@ -66,8 +67,9 @@ function subscription<F extends FunctionReference>(
         // a socket — so the reset path below is reachable, unlike a local early
         // return that would make it dead code.
         const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe => {
-            // Each emission starts from a clean slate: drop the error the
-            // previous args produced before opening the new subscription.
+            // Each emission starts from a clean slate: drop the value and error
+            // the previous args produced before opening the new subscription.
+            set(undefined);
             errorStore.set(undefined);
 
             return createQuerySubscription(
@@ -80,7 +82,13 @@ function subscription<F extends FunctionReference>(
                         errorStore.set(undefined);
                     },
                     onError: (subscriptionError) => {
-                        const error = new Error(subscriptionError.message);
+                        // Preserve the server-supplied `code` (matching Vue/Solid's
+                        // subscription primitives) so consumers can branch on it.
+                        const error =
+                            subscriptionError.code === undefined
+                                ? new Error(subscriptionError.message)
+                                : new LunoraError(subscriptionError.code, subscriptionError.message);
+
                         errorStore.set(error);
                         onError?.(error);
                     },

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -81,7 +81,7 @@ const { mutate, pending } = useMutation(api.messages.send);
 | `useQuery`            | `useQuery`            | Live query `ShallowRef` — re-subscribes when reactive args change.                |
 | `useMutation`         | `useMutation`         | Optimistic mutation handle (`data`, `error`, `pending`, `mutate`, `reset`).       |
 | `useSubscription`     | `useSubscription`     | Raw subscription `ShallowRef` — unbounded live stream.                            |
-| `usePaginatedQuery`   | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, and `results`.                  |
+| `usePaginatedQuery`   | `usePaginatedQuery`   | Cursor-paginated query with `loadMore`, `status`, `results`, and `error`.         |
 | `useInfiniteQuery`    | `useInfiniteQuery`    | Infinite-scroll variant of `usePaginatedQuery`.                                   |
 | `useAuth`             | `useAuth`             | Reactive auth: readonly `token`/`user` refs plus `setToken`.                      |
 | `usePresence`         | `usePresence`         | Collaborative-awareness — heartbeat + live present-members `ShallowRef`.          |

--- a/packages/vue/__tests__/hydrate-preloaded.test.ts
+++ b/packages/vue/__tests__/hydrate-preloaded.test.ts
@@ -168,6 +168,27 @@ describe("hydratePreloaded return type", () => {
         Reflect.deleteProperty(globalThis, "window");
     });
 
+    it("forwards onError so a server-pushed subscription error reaches the caller", () => {
+        // Regression: the live subscription behind the SSR seed had no error
+        // channel, so a session expiry after hydration was fanned to nobody and
+        // the snapshot kept rendering as if it were live.
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+        const scope = effectScope();
+
+        scope.run(() => {
+            fake.provide(() => {
+                hydratePreloaded(makePreloaded(["seed"]), { onError: (error) => errors.push(error) });
+            });
+        });
+
+        fake.subscribeCalls[0]?.options.onError?.({ code: "UNAUTHORIZED", message: "session expired" });
+
+        expect(errors).toStrictEqual([{ code: "UNAUTHORIZED", message: "session expired" }]);
+
+        scope.stop();
+    });
+
     it("is Ref<T>, not Ref<T | undefined> — the seed makes undefined unreachable", () => {
         const fake = createFakeClient();
         const scope = effectScope();
@@ -283,6 +304,9 @@ describe(useQuery, () => {
         channelId.value = "b";
         await nextTick();
 
+        // The previous args' value must not render under the new args until the
+        // new subscription's first frame lands.
+        expect(data?.value).toBeUndefined();
         expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
         expect(fake.subscribeCalls).toHaveLength(2);
         expect(fake.subscribeCalls[1]?.args).toStrictEqual({ channelId: "b" });

--- a/packages/vue/__tests__/use-paginated-query.test.ts
+++ b/packages/vue/__tests__/use-paginated-query.test.ts
@@ -1,3 +1,4 @@
+import type { SubscriptionError } from "@lunora/client";
 import type { PaginationResult } from "@lunora/client/pagination";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref } from "vue";
@@ -88,6 +89,18 @@ describe("usePaginatedQuery (Vue)", () => {
         result.loadMore(NUM_ITEMS);
         await flushAsync();
 
+        // `loadMore` pins the open-ended page into a bounded `(null, cur-1]`
+        // range: the open-ended subscription closes and a fresh bounded one
+        // opens alongside the new tail. An open-ended subscription kept alive
+        // under the pinned key would keep serving `LIMIT n` rows across the
+        // boundary (duplicating/dropping rows on insert/delete) and never SPLIT.
+        expect(fake.subscribeCalls.map((call) => call.args["paginationOpts"])).toStrictEqual([
+            { cursor: null, endCursor: null, numItems: NUM_ITEMS },
+            { cursor: null, endCursor: "cur-1", numItems: NUM_ITEMS },
+            { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS },
+        ]);
+        expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
+
         // The second page subscription should have been opened.
         const secondPageArgs = { paginationOpts: { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS } };
         const secondPage: PaginationResult<{ id: string }> = {
@@ -101,6 +114,104 @@ describe("usePaginatedQuery (Vue)", () => {
 
         expect(result.results.value).toStrictEqual([...firstPageItems, ...secondPageItems]);
         expect(result.status.value).toBe("Exhausted");
+
+        scope.stop();
+    });
+
+    it("loadMore works again after a JOIN reproduces the cursor of the previous loadMore", async () => {
+        // JOIN fires below 0.5 × numItems: with 4 a bounded page of 1 item merges
+        // into its open-ended neighbour, and the merged page carries the pinned
+        // page's result — whose `continueCursor` is the very cursor the previous
+        // `loadMore` applied. The re-entrancy guard must not treat that as a
+        // repeat and turn `loadMore` into a permanent no-op.
+        const NUM = 4;
+        const fake = createFakeClient();
+        const scope = effectScope();
+        const result = scope.run(() => fake.provide(() => usePaginatedQuery(fn, {}, { initialNumItems: NUM })))!;
+
+        fake.push(
+            "messages:list",
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM } },
+            { continueCursor: "c1", isDone: false, page: [{ id: "1" }, { id: "2" }, { id: "3" }, { id: "4" }] },
+        );
+        await flushAsync();
+
+        result.loadMore(NUM);
+        await flushAsync();
+
+        fake.push(
+            "messages:list",
+            { paginationOpts: { cursor: "c1", endCursor: null, numItems: NUM } },
+            { continueCursor: null, isDone: true, page: [{ id: "5" }, { id: "6" }] },
+        );
+        await flushAsync();
+
+        // The pinned page shrinks below the JOIN threshold → merged back into one
+        // open-ended page whose carried result still reports `continueCursor: c1`.
+        fake.push(
+            "messages:list",
+            { paginationOpts: { cursor: null, endCursor: "c1", numItems: NUM } },
+            { continueCursor: "c1", isDone: false, page: [{ id: "x" }] },
+        );
+        await flushAsync();
+
+        expect(result.status.value).toBe("CanLoadMore");
+
+        const before = fake.subscribeCalls.length;
+
+        result.loadMore(NUM);
+        await flushAsync();
+
+        expect(fake.subscribeCalls.slice(before).map((call) => call.args["paginationOpts"])).toStrictEqual([
+            { cursor: null, endCursor: "c1", numItems: NUM },
+            { cursor: "c1", endCursor: null, numItems: NUM },
+        ]);
+        expect(result.status.value).toBe("LoadingMore");
+
+        scope.stop();
+    });
+
+    it("a page error surfaces on `error`, returns status to CanLoadMore, and lets loadMore retry", async () => {
+        const fake = createFakeClient();
+        const errors: SubscriptionError[] = [];
+        const scope = effectScope();
+        const result = scope.run(() => fake.provide(() => usePaginatedQuery(fn, {}, { initialNumItems: NUM_ITEMS, onError: (error) => errors.push(error) })))!;
+
+        fake.push(
+            "messages:list",
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            { continueCursor: "cur-1", isDone: false, page: firstPageItems },
+        );
+        await flushAsync();
+
+        result.loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(result.status.value).toBe("LoadingMore");
+
+        const tailArgs = { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS };
+        const tail = fake.subscribeCalls.find((call) => JSON.stringify(call.args["paginationOpts"]) === JSON.stringify(tailArgs));
+
+        // An RLS denial on the new page: without an error channel the feed sat
+        // in `LoadingMore` forever with `isLoading` true and nothing surfaced.
+        tail?.options.onError?.({ code: "FORBIDDEN", message: "denied" });
+        await flushAsync();
+
+        expect(errors).toStrictEqual([{ code: "FORBIDDEN", message: "denied" }]);
+        expect(result.error.value).toStrictEqual({ code: "FORBIDDEN", message: "denied" });
+        expect(result.status.value).toBe("CanLoadMore");
+        expect(result.isLoading.value).toBe(false);
+        expect(result.results.value).toStrictEqual(firstPageItems);
+
+        // The failed tail was dropped, so `loadMore` re-opens exactly that range.
+        const before = fake.subscribeCalls.length;
+
+        result.loadMore(NUM_ITEMS);
+        await flushAsync();
+
+        expect(result.error.value).toBeUndefined();
+        expect(result.status.value).toBe("LoadingMore");
+        expect(fake.subscribeCalls.slice(before).map((call) => call.args["paginationOpts"])).toStrictEqual([tailArgs]);
 
         scope.stop();
     });

--- a/packages/vue/__tests__/use-subscription.test.ts
+++ b/packages/vue/__tests__/use-subscription.test.ts
@@ -1,6 +1,6 @@
 import type { FunctionReference } from "@lunora/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { effectScope } from "vue";
+import { effectScope, nextTick, ref } from "vue";
 
 import { useSubscription } from "../src/use-subscription";
 import { createFakeClient } from "./fake-client";
@@ -57,6 +57,31 @@ describe(useSubscription, () => {
         scope.run(() => fake.provide(() => useSubscription(msgRef, "skip")))!;
 
         expect(fake.subscribeCalls).toHaveLength(0);
+
+        scope.stop();
+    });
+
+    it("resets data to undefined when reactive args change, until the new subscription pushes", async () => {
+        const fake = createFakeClient();
+        const scope = effectScope();
+        const channelId = ref("c1");
+        const { data } = scope.run(() =>
+            fake.provide(() =>
+                useSubscription(msgRef, () => {
+                    return { channelId: channelId.value };
+                }),
+            ),
+        )!;
+
+        fake.push("messages:subscribe", { channelId: "c1" }, [{ id: "1" }]);
+
+        expect(data.value).toStrictEqual([{ id: "1" }]);
+
+        channelId.value = "c2";
+        await nextTick();
+
+        expect(fake.subscribeCalls).toHaveLength(2);
+        expect(data.value).toBeUndefined();
 
         scope.stop();
     });

--- a/packages/vue/docs/index.mdx
+++ b/packages/vue/docs/index.mdx
@@ -93,7 +93,8 @@ the server pushes. This is the Vue equivalent of React's `useQuery`.
 
 `args` may be a plain value, a `ref`, or a getter. Passing a reactive source
 makes the subscription reactive: when the args change, the previous subscription
-is torn down and a fresh one opens for the new args. Pass `"skip"` (or a source
+is torn down, the ref resets to `undefined`, and a fresh one opens for the new
+args. Pass `"skip"` (or a source
 resolving to `"skip"`) to short-circuit: no network call, no socket. Multiple
 `useQuery` calls with identical args share a single underlying subscription (the
 client de-dupes by `(fn, args, shardKey)`).
@@ -234,6 +235,11 @@ mismatch. After seeding it opens the live WebSocket subscription on the same
 `(functionPath, args, shardKey)` the loader used, so every later delta updates
 the ref exactly like `useQuery`.
 
+Pass `{ onError }` as the second argument to observe a subscription-scoped error
+the server pushes after hydration (a session expiry, an RLS denial). Without it
+such an error is dropped and the ref keeps rendering the SSR snapshot as if it
+were live.
+
 ```vue
 <script setup lang="ts">
 import { hydratePreloaded } from "@lunora/vue";
@@ -252,7 +258,7 @@ const posts = hydratePreloaded(props.preloaded);
 </template>
 ```
 
-`subscribeToQuery(client, fn, args, { seed?, shardKey? })` is the lower-level
+`subscribeToQuery(client, fn, args, { seed?, shardKey?, onError? })` is the lower-level
 primitive `hydratePreloaded` builds on: it subscribes with **fixed** args
 (never reactive) and seeds the ref synchronously. Reach for it only when you
 already hold a client and immutable args; otherwise prefer `useQuery` or

--- a/packages/vue/src/hydrate-preloaded.ts
+++ b/packages/vue/src/hydrate-preloaded.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, Preloaded } from "@lunora/client";
+import type { FunctionReference, Preloaded, SubscriptionErrorCallback } from "@lunora/client";
 import type { Ref } from "vue";
 
 import { useLunora } from "./lunora-provider";
@@ -18,6 +18,10 @@ import { subscribeToQuery } from "./use-query";
  * The subscription tears down with the surrounding effect scope (component
  * unmount or `effectScope().stop()`), inherited from `subscribeToQuery`.
  *
+ * Pass `onError` to surface a subscription-scoped error the server pushes (a
+ * session expiry, an RLS denial). Without it such an error is dropped and the
+ * ref keeps rendering the SSR snapshot as if it were live.
+ *
  * The ref is `Ref<T>`, not `Ref<T | undefined>`: `subscribeToQuery`'s ref widens
  * to `undefined` because it also serves the unseeded `useQuery` case, but this
  * entry point always passes `seed: preloaded.value`, so the "seeded
@@ -26,7 +30,7 @@ import { subscribeToQuery } from "./use-query";
  * consumers guarding a state that cannot occur.
  */
 // eslint-disable-next-line import/prefer-default-export -- the package barrel re-exports every composable by name; a default here would break the `import { hydratePreloaded } from "@lunora/vue"` surface.
-export const hydratePreloaded = <T>(preloaded: Preloaded<T>): Ref<T> => {
+export const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: { onError?: SubscriptionErrorCallback } = {}): Ref<T> => {
     const client = useLunora();
 
     const { args, functionPath, shardKey, value } = preloaded;
@@ -37,6 +41,7 @@ export const hydratePreloaded = <T>(preloaded: Preloaded<T>): Ref<T> => {
     const functionReference: FunctionReference = { __lunoraRef: functionPath };
 
     return subscribeToQuery<FunctionReference, T>(client, functionReference, args, {
+        onError: options.onError,
         seed: value,
         shardKey,
     }) as Ref<T>;

--- a/packages/vue/src/use-paginated-core.ts
+++ b/packages/vue/src/use-paginated-core.ts
@@ -1,4 +1,4 @@
-import type { FunctionReference, Unsubscribe } from "@lunora/client";
+import type { FunctionReference, SubscriptionError, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
 import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
 import type { MaybeRefOrGetter, ShallowRef } from "vue";
@@ -18,6 +18,8 @@ const buildPageArgs = (page: Page, baseArgs: Record<string, unknown>): Record<st
 };
 
 interface PaginatedCoreVueResult<T> {
+    /** The last page subscription error; cleared by the next successful frame, `loadMore`, or an args change. */
+    error: ShallowRef<SubscriptionError | undefined>;
     /** Request another page off the open-ended tail. A no-op unless `status === "CanLoadMore"`. */
     loadMore: (numberItems: number) => void;
     /** Per-page resolved results in order; entries are `undefined` until a page resolves. */
@@ -38,13 +40,14 @@ interface PaginatedCoreVueResult<T> {
 const usePaginatedCore = <T>(
     function_: FunctionReference,
     args: MaybeRefOrGetter<"skip" | Record<string, unknown>>,
-    options: { initialNumItems: number; shardKey?: string },
+    options: { initialNumItems: number; onError?: SubscriptionErrorCallback; shardKey?: string },
 ): PaginatedCoreVueResult<T> => {
     const client = useLunora();
-    const { initialNumItems, shardKey } = options;
+    const { initialNumItems, onError, shardKey } = options;
 
     const pages = shallowRef<Page[]>(initialPages(initialNumItems));
     const pageResults = shallowRef<(PaginationResult<T> | undefined)[]>([]);
+    const error = shallowRef<SubscriptionError | undefined>(undefined);
 
     /**
      * The cursor the most recent `loadMore` applied. `pageResults` is only
@@ -52,24 +55,15 @@ const usePaginatedCore = <T>(
      * `loadMore` calls (a double-click before the next flush) would both read the
      * same stale tail and re-apply the same `nextCursor` — pinning the just-added
      * open tail into a degenerate empty range and appending a duplicate tail.
-     * Track the last-applied cursor and no-op a repeat within the same flush.
+     * Track the last-applied cursor and no-op a repeat within the same flush; the
+     * `pages` watcher clears it once that flush has run.
      */
     let lastLoadMoreCursor: null | string | undefined;
 
-    /**
-     * Each active subscription entry. `currentKey` is mutable so that when
-     * `loadMore` re-keys a pinned page, the callback still stores its result
-     * under the correct key without needing a closure rebind.
-     */
-    interface SubEntry {
-        currentKey: string;
-        unsub: Unsubscribe;
-    }
+    /** Active subscriptions keyed by page key; `loadMore` closes and reopens a re-keyed page. */
+    const activeSubs = new Map<string, Unsubscribe>();
 
-    /** Active subscriptions keyed by their ORIGINAL page key (stable across re-keys). */
-    const activeSubs = new Map<string, SubEntry>();
-
-    /** Results keyed by `currentKey`, kept in sync when `loadMore` re-keys pages. */
+    /** Results keyed by page key. */
     const resultsByKey = new Map<string, PaginationResult<T>>();
 
     /**
@@ -129,35 +123,28 @@ const usePaginatedCore = <T>(
             wantedKeys.add(buildPageKey(function_["__lunoraRef"], buildPageArgs(page, baseArgs)));
         }
 
-        // Close stale subscriptions (those whose currentKey is no longer wanted).
-        for (const [originalKey, entry] of activeSubs) {
-            if (!wantedKeys.has(entry.currentKey)) {
-                entry.unsub();
-                activeSubs.delete(originalKey);
-                resultsByKey.delete(entry.currentKey);
+        // Close stale subscriptions (those whose key is no longer wanted).
+        for (const [key, unsub] of activeSubs) {
+            if (!wantedKeys.has(key)) {
+                unsub();
+                activeSubs.delete(key);
+                resultsByKey.delete(key);
                 // Drop any pending marker for this key too — a page closed before
                 // its first result would otherwise orphan its key in
                 // `pendingPageKeys` forever, permanently disabling the
                 // `pendingPageKeys.size === 0` split/join rebalance gate below.
-                pendingPageKeys.delete(entry.currentKey);
+                pendingPageKeys.delete(key);
             }
         }
 
         // Open new subscriptions for pages that have no active sub.
-        const coveredKeys = new Set<string>([...activeSubs.values()].map((subEntry) => subEntry.currentKey));
-
         for (const page of currentPages) {
             const pageArgs = buildPageArgs(page, baseArgs);
             const key = buildPageKey(function_["__lunoraRef"], pageArgs);
 
-            if (coveredKeys.has(key)) {
+            if (activeSubs.has(key)) {
                 continue;
             }
-
-            const entry: SubEntry = {
-                currentKey: key,
-                unsub: undefined as unknown as Unsubscribe,
-            };
 
             // Mark this page as pending until its first result arrives.
             pendingPageKeys.add(key);
@@ -166,12 +153,11 @@ const usePaginatedCore = <T>(
                 function_,
                 pageArgs,
                 (value) => {
-                    // Write to entry.currentKey — this may have been updated by
-                    // `loadMore` re-keying without closing the subscription.
-                    resultsByKey.set(entry.currentKey, value as PaginationResult<T>);
+                    resultsByKey.set(key, value as PaginationResult<T>);
 
                     // This page has resolved; remove from the pending set.
-                    pendingPageKeys.delete(entry.currentKey);
+                    pendingPageKeys.delete(key);
+                    error.value = undefined;
 
                     // Rebuild the indexed array from the key map.
                     const currentBaseArgs = toValue(args) as Record<string, unknown>;
@@ -192,18 +178,40 @@ const usePaginatedCore = <T>(
                         }
                     }
                 },
-                { shardKey },
+                {
+                    onError: (subscriptionError) => {
+                        pendingPageKeys.delete(key);
+                        error.value = subscriptionError;
+
+                        // A tail that fails before its first frame is dropped so
+                        // the feed leaves `LoadingMore` (status falls back to the
+                        // previous page's cursor) and `loadMore` can retry it. The
+                        // first page has nothing to fall back to and stays.
+                        const current = pages.value;
+                        const tail = current.at(-1);
+
+                        if (
+                            current.length > 1 &&
+                            tail &&
+                            !resultsByKey.has(key) &&
+                            buildPageKey(function_["__lunoraRef"], buildPageArgs(tail, baseArgs)) === key
+                        ) {
+                            pages.value = current.slice(0, -1);
+                        }
+
+                        onError?.(subscriptionError);
+                    },
+                    shardKey,
+                },
             );
 
-            entry.unsub = unsub;
-            activeSubs.set(key, entry);
-            coveredKeys.add(key);
+            activeSubs.set(key, unsub);
         }
     };
 
     const teardownAll = (): void => {
-        for (const entry of activeSubs.values()) {
-            entry.unsub();
+        for (const unsub of activeSubs.values()) {
+            unsub();
         }
 
         activeSubs.clear();
@@ -235,6 +243,7 @@ const usePaginatedCore = <T>(
             teardownAll();
             pages.value = initialPages(initialNumItems);
             pageResults.value = [];
+            error.value = undefined;
             lastLoadMoreCursor = undefined;
 
             if (current !== "skip") {
@@ -250,6 +259,10 @@ const usePaginatedCore = <T>(
         () => pages.value,
         (currentPages) => {
             const current = toValue(args);
+
+            // The flush `lastLoadMoreCursor` guards against has run: `pageResults`
+            // is rebuilt below, so the next `loadMore` reads a fresh tail.
+            lastLoadMoreCursor = undefined;
 
             if (current !== "skip") {
                 syncSubscriptions(currentPages, current);
@@ -285,8 +298,7 @@ const usePaginatedCore = <T>(
 
         // Re-entrancy guard: a second synchronous call sees the same not-yet-
         // rebuilt tail result and the same `nextCursor` — skip it so we don't
-        // pin an empty range and append a duplicate tail (self-heals only via a
-        // JOIN pass, which finding-1's leak could otherwise disable forever).
+        // pin an empty range and append a duplicate tail.
         if (nextCursor === lastLoadMoreCursor) {
             return;
         }
@@ -298,39 +310,41 @@ const usePaginatedCore = <T>(
         }
 
         lastLoadMoreCursor = nextCursor;
+        error.value = undefined;
 
         // `applyLoadMore` pins the open-ended tail: the last page's args shift
-        // from `endCursor: null` to `endCursor: cursor`. Re-key the existing
-        // subscription entry (by updating its `currentKey`) and the result map
-        // so both survive without closing/reopening the socket subscription.
+        // from `endCursor: null` to `endCursor: cursor`. Close the old open-ended
+        // subscription, carry its result to the pinned key, and let the `pages`
+        // watcher's `syncSubscriptions` open a fresh bounded subscription for the
+        // pinned page — an open-ended subscription keeps serving `LIMIT n` rows
+        // and no `splitCursor`, so keeping it alive under the pinned key would
+        // duplicate/drop rows at the page boundary and never SPLIT.
         const oldTail = pages.value.at(-1);
         const newPinnedPage = next.at(-2); // `applyLoadMore` inserts the new tail last
 
         if (oldTail && newPinnedPage) {
             const oldKey = buildPageKey(function_["__lunoraRef"], buildPageArgs(oldTail, currentArgs));
             const newKey = buildPageKey(function_["__lunoraRef"], buildPageArgs(newPinnedPage, currentArgs));
-            const entry = activeSubs.get(oldKey);
+            const unsub = activeSubs.get(oldKey);
 
-            if (entry && oldKey !== newKey) {
-                // Update the entry's key so its callback writes to the right slot.
-                entry.currentKey = newKey;
-                // Re-register under the new key in activeSubs.
-                activeSubs.set(newKey, entry);
-                activeSubs.delete(oldKey);
-                // Migrate the stored result.
+            if (unsub && oldKey !== newKey) {
                 const carried = resultsByKey.get(oldKey);
 
                 if (carried) {
                     resultsByKey.set(newKey, carried);
-                    resultsByKey.delete(oldKey);
                 }
+
+                unsub();
+                activeSubs.delete(oldKey);
+                resultsByKey.delete(oldKey);
+                pendingPageKeys.delete(oldKey);
             }
         }
 
         pages.value = next;
     };
 
-    return { loadMore, pageResults, status };
+    return { error, loadMore, pageResults, status };
 };
 
 export type { PaginatedCoreVueResult };

--- a/packages/vue/src/use-paginated-query.ts
+++ b/packages/vue/src/use-paginated-query.ts
@@ -1,4 +1,4 @@
-import type { ArgsOf, FunctionReference, ReturnOf } from "@lunora/client";
+import type { ArgsOf, FunctionReference, ReturnOf, SubscriptionError, SubscriptionErrorCallback } from "@lunora/client";
 import type { PaginationStatus } from "@lunora/client/pagination";
 import type { MaybeRefOrGetter, Ref } from "vue";
 import { computed } from "vue";
@@ -14,10 +14,19 @@ type PageItemOf<F extends FunctionReference> = ReturnOf<F> extends { page: (infe
 interface UsePaginatedQueryOptions {
     /** Page size for the first page (and the default for `loadMore`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` ref). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface UsePaginatedQueryResult<T> {
+    /**
+     * The last page subscription error, or `undefined`. A tail page that fails
+     * before its first frame is dropped so `status` returns to `"CanLoadMore"`
+     * and `loadMore` can retry it; cleared by the next successful frame,
+     * `loadMore`, or an args change.
+     */
+    error: Ref<SubscriptionError | undefined>;
     /** `true` while the first page or a `loadMore` page is in flight. */
     isLoading: Ref<boolean>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
@@ -51,22 +60,26 @@ const usePaginatedQuery = <F extends FunctionReference>(
     args: MaybeRefOrGetter<"skip" | PaginatedArgs<F>>,
     options: UsePaginatedQueryOptions,
 ): UsePaginatedQueryResult<PageItemOf<F>> => {
-    const { loadMore, pageResults, status } = usePaginatedCore<PageItemOf<F>>(function_, args, options);
+    const { error, loadMore, pageResults, status } = usePaginatedCore<PageItemOf<F>>(function_, args, options);
 
     const results = computed<PageItemOf<F>[]>(() => pageResults.value.flatMap((result) => result?.page ?? []));
 
     const isLoading = computed<boolean>(() => status.value === "LoadingFirstPage" || status.value === "LoadingMore");
 
-    return { isLoading, loadMore, results, status };
+    return { error, isLoading, loadMore, results, status };
 };
 
 interface UseInfiniteQueryOptions {
     /** Page size for the first page (and the default for `fetchNextPage`). */
     initialNumItems: number;
+    /** Called when a page subscription reports an error (also surfaced on the `error` ref). */
+    onError?: SubscriptionErrorCallback;
     shardKey?: string;
 }
 
 interface UseInfiniteQueryResult<T> {
+    /** The last page subscription error, or `undefined` — see `UsePaginatedQueryResult.error`. */
+    error: Ref<SubscriptionError | undefined>;
     /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
     fetchNextPage: (numberItems?: number) => void;
     /** `true` when the loaded tail reports it can load another page. */
@@ -96,7 +109,7 @@ const useInfiniteQuery = <F extends FunctionReference>(
     options: UseInfiniteQueryOptions,
 ): UseInfiniteQueryResult<PageItemOf<F>> => {
     const { initialNumItems } = options;
-    const { loadMore, pageResults, status } = usePaginatedCore<PageItemOf<F>>(function_, args, options);
+    const { error, loadMore, pageResults, status } = usePaginatedCore<PageItemOf<F>>(function_, args, options);
 
     const pages = computed<PageItemOf<F>[][]>(() => pageResults.value.flatMap((result) => (result ? [result.page] : [])));
 
@@ -108,7 +121,7 @@ const useInfiniteQuery = <F extends FunctionReference>(
         loadMore(numberItems ?? initialNumItems);
     };
 
-    return { fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
+    return { error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
 };
 
 export type { PageItemOf, PaginatedArgs, UseInfiniteQueryOptions, UseInfiniteQueryResult, UsePaginatedQueryOptions, UsePaginatedQueryResult };

--- a/packages/vue/src/use-query.ts
+++ b/packages/vue/src/use-query.ts
@@ -1,4 +1,4 @@
-import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, Unsubscribe } from "@lunora/client";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import { createQuerySubscription } from "@lunora/client/query";
 import type { MaybeRefOrGetter, Ref } from "vue";
 import { shallowRef, toValue, watch } from "vue";
@@ -18,7 +18,9 @@ import type { UseQueryOptions } from "./types";
  * replays the last value synchronously, so multiple consumers of the same query
  * ride one server-side registration. `seed` sets the ref's value synchronously
  * before the subscription attaches, so the first read shows the SSR value with
- * no loading flash.
+ * no loading flash. `onError` receives a subscription-scoped error the server
+ * pushes (a session expiry, an RLS denial); without it the ref keeps rendering
+ * the seed as if it were live.
  *
  * Teardown is wired to the active effect scope (`onScopeDispose`), so it fires
  * on component unmount or `effectScope().stop()`. Call it inside `setup()` / an
@@ -30,7 +32,7 @@ export const subscribeToQuery = <F extends FunctionReference, T = ReturnOf<F>>(
     client: LunoraClient,
     function_: F,
     args: ArgsOf<F>,
-    options: { seed?: T; shardKey?: string } = {},
+    options: { onError?: SubscriptionErrorCallback; seed?: T; shardKey?: string } = {},
 ): Ref<T | undefined> => {
     // `shallowRef` — query results are replaced wholesale on every push, never
     // mutated in place, so deep reactivity would only add overhead.
@@ -46,7 +48,7 @@ export const subscribeToQuery = <F extends FunctionReference, T = ReturnOf<F>>(
             (value) => {
                 data.value = value as T;
             },
-            { shardKey: options.shardKey },
+            { onError: options.onError, shardKey: options.shardKey },
         );
 
         onScopeDisposeOrWarn(
@@ -66,8 +68,8 @@ export const subscribeToQuery = <F extends FunctionReference, T = ReturnOf<F>>(
  * updates on every delta the server pushes — the Vue-idiomatic equivalent of
  * React's `useQuery`. `args` may be a plain value, a `ref`, or a getter: passing
  * a reactive source makes the subscription reactive — when the args change the
- * old subscription is torn down and a fresh one opens for the new args (matching
- * `@lunora/react`/`@lunora/solid`). Pass `"skip"` (or a source resolving to
+ * old subscription is torn down, the ref resets to `undefined`, and a fresh one
+ * opens for the new args (matching `@lunora/react`/`@lunora/solid`). Pass `"skip"` (or a source resolving to
  * `"skip"`) to short-circuit: no network call, no socket. The subscription tears
  * down automatically when the owning component unmounts (or the effect scope
  * stops).
@@ -103,6 +105,10 @@ export const useQuery = <F extends FunctionReference>(
             if (!isBrowser()) {
                 return;
             }
+
+            // The previous args' value must not render under the new args until
+            // the new subscription's first frame lands.
+            data.value = undefined;
 
             const unsubscribe = createQuerySubscription(
                 client,

--- a/packages/vue/src/use-subscription.ts
+++ b/packages/vue/src/use-subscription.ts
@@ -35,9 +35,12 @@ const useSubscription = <F extends FunctionReference>(
     watch(
         () => toValue(args),
         (currentArgs, _previous, onCleanup) => {
+            // Each args generation starts clean: the previous args' value must not
+            // render under the new args until the new subscription's first frame.
+            data.value = undefined;
+            error.value = undefined;
+
             if (currentArgs === "skip") {
-                data.value = undefined;
-                error.value = undefined;
                 return;
             }
 


### PR DESCRIPTION
## What

Vue's paginated core re-keyed the open-ended subscription to the pinned key instead of closing it, so the bounded range was never subscribed: page one kept an open `LIMIT n` query, duplicated or dropped rows across the boundary on writes, and could never split. Svelte, Solid and Angular already did this right. Verified by execution.

## Changes (all four adapters)

- Paginated APIs accept `onError` and expose `error`; a page failure no longer freezes the feed at `LoadingMore`.
- `hydratePreloaded` forwards `onError` (Vue, Svelte, Solid).
- The value resets when reactive args change instead of showing the previous args' rows until the first frame.
- Svelte keeps the server error `code`; agent stores accept `onError`.

## Replica

Frames are diffed by primary key instead of re-inserting every row per frame into an unbounded event log; the log is bounded (1000, drop oldest); the `/since` catch-up is paged and the unused `/range` removed.

Chain 3 of 8, stacked on #547.

---

Every branch in this chain was verified on its own: `build:packages`, `api:update`/`api:check`, golden-fixture capture, `lint:generated`, `vis run lint:types --no-cache`, and the group's package tests, all exit 0. The full gate suite (eslint, prettier, package-json, whole-repo no-cache tests, prod build + `dist:check`) is green on the chain tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated and infinite queries now expose subscription errors and support optional error callbacks across Angular, Solid, Svelte, and Vue.
  * Reactive queries clear stale data and errors when arguments change or subscriptions are skipped.
  * Event synchronization and initialization now process event logs in bounded, paginated batches.
  * Event log responses now include pagination cursors and truncation status.
  * Mirror updates apply only changed rows and respect configured primary keys.
  * Subscription errors can be surfaced during agent and preloaded-data hydration flows.
* **Documentation**
  * Updated adapter and event synchronization documentation for error handling and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->