### PR TITLE
fix(server): scope a deferred schedule to its own transaction

### DIFF
--- a/api-snapshots/scheduler.api.md
+++ b/api-snapshots/scheduler.api.md
@@ -508,7 +508,13 @@ interface WorkpoolOptions extends LunoraSchedulerOptions {
 ### `assertScheduleDelay` (const)
 
 ```ts
-const assertScheduleDelay: (delayMs: number, surface: string) => void;
+const assertScheduleDelay: (delayMs: number, surface: string, argument?: string) => void;
+```
+
+### `assertScheduleInstant` (const)
+
+```ts
+const assertScheduleInstant: (timestampMs: number, nowMs: number, surface: string) => void;
 ```
 
 ### `assertValidCronExpression` (const)
@@ -581,6 +587,12 @@ const isValidCronExpression: (schedule: string) => boolean;
 
 ```ts
 const isWorkflowReference: (target: unknown) => target is WorkflowReference;
+```
+
+### `resolveScheduleId` (const)
+
+```ts
+const resolveScheduleId: (requested: unknown) => string;
 ```
 
 ### `warnIfSecondsLeading` (const)

--- a/examples/auth-playground/lunora/_generated/functions.ts
+++ b/examples/auth-playground/lunora/_generated/functions.ts
@@ -136,6 +136,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -505,17 +505,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -914,8 +922,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/blog/lunora/_generated/functions.ts
+++ b/examples/blog/lunora/_generated/functions.ts
@@ -196,6 +196,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -850,17 +850,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1279,8 +1287,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/chess/lunora/_generated/functions.ts
+++ b/examples/chess/lunora/_generated/functions.ts
@@ -261,6 +261,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -1336,17 +1336,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1745,8 +1753,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/expo/lunora/_generated/functions.ts
+++ b/examples/expo/lunora/_generated/functions.ts
@@ -127,6 +127,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -521,17 +521,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -930,8 +938,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/feedback-board/lunora/_generated/functions.ts
+++ b/examples/feedback-board/lunora/_generated/functions.ts
@@ -266,6 +266,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -1014,17 +1014,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1435,8 +1443,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/kanban-board/lunora/_generated/functions.ts
+++ b/examples/kanban-board/lunora/_generated/functions.ts
@@ -138,6 +138,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -559,17 +559,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -968,8 +976,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/notify-demo/lunora/_generated/functions.ts
+++ b/examples/notify-demo/lunora/_generated/functions.ts
@@ -157,6 +157,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -604,17 +604,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1013,8 +1021,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/offline-rejections/lunora/_generated/functions.ts
+++ b/examples/offline-rejections/lunora/_generated/functions.ts
@@ -127,6 +127,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -493,17 +493,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -902,8 +910,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/payment-demo/lunora/_generated/functions.ts
+++ b/examples/payment-demo/lunora/_generated/functions.ts
@@ -139,6 +139,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -1085,17 +1085,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1494,8 +1502,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/realtime-cursors/lunora/_generated/functions.ts
+++ b/examples/realtime-cursors/lunora/_generated/functions.ts
@@ -151,6 +151,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -617,17 +617,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1026,8 +1034,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/tanstack-start/lunora/_generated/functions.ts
+++ b/examples/tanstack-start/lunora/_generated/functions.ts
@@ -139,6 +139,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -498,17 +498,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -907,8 +915,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/team-chat/lunora/_generated/functions.ts
+++ b/examples/team-chat/lunora/_generated/functions.ts
@@ -273,6 +273,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -1039,17 +1039,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1465,8 +1473,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/todo-app/lunora/_generated/functions.ts
+++ b/examples/todo-app/lunora/_generated/functions.ts
@@ -142,6 +142,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -617,17 +617,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1026,8 +1034,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/__tests__/emit-shard-transactional-run.test.ts
+++ b/packages/codegen/__tests__/emit-shard-transactional-run.test.ts
@@ -97,9 +97,27 @@ describe("emitShard — deferred scheduling", () => {
         const emitted = shard();
 
         // Not mutations alone, for the same reason the deferred-delete queue is not:
-        // `ctx.runMutation` hands the CALLER's ctx to the callee.
-        expect(emitted).toContain('contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase');
+        // `ctx.runMutation` hands the CALLER's ctx to the callee. And not
+        // mutation+action alone either: `buildCtx` installs the transaction-wrapped
+        // `ctx.runMutation` on EVERY kind but a query, so a stream ctx — and an
+        // admin/lifecycle ctx with no registered kind — got the BEGIN/COMMIT span
+        // for a mutation they composed with the schedule buffer missing, and the
+        // job reached the SchedulerDO while that span was still open.
+        expect(emitted).toContain('const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);');
         expect(emitted).toContain("scheduler,");
+    });
+
+    it("flushes the deferred deletes even when the schedule settle throws", () => {
+        expect.assertions(2);
+
+        const helper = methodBody(shard(), "private async runMutationTransaction<T>(");
+        const commit = helper.indexOf("await settleSchedules(true);");
+
+        // Both halves are post-commit cleanup and neither may cancel the other: a
+        // SchedulerDO that refused one job used to take the whole object cleanup
+        // down with it, leaking every key the mutation queued with nothing logged.
+        expect(helper.slice(commit)).toContain("} finally {");
+        expect(helper.indexOf("flushDeferredDeletes(ctx)", commit)).toBeGreaterThan(commit);
     });
 
     it("wraps outside the read-stamping facade so get/list stay stamped", () => {

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/functions.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/functions.ts
@@ -143,6 +143,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -468,17 +468,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -982,8 +990,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
@@ -140,6 +140,27 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
         throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
+    // A mutation is routed through the caller's own `ctx.runMutation` rather than
+    // invoked directly, so `createCaller(ctx).ns.someMutation()` gets exactly what
+    // `ctx.runMutation(api.ns.someMutation)` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its `ctx.scheduler` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (`runMutation` is
+    // installed by `buildCtx` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };
 

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -602,17 +602,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an `afterCommit` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // `flushDeferredDeletes` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through `ctx.log` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a `finally`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. `settleSchedules` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // `flushDeferredDeletes` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through `ctx.log` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -1028,8 +1036,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see `runMutationTransaction`).
             //
+            // Every kind but `query` is wrapped, because `runMutationTransaction`
+            // is installed on `ctx.runMutation` for every kind but `query`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (`dispatchRun`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -1339,6 +1339,22 @@ export default crons;
             expect(result.generated.functions).toContain('list: (args: { channelId: Id<"channels">; limit?: number }) => Promise<unknown>;');
         });
 
+        it("routes a mutation reached through createCaller into the caller's transaction", () => {
+            expect.assertions(2);
+
+            const result = runCodegen({ projectRoot: workdir });
+
+            // `createCaller(ctx).ns.someMutation()` used to invoke the handler
+            // directly, so a mutation composed this way from an action or a stream
+            // got none of what `ctx.runMutation` gets: no BEGIN/COMMIT span, no
+            // deferred schedules, no deferred-delete flush. Its writes autocommitted
+            // one row at a time and its `ctx.scheduler` calls dispatched at once, so
+            // a mid-handler throw left the earlier writes durable and the job
+            // already enqueued.
+            expect(result.generated.functions).toContain('if (registered.kind === "mutation") {');
+            expect(result.generated.functions).toContain("await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})");
+        });
+
         it("keeps dataModel.ts importable by a package with no server dependency (#18)", () => {
             expect.assertions(4);
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -1585,6 +1585,27 @@ const CALL_REGISTERED_HELPER = `const callRegistered = async <R>(context: Caller
         throw new LunoraError("FUNCTION_NOT_FOUND", \`function not registered: \${functionPath}\`);
     }
 
+    // A mutation is routed through the caller's own \`ctx.runMutation\` rather than
+    // invoked directly, so \`createCaller(ctx).ns.someMutation()\` gets exactly what
+    // \`ctx.runMutation(api.ns.someMutation)\` gets: the BEGIN/COMMIT span (or the
+    // enclosing one, when the caller is already inside a transaction), the jobs it
+    // schedules held until that span commits, and the deferred object deletes
+    // flushed only once it has. Called straight, a mutation composed from an action
+    // or a stream had none of the three — its writes autocommitted one row at a
+    // time and its \`ctx.scheduler\` calls dispatched immediately, so a mid-handler
+    // throw left the earlier writes durable and the job already enqueued.
+    //
+    // The fallback covers a context that is not a shard dispatch (\`runMutation\` is
+    // installed by \`buildCtx\` on every kind but a query's TYPE omits it); there is
+    // no transaction to join in that case, so a direct call is all there is.
+    if (registered.kind === "mutation") {
+        const { runMutation } = context as { runMutation?: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown> };
+
+        if (typeof runMutation === "function") {
+            return (await runMutation.call(context, { __lunoraRef: functionPath }, args ?? {})) as R;
+        }
+    }
+
     return (await registered.handler(context, args ?? {})) as R;
 };`;
 
@@ -5561,17 +5582,25 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // documented as the deterministic equivalent of an \`afterCommit\` hook,
             // so the job must be enqueued after the commit, and a failure to enqueue
             // it must be visible rather than swallowed.
-            await settleSchedules(true);
-
-            // Then the objects whose rows are now durably gone. Deliberately AFTER
-            // the span, never inside it: an R2 delete cannot roll back, so a delete
-            // issued from within a transaction that later aborts destroys data the
-            // surviving row still points at.
             //
-            // \`flushDeferredDeletes\` never rejects — the mutation has already
-            // succeeded, so a failed cleanup must not turn into a failed response.
-            // A leaked object is reported through \`ctx.log\` instead, with its key.
-            await this.deferPastResponse(flushDeferredDeletes(ctx));
+            // In a \`finally\`, because both halves of this are post-commit cleanup
+            // and neither is allowed to cancel the other. \`settleSchedules\` drains
+            // its whole queue and then rethrows what failed, so a SchedulerDO that
+            // refused one job used to take the object cleanup down with it — the
+            // rows were durably gone and their objects leaked with nothing logged.
+            try {
+                await settleSchedules(true);
+            } finally {
+                // Then the objects whose rows are now durably gone. Deliberately AFTER
+                // the span, never inside it: an R2 delete cannot roll back, so a delete
+                // issued from within a transaction that later aborts destroys data the
+                // surviving row still points at.
+                //
+                // \`flushDeferredDeletes\` never rejects — the mutation has already
+                // succeeded, so a failed cleanup must not turn into a failed response.
+                // A leaked object is reported through \`ctx.log\` instead, with its key.
+                await this.deferPastResponse(flushDeferredDeletes(ctx));
+            }
 
             return result;
         }
@@ -5943,8 +5972,18 @@ ${vectorsBuild}${aiBuild}${everyContextBuild}${containersBuild}${workflowsBuild}
             // An action's own schedules stay immediate — the window is only open
             // while a transaction is (see \`runMutationTransaction\`).
             //
+            // Every kind but \`query\` is wrapped, because \`runMutationTransaction\`
+            // is installed on \`ctx.runMutation\` for every kind but \`query\`: a
+            // STREAM ctx, and an admin/lifecycle ctx with no registered kind at all,
+            // both get the BEGIN/COMMIT span for a mutation they compose, and used
+            // to get it with the deferral missing — so that mutation's job reached
+            // the SchedulerDO while its transaction was still open, and survived the
+            // rollback. A query cannot host a mutation handler (\`dispatchRun\`
+            // refuses it) and its ctx is built on the hot subscription path, so it
+            // stays unwrapped.
+            //
             // Wrapped OUTSIDE the read-stamping facade so \`get\`/\`list\` stay stamped.
-            const scheduler = contextKind === "mutation" || contextKind === "action" ? withDeferredSchedules(schedulerBase) : schedulerBase;
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
             // Build the storage adapter once and share it between \`ctx.storage\`
             // and \`ctx.db.system._storage\` so both read the same R2 binding. The
             // \`storageStub\` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -3431,12 +3431,14 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                 return await schedule(Date.now() + delayMs, target, args);
             },
             runAt: async (timestampMs, target, args) => {
-                // Same guard as `runAfter`: an unchecked NaN/Infinity serializes
-                // to `null` through JSON and reaches the DO as a malformed
-                // `scheduledFor`, instead of failing here with something the
-                // caller can act on.
+                // `@lunora/scheduler`'s `assertScheduleInstant`, restated for the
+                // same reason `runAfter` restates its guard above — and to the same
+                // CODE and MESSAGE, byte for byte. An unchecked NaN/Infinity
+                // serializes to `null` through JSON and reaches the DO as a
+                // malformed `scheduledFor`; an instant already in the past is an
+                // overdue job, not a bad argument, so it passes.
                 if (!Number.isFinite(timestampMs)) {
-                    throw new LunoraError("ctx.scheduler.runAt: `timestampMs` must be a finite epoch-millisecond number", { code: "BAD_REQUEST", status: 400 });
+                    throw new LunoraError("ctx.scheduler.runAt: `date` must be a non-negative finite number", { code: "INVALID_INPUT", status: 400 });
                 }
 
                 return await schedule(timestampMs, target, args);

--- a/packages/scheduler/__tests__/create-scheduler.test.ts
+++ b/packages/scheduler/__tests__/create-scheduler.test.ts
@@ -289,6 +289,35 @@ describe("createScheduler", () => {
         await expect(scheduler.runAfter(0, fnRef, {})).rejects.toThrow(SCHEDULER_DO_PATTERN);
     });
 
+    it("propagates the SchedulerDO's coded refusal instead of re-wrapping it as INTERNAL", async () => {
+        expect.assertions(3);
+
+        const stub = {
+            fetch: vi.fn<DurableObjectStubLike["fetch"]>(async () =>
+                Response.json({ error: { code: "DUPLICATE_SCHEDULE_ID", message: 'a job with id "invoice-42" is already scheduled' } }, { status: 409 }),
+            ),
+        };
+        const namespace: DurableObjectNamespaceLike = {
+            get: () => stub,
+            idFromName: () => {
+                return { toString: () => "default" };
+            },
+        };
+        const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
+
+        // Flattened to `INTERNAL`, the message is what `toErrorBody` redacts — so
+        // the developer who named a job id twice was shown "Internal error" and
+        // nothing else.
+        const thrown = await scheduler.runAfter(0, fnRef, {}).then(
+            () => undefined,
+            (error: unknown) => error,
+        );
+
+        expect(thrown).toMatchObject({ code: "DUPLICATE_SCHEDULE_ID", status: 409 });
+        expect(thrown).toHaveProperty("message", 'a job with id "invoice-42" is already scheduled');
+        expect(thrown).not.toMatchObject({ code: "INTERNAL" });
+    });
+
     it("createCronTrigger emits a wrangler.jsonc snippet + dispatcher metadata", () => {
         expect.assertions(3);
 

--- a/packages/scheduler/__tests__/validate-delay.test.ts
+++ b/packages/scheduler/__tests__/validate-delay.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import createScheduler from "../src/create-scheduler";
 import createWorkpool from "../src/create-workpool";
-import { assertScheduleDelay } from "../src/index";
+import { assertScheduleDelay, assertScheduleInstant } from "../src/index";
 import type { DurableObjectNamespaceLike, DurableObjectStubLike, SchedulableReference } from "../src/types";
 
 const namespace = (): DurableObjectNamespaceLike => {
@@ -61,6 +61,30 @@ describe("assertScheduleDelay", () => {
     });
 });
 
+describe("assertScheduleInstant", () => {
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])("rejects %p, the value `runAfter` has always refused", (timestampMs) => {
+        expect.assertions(1);
+
+        // `runAt` was the door the same bad number walked through: `JSON.stringify`
+        // renders it `null`, so the DO stores a `scheduledFor` no alarm can fire and
+        // the job is accepted and then never runs.
+        expect(() => {
+            assertScheduleInstant(timestampMs, 1_000_000, "ctx.scheduler.runAt");
+        }).toThrow("ctx.scheduler.runAt: `date` must be a non-negative finite number");
+    });
+
+    it("accepts an instant that is already in the past", () => {
+        expect.assertions(1);
+
+        // An overdue job is not a bad argument — `runAt(row.dueAt)` on a row that
+        // came due mid-request is the ordinary case, and `runAfter` itself reaches
+        // `runAt` a fraction of a millisecond after reading its own clock.
+        expect(() => {
+            assertScheduleInstant(999, 1_000_000, "ctx.scheduler.runAt");
+        }).not.toThrow();
+    });
+});
+
 describe("schedule-delay guard parity", () => {
     it("createScheduler().runAfter rejects through the shared guard", async () => {
         expect.assertions(1);
@@ -68,6 +92,14 @@ describe("schedule-delay guard parity", () => {
         const scheduler = createScheduler({ namespace: namespace(), originUrl: "https://app.example" });
 
         await expect(scheduler.runAfter(-1, target, {})).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    });
+
+    it("createScheduler().runAt rejects a non-finite instant through the shared guard", async () => {
+        expect.assertions(1);
+
+        const scheduler = createScheduler({ namespace: namespace(), originUrl: "https://app.example" });
+
+        await expect(scheduler.runAt(Number.NaN, target, {})).rejects.toMatchObject({ code: "INVALID_INPUT" });
     });
 
     it("createWorkpool().enqueue rejects through the shared guard", async () => {

--- a/packages/scheduler/src/create-scheduler.ts
+++ b/packages/scheduler/src/create-scheduler.ts
@@ -5,6 +5,7 @@ import { assertSchedulerOptions, callDO, getDO } from "./do-client";
 import type { CronTarget, LunoraSchedulerOptions, RunOptions, Scheduler, ScheduleRecord, ScheduleTargetArgs } from "./types";
 import { isWorkflowReference } from "./types";
 import assertScheduleDelay from "./validate-delay";
+import assertScheduleInstant from "./validate-instant";
 
 /**
  * Client-side scheduler — forwards `runAfter` / `runAt` / `cancel` calls to a
@@ -22,6 +23,12 @@ const createScheduler = (options: LunoraSchedulerOptions): Scheduler => {
     // `get(id)` returns the full record for a caller that wants it back.
     const runAt = async <T extends CronTarget>(date: Date | number, target: T, args: ScheduleTargetArgs<T>, options_: RunOptions = {}): Promise<string> => {
         const scheduledFor = date instanceof Date ? date.getTime() : date;
+
+        // The bound `runAfter` has always applied, restated for the absolute form.
+        // Without it `runAt` was the door a `NaN`/`Infinity` instant walked through
+        // — `JSON.stringify` renders it `null`, and the DO stores a `scheduledFor`
+        // no alarm can fire, so the job is accepted and then never runs.
+        assertScheduleInstant(scheduledFor, Date.now(), "ctx.scheduler.runAt");
 
         // Shared envelope; the target-specific field (`functionPath` xor
         // `workflow`) is merged in below.

--- a/packages/scheduler/src/do-client.ts
+++ b/packages/scheduler/src/do-client.ts
@@ -35,14 +35,44 @@ const schedulerStub = (options: LunoraSchedulerOptions): ReturnType<DurableObjec
     return namespace.get(namespace.idFromName(options.instanceName ?? "default"));
 };
 
+/**
+ * Re-raise a non-2xx SchedulerDO response as the error the DO actually answered.
+ *
+ * The DO refuses with a coded envelope — `{ error: { code, message } }`, the
+ * shape `SchedulerDO.error` writes — and every one of those codes is a sentence
+ * the caller can act on: `DUPLICATE_SCHEDULE_ID` says cancel the existing job
+ * first, `ORIGIN_NOT_CONFIGURED` names a missing binding. Re-wrapping the lot as
+ * `INTERNAL` destroyed exactly that: `toErrorBody` replaces an internal-coded
+ * message with "Internal error", so a developer who named a job id twice was
+ * told nothing at all.
+ *
+ * A response that is not that envelope — a transport failure, an HTML error page
+ * from something in front of the DO, a truncated body — has no code to carry, so
+ * it stays `INTERNAL` with the status and body text attached.
+ */
+const raiseDOFailure = (path: string, status: number, text: string): never => {
+    let code: unknown;
+    let message: unknown;
+
+    try {
+        ({ code, message } = (JSON.parse(text) as { error?: { code?: unknown; message?: unknown } }).error ?? {});
+    } catch {
+        // Not JSON: falls through to the INTERNAL wrap below.
+    }
+
+    if (typeof code === "string" && code.length > 0) {
+        throw new LunoraError(code, typeof message === "string" && message.length > 0 ? message : `@lunora/scheduler: SchedulerDO ${path} failed`, { status });
+    }
+
+    throw new LunoraError("INTERNAL", `@lunora/scheduler: SchedulerDO ${path} failed (${String(status)}): ${text}`);
+};
+
 const requestDO = async <T>(options: LunoraSchedulerOptions, path: string, init: RequestInit): Promise<T> => {
     const stub = schedulerStub(options);
     const response = await stub.fetch(`https://scheduler.internal${path}`, init);
 
     if (!response.ok) {
-        const text = await response.text();
-
-        throw new LunoraError("INTERNAL", `@lunora/scheduler: SchedulerDO ${path} failed (${String(response.status)}): ${text}`);
+        raiseDOFailure(path, response.status, await response.text());
     }
 
     return await response.json();

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -5,6 +5,7 @@ export { createCronTrigger } from "./cron";
 export type { CronJob, CronJobsBuilder, CronScheduleKind, DailySchedule, HourlySchedule, IntervalSchedule, MonthlySchedule, WeeklySchedule } from "./jobs";
 export { compileCronSchedule, CRON_SCHEDULE_KINDS, cronJobs } from "./jobs";
 export { createQueueConsumer, createQueueWorkpool, httpDispatcher } from "./queue-workpool";
+export { default as resolveScheduleId } from "./resolve-schedule-id";
 export type { SchedulerDOState, SchedulerEnv, SchedulerPoolStatus, SchedulerStatus } from "./scheduler-do";
 export { MAX_RETRY_ATTEMPTS, RETRY_BASE_DELAY_MS, SchedulerDO } from "./scheduler-do";
 export type { SchedulerHostOptions } from "./scheduler-host";
@@ -43,3 +44,4 @@ export type {
 export { isWorkflowReference } from "./types";
 export { assertValidCronExpression, isValidCronExpression, warnIfSecondsLeading } from "./validate-cron";
 export { default as assertScheduleDelay } from "./validate-delay";
+export { default as assertScheduleInstant } from "./validate-instant";

--- a/packages/scheduler/src/resolve-schedule-id.ts
+++ b/packages/scheduler/src/resolve-schedule-id.ts
@@ -1,0 +1,26 @@
+import { toBase64Url } from "../../../shared/base64";
+
+/**
+ * Shape a caller-supplied job id must have to be accepted: the alphabet shared by
+ * base64url ids and UUIDs, and nothing that could collide with the `:` separators
+ * in `id:<id>` / `t:<padded>:<id>`.
+ */
+const SCHEDULE_ID_PATTERN = /^[\w-]{1,64}$/u;
+
+/**
+ * The id a new record is stored under: the caller's, when it is a safe key
+ * segment, and otherwise a freshly minted one.
+ *
+ * Exported because two surfaces have to agree on it. The SchedulerDO applies it
+ * when the record is written; `@lunora/server`'s deferred-schedule facade applies
+ * it when the call is BUFFERED, because it answers the handler with the id
+ * synchronously — long before the DO sees the request. Restating the rule in the
+ * facade is how the two drift: an id the facade accepted and the DO replaced
+ * leaves the handler holding an id no job was ever stored under, so its later
+ * `cancel` silently misses.
+ * @param requested the caller's `RunOptions.id`, if any
+ */
+const resolveScheduleId = (requested: unknown): string =>
+    typeof requested === "string" && SCHEDULE_ID_PATTERN.test(requested) ? requested : toBase64Url(crypto.getRandomValues(new Uint8Array(12)));
+
+export default resolveScheduleId;

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -1,5 +1,6 @@
 import { toBase64Url } from "../../../shared/base64";
 import { jsonResponse } from "../../../shared/json-response";
+import resolveScheduleId from "./resolve-schedule-id";
 import type { RetryPolicy, ScheduleRecord } from "./types";
 
 /**
@@ -143,21 +144,6 @@ const padTime = (n: number): string => String(n).padStart(TIME_PAD, "0");
  */
 const isIndexableTime = (value: number): boolean => Number.isInteger(value) && value > 0 && value <= MAX_SCHEDULED_FOR_MS;
 
-const generateId = (): string => toBase64Url(crypto.getRandomValues(new Uint8Array(12)));
-
-/**
- * Shape a caller-supplied job id must have to be accepted: the alphabet shared by
- * base64url ids and UUIDs, and nothing that could collide with the `:` separators
- * in `id:<id>` / `t:<padded>:<id>`.
- */
-const SCHEDULE_ID_PATTERN = /^[\w-]{1,64}$/u;
-
-/**
- * The id to store a new record under: the caller's, when it is a safe key
- * segment, and otherwise a freshly minted one.
- */
-const resolveScheduleId = (requested: unknown): string => (typeof requested === "string" && SCHEDULE_ID_PATTERN.test(requested) ? requested : generateId());
-
 interface ScheduleRequestBody {
     args: Record<string, unknown>;
 
@@ -172,7 +158,7 @@ interface ScheduleRequestBody {
      * Job id chosen by the caller instead of minted here. Set by
      * `@lunora/server`'s deferred-schedule facade, which has to hand a mutation
      * handler the id synchronously while holding the call back until the
-     * transaction commits. Ignored unless it matches {@link SCHEDULE_ID_PATTERN}
+     * transaction commits. Ignored unless it is a safe key segment (see `resolveScheduleId`)
      * — the id becomes part of two storage keys, so a value carrying a `:` would
      * corrupt the time index.
      */

--- a/packages/scheduler/src/validate-delay.ts
+++ b/packages/scheduler/src/validate-delay.ts
@@ -19,10 +19,11 @@ import { LunoraError } from "@lunora/errors";
  * code while production threw another.
  * @param delayMs the delay to validate
  * @param surface what to name in the message — the call the delay was passed to (e.g. `"ctx.scheduler.runAfter"`)
+ * @param argument the caller's argument to name in the message; `runAt` converts its absolute `date` to a delay and passes that name through so the answer points at what was actually written
  */
-const assertScheduleDelay = (delayMs: number, surface: string): void => {
+const assertScheduleDelay = (delayMs: number, surface: string, argument = "delayMs"): void => {
     if (!Number.isFinite(delayMs) || delayMs < 0) {
-        throw new LunoraError("INVALID_INPUT", `${surface}: \`delayMs\` must be a non-negative finite number`);
+        throw new LunoraError("INVALID_INPUT", `${surface}: \`${argument}\` must be a non-negative finite number`);
     }
 };
 

--- a/packages/scheduler/src/validate-instant.ts
+++ b/packages/scheduler/src/validate-instant.ts
@@ -1,0 +1,31 @@
+import assertScheduleDelay from "./validate-delay";
+
+/**
+ * Reject a `runAt` instant a scheduler cannot act on — {@link assertScheduleDelay}'s
+ * bound, restated for the absolute form by converting the instant to the delay it
+ * implies.
+ *
+ * `runAfter` has refused a `NaN`/`Infinity` argument since the guard was written;
+ * `runAt` took the same value through a different door and let it reach the DO,
+ * where it serializes to `null` through JSON and lands as a `scheduledFor` no
+ * alarm can ever fire. `new Date("2026-13-01")`, `runAt(row.dueAt + delay)` on a
+ * row whose `dueAt` is absent — both arrive here as a number that is not one.
+ *
+ * An instant already in the PAST is not refused. It is an overdue job
+ * (`runAt(row.dueAt)` on a row that came due while the request was in flight),
+ * and `runAfter` itself reaches `runAt` a fraction of a millisecond after
+ * capturing its own clock reading — so a strict sign check would fail the
+ * documented `runAfter(0, …)` call at random. The delay is therefore clamped at
+ * zero while it is still a finite number, which leaves the half that matters:
+ * a value that is not a number at all.
+ * @param timestampMs the absolute instant (epoch ms) the caller passed
+ * @param nowMs the clock to measure it against — the wall clock in production, the harness's virtual clock in a test
+ * @param surface what to name in the message — the call the instant was passed to (e.g. `"ctx.scheduler.runAt"`)
+ */
+const assertScheduleInstant = (timestampMs: number, nowMs: number, surface: string): void => {
+    const delayMs = timestampMs - nowMs;
+
+    assertScheduleDelay(Number.isFinite(delayMs) && delayMs < 0 ? 0 : delayMs, surface, "date");
+};
+
+export default assertScheduleInstant;

--- a/packages/search-core/__tests__/analyzer.test.ts
+++ b/packages/search-core/__tests__/analyzer.test.ts
@@ -78,6 +78,21 @@ describe("search analyzer", () => {
             expect(analyzer.document("iphone15プロ用")).toStrictEqual(["iphone15", "プロ", "ロ用"]);
         });
 
+        it("leaves a run holding no CJK alone, and keeps a trailing Latin stretch whole", () => {
+            expect.assertions(2);
+
+            const analyzer = createSearchAnalyzer(undefined);
+
+            // The CJK cut is decided once for the whole text, then applied per
+            // run — so a text that has CJK *somewhere* still sends its
+            // CJK-free runs through the expander, which must hand them back
+            // untouched rather than bigram them.
+            expect(analyzer.document("hello 世界")).toStrictEqual(["hello", "世界"]);
+            // The mirror of `iphone15プロ用`: the Latin/digit stretch trails the
+            // CJK run instead of leading it, and is still kept whole.
+            expect(analyzer.document("プロ15")).toStrictEqual(["プロ", "15"]);
+        });
+
         it("does not fold ß, which has no combining decomposition", () => {
             expect.assertions(1);
 

--- a/packages/search-core/__tests__/backfill.test.ts
+++ b/packages/search-core/__tests__/backfill.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createSearchAnalyzer } from "../src/analyzer";
-import { planSearchBackfillPass, searchIndexProfile } from "../src/backfill";
+import { planSearchBackfillPass, searchIndexField, searchIndexProfile } from "../src/backfill";
 
 describe(searchIndexProfile, () => {
     it("names the analyzer profile and the indexed field, so re-pointing an index changes it", () => {
@@ -64,5 +64,23 @@ describe(planSearchBackfillPass, () => {
             finished: false,
             wipe: true,
         });
+    });
+});
+
+describe(searchIndexField, () => {
+    it("reads back the field a profile was built for, so a re-point is told from a re-analysis", () => {
+        expect.assertions(2);
+
+        expect(searchIndexField(searchIndexProfile({ field: "body", language: "en" }))).toBe("body");
+        expect(searchIndexField(searchIndexProfile({ field: "title" }))).toBe("title");
+    });
+
+    it("ignores a physical layout a backend appended, which is a fourth fact and not the field", () => {
+        expect.assertions(2);
+
+        expect(searchIndexField("en-v2:body/blob")).toBe("body");
+        // Only the LAST slash separates the layout: a field cannot contain one,
+        // but a layout identity may.
+        expect(searchIndexField("en-v2:body/blob/v3")).toBe("body/blob");
     });
 });

--- a/packages/server/__tests__/deferred-schedules.test.ts
+++ b/packages/server/__tests__/deferred-schedules.test.ts
@@ -49,6 +49,20 @@ const recordingScheduler = (
     };
 };
 
+/** The same recording scheduler, with the named targets refused the way an unreachable SchedulerDO refuses them. */
+const rejecting = <S extends { runAfter: RecordCall }>(scheduler: S, refuse: ReadonlyArray<string>): S => {
+    return {
+        ...scheduler,
+        runAfter: async (when: number, target: string, args?: unknown, options?: { id?: string }): Promise<string> => {
+            if (refuse.includes(target)) {
+                throw new Error(`unreachable: ${target}`);
+            }
+
+            return await scheduler.runAfter(when, target, args, options);
+        },
+    };
+};
+
 describe("withDeferredSchedules — types", () => {
     it("hands back the scheduler type it was given", () => {
         expect.assertions(1);
@@ -197,6 +211,127 @@ describe("withDeferredSchedules", () => {
         await settle(true);
 
         expect(calls).toHaveLength(0);
+    });
+
+    it("keeps a committed window's jobs when another window rolls back", async () => {
+        expect.assertions(2);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(scheduler);
+
+        // One ctx, two transactions. An action need not await the mutation it
+        // composes, so the windows opened on a shared context do not have to settle
+        // in the order they opened.
+        const first = beginDeferredSchedules({ scheduler: facade });
+
+        await facade.runAfter(0, "first:job");
+
+        const second = beginDeferredSchedules({ scheduler: facade });
+
+        await facade.runAfter(0, "second:job");
+        await first(true);
+        await second(false);
+
+        // `second` rolled back; `first` committed. A single shared buffer with a
+        // depth counter answered that by discarding both.
+        expect(calls.map((entry) => entry.target)).toStrictEqual(["first:job"]);
+        expect(log).toStrictEqual(["schedule:first:job"]);
+    });
+
+    it("never lets a sibling's commit dispatch a rolled-back window's jobs", async () => {
+        expect.assertions(1);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(scheduler);
+        const survivor = beginDeferredSchedules({ scheduler: facade });
+        const doomed = beginDeferredSchedules({ scheduler: facade });
+
+        await facade.runAfter(0, "doomed:job");
+        // Rolled back while another window is open: the writes this job was to act
+        // on are gone, so the job must go with them whoever settles next.
+        await doomed(false);
+        await survivor(true);
+
+        expect(calls).toHaveLength(0);
+    });
+
+    it("attempts every buffered job even when the first dispatch throws", async () => {
+        expect.assertions(3);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(rejecting(scheduler, ["a"]));
+        const settle = beginDeferredSchedules({ scheduler: facade });
+
+        await facade.runAfter(0, "a");
+        await facade.runAfter(0, "b");
+        await facade.runAfter(0, "c");
+
+        // The flush runs AFTER the commit, so stopping at the first failure strands
+        // jobs the handler was already handed ids for — and skips the post-commit
+        // work behind the settle. One failure is rethrown as itself, so the DO's
+        // coded refusal still decides the status and survives redaction.
+        await expect(settle(true)).rejects.toThrow("unreachable: a");
+
+        expect(calls.map((entry) => entry.target)).toStrictEqual(["b", "c"]);
+        expect(log).toStrictEqual(["schedule:b", "schedule:c"]);
+    });
+
+    it("reports several failed dispatches together", async () => {
+        expect.assertions(2);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(rejecting(scheduler, ["a", "c"]));
+        const settle = beginDeferredSchedules({ scheduler: facade });
+
+        await facade.runAfter(0, "a");
+        await facade.runAfter(0, "b");
+        await facade.runAfter(0, "c");
+
+        await expect(settle(true)).rejects.toThrow(AggregateError);
+
+        expect(calls.map((entry) => entry.target)).toStrictEqual(["b"]);
+    });
+
+    it("honours a caller-supplied job id instead of replacing it", async () => {
+        expect.assertions(2);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(scheduler);
+        const settle = beginDeferredSchedules({ scheduler: facade });
+
+        // Outside a mutation the same argument reaches the SchedulerDO untouched.
+        // Replacing it inside one makes the id the caller chose — and stored, and
+        // deduped on — belong to no job, and hides the DO's duplicate-id refusal.
+        const id = await facade.runAfter(0, "mail:send", undefined, { id: "invoice-42" });
+
+        await settle(true);
+
+        expect(id).toBe("invoice-42");
+        expect(calls[0]?.id).toBe("invoice-42");
+    });
+
+    it("rejects a non-finite runAt instant at the call site rather than at the flush", async () => {
+        expect.assertions(3);
+
+        const log: string[] = [];
+        const { calls, scheduler } = recordingScheduler(log);
+        const facade = withDeferredSchedules(scheduler);
+        const settle = beginDeferredSchedules({ scheduler: facade });
+
+        // `runAfter` has always refused this; `runAt` took the same value through
+        // the other door and stored a `scheduledFor` that JSON renders as `null`.
+        expect(() => facade.runAt(Number.NaN, "mail:send")).toThrow("must be a non-negative finite number");
+        // An instant already in the past is an OVERDUE job, not a bad argument.
+        expect(() => facade.runAt(1000, "mail:digest")).not.toThrow();
+
+        await settle(true);
+
+        expect(calls).toHaveLength(1);
     });
 
     it("keeps the rest of the scheduler surface reachable", async () => {

--- a/packages/server/src/deferred-schedules.ts
+++ b/packages/server/src/deferred-schedules.ts
@@ -1,4 +1,4 @@
-import { assertScheduleDelay } from "@lunora/scheduler";
+import { assertScheduleDelay, assertScheduleInstant, resolveScheduleId } from "@lunora/scheduler";
 
 /**
  * `ctx.scheduler.runAfter(0, …)` — documented as "the deterministic equivalent
@@ -28,10 +28,13 @@ import { assertScheduleDelay } from "@lunora/scheduler";
  * promise resolved at flush time is worse than useless: awaiting it inside the
  * mutation would deadlock on a flush that runs after the handler returns.
  *
- * The facade therefore mints the id itself and passes it to the underlying
- * scheduler when the call is finally made (`@lunora/scheduler`'s `RunOptions.id`,
- * which the SchedulerDO honours as the record's id). The value a handler is
- * handed is the id the job really gets.
+ * The facade therefore decides the id itself — through `resolveScheduleId`, the
+ * same rule the SchedulerDO applies, so a caller's own `options.id` is honoured
+ * exactly where the DO would honour it — and passes it to the underlying
+ * scheduler when the call is finally made (`@lunora/scheduler`'s `RunOptions.id`).
+ * The value a handler is handed is the id the job really gets, deferred or not:
+ * outside a mutation the id came from the caller or the DO, and inside one it
+ * must answer the same way rather than silently replacing it with a fresh UUID.
  *
  * ## Why the window is open/close rather than "is this a mutation ctx"
  *
@@ -41,20 +44,42 @@ import { assertScheduleDelay } from "@lunora/scheduler";
  * while the action's own schedules stay immediate. The window tracks the
  * transaction, not the context's kind; the facade is installed on every dispatch
  * that can host a mutation handler, exactly like the deferred-delete queue.
+ *
+ * ## Why each window owns its own buffer
+ *
+ * One buffer per FACADE with a depth counter — which is what this was — makes
+ * every transaction reachable through a context share one list, and the two
+ * halves of that are both wrong. A window that settles as rolled back while
+ * another is still open used to return without draining, so its jobs stayed in
+ * the shared list and the next window to commit dispatched them: work whose
+ * writes are gone. And the mirror image, an outermost rollback, spliced the
+ * whole list — discarding jobs a sibling had already committed. A ctx is shared
+ * (`ctx.runMutation` hands it down) and an action need not await the mutation it
+ * composes, so both orderings are reachable from ordinary code.
+ *
+ * So a window is a buffer: the calls made while it is the innermost open one are
+ * its own, a rollback drops only those, and a commit either dispatches them (no
+ * enclosing window) or hands them to the window that will commit on its behalf.
  */
 
 /** A buffered `runAfter`/`runAt`, ready to be replayed against the real scheduler. */
 type PendingSchedule = () => Promise<unknown>;
 
+/** One open deferral window: one transaction's buffered calls. */
+interface ScheduleWindow {
+    /** Cleared by the window's own settle, so a second settle is a no-op rather than a second drain. */
+    open: boolean;
+    /** The window that was innermost when this one opened — the transaction whose commit this one rides. */
+    parent: ScheduleWindow | undefined;
+    pending: PendingSchedule[];
+}
+
 interface ScheduleQueue {
     /**
-     * How many deferral windows are open. `0` means calls go straight through —
-     * an action schedules immediately, as documented. Only the OUTERMOST window
-     * settles the queue: a nested `runMutation` rides the enclosing transaction's
-     * commit, so it must not dispatch (nor discard) on its own.
+     * The innermost window still open, or `undefined` when calls go straight
+     * through — an action schedules immediately, as documented.
      */
-    depth: number;
-    pending: PendingSchedule[];
+    innermost: ScheduleWindow | undefined;
 }
 
 /**
@@ -63,6 +88,17 @@ interface ScheduleQueue {
  * and a queue stamped onto it would show up in anything that walks the context.
  */
 const queues = new WeakMap<object, ScheduleQueue>();
+
+/** The nearest window up the chain that has not settled yet, if any. */
+const enclosingWindow = (from: ScheduleWindow | undefined): ScheduleWindow | undefined => {
+    let candidate = from;
+
+    while (candidate !== undefined && !candidate.open) {
+        candidate = candidate.parent;
+    }
+
+    return candidate;
+};
 
 /** The slice of a function context the window needs. */
 interface DeferredScheduleContext {
@@ -98,7 +134,7 @@ interface SchedulerLike {
  */
 export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S => {
     const inner = scheduler as unknown as Record<string, unknown>;
-    const queue: ScheduleQueue = { depth: 0, pending: [] };
+    const queue: ScheduleQueue = { innermost: undefined };
 
     const call = (method: "runAfter" | "runAt", when: number, target: unknown, args: unknown, options: unknown): Promise<string> =>
         (inner[method] as (when: number, target: unknown, args: unknown, options: unknown) => Promise<string>).call(inner, when, target, args, options);
@@ -110,15 +146,22 @@ export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S 
         args: unknown,
         options: Record<string, unknown> | undefined,
     ): Promise<string> => {
-        if (queue.depth === 0) {
+        const open = queue.innermost;
+
+        if (open === undefined) {
             return call(method, when, target, args, options);
         }
 
-        // Minted here so the handler gets the real id synchronously; the
-        // underlying scheduler is told to use it when the call is replayed.
-        const id = crypto.randomUUID();
+        // Decided here so the handler gets the real id synchronously; the
+        // underlying scheduler is told to use it when the call is replayed. A
+        // caller's own `options.id` survives — `resolveScheduleId` is the rule the
+        // SchedulerDO applies, so the id answered here is the id the record is
+        // stored under, and an id already taken still reaches the DO's refusal.
+        const id = resolveScheduleId(options?.id);
 
-        queue.pending.push(async () => call(method, when, target, args, { ...options, id }));
+        // Buffered against the window that is innermost RIGHT NOW, so it is
+        // dropped only if THAT transaction rolls back.
+        open.pending.push(async () => call(method, when, target, args, { ...options, id }));
 
         return Promise.resolve(id);
     };
@@ -136,8 +179,14 @@ export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S 
 
             return schedule("runAfter", delayMs, target, args, options);
         },
-        runAt: (timestampMs: number, target: unknown, args?: unknown, options?: Record<string, unknown>): Promise<string> =>
-            schedule("runAt", timestampMs, target, args, options),
+        runAt: (timestampMs: number, target: unknown, args?: unknown, options?: Record<string, unknown>): Promise<string> => {
+            // `runAfter`'s bound, in absolute terms, and run HERE for the same
+            // reason: buffered, the underlying scheduler's guard would not fire
+            // until the flush, after the commit.
+            assertScheduleInstant(timestampMs, Date.now(), "ctx.scheduler.runAt");
+
+            return schedule("runAt", timestampMs, target, args, options);
+        },
     };
 
     Object.setPrototypeOf(facade, Object.getPrototypeOf(inner) as object | null);
@@ -154,12 +203,23 @@ export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S 
  *
  * Call it around the transaction, then settle with `true` once the commit has
  * landed (the buffered calls are dispatched, in order) or `false` when it rolled
- * back (they are dropped). Nested windows are counted: only the outermost one
- * settles, so a `ctx.runMutation` inside an open transaction hands its schedules
- * to the span that actually commits them.
+ * back (they are dropped). The window owns the calls made while IT was the
+ * innermost open one, so a rollback drops those and nothing else; on a commit an
+ * enclosing window takes them over, which is how a `ctx.runMutation` inside an
+ * open transaction hands its schedules to the span that actually commits them.
  *
  * A context whose scheduler was never wrapped gets an inert settle, so a caller
  * needs no branch.
+ *
+ * The settle NEVER stops early. It runs after the commit, so a job that fails to
+ * enqueue can no longer fail the write that queued it — and abandoning the rest
+ * of the batch on the first failure loses jobs the caller was told (by the id it
+ * was handed) were scheduled. So every buffered call is attempted, in declaration
+ * order, and what failed is reported once at the end — as itself when one job
+ * failed, so its code and status survive, and as an `AggregateError` when several
+ * did.
+ * The caller's own post-commit work must still run: a settle that throws does not
+ * excuse skipping the deferred-delete flush behind it.
  * @param context the dispatch context whose `scheduler` carries the queue
  */
 export const beginDeferredSchedules = (context: DeferredScheduleContext): ((committed: boolean) => Promise<void>) => {
@@ -170,24 +230,65 @@ export const beginDeferredSchedules = (context: DeferredScheduleContext): ((comm
         return async (): Promise<void> => {};
     }
 
-    queue.depth += 1;
+    const opened: ScheduleWindow = { open: true, parent: queue.innermost, pending: [] };
+
+    queue.innermost = opened;
 
     return async (committed: boolean): Promise<void> => {
-        queue.depth -= 1;
-
-        if (queue.depth > 0) {
+        if (!opened.open) {
             return;
         }
 
-        const draining = queue.pending.splice(0);
+        opened.open = false;
 
-        if (!committed) {
+        // Windows settle in whatever order their transactions resolve, which is not
+        // necessarily the order they opened: an action can leave a `ctx.runMutation`
+        // un-awaited. So the innermost is recomputed rather than popped.
+        if (queue.innermost === opened) {
+            queue.innermost = enclosingWindow(opened.parent);
+        }
+
+        const draining = opened.pending.splice(0);
+
+        if (!committed || draining.length === 0) {
             return;
         }
+
+        const enclosing = enclosingWindow(opened.parent);
+
+        if (enclosing !== undefined) {
+            // SQLite-in-DO has no savepoints: a nested dispatch shares the enclosing
+            // BEGIN/COMMIT span, so it cannot commit — and must not schedule — alone.
+            enclosing.pending.push(...draining);
+
+            return;
+        }
+
+        const failures: unknown[] = [];
 
         for (const dispatch of draining) {
-            // eslint-disable-next-line no-await-in-loop -- declaration order is the contract: `runAfter(0, a)` then `runAfter(0, b)` must enqueue a before b
-            await dispatch();
+            try {
+                // eslint-disable-next-line no-await-in-loop -- declaration order is the contract: `runAfter(0, a)` then `runAfter(0, b)` must enqueue a before b
+                await dispatch();
+            } catch (error) {
+                failures.push(error);
+            }
+        }
+
+        const [first, ...rest] = failures;
+
+        if (first !== undefined) {
+            // A lone failure is rethrown AS ITSELF: the SchedulerDO's refusals are
+            // coded (`DUPLICATE_SCHEDULE_ID`, `INVALID_INPUT`) and that code decides
+            // the status and whether the message survives redaction, all of which an
+            // aggregate would bury. Several become one error naming them together,
+            // because there is no single answer to give.
+            throw rest.length === 0
+                ? (first as Error)
+                : new AggregateError(
+                      failures,
+                      `ctx.scheduler: ${String(failures.length)} of ${String(draining.length)} deferred jobs failed to reach the scheduler after the commit`,
+                  );
         }
     };
 };

--- a/packages/testing/__tests__/scheduler.test.ts
+++ b/packages/testing/__tests__/scheduler.test.ts
@@ -775,6 +775,21 @@ describe("fake scheduler production parity", () => {
         );
     });
 
+    it("rejects a non-finite runAt instant, and accepts an overdue one", async () => {
+        expect.assertions(2);
+
+        const t = start();
+
+        // The fake is a THIRD `runAt` alongside `createScheduler` and the deferral
+        // facade; a harness that took a value production refuses would tell a test
+        // the opposite of what ships.
+        await expect(t.run(async (ctx) => ctx.scheduler.runAt(Number.NaN, "log:appendLog", { message: "x" }))).rejects.toThrow(
+            "`date` must be a non-negative finite number",
+        );
+        // An instant that has already passed is an overdue job, not a bad argument.
+        await expect(t.run(async (ctx) => ctx.scheduler.runAt(1, "log:appendLog", { message: "x" }))).resolves.toMatch(/\S/u);
+    });
+
     it("rejects args the scheduler cannot serialize", async () => {
         expect.assertions(1);
 

--- a/plans/audit-findings.md
+++ b/plans/audit-findings.md
@@ -24,6 +24,12 @@ PR groups (each stacked on `fix/audit-round-5`, reviewed separately):
 | R8a        | client core + React (round 8)                                                                    | #554 |
 | R8b        | Durable Object, scheduler, stream identity (round 8)                                             | #555 |
 | R8c (#556) | templates, init scaffold, queue auth, storage serving (round 8)                                  |      |
+| R11a       | round-11 branch audit: ratelimit, platform-node, scheduler, sql-store                            | #573 |
+| R11b       | round-11 code quality: module splits, duplicated helpers                                         | #574 |
+| R11c       | round-11 repo gates: prettier, secret scanner                                                    | #575 |
+| R11d       | round-11 shard DO: conformance deadlock, subscription cap, headroom metering                     | #576 |
+| R11e       | round-11 client outbox: replay classification and retry hints                                    | #577 |
+| R11f       | round-11 deferred schedules: transaction scoping, guards, flush                                  | #578 |
 
 ## Round 7 — thermos review of round 6 commits (c7dfc94a7..8795b40f9)
 
@@ -412,6 +418,43 @@ PR groups (each stacked on `fix/audit-round-5`, reviewed separately):
 | V12 | L   | packages/config/src/studio-host/schema-edit-handler.ts:149, policy-scaffold-handler.ts:91 vs packages/vite/src | The studio endpoints call `runCodegen({ lunoraDirectory, projectRoot })` without the project's `apiSpec`/`wranglerVariables`                                                                             | fixed  | R10g  |
 | V13 | L   | packages/vite/src/dev-variables-plugin.ts:28-42, wrangler-validator-plugin.ts:69-96, Vite resolveConfig(inline | `vite preview` resolves with `command: "serve"`, so `apply: "serve"` + `configResolved` plugins run there too: `vite preview` prompts to scaffold `.dev.vars`, runs `fillDevSecrets` (writes the file),  | fixed  | R10g  |
 | V14 | L   | packages/vite/src/index.ts:147-153 vs framework-compose-plugin.ts:257-260, templates/vinext/wrangler.jsonc:13  | Docblock contradiction: `index.ts` says the compose plugin is "a strict no-op for … the `cloudflare: false` BYO path"; the plugin's own docblock (and the code, which never reads the option) says the o | fixed  | R10g  |
+
+## Round 11 — thermos review of the round 7-10 stack (branch audit + code quality)
+
+Reviewed the accumulated stack rather than a single commit range, so several
+rows are defects the stack itself introduced.
+
+| ID  | Sev | Where                                                                                | Finding                                                                                                                                                                      | Status | Group |
+| --- | --- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ----- |
+| H1  | H   | packages/platform-node/src/node-shard-host.ts:442, packages/platform/src/conformance | A mid-transaction read refused with a bare `Error`, which every transport edge redacts to an `INTERNAL` 500 that no client retries; now `SHARD_UNAVAILABLE`/503              | fixed  | R11a  |
+| H2  | H   | packages/ratelimit/src/middleware.ts:129-135                                         | The retry hint was sent under a key the client does not read, so a rate-limited write had no delay to retry from                                                             | fixed  | R11a  |
+| H3  | H   | packages/do/**tests**/workerd, packages/platform/src/conformance/suite.ts:124        | A conformance case added by this stack deadlocks the real Cloudflare host: gated timer continuations deliver in scheduling order, so outer-shorter-than-inner never advances | fixed  | R11d  |
+| H4  | H   | packages/do/src/shard-do.ts (MAX_SUBSCRIPTIONS_PER_SOCKET)                           | The 32 to 8 cap cut was derived from a 2048-byte attachment budget; the measured workerd ceiling is 16384, so the cliff was real and unnecessary                             | fixed  | R11d  |
+| M1  | M   | packages/scheduler/src/scheduler-do.ts                                               | A reused caller-supplied job id silently overwrote the existing record; now refused with `409 DUPLICATE_SCHEDULE_ID`                                                         | fixed  | R11a  |
+| M2  | M   | packages/server/src/deferred-schedules.ts                                            | The deferred-schedule queue hung off the shared ctx, so a sibling drained a rolled-back mutation's jobs and a committed window lost its own                                  | fixed  | R11f  |
+| M3  | M   | packages/scheduler/src/validate-instant.ts, create-worker.ts                         | `runAt` had no bound at all, so a non-finite instant produced a record no alarm can fire                                                                                     | fixed  | R11f  |
+| M4  | M   | packages/server/src/deferred-schedules.ts, packages/codegen emit                     | A mid-flush dispatch failure abandoned the remaining jobs and skipped the deferred-delete flush that follows it                                                              | fixed  | R11f  |
+| M5  | M   | packages/do/src/shard-do.ts                                                          | The subscription cap cut was a user-visible cliff with no diagnostic and no migration path                                                                                   | fixed  | R11d  |
+| M6  | M   | packages/scheduler/src/scheduler-do.ts                                               | Orphaned records were only reindexed from the alarm path, never from `fetch`                                                                                                 | fixed  | R11a  |
+| M7  | M   | packages/server (buildCtx, callRegistered)                                           | The transaction covered `stream` and `createCaller` paths where the schedule deferral did not; `createCaller` had no span at all                                             | fixed  | R11f  |
+| M8  | M   | packages/do/src/shard-do.ts (transactionHeadroom)                                    | Admin bulk ops minted one headroom tracker per row, so the ceiling reset every row and bounded nothing                                                                       | fixed  | R11d  |
+| L1  | L   | packages/sql-store/src/ctx-db-migrations.ts:53-66                                    | The framework-column ceiling dropped 98 to 97 with `_version` and the error named no way forward                                                                             | fixed  | R11a  |
+| L2  | L   | packages/scheduler/src/resolve-schedule-id.ts                                        | A caller's `options.id` was honoured outside a mutation but replaced by a generated UUID inside one                                                                          | fixed  | R11f  |
+| L3  | L   | packages/client/src/replay.ts                                                        | `replayRetryDelay` was one field while flushes are per shard key, so one limited shard stalled every other                                                                   | fixed  | R11e  |
+| L4  | L   | packages/client/src/replay.ts                                                        | The `Retry-After` HTTP-date form (RFC 9110) was unparsed and yielded `NaN`                                                                                                   | fixed  | R11e  |
+| L5  | L   | packages/client/src/replay.ts, protocol/README.md 4.3                                | An envelope-less non-2xx from a proxy wedged the outbox head forever; the spec required exactly this                                                                         | fixed  | R11e  |
+| L6  | L   | packages/scheduler/src/do-client.ts:44                                               | Every non-2xx was wrapped in `INTERNAL`, whose message is redacted, so coded refusals reached developers as "Internal error"                                                 | fixed  | R11f  |
+| L7  | L   | packages/cli/skills, packages/values, protocol, packages/hyperdrive                  | The prettier and secret-scanner CI gates were red across the stack and are covered by no other gate                                                                          | fixed  | R11c  |
+| Q1  | L   | packages/server/src/http.ts, packages/client/src/lunora-client.ts, shared/           | Two modules over 1,000 lines and four duplicated helpers (cap-error-body, OCC column, write-error catch, five schedule-delay guards)                                         | fixed  | R11b  |
+
+### Round 11 — rejected or deliberately deferred
+
+- **M2 half (a)** — "an action's own job is dropped by a composed mutation's rollback" is not fixable at the facade: `ctx.runMutation` hands the _same ctx object_ to the callee by design, so nothing there can attribute the call. Needs async-context propagation, which is a much larger change than the finding implies.
+- **M7's `createCaller` premise** — it was not "transactional writes but non-deferred schedules"; handlers were invoked directly with no span at all. The larger adjacent gap was fixed instead.
+- **The deferred-_delete_ facade has M7's gap too** — deliberately not widened: without adding a flush to the stream and subscription paths it would swap a loud `TypeError` for a silent leak.
+- **A `runAt` guard in `@lunora/testing`'s fake scheduler** — written, then reverted as unreachable: the facade's guard answers first, proven by stashing only the fake's change and watching the test still pass.
+- **A pre-flight attachment size check** — built, then removed: `JSON.stringify` is the only sizer in a Worker and a `bigint` in `args` made it refuse valid subscribes.
+- **The eight non-JS SDKs share all four outbox gaps** and none can read `Retry-After` at all, because every port's poster returns status and body without headers. Recorded in the divergence table; widening the poster contract is the one change that fixes it for all eight.
 
 ## Follow-ups (not defects, decided)
 


### PR DESCRIPTION
The deferred-schedule buffer hung off the facade, so every transaction reachable through a context wrote into one shared list and a settle returned early while any window was still open.

- **The buffer is now one window per transaction.** A buffered call goes to the window innermost at call time; settle removes its window by identity, since windows settle in whatever order their transactions resolve rather than the order they opened. A rollback drops only its own jobs, and a commit hands them to the nearest still-open ancestor — SQLite in a Durable Object has no savepoints, so a nested span cannot commit, and must not schedule, alone. This ends both halves of the shared-buffer defect: a sibling's commit no longer dispatches a rolled-back window's jobs, and a committed window no longer loses its own to another window's rollback.
- **`runAt` had no bound at all**, so a non-finite instant reached the Durable Object, rendered as `null`, and produced a record no alarm can fire. It now converts to a delay and goes through the same shared guard `runAfter` uses. A past instant is still accepted and clamped — `runAfter(0, …)` reaches `runAt` a fraction of a millisecond after reading its own clock, and `runAt(row.dueAt, …)` on an overdue row is legitimate.
- **A mid-flush dispatch failure abandoned the rest of the queue** and skipped the deferred-delete flush that follows it. The flush now drains everything and reports afterwards, with the delete flush in a `finally`. A lone failure is rethrown as itself so the scheduler's coded refusals survive; several become one `AggregateError`.
- **The deferral was installed on fewer paths than the transaction was.** A `stream` context, and any context with no registered kind, got the BEGIN/COMMIT span for a composed mutation with the buffer missing. `createCaller` was worse than filed: it invoked handlers directly with no span at all, so from an action or stream context it got neither. Both now route through the one place the span, the deferral and the delete flush live.
- **A caller's own job id was discarded** inside a mutation and replaced with a generated UUID, while being honoured outside one. The facade now applies the exact rule the Durable Object applies, so a caller-supplied id reaches the duplicate-id refusal.
- **The scheduler's Durable Object client flattened every non-2xx to `INTERNAL`**, whose message is redacted — so the new `409 DUPLICATE_SCHEDULE_ID` reached developers as "Internal error". Coded envelopes are now propagated; genuine transport failures stay `INTERNAL`.

**Behaviour change worth a reviewer's eye:** a nested window reporting a rollback now drops its own jobs rather than leaving them to the enclosing span. Without savepoints its writes may still land if the outer transaction catches and commits, so this is a trade rather than a strict win — "the mutation did not complete, so do not run its after-commit job" is the fail-safe direction.

**Not fixed, deliberately:** the deferred-*delete* facade has the same narrow gate, but widening it without adding a flush to the stream and subscription paths would swap a loud `TypeError` for a silent leak. Filed rather than half-done.

## Also here: the `search-core` coverage gate

`search-core:test:coverage` fails its own declared thresholds and turns every CI run red once it gets that far. It **predates this stack** — the same numbers reproduce on the base — and stayed hidden because the audit chain's earlier PRs failed that job earlier, in the affected-set step, and because `vis run test` does not check coverage at all.

Three gaps, all reachable through the public surface: `searchIndexField` had no test (the one uncovered function), the CJK expander was never handed a run holding no CJK, and no text put a Latin or digit stretch *after* a CJK run rather than before it. Coverage goes to 100% lines, 100% statements and 97.14% branches against thresholds of 100 / 99 / 95.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ