### PR TITLE
chore: open round 14 for review (do not merge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,91 @@
               "run": |
                   pnpm --filter "@lunora/${{ matrix.package }}" run test --project workerd
 
+    # `@lunora/hyperdrive`'s MySQL suites — the only gate proving the SQL the store
+    # core renders for a `.global()` MySQL backend actually executes. mysqld comes
+    # from `mysql-memory-server`, provisioned from npm like pglite and workerd
+    # rather than from a service container, so the job needs no `services:` block.
+    #
+    # The point of the job is that the suites cannot report green having run
+    # nothing. They skip when the binary is unobtainable, and no CI job had ever
+    # declared that mysqld was expected — so a suite that had never been observed
+    # to run reported success on every PR. `LUNORA_MYSQL_TESTS=1` turns that skip
+    # into a failure (`__tests__/_helpers/mysql-mem.ts`), and the assertion below
+    # closes the other half: a run that executes zero cases, or skips any, fails
+    # here instead of passing quietly.
+    "test-mysql":
+        "name": "MySQL integration (@lunora/hyperdrive)"
+        "if": "needs.files-changed.outputs.packages == 'true'"
+        "needs": "files-changed"
+        "runs-on": "ubuntu-latest"
+        "timeout-minutes": 20
+        "steps":
+            - "name": "Harden Runner"
+              "uses": "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411" # v2.19.4
+              "with":
+                  # `mysql-memory-server` fetches mysqld from cdn.mysql.com on first use.
+                  "egress-policy": "audit"
+
+            - "name": "Git checkout"
+              "uses": "anolilab/workflows/step/checkout-with-retry@6c16895f4c3b5273b373656988505d1a8264e78b" # main
+
+            - "name": "Setup resources and environment"
+              "uses": "anolilab/workflows/step/node@acba5fb15ac98ad23dec1ad233e40e1bb79c1dae" # v19.0.4
+              "with":
+                  "node-version": "22.15"
+                  "cache-prefix": "test-mysql"
+                  "install-node-gyp": "true"
+                  "skip-playwright": "true"
+                  "enable-nx-cache": "false"
+                  "run-npm-audit": "false"
+                  "run-signatures-audit": "false"
+
+            # The run step names its suites by path, so a fourth one added against the
+            # same harness would not be picked up and nothing else would notice — the
+            # same hazard the workerd matrix assertion above exists for.
+            - "name": "Assert the run covers every suite using the MySQL harness"
+              "run": |
+                  declared="$(grep -rl '_helpers/mysql-mem' packages/hyperdrive/__tests__/*.test.ts | sort | tr '\n' ' ')"
+                  expected='packages/hyperdrive/__tests__/create-hyperdrive.test.ts packages/hyperdrive/__tests__/global-collation-parity.test.ts packages/hyperdrive/__tests__/global-mysql.integration.test.ts '
+                  if [ "$declared" != "$expected" ]; then
+                    echo "::error file=.github/workflows/test.yml::Suites using the MySQL harness are [$declared] but this job runs [$expected]. Update the run step below."
+                    exit 1
+                  fi
+
+            - "name": "Build package and dependencies"
+              "run": |
+                  pnpm exec vis run build --query "project=hyperdrive"
+
+            - "name": "Run the MySQL suites against a real mysqld"
+              "env":
+                  "LUNORA_MYSQL_TESTS": "1"
+              "run": |
+                  pnpm --filter "@lunora/hyperdrive" run test \
+                      __tests__/create-hyperdrive.test.ts \
+                      __tests__/global-collation-parity.test.ts \
+                      __tests__/global-mysql.integration.test.ts \
+                      --reporter=default --reporter=json --outputFile.json=test-results/mysql.json
+
+            - "name": "Assert the suites executed their cases"
+              "run": |
+                  node -e '
+                      const { appendFileSync, readFileSync } = require("node:fs");
+
+                      const report = JSON.parse(readFileSync("packages/hyperdrive/test-results/mysql.json", "utf8"));
+                      const passed = report.numPassedTests;
+                      const skipped = report.numPendingTests + report.numTodoTests;
+
+                      appendFileSync(
+                          process.env.GITHUB_STEP_SUMMARY,
+                          `- MySQL parity on \`@lunora/hyperdrive\`: **${passed} cases executed** against a real mysqld (${skipped} skipped).\n`,
+                      );
+
+                      if (passed === 0 || skipped > 0) {
+                          console.error(`::error::The MySQL suites passed ${passed} and skipped ${skipped} cases. This job exists so the gate cannot pass by skipping.`);
+                          process.exit(1);
+                      }
+                  '
+
     "e2e":
         "name": "E2E (Playwright + Miniflare)"
         "if": "needs.files-changed.outputs.e2e == 'true'"
@@ -662,7 +747,7 @@
     # skipped (so a no-package-change PR with all jobs skipped still passes).
     "test-required-check":
         "name": "Check Test Run"
-        "needs": ["files-changed", "test", "test-workerd", "e2e", "templates", "worker-size", "sdk-conformance"]
+        "needs": ["files-changed", "test", "test-workerd", "test-mysql", "e2e", "templates", "worker-size", "sdk-conformance"]
         "if": "always()"
         "runs-on": "ubuntu-latest"
         "timeout-minutes": 5

--- a/api-snapshots/mcp.api.md
+++ b/api-snapshots/mcp.api.md
@@ -169,11 +169,25 @@ const OBSERVABILITY_TOOL_DEFINITIONS: ReadonlyArray<ToolDefinition>;
 type PaidMcpChargeConfig = X402ChargeSettings;
 ```
 
+### `PaidMcpExecutionContext` (interface)
+
+```ts
+interface PaidMcpExecutionContext {
+    waitUntil?: (promise: Promise<unknown>) => void;
+}
+```
+
+### `PaidMcpFetchHandler` (type)
+
+```ts
+type PaidMcpFetchHandler = (request: Request, env?: unknown, context?: PaidMcpExecutionContext) => Promise<Response>;
+```
+
 ### `PaidMcpServer` (interface)
 
 ```ts
 interface PaidMcpServer {
-    readonly fetchHandler: McpFetchHandler;
+    readonly fetchHandler: PaidMcpFetchHandler;
     paidTool: (options: RegisterPaidToolOptions, handler: ToolHandler) => void;
     tool: (options: RegisterToolOptions, handler: ToolHandler) => void;
 }

--- a/api-snapshots/mcp.api.md
+++ b/api-snapshots/mcp.api.md
@@ -25,6 +25,7 @@ const AGENT_STATUS_TOOL_NAME = "lunora_agent_status";
 
 ```ts
 interface AuthedMcpFetchHandlerOptions {
+    maxRequestBytes?: number;
     protect: McpAuthProtect;
     server: AuthedMcpServerOptions;
 }
@@ -46,6 +47,12 @@ interface CallAgentToolOptions {
     pollIntervalMs?: number;
     wait?: (ms: number) => Promise<void>;
 }
+```
+
+### `DEFAULT_MAX_REQUEST_BYTES` (const)
+
+```ts
+const DEFAULT_MAX_REQUEST_BYTES: number;
 ```
 
 ### `LOCAL_SERVER_NAME` (const)
@@ -133,6 +140,14 @@ type McpAuthProtect = (handler: (request: Request, claims: McpAccessTokenClaims)
 type McpFetchHandler = (request: Request) => Promise<Response>;
 ```
 
+### `McpFetchHandlerOptions` (interface)
+
+```ts
+interface McpFetchHandlerOptions extends LunoraMcpServerOptions {
+    maxRequestBytes?: number;
+}
+```
+
 ### `McpServerInfo` (interface)
 
 ```ts
@@ -198,6 +213,7 @@ interface PaidMcpServer {
 ```ts
 interface PaidMcpServerConfig {
     charge: PaidMcpChargeConfig;
+    maxRequestBytes?: number;
     serverInfo?: {
         name: string;
         version: string;
@@ -336,7 +352,7 @@ const createLunoraMcpServer: (options: LunoraMcpServerOptions) => Server;
 ### `createMcpFetchHandler` (const)
 
 ```ts
-const createMcpFetchHandler: (options: LunoraMcpServerOptions) => McpFetchHandler;
+const createMcpFetchHandler: (options: McpFetchHandlerOptions) => McpFetchHandler;
 ```
 
 ### `createPaidMcpServer` (const)

--- a/api-snapshots/notify.api.md
+++ b/api-snapshots/notify.api.md
@@ -201,8 +201,10 @@ interface PushBroadcastJob {
 ### `PushBroadcastPageOutcome` (interface)
 
 ```ts
-interface PushBroadcastPageOutcome extends BroadcastPageResult {
+interface PushBroadcastPageOutcome {
     failedIds: string[];
+    nextFilter?: SubscriptionFilter;
+    result: BroadcastResult;
 }
 ```
 
@@ -407,7 +409,7 @@ const fcmId: (token: string) => string;
 ### `isGoneError` (const)
 
 ```ts
-const isGoneError: (message: string | undefined) => boolean;
+const isGoneError: (message: string | undefined, kind?: StoredSubscription["kind"]) => boolean;
 ```
 
 ### `isNotifyDefinition` (const)
@@ -483,6 +485,15 @@ interface SubscribeToPushOptions {
 }
 ```
 
+### `SubscribeToPushResult` (interface)
+
+```ts
+interface SubscribeToPushResult {
+    replacedEndpoint?: string;
+    subscription: SerializedPushSubscription;
+}
+```
+
 ### `isPushSupported` (const)
 
 ```ts
@@ -492,7 +503,7 @@ const isPushSupported: () => boolean;
 ### `subscribeToPush` (const)
 
 ```ts
-const subscribeToPush: (options: SubscribeToPushOptions) => Promise<SerializedPushSubscription>;
+const subscribeToPush: (options: SubscribeToPushOptions) => Promise<SubscribeToPushResult>;
 ```
 
 ### `unsubscribeFromPush` (const)

--- a/api-snapshots/seed.api.md
+++ b/api-snapshots/seed.api.md
@@ -61,6 +61,7 @@ type SeedClient<InsertModel> = SeedClientState & {
 ```ts
 interface SeedClientOptions {
     defaultCount?: number;
+    now?: number;
     persist?: (table: string, rows: ReadonlyArray<Record<string, unknown>>) => Promise<void> | void;
     seed?: number;
 }

--- a/apps/docs/src/content/docs/concepts/notifications.mdx
+++ b/apps/docs/src/content/docs/concepts/notifications.mdx
@@ -65,17 +65,31 @@ write) and persist it with `ctx.push.register`:
 // client
 import { subscribeToPush } from "@lunora/notify/web";
 
-const subscription = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
-await client.mutation("registerDevice", { subscription });
+const { replacedEndpoint, subscription } = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
+await client.mutation("registerDevice", { replacedEndpoint, subscription });
 ```
+
+`replacedEndpoint` is set only after a **VAPID key rotation**, when the helper
+drops the stale browser subscription and mints a new one. The new subscription
+has a new endpoint — hence a new store id — so it never upserts over the old
+row, and every send to that row now answers `403 VapidPkHashMismatch`, which is
+(correctly) not a "gone" signal, so nothing prunes it either. Unregister it:
 
 ```ts
 // lunora/registerDevice.ts
+import { webPushId } from "@lunora/notify";
+
 import { mutation, v } from "@/lunora/_generated/server";
 
-export const registerDevice = mutation.input({ subscription: v.any() }).mutation(async ({ ctx, args: { subscription } }) => {
-    await ctx.push.register({ subscription, userId: ctx.auth?.userId });
-});
+export const registerDevice = mutation
+    .input({ replacedEndpoint: v.optional(v.string()), subscription: v.any() })
+    .mutation(async ({ ctx, args: { replacedEndpoint, subscription } }) => {
+        if (replacedEndpoint !== undefined) {
+            await ctx.push.unregister(webPushId(replacedEndpoint));
+        }
+
+        await ctx.push.register({ subscription, userId: ctx.auth?.userId });
+    });
 ```
 
 ## Send from an action
@@ -114,7 +128,7 @@ Move a large broadcast off the request path with
 [`@lunora/queue`](/docs/packages/queue).
 
 Each queue message delivers exactly **one bounded page** (250 subscriptions by
-default), so the consumer has to re-enqueue while `nextCursor` is set —
+default), so the consumer has to re-enqueue while `nextFilter` is set —
 discarding the result silently stops the broadcast after the first page and
 still acks the message as a success:
 
@@ -124,15 +138,13 @@ await enqueuePushBroadcast(ctx.queues.push, { payload: { title: "New drop", body
 
 // consumer (lunora/queues.ts)
 for (const message of batch.messages) {
-    const { failedIds, nextCursor } = await runPushBroadcastPage(ctx.push, message.body);
+    const { failedIds, nextFilter } = await runPushBroadcastPage(ctx.push, message.body);
 
-    if (nextCursor !== undefined) {
+    if (nextFilter !== undefined) {
         // More pages remain — enqueue the continuation. Each message still does
-        // only ONE bounded page of work.
-        await enqueuePushBroadcast(ctx.queues.push, {
-            filter: { ...message.body.filter, after: nextCursor },
-            payload: message.body.payload,
-        });
+        // only ONE bounded page of work. Pass `nextFilter` verbatim: it carries
+        // the cursor AND the remaining `filter.limit` budget.
+        await enqueuePushBroadcast(ctx.queues.push, { filter: nextFilter, payload: message.body.payload });
     }
 
     // Redeliver ONLY the recipients that failed. Retrying the whole page would
@@ -146,8 +158,13 @@ for (const message of batch.messages) {
 ```
 
 A page never throws on a partial failure — it reports `failedIds` alongside
-`nextCursor`, so one permanently-failing device cannot strand the cursor and
+`nextFilter`, so one permanently-failing device cannot strand the cursor and
 halt the broadcast for everyone behind it. Re-enqueue those ids with
-`retryIds`; that job throws while any of them still fail, so only the failing
-device reaches the dead-letter queue. A page that merely pruned gone
-subscriptions is a success.
+`retryIds`; that job throws while **all** of them still fail, so only the
+failing device reaches the dead-letter queue — once any recipient recovers it
+resolves instead, and the narrower retry never re-sends to a device the message
+already reached. A page that merely pruned gone subscriptions is a success.
+
+`filter.limit` is an overall audience cap here too: `nextFilter` carries the
+remaining budget and is `undefined` once it is spent, so the walk stops rather
+than granting each message a fresh `limit`.

--- a/examples/notify-demo/lunora/_generated/api.ts
+++ b/examples/notify-demo/lunora/_generated/api.ts
@@ -11,7 +11,7 @@ export interface ApiTypes {
         announce: FunctionReference<"mutation", { body: string; title: string }, Id<"announcements">>;
         broadcast: FunctionReference<"action", { body: string; title: string }, { failed: number; pruned: number; sent: number; total: number; }>;
         listAnnouncements: FunctionReference<"query", {}, { _id: Id<"announcements">; body: string; sentAt: number; title: string }[]>;
-        registerDevice: FunctionReference<"mutation", { subscription: { endpoint: string; keys: { auth: string; p256dh: string } } }, void>;
+        registerDevice: FunctionReference<"mutation", { replacedEndpoint?: string; subscription: { endpoint: string; keys: { auth: string; p256dh: string } } }, void>;
     };
 }
 

--- a/examples/notify-demo/lunora/_generated/functions.ts
+++ b/examples/notify-demo/lunora/_generated/functions.ts
@@ -82,6 +82,14 @@ return { "body": source["body"], "title": source["title"] };
 installCompiledValidatorMap(lunora_push_0.registerDevice.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (Object.getPrototypeOf(source) !== Object.prototype && Object.getPrototypeOf(source) !== null) return DEFER;
+let __has1 = false;
+let __val1;
+if (source["replacedEndpoint"] !== undefined) {
+if (typeof source["replacedEndpoint"] !== "string") return DEFER;
+if (source["replacedEndpoint"].length > 2048) return DEFER;
+__val1 = source["replacedEndpoint"];
+__has1 = true;
+}
 if (typeof source["subscription"] !== "object" || source["subscription"] === null || Array.isArray(source["subscription"])) return DEFER;
 if (Object.getPrototypeOf(source["subscription"]) !== Object.prototype && Object.getPrototypeOf(source["subscription"]) !== null) return DEFER;
 if (typeof source["subscription"]["endpoint"] !== "string") return DEFER;
@@ -92,9 +100,9 @@ if (typeof source["subscription"]["keys"]["auth"] !== "string") return DEFER;
 if (source["subscription"]["keys"]["auth"].length > 256) return DEFER;
 if (typeof source["subscription"]["keys"]["p256dh"] !== "string") return DEFER;
 if (source["subscription"]["keys"]["p256dh"].length > 256) return DEFER;
-const __obj1 = { "auth": source["subscription"]["keys"]["auth"], "p256dh": source["subscription"]["keys"]["p256dh"] };
-const __obj2 = { "endpoint": source["subscription"]["endpoint"], "keys": __obj1 };
-return { "subscription": __obj2 };
+const __obj2 = { "auth": source["subscription"]["keys"]["auth"], "p256dh": source["subscription"]["keys"]["p256dh"] };
+const __obj3 = { "endpoint": source["subscription"]["endpoint"], "keys": __obj2 };
+return { ...(__has1 ? { "replacedEndpoint": __val1 } : {}), "subscription": __obj3 };
 });
 
 /**
@@ -146,7 +154,7 @@ export interface Caller {
         announce: (args: { body: string; title: string }) => Promise<Id<"announcements">>;
         broadcast: (args: { body: string; title: string }) => Promise<{ failed: number; pruned: number; sent: number; total: number; }>;
         listAnnouncements: (args?: {}) => Promise<{ _id: Id<"announcements">; body: string; sentAt: number; title: string }[]>;
-        registerDevice: (args: { subscription: { endpoint: string; keys: { auth: string; p256dh: string } } }) => Promise<void>;
+        registerDevice: (args: { replacedEndpoint?: string; subscription: { endpoint: string; keys: { auth: string; p256dh: string } } }) => Promise<void>;
     };
 }
 

--- a/examples/notify-demo/lunora/_generated/openapi.json
+++ b/examples/notify-demo/lunora/_generated/openapi.json
@@ -263,6 +263,9 @@
                   "args": {
                     "additionalProperties": false,
                     "properties": {
+                      "replacedEndpoint": {
+                        "type": "string"
+                      },
                       "subscription": {
                         "additionalProperties": false,
                         "properties": {

--- a/examples/notify-demo/lunora/_generated/openapi.ts
+++ b/examples/notify-demo/lunora/_generated/openapi.ts
@@ -266,6 +266,9 @@ export const openApiSpec: Record<string, unknown> = {
                                     "args": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "replacedEndpoint": {
+                                                "type": "string"
+                                            },
                                             "subscription": {
                                                 "additionalProperties": false,
                                                 "properties": {

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -119,12 +119,12 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
-        "cacheKey": "nondeterministic_query_mutation:push:54:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:push:63:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in announce (push:54) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `announce` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in announce (push:63) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `announce` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -132,7 +132,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "announce",
             "file": "push",
             "kind": "mutation",
-            "line": 54
+            "line": 63
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",

--- a/examples/notify-demo/lunora/push.ts
+++ b/examples/notify-demo/lunora/push.ts
@@ -1,3 +1,4 @@
+import { webPushId } from "@lunora/notify";
 import { rateLimit } from "lunorash/ratelimit";
 
 import { makeRateLimiter } from "./ratelimit/schema.js";
@@ -30,6 +31,10 @@ interface AnnouncementDoc {
  */
 export const registerDevice = mutation
     .input({
+        // Set only after a VAPID rotation — the endpoint of the subscription the
+        // browser just replaced. Its server row is keyed on that endpoint, so
+        // nothing else will ever overwrite or prune it.
+        replacedEndpoint: v.optional(v.string().max(2048)),
         // The exact Web Push subscription shape, declared rather than `v.any()`:
         // this is a trust boundary (the endpoint is a URL the server will later
         // POST to), so the validator rejects anything else before it reaches the
@@ -43,7 +48,11 @@ export const registerDevice = mutation
         }),
     })
     .use(rateLimit(mutationLimiter, "write", byCaller))
-    .mutation(async ({ args: { subscription }, ctx }): Promise<void> => {
+    .mutation(async ({ args: { replacedEndpoint, subscription }, ctx }): Promise<void> => {
+        if (replacedEndpoint !== undefined) {
+            await ctx.push.unregister(webPushId(replacedEndpoint));
+        }
+
         await ctx.push.register({ subscription });
     });
 

--- a/examples/notify-demo/src/client/App.tsx
+++ b/examples/notify-demo/src/client/App.tsx
@@ -35,9 +35,12 @@ export const App = (): ReactElement => {
 
     const enablePush = async (): Promise<void> => {
         try {
-            const subscription = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey: VAPID_PUBLIC_KEY });
+            // `replacedEndpoint` is set only after a VAPID rotation: the stale
+            // subscription is dropped for a new one under a new endpoint, so the
+            // server row keyed on the old endpoint is orphaned until we say so.
+            const { replacedEndpoint, subscription } = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey: VAPID_PUBLIC_KEY });
 
-            await registerDevice({ subscription });
+            await registerDevice({ replacedEndpoint, subscription });
             setStatus("Device registered for push.");
         } catch (error) {
             setStatus(`Could not enable push: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/advisor/__tests__/flag-gates-security-with-unsafe-default-lint.test.ts
+++ b/packages/advisor/__tests__/flag-gates-security-with-unsafe-default-lint.test.ts
@@ -51,6 +51,74 @@ describe("flag_gates_security_with_unsafe_default", () => {
         expect(findings[1]?.detail).toContain("granting the guarded permission");
     });
 
+    // The kill-switch spelling is the common one, and it inverts the polarity:
+    // `disableRls: true` leaves RLS OFF for every request the flag backend can't
+    // be reached for. Scoring these off the un-negated token flagged the SAFE
+    // spelling and handed the user a remediation that creates the hole.
+    it.each([
+        ["disableRls", true],
+        ["rlsDisabled", true],
+        ["skipEnforcement", true],
+        ["disable_rls", true],
+        ["noGate", true],
+    ] as const)("flags the negated protection key %s defaulting %s", (key, defaultValue) => {
+        expect.assertions(2);
+
+        const findings = flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row(key, defaultValue, 1)], schema: schema() });
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.detail).toContain("granting the guarded permission");
+    });
+
+    it.each([["disableRls"], ["rlsDisabled"], ["skipEnforcement"], ["disable_rls"], ["noGate"]] as const)(
+        "does not flag the negated protection key %s defaulting false",
+        (key) => {
+            expect.assertions(1);
+
+            expect(flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row(key, false, 1)], schema: schema() })).toHaveLength(0);
+        },
+    );
+
+    // A double negation lands back on the un-negated polarity.
+    it("scores a doubly-negated key as un-negated", () => {
+        expect.assertions(2);
+
+        expect(flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("disableSkipRls", false, 1)], schema: schema() })).toHaveLength(1);
+        expect(flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("disableSkipRls", true, 1)], schema: schema() })).toHaveLength(0);
+    });
+
+    // `enforce` alone never matched the words teams actually write.
+    it.each([["skipEnforcement"], ["enforcementDisabled"], ["enforcedChecks"]] as const)("recognises the %s spelling of the enforce token", (key) => {
+        expect.assertions(1);
+
+        const flagged = [true, false].filter(
+            (defaultValue) => flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row(key, defaultValue, 1)], schema: schema() }).length > 0,
+        );
+
+        expect(flagged).toHaveLength(1);
+    });
+
+    // `disallow*` names a restriction, so it scores as a protection: default it
+    // `false` and the thing it disallows is allowed on every provider outage.
+    it("treats disallow* as a protection key", () => {
+        expect.assertions(2);
+
+        expect(flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("disallowUploads", false, 1)], schema: schema() })).toHaveLength(1);
+        expect(flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("disallowUploads", true, 1)], schema: schema() })).toHaveLength(0);
+    });
+
+    // The remediation is the finding's whole value; on a negated key "default it
+    // to `true`" is the instruction that opens the hole.
+    it("names the safe default in the finding detail", () => {
+        expect.assertions(2);
+
+        const [negated] = flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("disableRls", true, 1)], schema: schema() });
+        const [plain] = flagGatesSecurityWithUnsafeDefault.run({ flagSecurityDefaults: [row("enforceRls", false, 1)], schema: schema() });
+
+        expect(negated?.detail).toContain("default it to `false`");
+        expect(plain?.detail).toContain("default it to `true`");
+    });
+
     it("does not flag a permission key that defaults to the restrictive branch", () => {
         expect.assertions(1);
 

--- a/packages/advisor/__tests__/geo-index-field-not-geopoint.test.ts
+++ b/packages/advisor/__tests__/geo-index-field-not-geopoint.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { fromServerSchema } from "../src";
 import geoIndexFieldNotGeopoint from "../src/lints/static/geo-index-field-not-geopoint";
+import type { AdvisorSchema } from "../src/schema";
 
 const run = (schema: ReturnType<typeof defineSchema>) => geoIndexFieldNotGeopoint.run({ schema: fromServerSchema(schema) });
 
@@ -35,6 +36,24 @@ describe("geo_index_field_not_geopoint", () => {
             cacheKey: "geo_index_field_not_geopoint:places:by_location:location",
             metadata: { field: "location", index: "by_location", kind: "string", table: "places" },
         });
+    });
+
+    it("ignores a geo index over an Object.prototype member that is not a declared column", () => {
+        expect.assertions(1);
+
+        const schema: AdvisorSchema = {
+            tables: [
+                {
+                    columnKinds: { name: "string" },
+                    fields: ["name"],
+                    indexes: [{ fields: ["constructor"], kind: "geo", name: "by_location" }],
+                    name: "places",
+                    relations: [],
+                },
+            ],
+        };
+
+        expect(geoIndexFieldNotGeopoint.run({ schema })).toHaveLength(0);
     });
 
     it("ignores tables without a geo index", () => {

--- a/packages/advisor/__tests__/ratelimit-middleware-fail-open-lint.test.ts
+++ b/packages/advisor/__tests__/ratelimit-middleware-fail-open-lint.test.ts
@@ -46,6 +46,40 @@ describe("ratelimit_middleware_fail_open", () => {
         expect(findings).toHaveLength(1);
     });
 
+    it("does not flag a benign procedure that merely spells a sensitive token inside a word", () => {
+        expect.assertions(1);
+
+        // `updatePresets` contains "reset"; `snapshotPrune` and
+        // `listSlotProfiles` contain "otp". None is an auth/payment flow, and a
+        // lint documenting itself as high-precision must not claim they are.
+        const findings = ratelimitMiddlewareFailOpen.run({
+            failOpenGuards: [
+                { callee: "rateLimit", exportName: "updatePresets", failOpen: true, file: "presets", limitName: "presets", line: 1 },
+                { callee: "rateLimit", exportName: "snapshotPrune", failOpen: true, file: "snapshots", limitName: "snapshots", line: 2 },
+                { callee: "rateLimit", exportName: "listSlotProfiles", failOpen: true, file: "slots", limitName: "slots", line: 3 },
+            ],
+            schema: schema(),
+        });
+
+        expect(findings).toHaveLength(0);
+    });
+
+    it("still flags a sensitive word inside a longer camelCase or one-word name", () => {
+        expect.assertions(1);
+
+        const findings = ratelimitMiddlewareFailOpen.run({
+            failOpenGuards: [
+                { callee: "rateLimit", exportName: "signInWithEmail", failOpen: true, file: "auth", limitName: "", line: 1 },
+                { callee: "rateLimit", exportName: "loginHandler", failOpen: true, file: "auth", limitName: "", line: 2 },
+                { callee: "rateLimit", exportName: "createCheckoutSession", failOpen: true, file: "billing", limitName: "", line: 3 },
+                { callee: "rateLimit", exportName: "start", failOpen: true, file: "auth", limitName: "otp-start", line: 4 },
+            ],
+            schema: schema(),
+        });
+
+        expect(findings).toHaveLength(4);
+    });
+
     it("returns [] when failOpenGuards is undefined", () => {
         expect.assertions(1);
 

--- a/packages/advisor/__tests__/security-lints.test.ts
+++ b/packages/advisor/__tests__/security-lints.test.ts
@@ -75,6 +75,17 @@ describe("public_mutation_without_ratelimit", () => {
         });
     });
 
+    it("does not call a benign write auth-sensitive on a substring match", () => {
+        expect.assertions(2);
+
+        // "reset" inside `updatePresets`, "subscribe" inside `unsubscribeAll`.
+        const procedures = [procedure({ exportName: "updatePresets" }), procedure({ exportName: "unsubscribeAll" })];
+        const findings = publicMutationWithoutRatelimit.run({ procedureProtections: procedures, schema: schema() });
+
+        expect(findings.map((finding) => finding.metadata?.sensitive)).toStrictEqual([false, false]);
+        expect(findings.every((finding) => !finding.detail.includes("auth/abuse-sensitive"))).toBe(true);
+    });
+
     it("ignores rate-limited writes, internal functions, and queries", () => {
         expect.assertions(1);
 

--- a/packages/advisor/__tests__/ttl-field-not-timestamp.test.ts
+++ b/packages/advisor/__tests__/ttl-field-not-timestamp.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { fromServerSchema } from "../src";
 import ttlFieldNotTimestamp from "../src/lints/static/ttl-field-not-timestamp";
+import type { AdvisorSchema } from "../src/schema";
 
 const run = (schema: ReturnType<typeof defineSchema>) => ttlFieldNotTimestamp.run({ schema: fromServerSchema(schema) });
 
@@ -45,6 +46,19 @@ describe("ttl_field_not_timestamp", () => {
             cacheKey: "ttl_field_not_timestamp:sessions:expiresAt",
             metadata: { field: "expiresAt", kind: "string", table: "sessions" },
         });
+    });
+
+    it("ignores a TTL field that names an Object.prototype member but no declared column", () => {
+        expect.assertions(1);
+
+        // A bare `columnKinds[field]` index read resolves "toString" to the
+        // inherited function, which is neither undefined nor a time kind — an
+        // ERROR whose detail reads "is a function toString() { [native code] }".
+        const schema: AdvisorSchema = {
+            tables: [{ columnKinds: { token: "string" }, fields: ["token"], indexes: [], name: "sessions", relations: [], ttl: { field: "toString" } }],
+        };
+
+        expect(ttlFieldNotTimestamp.run({ schema })).toHaveLength(0);
     });
 
     it("ignores tables without a TTL policy", () => {

--- a/packages/advisor/src/lints/helpers.ts
+++ b/packages/advisor/src/lints/helpers.ts
@@ -117,6 +117,51 @@ export const isPiiColumn = (column: string): boolean => NORMALIZED_PII_NAMES.has
 export const PII_FIELD_NAMES: ReadonlySet<string> = new Set(PII_FIELD_NAME_LIST);
 
 /**
+ * `true` when `identifier` names one of `phrases`, matched on WORD boundaries.
+ *
+ * A substring scan matches a phrase ANYWHERE in the normalized string — `reset`
+ * inside `updatePresets`, `otp` inside `snapshotPrune` and `listSlotProfiles` —
+ * so plainly benign procedures come back tagged auth-sensitive. That is the
+ * false-positive class {@link isPiiColumn} and the flag-polarity lint's own
+ * tokenizer both exist to avoid, and a security lint that cries wolf on
+ * `updatePresets` is how a team learns to ignore the advisor.
+ *
+ * A phrase matches when its words appear as a contiguous run of `identifier`'s
+ * words (`signIn` matches `signInWithEmail`), or when the two normalize
+ * identically (the identifier `signin` matches the phrase `signIn`). List a
+ * phrase under every spelling a caller might write it as ONE word (`login` as
+ * well as `logIn`): `loginHandler` tokenizes to `["login", "handler"]` and
+ * shares no word with `logIn`.
+ */
+export const matchesNamePhrase = (identifier: string, phrases: ReadonlyArray<string>): boolean => {
+    const tokens = tokenize(identifier);
+    const normalized = normalize(identifier);
+
+    return phrases.some((phrase) => {
+        if (normalized === normalize(phrase)) {
+            return true;
+        }
+
+        const words = tokenize(phrase);
+
+        return words.length > 0 && tokens.some((_, start) => words.every((word, offset) => tokens[start + offset] === word));
+    });
+};
+
+/**
+ * The declared validator kind of `table`'s `column`, or `undefined` when the
+ * table has no such column (or the feeder carries no column kinds at all).
+ *
+ * `columnKinds` is a plain object, so a bare index read inherits from
+ * `Object.prototype`: a column named `toString`/`constructor` resolves to a
+ * function and a type lint reports an ERROR whose detail is `[native code]`.
+ * Own-property lookup keeps an undeclared column undeclared — the same hazard
+ * {@link shardKindsByTable} answers with a `Map`.
+ */
+export const columnKind = (table: AdvisorTable, column: string): string | undefined =>
+    table.columnKinds !== undefined && Object.hasOwn(table.columnKinds, column) ? table.columnKinds[column] : undefined;
+
+/**
  * Framework-managed columns every table has implicitly. They never appear in a
  * table's declared `fields`, so a column-resolution check must treat them as
  * always valid (an index or relation may legitimately reference `_id`).

--- a/packages/advisor/src/lints/static/browser-user-url-without-allowlist.ts
+++ b/packages/advisor/src/lints/static/browser-user-url-without-allowlist.ts
@@ -43,6 +43,14 @@ const browserUserUrlWithoutAllowlist: Lint = makeArgumentDerivedSinkLint<Advisor
     // `resolveDns` contains the SSRF surface — suppress every finding when one is
     // visible. Only an analyzable (non-spread, static object-literal) config call
     // counts; an opaque config could set the key elsewhere but can't be relied on.
+    //
+    // App-global on purpose, and sound because `ctx.browser` resolves from ONE
+    // `browser: (env) => createBrowser(...)` config thunk: every navigation this
+    // lint sees goes through that instance, so "a hardened createBrowser exists"
+    // and "the instance behind ctx.browser is hardened" are the same statement.
+    // A second `createBrowser` built for something else is not reachable as
+    // `ctx.browser`, and requiring EVERY call to be hardened would flag
+    // navigations that the allowlist does in fact contain.
     suppressWhen: (context) =>
         (context.configCalls ?? []).some(
             (call) =>

--- a/packages/advisor/src/lints/static/flag-gates-security-with-unsafe-default.ts
+++ b/packages/advisor/src/lints/static/flag-gates-security-with-unsafe-default.ts
@@ -1,5 +1,4 @@
 import emit from "../../finding";
-import type { AdvisorFlagSecurityDefault } from "../../flag-security-defaults";
 import type { Lint } from "../../types";
 
 /**
@@ -8,14 +7,31 @@ import type { Lint } from "../../types";
  * `true` (the protection stays on during a provider outage), so a `false`
  * default is unsafe.
  */
-const PROTECT_TOKENS = new Set(["enforce", "gate", "lockdown", "rls"]);
+const PROTECT_TOKENS = new Set(["disallow", "disallowed", "enforce", "enforced", "enforcement", "enforcing", "gate", "gated", "gating", "lockdown", "rls"]);
 
 /**
  * Security-shaped key tokens naming a *permission or bypass* the flag grants. The
  * fail-open-safe default for these is `false` (nothing is granted during a
  * provider outage), so a `true` default is unsafe.
  */
-const PERMIT_TOKENS = new Set(["allow", "bypass", "permit"]);
+const PERMIT_TOKENS = new Set(["allow", "allowed", "bypass", "bypassed", "permit", "permitted"]);
+
+/**
+ * Tokens that INVERT the key's polarity: they name turning the protection (or
+ * the permission) *off* rather than on.
+ *
+ * Without this, the whole kill-switch family is scored backwards.
+ * `ctx.flags.boolean("disableRls", true)` — RLS off for every request once the
+ * provider is unreachable — tokenizes to `["disable", "rls"]`, `rls` is a
+ * protect token, and a protect key defaulting `true` reads as safe: zero
+ * findings on the dangerous spelling, while the safe `disableRls: false` was
+ * flagged with a remediation telling the user to set it `true`.
+ *
+ * `disallow*` is deliberately NOT here: it names a restriction outright, so it
+ * scores as a protection token above (`disallowUploads: false` means uploads are
+ * allowed on an outage — unsafe, same as any protect key defaulting `false`).
+ */
+const NEGATION_TOKENS = new Set(["disable", "disabled", "no", "off", "skip", "skipped", "without"]);
 
 /**
  * Zero-width boundary between an acronym's last letter and a following
@@ -46,23 +62,31 @@ const tokenize = (key: string): string[] =>
         .filter((token) => token.length > 0);
 
 /**
- * Whether a security-shaped flag's boolean default selects the permissive branch
- * on a provider outage. A key with a *protection* token (`enforce`/`rls`/`gate`/
- * `lockdown`) is unsafe defaulting `false`; one with a *permission* token
- * (`allow`/`permit`/`bypass`) is unsafe defaulting `true`. A key with neither
- * family (e.g. a bare `auth`/`admin`, whose polarity is indeterminate) or with
- * both is deliberately not flagged — the lowest-false-positive subset.
+ * The boolean default that fails CLOSED for `key`, or `undefined` when the key's
+ * polarity is indeterminate.
+ *
+ * A key with a *protection* token (`enforce`/`rls`/`gate`/`lockdown`/`disallow`)
+ * must default `true`; one with a *permission* token (`allow`/`permit`/`bypass`)
+ * must default `false`. Each {@link NEGATION_TOKENS} token in the key flips that,
+ * so `disableRls`/`rlsDisabled`/`skipEnforcement` must default `false` — counted
+ * by parity, so a double negation (`disableSkipRls`) lands back on the
+ * un-negated polarity.
+ *
+ * A key with neither family (a bare `auth`/`admin`) or with both is deliberately
+ * indeterminate and never flagged — the lowest-false-positive subset.
  */
-const hasUnsafeDefault = (row: AdvisorFlagSecurityDefault): boolean => {
-    const tokens = tokenize(row.key);
+const safeDefaultFor = (key: string): boolean | undefined => {
+    const tokens = tokenize(key);
     const isProtect = tokens.some((token) => PROTECT_TOKENS.has(token));
     const isPermit = tokens.some((token) => PERMIT_TOKENS.has(token));
 
     if (isProtect === isPermit) {
-        return false;
+        return undefined;
     }
 
-    return isProtect ? !row.defaultValue : row.defaultValue;
+    const negated = tokens.filter((token) => NEGATION_TOKENS.has(token)).length % 2 === 1;
+
+    return negated ? !isProtect : isProtect;
 };
 
 /**
@@ -74,7 +98,9 @@ const hasUnsafeDefault = (row: AdvisorFlagSecurityDefault): boolean => {
  * a protection (`enforce*`/`rls*`/`gate*`/`lockdown*`) and defaults `false`, or
  * names a permission/bypass (`allow*`/`permit*`/`bypass*`) and defaults `true`,
  * a flag-backend outage silently disables the protection or grants the
- * permission for every request.
+ * permission for every request. A negating token in the key
+ * (`disable*`/`*Disabled`/`skip*`/`no*`) inverts that — see
+ * {@link safeDefaultFor}.
  *
  * Runs only when the codegen feeder supplies flag-default evidence
  * (`context.flagSecurityDefaults`); a runtime caller flags nothing. Deliberately
@@ -86,23 +112,27 @@ const hasUnsafeDefault = (row: AdvisorFlagSecurityDefault): boolean => {
 const flagGatesSecurityWithUnsafeDefault: Lint = {
     categories: ["SECURITY"],
     description:
-        "A `ctx.flags.boolean(key, default)` read on a security-shaped key has a fail-open default that selects the permissive branch. OpenFeature returns the default when the provider errors, so an outage silently disables a protection (a `false` default on an `enforce`/`rls`/`gate`/`lockdown` key) or grants a permission (a `true` default on an `allow`/`permit`/`bypass` key).",
+        "A `ctx.flags.boolean(key, default)` read on a security-shaped key has a fail-open default that selects the permissive branch. OpenFeature returns the default when the provider errors, so an outage silently disables a protection (a `false` default on an `enforce`/`rls`/`gate`/`lockdown` key) or grants a permission (a `true` default on an `allow`/`permit`/`bypass` key). A negating token in the key (`disableRls`, `rlsDisabled`, `skipEnforcement`) inverts which default is the safe one.",
     facing: "EXTERNAL",
     level: "WARN",
     name: "flag_gates_security_with_unsafe_default",
     remediation:
-        "Flip the default so a provider outage fails closed: default a protection flag (`enforce*`/`rls*`/`gate*`/`lockdown*`) to `true`, and a permission/bypass flag (`allow*`/`permit*`/`bypass*`) to `false`. The safe default is always the restrictive branch — never let an unreachable flag backend open access.",
+        "Flip the default so a provider outage fails closed — the finding's own detail names the value to write. The safe default is always the RESTRICTIVE branch, which is not a fixed value: a protection flag (`enforce*`/`rls*`/`gate*`/`lockdown*`/`disallow*`) defaults `true` and a permission/bypass flag (`allow*`/`permit*`/`bypass*`) defaults `false`, but a negated key (`disableRls`, `rlsDisabled`, `skipEnforcement`) inverts both. Never let an unreachable flag backend open access.",
     run: (context) => {
         if (context.flagSecurityDefaults === undefined) {
             return [];
         }
 
         return context.flagSecurityDefaults
-            .filter((row) => hasUnsafeDefault(row))
+            .filter((row) => {
+                const safeDefault = safeDefaultFor(row.key);
+
+                return safeDefault !== undefined && safeDefault !== row.defaultValue;
+            })
             .map((row) =>
                 emit(flagGatesSecurityWithUnsafeDefault, {
                     cacheKey: `flag_gates_security_with_unsafe_default:${row.file}:${row.line.toString()}`,
-                    detail: `\`ctx.flags.boolean("${row.key}", ${String(row.defaultValue)})\` in \`${row.exportName}\` (${row.file}:${row.line.toString()}) fails open to the permissive branch — a provider outage returns \`${String(row.defaultValue)}\`, ${row.defaultValue ? "granting the guarded permission" : "disabling the guarded protection"}.`,
+                    detail: `\`ctx.flags.boolean("${row.key}", ${String(row.defaultValue)})\` in \`${row.exportName}\` (${row.file}:${row.line.toString()}) fails open to the permissive branch — a provider outage returns \`${String(row.defaultValue)}\`, ${row.defaultValue ? "granting the guarded permission" : "disabling the guarded protection"}. Fail closed: default it to \`${String(!row.defaultValue)}\`.`,
                     metadata: { defaultValue: row.defaultValue, exportName: row.exportName, file: row.file, key: row.key, line: row.line },
                 }),
             );

--- a/packages/advisor/src/lints/static/geo-index-field-not-geopoint.ts
+++ b/packages/advisor/src/lints/static/geo-index-field-not-geopoint.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { columnKind } from "../helpers";
 
 /**
  * A correctness lint exploiting Lunora's static edge: a `.geoIndex(name, { field })`
@@ -33,7 +34,9 @@ const geoIndexFieldNotGeopoint: Lint = {
                 }
 
                 // Skip when the feeder doesn't carry column kinds (can't decide).
-                const kind = table.columnKinds?.[field];
+                // Own-property lookup, so an index over an undeclared `toString`
+                // reads as unknown instead of inheriting from `Object.prototype`.
+                const kind = columnKind(table, field);
 
                 if (kind === undefined || kind === "geoPoint") {
                     continue;

--- a/packages/advisor/src/lints/static/public-mutation-without-ratelimit.ts
+++ b/packages/advisor/src/lints/static/public-mutation-without-ratelimit.ts
@@ -1,9 +1,32 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
-import { isPublicWrite } from "../helpers";
+import { isPublicWrite, matchesNamePhrase } from "../helpers";
 
-/** Export names that strongly imply an abuse-sensitive endpoint — surfaced in the detail to raise urgency. */
-const SENSITIVE_NAME_RE = /contact|forgot|login|magic|otp|register|reset|signin|signup|subscribe|verify/iu;
+/**
+ * Export-name phrases that strongly imply an abuse-sensitive endpoint —
+ * surfaced in the detail to raise urgency.
+ *
+ * Matched as WORDS via {@link matchesNamePhrase}, not as substrings: a
+ * substring scan tags `updatePresets` (`reset`) and `unsubscribeAll`
+ * (`subscribe`) high-risk, and prose that overstates a benign finding costs the
+ * same trust a false finding does.
+ */
+const SENSITIVE_PHRASES = [
+    "contact",
+    "forgot",
+    "login",
+    "logIn",
+    "magic",
+    "otp",
+    "register",
+    "reset",
+    "signin",
+    "signIn",
+    "signup",
+    "signUp",
+    "subscribe",
+    "verify",
+];
 
 /**
  * Flags a public `mutation`/`action` whose builder chain installs no rate limit.
@@ -37,7 +60,7 @@ const publicMutationWithoutRatelimit: Lint = {
         return context.procedureProtections
             .filter((procedure) => isPublicWrite(procedure) && !procedure.usesRateLimit)
             .map((procedure) => {
-                const sensitive = SENSITIVE_NAME_RE.test(procedure.exportName);
+                const sensitive = matchesNamePhrase(procedure.exportName, SENSITIVE_PHRASES);
 
                 return emit(publicMutationWithoutRatelimit, {
                     cacheKey: `public_mutation_without_ratelimit:${procedure.file}:${procedure.exportName}`,

--- a/packages/advisor/src/lints/static/ratelimit-middleware-fail-open.ts
+++ b/packages/advisor/src/lints/static/ratelimit-middleware-fail-open.ts
@@ -1,27 +1,26 @@
 import type { AdvisorFailOpenGuard } from "../../fail-open-guards";
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { matchesNamePhrase } from "../helpers";
 
 /**
- * Auth/payment-sensitive flow tokens. A guard on a procedure whose export name or
- * rate-limit `name` normalizes to one of these is the narrow, high-precision
- * subset where fail-open is dangerous — a limiter outage on a sign-in / OTP /
- * checkout endpoint becomes a brute-force or abuse window.
+ * Auth/payment-sensitive flow phrases. A guard on a procedure whose export name
+ * or rate-limit `name` contains one of these as a WORD is the narrow,
+ * high-precision subset where fail-open is dangerous — a limiter outage on a
+ * sign-in / OTP / checkout endpoint becomes a brute-force or abuse window.
+ *
+ * Matched through {@link matchesNamePhrase} rather than as substrings: a
+ * substring scan flags `updatePresets` (`reset`), `snapshotPrune` and
+ * `listSlotProfiles` (`otp`), which is exactly the noise a lint documenting
+ * itself as high-precision must not produce. The one-word spellings sit beside
+ * the camelCase ones because they tokenize differently (`loginHandler` shares no
+ * word with `logIn`).
  */
-const SENSITIVE_TOKENS = ["signin", "signup", "login", "register", "reset", "password", "otp", "verify", "payment", "checkout"];
-
-/** Normalize an identifier to lowercase alphanumerics so `sign-in` / `signIn` / `sign_in` all reduce to `signin`. */
-const normalize = (value: string): string => value.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "");
-
-/** Whether a normalized identifier contains any sensitive-flow token. */
-const matchesSensitiveToken = (value: string): boolean => {
-    const normalized = normalize(value);
-
-    return SENSITIVE_TOKENS.some((token) => normalized.includes(token));
-};
+const SENSITIVE_PHRASES = ["signin", "signIn", "signup", "signUp", "login", "logIn", "register", "reset", "password", "otp", "verify", "payment", "checkout"];
 
 /** Whether either the guarded procedure's export name or its rate-limit `name` looks auth/payment-sensitive. */
-const guardsSensitiveFlow = (row: AdvisorFailOpenGuard): boolean => matchesSensitiveToken(row.exportName) || matchesSensitiveToken(row.limitName);
+const guardsSensitiveFlow = (row: AdvisorFailOpenGuard): boolean =>
+    matchesNamePhrase(row.exportName, SENSITIVE_PHRASES) || matchesNamePhrase(row.limitName, SENSITIVE_PHRASES);
 
 /**
  * Flags a `rateLimit`/`dbRateLimit`/`verifyTurnstileMiddleware` guard configured
@@ -37,8 +36,8 @@ const guardsSensitiveFlow = (row: AdvisorFailOpenGuard): boolean => matchesSensi
  * Runs only when the codegen feeder supplies fail-open-guard evidence
  * (`context.failOpenGuards`); a runtime caller flags nothing. Deliberately narrow
  * — fires only when the options literal provably set `failOpen: true` AND the
- * guarded procedure's export name or rate-limit `name` matches an auth/payment
- * token, keeping the false-positive rate low. One finding per guard.
+ * guarded procedure's export name or rate-limit `name` carries an auth/payment
+ * WORD, keeping the false-positive rate low. One finding per guard.
  */
 const ratelimitMiddlewareFailOpen: Lint = {
     categories: ["SECURITY"],

--- a/packages/advisor/src/lints/static/ttl-field-not-timestamp.ts
+++ b/packages/advisor/src/lints/static/ttl-field-not-timestamp.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { columnKind } from "../helpers";
 
 /** Column kinds that carry an epoch-millisecond instant a TTL sweep can compare against `now`. */
 const TIME_KINDS = new Set(["date", "number", "timestamp"]);
@@ -31,8 +32,10 @@ const ttlFieldNotTimestamp: Lint = {
             }
 
             // The feeder may not carry column kinds (some runtime callers); skip
-            // the check rather than guess when the type isn't known.
-            const kind = table.columnKinds?.[ttl.field];
+            // the check rather than guess when the type isn't known. Own-property
+            // lookup, so a `.ttl("toString")` naming no declared column reads as
+            // unknown instead of inheriting an `Object.prototype` member.
+            const kind = columnKind(table, ttl.field);
 
             if (kind === undefined || TIME_KINDS.has(kind)) {
                 continue;

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -563,6 +563,62 @@ describe(defineRag, () => {
         expect(vi.mocked(embed)).toHaveBeenCalledTimes(embedCallsAfterFirst);
     });
 
+    // A tenant move (or an ACL/status correction) changes only `metadata`, and
+    // `metadata` is exactly what `rlsFilter`/`metadataFilter` scope a retrieval
+    // on. Hashing the body alone made that a reported-success no-op: every
+    // vector kept the OLD `orgId`, so the old tenant retrieved the document
+    // forever and the new one never saw it.
+    it("re-indexes when only the metadata changed", async () => {
+        expect.assertions(3);
+
+        const { store, vectors } = memoryVectors();
+        const ctx = fakeCtx(vectors);
+        const rag = defineRag({ allowSharedNamespace: true, chunk: pipeChunker, index: "docs" })(ctx);
+
+        await rag.index({ id: "doc-1", metadata: { orgId: "org-a" }, text: "alpha | beta" });
+
+        const moved = await rag.index({ id: "doc-1", metadata: { orgId: "org-b" }, text: "alpha | beta" });
+
+        expect(moved.unchanged).toBe(false);
+        expect(store.get("doc-1#0")?.metadata).toMatchObject({ orgId: "org-b" });
+        expect(store.get("doc-1#1")?.metadata).toMatchObject({ orgId: "org-b" });
+    });
+
+    // `importance` is written onto every chunk and multiplied into the match
+    // score, so demoting a source over an unchanged body must not short-circuit.
+    it("re-indexes when only the importance changed", async () => {
+        expect.assertions(2);
+
+        const { store, vectors } = memoryVectors();
+        const ctx = fakeCtx(vectors);
+        const rag = defineRag({ allowSharedNamespace: true, chunk: pipeChunker, index: "docs" })(ctx);
+
+        await rag.index({ id: "doc-1", importance: 1, text: "alpha | beta" });
+
+        const demoted = await rag.index({ id: "doc-1", importance: 0, text: "alpha | beta" });
+
+        expect(demoted.unchanged).toBe(false);
+        expect(store.get("doc-1#0")?.metadata).toMatchObject({ __ragImportance: 0 });
+    });
+
+    // The identity encoding sorts object keys at every depth, so a re-sync that
+    // merely reorders the same metadata stays the cheap no-op it was.
+    it("still short-circuits when the same metadata is written in a different key order", async () => {
+        expect.assertions(2);
+
+        const { vectors } = memoryVectors();
+        const ctx = fakeCtx(vectors);
+        const rag = defineRag({ allowSharedNamespace: true, chunk: pipeChunker, index: "docs" })(ctx);
+
+        await rag.index({ id: "doc-1", metadata: { orgId: "org-a", title: "t" }, text: "alpha | beta" });
+
+        const embedCallsAfterFirst = vi.mocked(embed).mock.calls.length;
+        const second = await rag.index({ id: "doc-1", metadata: { title: "t", orgId: "org-a" }, text: "alpha | beta" });
+
+        expect(second.unchanged).toBe(true);
+        expect(vi.mocked(embed)).toHaveBeenCalledTimes(embedCallsAfterFirst);
+    });
+
     it("re-runs the whole index path under `reindex`, mirroring into a newly attached store", async () => {
         expect.assertions(3);
 

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -1134,6 +1134,28 @@ describe(defineRag, () => {
             await expect(rag.retrieve("hello", { filter: "nonexistent" })).rejects.toThrow(LunoraError);
         });
 
+        it.each(["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"])(
+            "refuses the inherited Object.prototype key %s instead of retrieving unfiltered",
+            async (inherited) => {
+                expect.assertions(2);
+
+                // `config.filters?.[name]` walks the prototype chain, so
+                // `Object.prototype.constructor` answered truthy, skipped the
+                // NOT_FOUND guard, and then `resolved.filter` was `undefined` —
+                // an UNFILTERED retrieval from a name the caller may forward
+                // straight out of a request parameter.
+                const { queryCalls, vectors } = memoryVectors();
+                const ctx = fakeCtx(vectors);
+                const docs = defineRag({ allowSharedNamespace: true, filters: { published: { filter: { status: "published" } } }, index: "docs" });
+                const rag = docs(ctx);
+
+                await rag.index({ id: "doc-1", text: "hello world" });
+
+                await expect(rag.retrieve("hello", { filter: inherited })).rejects.toThrow(LunoraError);
+                expect(queryCalls).toHaveLength(0);
+            },
+        );
+
         it("passes through a literal Record filter unchanged", async () => {
             expect.assertions(1);
 
@@ -1229,6 +1251,66 @@ describe(defineRag, () => {
             expect(result.chunks.map((chunk) => chunk.sourceId)).toContain("doc-2");
             // The genuine semantic match still passes the (unaffected) vector-leg threshold.
             expect(result.chunks.map((chunk) => chunk.sourceId)).toContain("doc-1");
+        });
+
+        it("recovers importance and caller metadata for a lexical-only hit", async () => {
+            expect.assertions(3);
+
+            // The lexical leg minted its chunks with a hard-coded
+            // `importance: 1, metadata: undefined`, so a source deliberately
+            // demoted to `importance: 0` got FULL weight the moment a keyword hit
+            // surfaced it (exactly the case hybrid retrieval exists to create),
+            // and `sources[].metadata` — which a caller filters or badges on —
+            // read `undefined`.
+            const { vectors } = memoryVectors();
+            const ctx = fakeCtx(vectors);
+            const lexicalOnly: RagLexicalStore = {
+                index: async () => {},
+                search: async () => [{ id: "doc-2#0", score: 0.3, text: "gizmo contraption" }],
+            };
+            // `candidates: 1` keeps the vector leg's pool to the single best
+            // chunk, so doc-2 reaches fusion through the LEXICAL leg alone —
+            // which is what "lexical-only" means in practice (`index()` always
+            // writes both stores; the chunk is present, just out of the pool).
+            const docs = defineRag({ allowSharedNamespace: true, candidates: 1, chunk: pipeChunker, index: "docs", lexicalStore: lexicalOnly });
+            const rag = docs(ctx);
+
+            await rag.index({ id: "doc-1", text: "rain storm cloud" });
+            await rag.index({ id: "doc-2", importance: 0, metadata: { orgId: "org-a" }, text: "gizmo contraption" });
+
+            const result = await rag.retrieve("rain storm cloud", { topK: 5 });
+            const demoted = result.sources.find((source) => source.id === "doc-2");
+
+            expect(demoted).toBeDefined();
+            expect(demoted?.weight).toBe(0);
+            expect(demoted?.metadata).toStrictEqual({ orgId: "org-a" });
+        });
+
+        it("does not re-admit a chunk the vector leg rejected for minScore", async () => {
+            expect.assertions(2);
+
+            // A lexical-only hit the vector leg never scored is legitimately not
+            // gated (see the test above) — but a chunk the vector leg DID score
+            // and rejected must stay rejected. Re-admitting it through the
+            // lexical leg contradicts the caller's explicit instruction about
+            // that exact chunk, and made `minScore` unreachable once a
+            // `lexicalStore` was attached.
+            const { vectors } = memoryVectors();
+            const ctx = fakeCtx(vectors);
+            const docs = defineRag({ allowSharedNamespace: true, chunk: pipeChunker, index: "docs", lexicalStore: bm25LexicalStore() });
+            const rag = docs(ctx);
+
+            await rag.index({ id: "doc-1", text: "rain storm cloud" });
+
+            // No cosine similarity can reach 1.5, so the vector leg rejects every chunk.
+            const gated = await rag.retrieve("rain storm cloud", { minScore: 1.5 });
+
+            expect(gated.chunks).toStrictEqual([]);
+
+            // Sanity: without the gate the same query DOES find it.
+            const ungated = await rag.retrieve("rain storm cloud");
+
+            expect(ungated.chunks).not.toStrictEqual([]);
         });
 
         it("removes chunks from the lexical store on remove()", async () => {

--- a/packages/ai/__tests__/rag/rerank-transform.test.ts
+++ b/packages/ai/__tests__/rag/rerank-transform.test.ts
@@ -412,6 +412,62 @@ describe("embedding batching and cache", () => {
         expect(counters.embedMany).toBe(1);
     });
 
+    it("keeps each concurrent index() call's batch to itself", async () => {
+        expect.assertions(3);
+
+        // `defineRagSource` drives up to `concurrency` (default 4) index() calls
+        // through ONE bound Rag, so a batch map shared across calls is wiped by
+        // whichever sibling finishes first — every still-pending chunk then falls
+        // back to a single embed and the batch is pure cost.
+        let calls = 0;
+        let reachedA = (): void => {};
+        const aStarted = new Promise<void>((resolve) => {
+            reachedA = resolve;
+        });
+        let releaseA = (): void => {};
+        const aHeld = new Promise<void>((resolve) => {
+            releaseA = resolve;
+        });
+
+        const vectors: RagVectors = {
+            deleteByIds: () => Promise.resolve(undefined),
+            getByIds: () => Promise.resolve([]),
+            query: () => Promise.resolve({ count: 0, matches: [] }),
+            upsert: async (_index, input) => {
+                if (input.id.startsWith("a#")) {
+                    reachedA();
+                    await aHeld;
+                }
+
+                if (input.embed) {
+                    calls += 1;
+                    await input.embed(input.input);
+                }
+
+                return undefined;
+            },
+        };
+
+        const docs = defineRag({ allowSharedNamespace: true, chunkOverlap: 0, chunkSize: 10, embeddingModel: model, index: "docs" });
+        const rag = docs({ vectors });
+
+        const first = rag.index({ id: "a", text: ["alpha00000", "bravo11111"].join("") });
+
+        await aStarted;
+        // The sibling runs to completion — including its `finally` — while `a`'s
+        // upserts are still pending.
+        await rag.index({ id: "b", text: ["charl22222", "delta33333"].join("") });
+
+        releaseA();
+        await first;
+
+        expect(counters.embedMany).toBe(2);
+        expect(calls).toBe(4);
+        // Every chunk resolved from its OWN call's batch; a single `embed` here
+        // means the sibling's `clear()` wiped this document's entries mid-flight.
+        expect(counters.embed).toBe(0);
+    });
+
     it("does not batch a single-chunk document", async () => {
         expect.assertions(1);
 

--- a/packages/ai/docs/index.mdx
+++ b/packages/ai/docs/index.mdx
@@ -113,8 +113,10 @@ What you get beyond the manual loop:
 
 - **Deterministic chunk ids** (`${sourceId}#${n}`): re-indexing a source replaces
   its chunks; shrinking documents have stale trailing chunks deleted automatically.
-- **Content-hash short-circuit**: re-indexing unchanged text skips chunking,
+- **Content-hash short-circuit**: re-indexing an unchanged source skips chunking,
   embedding, and every write (`{ unchanged: true }`), so periodic re-syncs are free.
+  The hash covers `text`, `metadata` and `importance` together, so changing a
+  document's tenant or ACL tags over an unchanged body still re-indexes.
 - **Tenant isolation**: thread `namespace` (your shard/tenant key) through both
   sides; a namespace-less call gets a one-time dev warning (Vectorize indexes are
   account-global). Multi-tenant apps should set `requireNamespace: true` to turn
@@ -543,9 +545,11 @@ work out what disappeared — while object bodies are fetched `concurrency` at a
 time (`concurrency`, default **4**), so peak memory is that many bodies, not one.
 Lower it when the objects are large.
 
-**Re-syncing is free.** `rag.index` short-circuits on a content hash, so an
-unchanged object costs one `get` and no embedding — which makes running this on
-a cron the normal way to use it.
+**Re-syncing is free.** `rag.index` short-circuits on a content hash — over the
+object's body, `metadata` and `importance` together — so an unchanged object
+costs one `get` and no embedding, which makes running this on a cron the normal
+way to use it. An object whose `metadata` changed is not unchanged: it re-indexes,
+so a tenant move never leaves the old scope on the vectors.
 
 **Pruning keeps the index a mirror**, and it is the caller's set. Pass
 `knownKeys` — the keys you believe the index holds — and anything missing from

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -2,6 +2,10 @@ import { isLunoraError, LunoraError } from "@lunora/errors";
 import type { EmbeddingModel } from "ai";
 import { embed as aiEmbed, embedMany as aiEmbedMany, jsonSchema, tool } from "ai";
 
+// Repo-root inlined helper (see shared/stable-key.ts) — the canonical
+// code-point-stable, recursively-sorted encoder, used here to give a source's
+// `metadata` one canonical form to hash (see `sourceIdentity`).
+import { stableStringify } from "../../../../shared/stable-key";
 import { estimateModelCost } from "../pricing";
 import fixedWindowChunks from "./chunk";
 import { concurrentMap, INDEX_CONCURRENCY } from "./concurrent";
@@ -175,6 +179,37 @@ const parseChunkVectorId = (id: string, namespace: string | undefined): { chunkI
 };
 
 const sha256Hex = async (text: string): Promise<string> => contentHash(new TextEncoder().encode(text));
+
+/**
+ * The canonical encoding of everything an `index()` call writes onto a source's
+ * vectors — its body, its `metadata`, and its `importance`.
+ *
+ * The re-index short-circuit compares a hash of this, not of `text` alone.
+ * `metadata` is what scopes a document: `rlsFilter` and `metadataFilter` both
+ * evaluate against it, so hashing the body only made a tenant move over an
+ * unchanged body (`{ orgId: "org-a" }` → `{ orgId: "org-b" }`) report
+ * `{ unchanged: true }` while every vector kept the OLD `orgId` — the previous
+ * tenant kept retrieving the document forever and the new one never saw it.
+ * `importance` is written onto every chunk and multiplied into its score, so it
+ * belongs here for the same reason.
+ *
+ * `stableStringify` sorts object keys at every depth, so re-syncing the same
+ * metadata written in a different key order is still the cheap no-op it was. It
+ * throws on a value it cannot faithfully encode (a `Date`, a `bigint`, a cycle);
+ * that is not a reason to refuse the index, so it returns `undefined` and the
+ * caller skips the short-circuit — the source re-indexes, exactly as it would
+ * under `reindex: true`.
+ */
+const sourceIdentity = (input: IndexInput): string | undefined => {
+    try {
+        // An array, not an object: `stableStringify` skips `undefined` object
+        // fields (so an absent `metadata` would collide with a present one) but
+        // encodes it positionally inside an array.
+        return stableStringify([input.text, input.metadata, input.importance]);
+    } catch {
+        return undefined;
+    }
+};
 
 /** Keep only chunks scoring at or above `minScore`. */
 const aboveScore = (chunks: ReadonlyArray<RetrievedChunk>, minScore: number): RetrievedChunk[] => chunks.filter((chunk) => chunk.score >= minScore);
@@ -730,14 +765,19 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
             }
 
             const effectiveNamespace = withModelTag(input.namespace);
-            const hash = await sha256Hex(input.text);
+            // Hashes the whole stored identity (body + metadata + importance),
+            // not just the body — see {@link sourceIdentity}. An identity that
+            // cannot be encoded still needs a stored hash, so it falls back to
+            // the body and forfeits only the short-circuit below.
+            const identity = sourceIdentity(input);
+            const hash = await sha256Hex(identity ?? input.text);
             const previous = await readHead(input.id, effectiveNamespace);
 
             // Unchanged content is a no-op re-sync: skip chunking, embedding,
             // and every write. (Vectorize applies mutations asynchronously, so
             // a hash written moments ago may not be visible yet — the worst
             // case is a redundant, idempotent re-index.)
-            if (input.reindex !== true && previous.hash === hash && previous.chunks !== undefined) {
+            if (input.reindex !== true && identity !== undefined && previous.hash === hash && previous.chunks !== undefined) {
                 return {
                     chunks: previous.chunks,
                     ids: Array.from({ length: previous.chunks }, (_, chunkIndex) => chunkVectorId(effectiveNamespace, input.id, chunkIndex)),

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -211,8 +211,25 @@ const sourceIdentity = (input: IndexInput): string | undefined => {
     }
 };
 
-/** Keep only chunks scoring at or above `minScore`. */
-const aboveScore = (chunks: ReadonlyArray<RetrievedChunk>, minScore: number): RetrievedChunk[] => chunks.filter((chunk) => chunk.score >= minScore);
+/**
+ * Split `chunks` into those at or above `minScore` and the ids of those below
+ * it. The rejected ids are kept because a chunk the vector leg SCORED and
+ * rejected must not be handed back by the lexical leg (see `retrieve`).
+ */
+const partitionByScore = (chunks: ReadonlyArray<RetrievedChunk>, minScore: number): { kept: RetrievedChunk[]; rejectedIds: string[] } => {
+    const kept: RetrievedChunk[] = [];
+    const rejectedIds: string[] = [];
+
+    for (const chunk of chunks) {
+        if (chunk.score >= minScore) {
+            kept.push(chunk);
+        } else {
+            rejectedIds.push(chunk.id);
+        }
+    }
+
+    return { kept, rejectedIds };
+};
 
 /** Split stored metadata into the caller's fields (internal `__rag*` keys stripped). */
 const userMetadataOf = (metadata: Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
@@ -533,16 +550,6 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
          */
         const embedCache = new Map<string, ReadonlyArray<number>>();
 
-        /**
-         * Embeddings produced by the in-flight `index()` batch. Deliberately
-         * UNBOUNDED and separate from {@link embedCache}: the batch seeds one
-         * entry per chunk of the document being indexed, and the per-chunk
-         * `embed` callbacks `store.upsert` invokes must all hit it — otherwise
-         * every chunk is embedded a second time and the batch is pure cost.
-         * Cleared when `index()` returns, so it never grows past one document.
-         */
-        const batchEmbeddings = new Map<string, ReadonlyArray<number>>();
-
         /** Evict oldest-first once the cache passes its bound (insertion-ordered Map). */
         const rememberEmbedding = (text: string, embedding: ReadonlyArray<number>): void => {
             if (cacheLimit === 0) {
@@ -563,7 +570,7 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
         };
 
         const embedText = async (text: string): Promise<ReadonlyArray<number>> => {
-            const cached = embedCache.get(text) ?? batchEmbeddings.get(text);
+            const cached = embedCache.get(text);
 
             if (cached !== undefined) {
                 return cached;
@@ -654,20 +661,30 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
         };
 
         /**
-         * Embed `texts` in one batched call and seed {@link batchEmbeddings}, so
-         * the per-chunk `embed` callbacks that follow resolve without further
-         * I/O.
+         * Embed `texts` in one batched call and return the resulting map, so the
+         * per-chunk `embed` callbacks that follow resolve without further I/O.
+         *
+         * The map belongs to ONE `index()` call and is deliberately UNBOUNDED and
+         * separate from {@link embedCache}: it seeds one entry per chunk of the
+         * document being indexed, and the per-chunk `embed` callbacks
+         * `store.upsert` invokes must all hit it — otherwise every chunk is
+         * embedded a second time and the batch is pure cost. Returning it rather
+         * than sharing one map across the bound context is what makes it
+         * request-scoped in fact: `defineRagSource` drives up to `concurrency`
+         * index() calls through one bound `Rag`, and a shared map was wiped by
+         * whichever sibling finished first, mid-flight.
          *
          * Best-effort: a provider that rejects the batch (or an AI SDK build
-         * without `embedMany`) leaves the map empty and every chunk falls back
+         * without `embedMany`) returns an empty map and every chunk falls back
          * to its own single embed — the pre-existing path. A batching
          * optimisation must never be the reason indexing fails.
          */
-        const prefillEmbeddings = async (texts: ReadonlyArray<string>): Promise<void> => {
-            const pending = [...new Set(texts.filter((text) => !embedCache.has(text) && !batchEmbeddings.has(text)))];
+        const prefillEmbeddings = async (texts: ReadonlyArray<string>): Promise<Map<string, ReadonlyArray<number>>> => {
+            const batch = new Map<string, ReadonlyArray<number>>();
+            const pending = [...new Set(texts.filter((text) => !embedCache.has(text)))];
 
             if (pending.length < 2) {
-                return;
+                return batch;
             }
 
             model ??= resolveEmbeddingModel(config.embeddingModel, context.ai);
@@ -676,7 +693,7 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                 const { embeddings } = await aiEmbedMany({ model, values: pending });
 
                 if (embeddings.length !== pending.length) {
-                    return;
+                    return batch;
                 }
 
                 const [first] = embeddings;
@@ -686,7 +703,7 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                 }
 
                 for (const [position, text] of pending.entries()) {
-                    batchEmbeddings.set(text, embeddings[position] as ReadonlyArray<number>);
+                    batch.set(text, embeddings[position] as ReadonlyArray<number>);
                 }
             } catch (error) {
                 // A dimension breach is a real configuration error and must
@@ -695,6 +712,8 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                     throw error;
                 }
             }
+
+            return batch;
         };
 
         const checkNamespace = (namespace: string | undefined): void => {
@@ -836,56 +855,54 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
             // endpoint still fans out internally, so this is never worse — and
             // with one it collapses a 200-chunk document from 200 round-trips to
             // a handful.
-            await prefillEmbeddings(pieces);
+            const batch = await prefillEmbeddings(pieces);
+            // This call's OWN batch first, then the shared per-context paths
+            // (cache, then a single embed). Scoped to the call so a sibling
+            // `index()` on the same bound Rag can neither read it nor drop it.
+            const embedChunk = async (text: string): Promise<ReadonlyArray<number>> => batch.get(text) ?? (await embedText(text));
 
-            try {
-                await concurrentMap(pieces, INDEX_CONCURRENCY, async (piece, chunkIndex) => {
-                    const id = ids[chunkIndex] as string;
-                    const metadata: Record<string, unknown> = {
-                        ...input.metadata,
-                        [CHUNK_INDEX_KEY]: chunkIndex,
-                        [SOURCE_KEY]: input.id,
-                    };
+            await concurrentMap(pieces, INDEX_CONCURRENCY, async (piece, chunkIndex) => {
+                const id = ids[chunkIndex] as string;
+                const metadata: Record<string, unknown> = {
+                    ...input.metadata,
+                    [CHUNK_INDEX_KEY]: chunkIndex,
+                    [SOURCE_KEY]: input.id,
+                };
 
-                    if (!textStore) {
-                        metadata[TEXT_KEY] = piece;
+                if (!textStore) {
+                    metadata[TEXT_KEY] = piece;
+                }
+
+                if (input.importance !== undefined) {
+                    metadata[IMPORTANCE_KEY] = input.importance;
+                }
+
+                // Chunk #0 carries the source's bookkeeping so re-index and
+                // remove() need no external record of the previous state.
+                if (chunkIndex === 0) {
+                    metadata[HASH_KEY] = hash;
+                    metadata[COUNT_KEY] = pieces.length;
+
+                    if (modelTag !== undefined) {
+                        metadata[MODEL_KEY] = modelTag;
                     }
+                }
 
-                    if (input.importance !== undefined) {
-                        metadata[IMPORTANCE_KEY] = input.importance;
-                    }
+                assertMetadataFits(metadata, chunkIndex, input.id, store.capabilities.maxMetadataBytes);
 
-                    // Chunk #0 carries the source's bookkeeping so re-index and
-                    // remove() need no external record of the previous state.
-                    if (chunkIndex === 0) {
-                        metadata[HASH_KEY] = hash;
-                        metadata[COUNT_KEY] = pieces.length;
-
-                        if (modelTag !== undefined) {
-                            metadata[MODEL_KEY] = modelTag;
-                        }
-                    }
-
-                    assertMetadataFits(metadata, chunkIndex, input.id, store.capabilities.maxMetadataBytes);
-
-                    // Vector upsert
-                    await store.upsert({
-                        embed: embedText,
-                        id,
-                        input: piece,
-                        metadata,
-                        namespace: effectiveNamespace,
-                    });
-
-                    // Progress callback — fires after the upsert so callers see a
-                    // consistent state when the callback runs.
-                    input.onChunk?.({ chunkIndex, id, text: piece, total: pieces.length });
+                // Vector upsert
+                await store.upsert({
+                    embed: embedChunk,
+                    id,
+                    input: piece,
+                    metadata,
+                    namespace: effectiveNamespace,
                 });
-            } finally {
-                // Request-scoped by construction: one document's worth of
-                // embeddings, released the moment its upserts are done.
-                batchEmbeddings.clear();
-            }
+
+                // Progress callback — fires after the upsert so callers see a
+                // consistent state when the callback runs.
+                input.onChunk?.({ chunkIndex, id, text: piece, total: pieces.length });
+            });
 
             // A shrinking re-index leaves stale trailing chunks behind — delete
             // them so they cannot keep matching. New chunks are already written,
@@ -1007,7 +1024,14 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
         /** Resolve a named filter or pass a literal filter through. */
         const resolveFilter = (filter: Record<string, unknown> | string | undefined): Record<string, unknown> | undefined => {
             if (typeof filter === "string") {
-                const resolved = config.filters?.[filter];
+                // `Object.hasOwn`, not a plain index: `config.filters?.["constructor"]`
+                // (or `toString`, `valueOf`, …) resolves to an inherited
+                // `Object.prototype` member, which is truthy, so the NOT_FOUND guard
+                // was skipped and `resolved.filter` came back `undefined` — an
+                // UNFILTERED retrieval, in a package whose `matchesMetadataFilter`
+                // otherwise fails closed. Siblings here already do it this way (see
+                // `pricing.ts`, `source.ts`).
+                const resolved = config.filters !== undefined && Object.hasOwn(config.filters, filter) ? config.filters[filter] : undefined;
 
                 if (!resolved) {
                     throw new LunoraError(
@@ -1121,6 +1145,15 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
 
             const minScore = options?.minScore;
 
+            // Chunks the vector leg SCORED and rejected for `minScore`. The
+            // lexical leg must not hand them back: a lexical-only hit the vector
+            // leg never scored is legitimately not gated (its BM25 score is not
+            // on the cosine scale — see `hybridRank`'s docs), but re-admitting
+            // one that failed the caller's threshold contradicts an explicit
+            // instruction about that exact chunk, and made `minScore` unreachable
+            // for the whole retrieval the moment a `lexicalStore` was attached.
+            const belowMinScore = new Set<string>();
+
             const runVectorLeg = async (searchQuery: string): Promise<RetrievedChunk[]> => {
                 const vectorResult = await store.query({
                     embed: embedText,
@@ -1142,7 +1175,17 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                 // random. Filtering each leg before fusion is also the stricter
                 // reading: a chunk too weak to pass on its own does not get in
                 // by being surfaced twice.
-                return minScore === undefined ? legChunks : aboveScore(legChunks, minScore);
+                if (minScore === undefined) {
+                    return legChunks;
+                }
+
+                const { kept, rejectedIds } = partitionByScore(legChunks, minScore);
+
+                for (const id of rejectedIds) {
+                    belowMinScore.add(id);
+                }
+
+                return kept;
             };
 
             // Multi-query expansion: each rewrite is its own ranking, fused by
@@ -1158,8 +1201,8 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
 
             // Hybrid search: also rank via the lexical (BM25) leg and fuse the
             // two rankings with RRF — recovering exact-term matches the embedding
-            // misses. Lexical-only hits carry no stored metadata/importance; a hit
-            // shared with the vector leg keeps the (richer) vector chunk in RRF.
+            // misses. A hit shared with the vector leg keeps the (richer) vector
+            // chunk in RRF; a lexical-only hit is hydrated below.
             if (config.lexicalStore) {
                 const lexicalMatches = await config.lexicalStore.search(primaryQuery, {
                     filter: effectiveFilter,
@@ -1167,14 +1210,35 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                     topK: config.lexicalTopK ?? candidateK,
                 });
 
-                const lexicalChunks: RetrievedChunk[] = lexicalMatches.map((match) => {
+                const fusedIds = new Set(chunks.map((chunk) => chunk.id));
+                // A chunk the vector leg rejected for `minScore` stays rejected —
+                // unless another leg kept it, in which case it is already in
+                // `chunks` and this is only an RRF boost. See `belowMinScore`.
+                const admissible = lexicalMatches.filter((match) => !belowMinScore.has(match.id) || fusedIds.has(match.id));
+
+                // `importance` and the caller `metadata` live on the VECTOR record —
+                // `LexicalMatch` carries neither, and `StoredRagChunk.metadata`
+                // deliberately excludes the internal `__rag*` keys that hold
+                // importance. Hard-coding `importance: 1, metadata: undefined` gave a
+                // source demoted to `importance: 0` full weight on every keyword hit
+                // (the case hybrid retrieval exists to create) and blanked
+                // `sources[].metadata`. One `getByIds` over the lexical-only ids
+                // recovers both from the single source of truth; ids the vector leg
+                // already returned need no round trip.
+                const unhydratedIds = admissible.map((match) => match.id).filter((id) => !fusedIds.has(id));
+                const lexicalRecords = unhydratedIds.length === 0 ? [] : await store.getByIds(unhydratedIds, effectiveNamespace);
+                const metadataById = new Map(lexicalRecords.map((record) => [record.id, record.metadata]));
+
+                const lexicalChunks: RetrievedChunk[] = admissible.map((match) => {
                     const parsed = parseChunkVectorId(match.id, effectiveNamespace);
+                    const fullMetadata = metadataById.get(match.id);
+                    const rawImportance = fullMetadata?.[IMPORTANCE_KEY];
 
                     return {
                         chunkIndex: parsed.chunkIndex,
                         id: match.id,
-                        importance: 1,
-                        metadata: undefined,
+                        importance: typeof rawImportance === "number" && rawImportance >= 0 && rawImportance <= 1 ? rawImportance : 1,
+                        metadata: userMetadataOf(fullMetadata),
                         score: match.score,
                         sourceId: parsed.sourceId,
                         text: match.text,

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -514,7 +514,8 @@ export interface IndexInput {
     onChunk?: (info: { chunkIndex: number; id: string; text: string; total: number }) => void;
 
     /**
-     * Index this source even when its content hash is unchanged.
+     * Index this source even when its identity hash (`text` + `metadata` +
+     * `importance`) is unchanged.
      *
      * The hash short-circuit skips chunking, embedding and every write — which
      * is what makes a cron re-sync cheap, and also what makes attaching a
@@ -540,8 +541,11 @@ export interface IndexResult {
     ids: ReadonlyArray<string>;
 
     /**
-     * True when the source's content hash matched the previously indexed hash —
+     * True when the source's identity hash — its `text`, `metadata` and
+     * `importance` together — matched the previously indexed one, so
      * chunking/embedding/upserts were skipped entirely (a no-op re-sync).
+     * Changing `metadata` alone (a tenant move, an ACL correction) therefore
+     * re-indexes: the old values are what `rlsFilter` scopes retrieval on.
      */
     unchanged: boolean;
 }

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -226,8 +226,10 @@ export interface RagLexicalStore {
      * Rank chunks by lexical relevance to `query`. `filter` carries the same
      * (RLS-merged) metadata predicate handed to the vector leg — a store that
      * indexes metadata MUST honour it so hybrid retrieval can't surface a row
-     * the RLS filter would exclude; a namespace-only store (the reference
-     * adapter) isolates by `namespace` and documents that it ignores `filter`.
+     * the RLS filter would exclude. The shipped `bm25LexicalStore` does — it
+     * evaluates the predicate against each document's stored `metadata`. A store
+     * that indexes no metadata has nothing to filter on and must fail CLOSED on
+     * every filtered query rather than ignore the predicate.
      */
     search: (query: string, options: { filter?: Record<string, unknown>; namespace?: string; topK: number }) => Promise<ReadonlyArray<LexicalMatch>>;
 }
@@ -579,7 +581,18 @@ export interface RetrieveOptions {
      * call time, catching spelling mistakes early.
      */
     filter?: Record<string, unknown> | string;
-    /** Drop matches whose (importance-adjusted) score falls below this threshold. */
+
+    /**
+     * Drop matches whose (importance-adjusted) score falls below this threshold.
+     *
+     * Applied to the VECTOR leg, where the score is still the cosine scale this
+     * option is documented against — every fusion below replaces `score` with an
+     * RRF score, and thresholding that against a cosine number keeps or drops
+     * chunks essentially at random. A chunk the vector leg rejected here stays
+     * rejected even if the lexical leg also ranks it; a lexical-only hit the
+     * vector leg never scored is NOT gated, since its BM25 score is not on this
+     * scale (see `hybridRank`).
+     */
     minScore?: number;
     namespace?: string;
 

--- a/packages/browser/__tests__/create-browser.test.ts
+++ b/packages/browser/__tests__/create-browser.test.ts
@@ -421,6 +421,29 @@ describe("session reuse", () => {
         expect(harness.closed).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+        ["zero", 0],
+        ["negative", -5],
+        ["NaN", Number.NaN],
+        ["Infinity", Number.POSITIVE_INFINITY],
+    ])("still always closes when keepAlive is %s", async (_label, keepAlive) => {
+        expect.assertions(2);
+
+        // `keepAlive: 0` is the natural spelling of "do not keep alive", and what
+        // a `Number(...)` over an unset env var yields, so it must take the
+        // always-close path rather than skipping the `finally`
+        // AND sending `keep_alive: 0`/`NaN` — that leaks a billed session. The
+        // sibling numeric inputs (`timeoutMs`, `viewport`) already reject
+        // non-finite values; this one did not.
+        const harness = makeSessionHarness();
+        const browser = createBrowser({ binding, launch: harness.launch });
+
+        await browser.launch(async () => "done", { keepAlive });
+
+        expect(harness.launchOptions[0]).toBeUndefined();
+        expect(harness.closed).toHaveBeenCalledTimes(1);
+    });
+
     it("connect re-attaches without closing, unless asked", async () => {
         expect.assertions(4);
 

--- a/packages/browser/src/create-browser.ts
+++ b/packages/browser/src/create-browser.ts
@@ -250,7 +250,17 @@ export const createBrowser = (options: LunoraBrowserOptions): Browser => {
      * so this is the one real footgun. The close error is swallowed (we never
      * mask the caller's original error with a close failure).
      */
-    const withBrowser = async <T>(use: (browser: BrowserLike) => Promise<T>, keepAlive?: number): Promise<T> => {
+    const withBrowser = async <T>(use: (browser: BrowserLike) => Promise<T>, requestedKeepAlive?: number): Promise<T> => {
+        // Only a FINITE, POSITIVE duration asks for a held-open session. `0` is
+        // the natural spelling of "do not keep alive", and what a `Number(...)`
+        // over an unset env var yields; `NaN` is what a failed parse of one
+        // yields. Treating either as a
+        // keep-alive request both sent a nonsense `keep_alive` AND skipped the
+        // always-close `finally`, leaking exactly the billed session that
+        // `finally` exists to prevent. The sibling numeric inputs are
+        // non-finite-safe the same way — see `resolveTimeout`, `clampDimension`.
+        const keepAlive = requestedKeepAlive !== undefined && Number.isFinite(requestedKeepAlive) && requestedKeepAlive > 0 ? requestedKeepAlive : undefined;
+
         // `keep_alive` (seconds) holds the Browser Rendering session open after
         // this worker detaches so a later `connect(sessionId)` can re-attach.
         // Closing it here would defeat that, so the close is skipped — the

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -318,9 +318,12 @@ export interface Browser {
      * `fn` (e.g. for multi-page flows or APIs not surfaced here).
      *
      * The browser is **always closed** when `fn` resolves or throws — unless
-     * `keepAlive` is set, which holds the session open for that many seconds so
-     * a later {@link Browser.connect} can re-attach. Do not retain references to
-     * the browser past the callback either way.
+     * `keepAlive` is a finite, positive number of seconds, which holds the
+     * session open for that long so a later {@link Browser.connect} can
+     * re-attach. `0`, a negative value and `NaN` all mean "do not keep alive"
+     * and take the always-close path (a held session is billed, so the
+     * ambiguous values fall to the safe side). Do not retain references to the
+     * browser past the callback either way.
      */
     launch: <T>(function_: (browser: BrowserLike) => Promise<T>, options?: { keepAlive?: number }) => Promise<T>;
 

--- a/packages/cli/__tests__/commands/registry-features.test.ts
+++ b/packages/cli/__tests__/commands/registry-features.test.ts
@@ -241,6 +241,29 @@ describe("lunora add — shadcn-parity features", () => {
         expect(lines.join("\n")).not.toMatch(/^ {2}bind {2}vars\.ADMIN/mu);
     });
 
+    it("registry list sanitizes a fallback catalog's directory names before printing them", async () => {
+        expect.assertions(3);
+
+        // With no `index.json` the catalog falls back to the item DIRECTORIES. A
+        // remote registry is unpacked into that root, so a tarball entry can
+        // carry escape or BIDI bytes in its path, and `list` renders the name
+        // straight to the terminal — as untrusted as the manifest beside it.
+        const hostile = "foo\u001B[2J\u202Ebar";
+
+        mkdirSync(join(registryRoot, hostile), { recursive: true });
+        writeFileSync(join(registryRoot, hostile, "registry.json"), JSON.stringify({ description: "hostile", files: [], name: hostile }), "utf8");
+
+        const { lines, logger } = capturingLogger();
+
+        await runAddCommand({ cwd: workdir, from: registryRoot, list: true, logger, names: [] });
+
+        const printed = lines.join("\n");
+
+        expect(printed).not.toContain("\u001B");
+        expect(printed).not.toContain("\u202E");
+        expect(printed).toContain("foo[2Jbar");
+    });
+
     it("registry build generates index.json and --check detects drift", async () => {
         expect.assertions(3);
 

--- a/packages/cli/skills/lunora-setup-storage/SKILL.md
+++ b/packages/cli/skills/lunora-setup-storage/SKILL.md
@@ -103,10 +103,18 @@ R2 binding to hand, so it serves whole objects and skips `Range`/`ETag`. Both
 verbs, by hand:
 
 ```ts
+import { isSafeHeaderValue } from "@lunora/server";
 import { verifySignedUrl } from "@lunora/storage";
 
 /** Cap what a single signed PUT may store. */
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Origins allowed to upload cross-origin. Leave it empty when
+ * `STORAGE_PUBLIC_BASE_URL` is your app's own origin — then `cors` is inert and
+ * no browser ever preflights these routes.
+ */
+const ALLOWED_ORIGINS = new Set(["https://app.example.com"]);
 
 /**
  * Types safe to render in the browser. Everything else downloads — an uploader
@@ -132,6 +140,24 @@ export default {
         const url = new URL(request.url);
 
         if (url.pathname.startsWith("/storage/")) {
+            const origin = request.headers.get("origin");
+            // `vary` rides on EVERY response, allowed origin or not: a shared
+            // cache keyed on the URL alone would otherwise replay one origin's
+            // `access-control-allow-origin` to another.
+            const cors = {
+                vary: "origin",
+                ...(origin !== null && ALLOWED_ORIGINS.has(origin)
+                    ? { "access-control-allow-headers": "content-type", "access-control-allow-methods": "GET, PUT", "access-control-allow-origin": origin }
+                    : {}),
+            };
+
+            // Before the verb check and the signature check: a preflight carries
+            // neither the signed method nor any credentials, so answering it
+            // later would 405 every cross-origin upload.
+            if (request.method === "OPTIONS") {
+                return new Response(null, { headers: cors, status: 204 });
+            }
+
             // The method is signed, so a GET URL cannot be replayed as a PUT —
             // check the verb anyway rather than relying on that alone.
             if (request.method !== (url.searchParams.get("method") ?? "GET")) {
@@ -172,7 +198,10 @@ export default {
 
                 await env.UPLOADS.put(result.key, request.body, { httpMetadata: { contentType: result.contentType } });
 
-                return new Response(null, { status: 204 });
+                // The preflight's answer does not carry over: without CORS
+                // headers HERE too the browser passes preflight and then rejects
+                // the actual response.
+                return new Response(null, { headers: cors, status: 204 });
             }
 
             const object = await env.UPLOADS.get(result.key);
@@ -181,10 +210,17 @@ export default {
                 return new Response("not found", { status: 404 });
             }
 
-            const contentType = object.httpMetadata?.contentType ?? "application/octet-stream";
+            // The stored content type came off an uploader-signed URL, so it is
+            // attacker-influenced: a CR/LF/NUL in it either throws inside
+            // `Headers` (an unhandled 500) or, on a permissive runtime, splits
+            // the response. Reject the value rather than reflect it — this is
+            // exactly what `isSafeHeaderValue` does inside `serveStorageObject`.
+            const rawContentType = object.httpMetadata?.contentType;
+            const contentType = rawContentType !== undefined && isSafeHeaderValue(rawContentType) ? rawContentType : "application/octet-stream";
 
             return new Response(object.body, {
                 headers: {
+                    ...cors,
                     // The URL expires; a cached copy would not. Without this a
                     // browser or CDN can keep serving private bytes past `exp`,
                     // with `verifySignedUrl` never consulted again.
@@ -202,28 +238,17 @@ export default {
 };
 ```
 
-**Cross-origin uploads need a preflight branch.** The sample assumes
-`STORAGE_PUBLIC_BASE_URL` is your app's own origin. If it is a different one, the
-browser `PUT` below is preflighted (`PUT` is not a simple method, and
-`content-type: image/png` is not a safelisted value), so the route must answer
-`OPTIONS` and echo CORS headers on the real response — otherwise the upload never
-leaves the browser:
-
-```ts
-const ALLOWED_ORIGINS = new Set(["https://app.example.com"]);
-const origin = request.headers.get("origin");
-const cors =
-    origin !== null && ALLOWED_ORIGINS.has(origin)
-        ? { "access-control-allow-headers": "content-type", "access-control-allow-methods": "GET, PUT", "access-control-allow-origin": origin, vary: "origin" }
-        : {};
-
-if (request.method === "OPTIONS") {
-    return new Response(null, { headers: cors, status: 204 });
-}
-```
+**Why the CORS lines are there.** If `STORAGE_PUBLIC_BASE_URL` is not your app's
+own origin, the browser `PUT` below is preflighted (`PUT` is not a simple method,
+and `content-type: image/png` is not a safelisted value). Answering `OPTIONS` is
+only half of it: the browser also reads
+`access-control-allow-origin` off the **real** response, so the 204 and the
+download response carry `...cors` too — a route that answers only the preflight
+passes it and then fails the request it was preflighting.
 
 Keep `STORAGE_PUBLIC_BASE_URL` same-origin if you would rather not maintain an
-allowlist.
+allowlist; then `ALLOWED_ORIGINS` can be empty and `cors` never adds a header
+beyond `vary: origin`.
 
 `verifySignedUrl` checks expiry, then the HMAC. On a host-rewrite / CDN topology
 pass `{ expectedHost }` (the `STORAGE_PUBLIC_BASE_URL` host) so the signature

--- a/packages/cli/src/commands/registry/catalog.ts
+++ b/packages/cli/src/commands/registry/catalog.ts
@@ -56,7 +56,11 @@ const collectCatalog = (root: string): CatalogItem[] => {
     return listItemDirectories(root).map((name) => {
         const raw = JSON.parse(readFileSync(join(root, name, "registry.json"), "utf8")) as { description?: string };
 
-        return { description: raw.description === undefined ? undefined : safe(raw.description), name };
+        // The directory NAME is as untrusted as the manifest text beside it — a
+        // remote registry is unpacked into this root, and a tarball entry may
+        // carry escape or BIDI bytes in its path. `list` renders it, so it is
+        // sanitized like every other rendered value.
+        return { description: raw.description === undefined ? undefined : safe(raw.description), name: safe(name) };
     });
 };
 

--- a/packages/flags/README.md
+++ b/packages/flags/README.md
@@ -79,7 +79,11 @@ export const listPosts = query(async (ctx) => {
 ```
 
 `ctx.flags` never throws: a missing flag, type mismatch, or provider error resolves
-with the `defaultValue`. The default `targetingKey` (from `identify`) is merged under
+with the `defaultValue`. It does not do so silently — a provider that fails to BIND
+(a missing binding, an unset token, a throwing `initialize`) is logged through
+`defineFlags({ logger })`, or on `console.error` when none is configured, since
+otherwise a misconfigured deployment serves every flag at its checked-in default
+with nothing to notice. The default `targetingKey` (from `identify`) is merged under
 any per-call context, and identical evaluations within one request are memoized.
 
 ## Exports

--- a/packages/flags/__tests__/flags.test.ts
+++ b/packages/flags/__tests__/flags.test.ts
@@ -293,6 +293,45 @@ describe("createFlags", () => {
         await expect(flags.boolean("dark-mode", true)).resolves.toBe(true);
     });
 
+    // Failing closed to the default is the OpenFeature contract and stays. Doing
+    // it SILENTLY is the defect: a deployment whose `flagship` binding was never
+    // added — or whose `FLAGSHIP_TOKEN` is unset — boots normally and serves every
+    // kill-switch and rollout at its checked-in default across the whole fleet,
+    // with no thrown error and no log line. `client.setLogger` runs only AFTER a
+    // successful bind, so the user's own logger never saw a failed one.
+    it("reports a failed provider bind through the definition's logger", async () => {
+        expect.assertions(3);
+
+        const error = vi.fn<(...arguments_: unknown[]) => void>();
+        const noop = (): void => {};
+        const logged = defineFlags({
+            logger: { debug: noop, error, info: noop, warn: noop },
+            provider: () => {
+                throw new Error('no binding "FLAGS" found on env');
+            },
+        });
+
+        await expect(createFlags(logged, env).boolean("kill-switch", true)).resolves.toBe(true);
+
+        expect(error).toHaveBeenCalledTimes(1);
+        expect(String(error.mock.calls[0]?.[0])).toContain('no binding "FLAGS" found on env');
+    });
+
+    it("reports a failed provider bind on the console when no logger is configured", async () => {
+        expect.assertions(2);
+
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+        const unlogged = defineFlags({
+            provider: () => {
+                throw new Error("authToken resolved to an empty or non-string value");
+            },
+        });
+
+        await expect(createFlags(unlogged, env).boolean("kill-switch", true)).resolves.toBe(true);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+    });
+
     it("retries the bind on a later request after a failed construction", async () => {
         expect.assertions(3);
 

--- a/packages/flags/docs/index.mdx
+++ b/packages/flags/docs/index.mdx
@@ -60,7 +60,9 @@ export default defineFlags({
 
 The `provider` is either a Flagship config or any factory `(env) => OpenFeatureProvider`. `identify` derives the default `targetingKey` from each request's auth, so per-user targeting works without threading the key through every call.
 
-HTTP mode's `authToken` takes either the literal token or a thunk resolved against the Worker `env` at construction, so the secret never has to be inlined in source. A thunk that resolves to anything but a non-empty string throws at construction rather than sending `Bearer undefined` and letting every evaluation fall silently back to its default.
+HTTP mode's `authToken` takes either the literal token or a thunk resolved against the Worker `env` at construction, so the secret never has to be inlined in source. A thunk that resolves to anything but a non-empty string throws rather than sending `Bearer undefined`.
+
+That throw happens at **bind** time, not at `defineFlags` time — the thunk cannot run before the Worker `env` exists, and the same is true of binding mode's missing-`FLAGS`-binding check. `ctx.flags` never throws, so those refusals still resolve as the caller's `defaultValue`; what they do not do is pass unnoticed. A failed bind is logged once — through `defineFlags({ logger })` if you configured one, on `console.error` otherwise — because a deployment silently serving every kill-switch and rollout at its checked-in default is invisible in every other signal. The per-evaluation error is also on `ctx.flags.details.*()` as `errorCode` / `errorMessage`.
 
 Its argument is a `FlagsAuth` — `{ identity, userId }`, both `null` when the request is anonymous — **not** the function `ctx`. Return `undefined` (not `null`) for "no targeting key", which is why the `?? undefined` matters: `auth.userId` alone is `string | null`, and the property is typed `string | undefined`.
 

--- a/packages/flags/src/flags.ts
+++ b/packages/flags/src/flags.ts
@@ -1,5 +1,5 @@
 import { LunoraError } from "@lunora/errors";
-import type { Client, EvaluationContext, EvaluationDetails, FlagValue, Provider } from "@openfeature/server-sdk";
+import type { Client, EvaluationContext, EvaluationDetails, FlagValue, Logger, Provider } from "@openfeature/server-sdk";
 import { ErrorCode, OpenFeature } from "@openfeature/server-sdk";
 
 // Repo-root inlined helper (see shared/stable-key.ts) — the canonical
@@ -71,6 +71,44 @@ const EMPTY_ENV: Record<string, never> = {};
 const envKeyFor = (env: object): object => (Object.keys(env).length === 0 ? EMPTY_ENV : env);
 
 /**
+ * Report a provider bind that failed — the ONE place this package is allowed to
+ * be loud.
+ *
+ * Every evaluation is contractually silent: `ctx.flags.*` never throws, and a
+ * provider error resolves with the caller's `defaultValue`. That is right for an
+ * evaluation and wrong for a bind, because a bind fails for exactly one reason —
+ * the deployment is misconfigured (`flagshipProvider`'s missing `FLAGS` binding,
+ * its `authToken` thunk resolving to nothing, a provider `initialize` that
+ * throws) — and the resulting fleet-wide fallback to checked-in defaults is
+ * invisible in every other signal. The error is reachable per-evaluation via
+ * `ctx.flags.details.*().errorMessage`, but nothing reads that on the path a
+ * kill-switch is written on.
+ *
+ * The definition's own `logger` is preferred (it is where the app already sends
+ * OpenFeature diagnostics); `console.error` is the fallback, since a Worker with
+ * no logger configured still has a tail. `client.setLogger` cannot serve here —
+ * it runs only after a bind SUCCEEDS.
+ *
+ * Fires once per failed bind attempt, and bind attempts are coalesced per
+ * (definition, env) pair while one is in flight, so a broken deployment logs on
+ * the order of once per request rather than once per flag read.
+ */
+const reportBindFailure = (logger: Logger | undefined, error: unknown): void => {
+    const message = `@lunora/flags: could not bind the OpenFeature provider — every flag read falls back to its caller-supplied default until this is fixed: ${
+        error instanceof Error ? error.message : String(error)
+    }`;
+
+    if (logger) {
+        logger.error(message);
+
+        return;
+    }
+
+    // eslint-disable-next-line no-console -- a misconfigured flag provider silently serving checked-in defaults fleet-wide is worth a Worker tail line
+    console.error(message);
+};
+
+/**
  * Bind (or reuse) the OpenFeature client for one (definition, env) pair.
  * `provider` resolves the provider to bind — the definition's own factory,
  * unless a caller overrode it.
@@ -79,6 +117,13 @@ const envKeyFor = (env: object): object => (Object.keys(env).length === 0 ? EMPT
  * provider whose `initialize` throws retries on the same domain instead of
  * renaming it (which would strand an external reader on a dead domain). Only
  * the client promise is dropped on rejection, so the next request re-attempts.
+ *
+ * A rejected bind is REPORTED (see {@link reportBindFailure}). Evaluations
+ * still fail closed to the caller's default — that is the OpenFeature contract
+ * `ctx.flags` documents — but they must not do it silently: a deployment missing
+ * its `flagship` binding, or whose `FLAGSHIP_TOKEN` is unset, otherwise boots
+ * clean and serves every kill-switch and rollout at its checked-in default
+ * across the whole fleet with nothing to notice.
  */
 const bindClient = (definition: FlagsDefinition, rawEnv: object, provider: () => Provider): Promise<Client> => {
     const env = envKeyFor(rawEnv);
@@ -126,10 +171,12 @@ const bindClient = (definition: FlagsDefinition, rawEnv: object, provider: () =>
 
     // Don't memoize a failed bind — let the next request re-attempt. Guarded on
     // identity so a reset-then-rebind is never clobbered by a stale rejection.
-    pending.catch(() => {
+    pending.catch((error: unknown) => {
         if (entry.client === pending) {
             entry.client = undefined;
         }
+
+        reportBindFailure(logger, error);
     });
 
     return pending;

--- a/packages/flags/src/providers/flagship.ts
+++ b/packages/flags/src/providers/flagship.ts
@@ -37,8 +37,9 @@ interface FlagshipHttpOptions {
      * Either the literal token, or a thunk resolved against the Worker `env` at
      * construction (`(env) => env.FLAGSHIP_TOKEN`) so the secret never has to be
      * inlined in source. A thunk resolving to anything but a non-empty string
-     * throws: `Bearer undefined` would otherwise make every evaluation fall
-     * silently back to its default.
+     * throws from the bind (`createFlags` logs it and evaluations fall back to
+     * their caller-supplied defaults): `Bearer undefined` would otherwise make
+     * every evaluation fall back with nothing said.
      */
     authToken?: ((env: Record<string, unknown>) => unknown) | string;
     /** Base URL override (only used with `appId`). */
@@ -94,11 +95,12 @@ const flagshipProvider = (options: FlagshipProviderOptions): FlagsProviderFactor
         };
     }
 
-    // HTTP mode carries no env-resolved binding, so — unlike binding mode — the
-    // full config is known here. Validate it up front: a misconfiguration must
-    // surface as a directed error at `defineFlags` time, not get swallowed into
-    // silent fail-closed defaults by `createFlags` (which buries any provider
-    // construction/initialize failure in `EvaluationDetails.errorMessage`).
+    // `appId`/`endpoint` need no env, so — unlike the binding and `authToken`
+    // checks below — they are known here and refused at `defineFlags` time,
+    // where the throw reaches the developer directly. The env-dependent
+    // refusals cannot run this early; they throw from inside the factory, which
+    // `createFlags` catches, logs (see `reportBindFailure`), and falls back to
+    // the caller's default for.
     const { appId, endpoint } = options;
 
     if (appId === undefined && endpoint === undefined) {
@@ -126,7 +128,9 @@ const flagshipProvider = (options: FlagshipProviderOptions): FlagsProviderFactor
         // A thunk was written to supply a token, so resolving to nothing is a
         // misconfigured deployment, not "no auth": the unset secret would go out
         // as `Bearer undefined` and every evaluation would fail closed to its
-        // default with no signal. Only an OMITTED `authToken` means "no token".
+        // default. Throwing here makes `createFlags` log the bind failure rather
+        // than let the fleet drift onto checked-in defaults unremarked. Only an
+        // OMITTED `authToken` means "no token".
         const resolved = authToken(env);
 
         if (typeof resolved !== "string" || resolved.length === 0) {

--- a/packages/hyperdrive/__tests__/_helpers/mysql-mem.ts
+++ b/packages/hyperdrive/__tests__/_helpers/mysql-mem.ts
@@ -60,17 +60,38 @@ const createMysqlHarness = async (): Promise<MysqlHarness> => {
 };
 
 /**
+ * Set to `1` where mysqld is expected to be obtainable — the `test-mysql` job in
+ * `.github/workflows/test.yml`, and any local run that wants the gate to be a
+ * gate. It turns {@link tryCreateMysqlHarness}'s skip into a failure.
+ */
+const MYSQL_REQUIRED_ENV = "LUNORA_MYSQL_TESTS";
+
+/**
  * Like {@link createMysqlHarness}, but gated on the environment actually being
  * able to provision mysqld: `mysql-memory-server` downloads the MySQL binary on
  * first use, and restricted sandboxes (e.g. an egress proxy answering the CDN
  * with HTTP 403) make that download impossible. Suites consume this and skip —
  * with the captured reason — instead of failing on an environment limitation.
+ *
+ * A skip is indistinguishable from a pass, though: the MySQL suites are the only
+ * gate proving the dialect's SQL executes, and for as long as nothing asserted
+ * otherwise they could report green having run nothing. So where mysqld IS meant
+ * to be obtainable — {@link MYSQL_REQUIRED_ENV} set — the failure is raised
+ * rather than captured, and the suite goes red instead of quietly empty.
  */
 const tryCreateMysqlHarness = async (): Promise<{ harness?: MysqlHarness; unavailable?: string }> => {
     try {
         return { harness: await createMysqlHarness() };
     } catch (error) {
-        return { unavailable: `mysql-memory-server could not provision mysqld in this environment: ${error instanceof Error ? error.message : String(error)}` };
+        const reason = `mysql-memory-server could not provision mysqld in this environment: ${error instanceof Error ? error.message : String(error)}`;
+
+        if (process.env[MYSQL_REQUIRED_ENV] === "1") {
+            throw new Error(`${reason} — ${MYSQL_REQUIRED_ENV}=1 says it should have been, so this is a broken gate, not an environment limitation.`, {
+                cause: error,
+            });
+        }
+
+        return { unavailable: reason };
     }
 };
 

--- a/packages/hyperdrive/__tests__/global-collation-parity.test.ts
+++ b/packages/hyperdrive/__tests__/global-collation-parity.test.ts
@@ -26,9 +26,10 @@ import createPgliteHarness from "./_helpers/pglite-exec";
  *
  * MySQL is provisioned by `mysql-memory-server`, which downloads mysqld on first
  * use. Where that download is blocked the MySQL half cannot run, so the suite
- * skips with the captured reason — see `_helpers/mysql-mem.ts`. That is a real
- * hole: no CI workflow provisions MySQL today, so this gate can pass by skipping.
- * The always-runs half of the same guarantee is the DDL assertion in
+ * skips with the captured reason — see `_helpers/mysql-mem.ts`. CI runs it under
+ * `LUNORA_MYSQL_TESTS=1` (the `test-mysql` job), where that same failure is
+ * raised instead of captured, so the gate cannot pass by skipping. The
+ * always-runs half of the same guarantee is the DDL assertion in
  * `global-dialect.test.ts`, which needs no server.
  */
 const FIXED_CLOCK = 1_700_000_000_000;

--- a/packages/hyperdrive/__tests__/global-mysql.integration.test.ts
+++ b/packages/hyperdrive/__tests__/global-mysql.integration.test.ts
@@ -29,7 +29,9 @@ import { tryCreateMysqlHarness } from "./_helpers/mysql-mem";
  * `mysql-memory-server` downloads the MySQL binary on first use; in sandboxes
  * where that download is blocked (e.g. an egress proxy answering 403) the whole
  * suite skips — with the captured reason — instead of failing on an environment
- * limitation.
+ * limitation. CI runs it under `LUNORA_MYSQL_TESTS=1` (the `test-mysql` job),
+ * where the same failure is raised rather than captured, so a green run means
+ * the cases executed rather than that they were skipped.
  */
 const FIXED_CLOCK = 1_700_000_000_000;
 const STARTUP_TIMEOUT = 180_000;

--- a/packages/hyperdrive/docs/index.mdx
+++ b/packages/hyperdrive/docs/index.mdx
@@ -456,14 +456,14 @@ a no-op.
     equality: `{ tags: ["x"] }` also matches a row whose tags are `["x", "y"]`, and
     `{ author: {} }` matches every row carrying an `author` key. A filter value
     JSON cannot represent (`undefined`, a function, a symbol) is rejected, because
-    dropping it would widen the filter to match every row. A comparison operator — a comparison operator like like `{ views: { $gt: 10 } }` and
-    Vectorize's dot-addressed `"author.role"` syntax throw for the same reason.
-    **`returnMetadata: "indexed"` behaves as `"all"`** — note this defeats a
-    deliberate default: `ctx.vectors` asks for `"indexed"` precisely so a query
+    dropping it would widen the filter to match every row. A comparison operator
+    like `{ views: { $gt: 10 } }` and Vectorize's dot-addressed `"author.role"`
+    syntax throw for the same reason. **`returnMetadata: "indexed"` behaves as
+    `"all"`**, since Postgres indexes the whole JSONB document — note this defeats
+    a deliberate default: `ctx.vectors` asks for `"indexed"` precisely so a query
     that opted into nothing does not return every stored field. And **`dimensions`
     is fixed at first provisioning**: `CREATE TABLE IF NOT EXISTS` no-ops on a
-    later change, so writes fail against the original width. **`returnMetadata: "indexed"` behaves as
-    `"all"`**, since Postgres indexes the whole JSONB document. And **`mutationId`
+    later change, so writes fail against the original width. Finally **`mutationId`
     is a local counter**: Vectorize's is a handle for an async mutation queue,
     while a Postgres write is already durable when its promise resolves.
 

--- a/packages/hyperdrive/src/global-dialect.ts
+++ b/packages/hyperdrive/src/global-dialect.ts
@@ -153,7 +153,9 @@ export const postgresDialect: SqlDialect = {
                 return "DOUBLE PRECISION";
             }
             default: {
-                // string/id/literal, bigint (decimal string), object/array/record/union/any (JSON text).
+                // string/id/literal, bigint (the order-preserving 40-character
+                // key `bigintSqlKey` builds, same as the MySQL arm above),
+                // object/array/record/union/any (JSON text).
                 return "TEXT";
             }
         }

--- a/packages/mail/__tests__/inbound-parse.test.ts
+++ b/packages/mail/__tests__/inbound-parse.test.ts
@@ -179,6 +179,66 @@ describe("parseInboundEmail", () => {
         });
     });
 
+    it("parses a method version and CFWS around a property's dot", async () => {
+        expect.assertions(1);
+
+        // RFC 8601: `method = Keyword [ [CFWS] "/" [CFWS] 1*DIGIT ]` and
+        // `propspec = ptype [CFWS] "." [CFWS] property [CFWS] "=" [CFWS] pvalue`.
+        // A clause written either way reported NOTHING — the method regex stopped
+        // at the version and the property regex at the spaced dot — so a fully
+        // authenticated message read as unauthenticated and the inbound gate
+        // rejected it.
+        const versioned = crlf([
+            "From: Alice <alice@example.com>",
+            "To: rcpt@example.test",
+            "Subject: Versioned",
+            "Message-ID: <auth-version-1@example.com>",
+            "Authentication-Results: mx.cloudflare.net; dkim/1=pass header . d = example.com; spf / 1 = pass smtp . mailfrom = alice@example.com; dmarc/1=pass header.from=example.com",
+            "Content-Type: text/plain; charset=utf-8",
+            "",
+            "body",
+            "",
+        ]);
+
+        const parsed = await parseInboundEmail(versioned);
+
+        expect(parsed.authentication).toStrictEqual({
+            dkim: [{ domain: "example.com", result: "pass" }],
+            dmarc: [{ domain: "example.com", result: "pass" }],
+            spf: [{ domain: "example.com", result: "pass" }],
+        });
+    });
+
+    it("does not let a quoted value forge a CFWS-spaced property the MX never wrote", async () => {
+        expect.assertions(1);
+
+        // Accepting CFWS around the `ptype.property` dot is what RFC 8601 asks
+        // for, but a quoted local part is sender text sitting INSIDE the clause
+        // and EARLIER than the genuine property — first match wins. So an `=`
+        // inside a quoted-string is neutralised along with `;`: without that,
+        // this header would report `header.d=victim.example` on a DKIM clause the
+        // MX failed.
+        const injected = crlf([
+            'Authentication-Results: mx.cloudflare.net; dkim=fail header.i="x header . d = victim.example" header.d=evil.example; spf=fail; dmarc=fail header.from=victim.example',
+            "From: CEO <ceo@victim.example>",
+            "To: rcpt@example.test",
+            "Subject: approve the wire",
+            "Message-ID: <inject-propspec@evil.example>",
+            "Content-Type: text/plain; charset=utf-8",
+            "",
+            "please approve",
+            "",
+        ]);
+
+        const parsed = await parseInboundEmail(injected);
+
+        expect(parsed.authentication).toStrictEqual({
+            dkim: [{ domain: "evil.example", result: "fail" }],
+            dmarc: [{ domain: "victim.example", result: "fail" }],
+            spf: [{ domain: null, result: "fail" }],
+        });
+    });
+
     it("keeps every reported clause when a method appears more than once", async () => {
         expect.assertions(1);
 

--- a/packages/mail/src/inbound/parse.ts
+++ b/packages/mail/src/inbound/parse.ts
@@ -178,8 +178,17 @@ const CFWS_OR_QUOTED_STRING = /"(?:[^"\\]|\\.)*(?:"|$)|\((?:[^()\\]|\\.)*(?:\)|$
  * domain, and a consumer asking "does ANY clause pass and align?" then accepts a
  * message that authenticated nothing.
  *
- * Comments are dropped (they are pure CFWS) and a quoted-string's `;` becomes a
- * space (the value itself must survive so the property reader still finds it).
+ * Comments are dropped (they are pure CFWS) and a quoted-string's `;` and `=`
+ * become spaces. Both are grammar inside a clause and neither can be sender
+ * text: a `;` manufactures a clause, and an `=` manufactures a `propspec`, which
+ * matters because the property reader accepts CFWS around the `ptype.property`
+ * dot. Without this, a quoted local part of `"x header . d = victim.example"`
+ * would plant a `header.d` the MX never wrote, EARLIER in the clause than the
+ * genuine one, and the first match wins. The quoted value's leading run still
+ * survives, which is all the reader ever captures (it stops at the first space
+ * or quote), so a quoted identifier keeps yielding garbage rather than a real
+ * domain — garbage aligns with nothing.
+ *
  * ONE scan, not two passes: parens inside a quoted-string are literal and quotes
  * inside a comment are literal, so stripping either kind first can unbalance the
  * other and re-expose the `;` it was about to protect. Whichever token opens
@@ -190,7 +199,7 @@ const CFWS_OR_QUOTED_STRING = /"(?:[^"\\]|\\.)*(?:"|$)|\((?:[^()\\]|\\.)*(?:\)|$
  * manufactured, and this only happens on a header no conformant MX emits.
  */
 const neutralizeClauseSeparators = (authResults: string): string =>
-    authResults.replaceAll(CFWS_OR_QUOTED_STRING, (token) => (token.startsWith('"') ? token.replaceAll(";", " ") : " "));
+    authResults.replaceAll(CFWS_OR_QUOTED_STRING, (token) => (token.startsWith('"') ? token.replaceAll(/[;=]/gu, " ") : " "));
 
 /**
  * Pull EVERY one of a method's `method=result [ptype.property=value …]` clauses
@@ -213,8 +222,12 @@ const neutralizeClauseSeparators = (authResults: string): string =>
  * real one — which is the point: garbage aligns with nothing.
  */
 const authVerdicts = (authResults: string, method: string, property: string): InboundAuthResult[] => {
-    const clauses = neutralizeClauseSeparators(authResults).matchAll(new RegExp(String.raw`(?:^|;)\s*${method}\s*=\s*([a-z]+)([^;]*)`, "gi"));
-    const propertyRe = new RegExp(String.raw`\b${property.replaceAll(".", String.raw`\.`)}\s*=\s*"?([^\s;"]+)`, "i");
+    // `method` may carry a version (`dkim/1=pass`), and a `ptype.property` may
+    // carry CFWS around its dot (`header . d = …`) — RFC 8601 permits both, and
+    // a clause written either way reported nothing at all, so a fully
+    // authenticated message read as unauthenticated.
+    const clauses = neutralizeClauseSeparators(authResults).matchAll(new RegExp(String.raw`(?:^|;)\s*${method}\s*(?:/\s*\d+\s*)?=\s*([a-z]+)([^;]*)`, "gi"));
+    const propertyRe = new RegExp(String.raw`\b${property.split(".").join(String.raw`\s*\.\s*`)}\s*=\s*"?([^\s;"]+)`, "i");
 
     return [...clauses].map((clause) => {
         const value = propertyRe.exec(clause[2] ?? "")?.[1];

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -144,7 +144,14 @@ await server.connect(myTransport);
 
 A deployment's durable [`@lunora/agent`](https://www.npmjs.com/package/@lunora/agent) agents can be fronted as MCP tools. This is **opt-in and fail-closed**, mirroring `allowWrites`: starting an agent run is a side effect, so the agent tools are omitted from the advertised list _and_ refused at dispatch unless you explicitly enable them. `@lunora/mcp` takes no dependency on `@lunora/agent` — it reaches the agent's public `agents:agentRun` mutation over RPC like any other function.
 
-Enable it with two env vars (or the matching `createLunoraMcpServer` options):
+Two opt-ins are needed, on **both** sides:
+
+1. **On the agent**, `defineAgent({ publicRun: true })`. `agents:agentRun` refuses
+   any agent without it (`FORBIDDEN`), because starting a durable run from
+   outside the deployment is a side effect the agent's author has to allow. The
+   env vars below do not grant it — an agent exposed here but not marked
+   `publicRun` is advertised and fails on its first call.
+2. **On this server**, the env vars (or the matching `createLunoraMcpServer` options):
 
 - `LUNORA_MCP_ALLOW_AGENTS` — set to `1`/`true`/`yes`/`on` to expose the agent tools. Default: agents disabled.
 - `LUNORA_MCP_AGENTS` — a `;`-separated list of `name:description` pairs selecting which agents to expose, e.g. `"support:Support questions;billing:Billing help"`.

--- a/packages/mcp/__tests__/http.test.ts
+++ b/packages/mcp/__tests__/http.test.ts
@@ -103,6 +103,47 @@ describe("createMcpFetchHandler", () => {
         await expect(response.text()).resolves.toContain("batched requests are not supported");
     });
 
+    /**
+     * The public-function registry memo in `./tools` is keyed by client identity,
+     * so a handler that builds a `LunoraClient` per request never hits it and
+     * every tool call pays the admin round trip again.
+     */
+    it("shares one client across requests, so the function registry is fetched once", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ functions: [{ kind: "query", path: "messages:list" }] }));
+        const handle = createMcpFetchHandler({ fetch: fetchMock, token: "admin-token", url: "https://app.example" });
+        const listCall = (id: number): unknown => {
+            return { id, jsonrpc: "2.0", method: "tools/call", params: { arguments: {}, name: "lunora_list_functions" } };
+        };
+
+        await handle(mcpRequest(initializeBody));
+
+        const first = await handle(mcpRequest(listCall(2)));
+
+        await handle(mcpRequest(listCall(3)));
+
+        expect(first.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a misconfiguration when the handler is built, not on the first request", () => {
+        expect.assertions(1);
+
+        // The client is resolved once, up front — so `url` with no admin bearer
+        // fails where `createLunoraMcpServer` documents reporting it.
+        expect(() => createMcpFetchHandler({ url: "https://app.example" })).toThrow(/token/u);
+    });
+
+    it("honours a custom maxRequestBytes", async () => {
+        expect.assertions(1);
+
+        const handle = createMcpFetchHandler({ client: mockClient(), maxRequestBytes: 16 });
+        const response = await handle(mcpRequest(initializeBody));
+
+        expect(response.status).toBe(413);
+    });
+
     it("refuses a body over the size limit", async () => {
         expect.assertions(2);
 

--- a/packages/mcp/__tests__/observability-tools.test.ts
+++ b/packages/mcp/__tests__/observability-tools.test.ts
@@ -123,7 +123,7 @@ describe("lunora_get_logs", () => {
 
         expect(mock.query).toHaveBeenCalledWith({ __lunoraRef: ADMIN_FUNCTIONS.getLogs }, {}, {});
         expect(result.isError).toBeUndefined();
-        expect(result.structuredContent).toStrictEqual({ entries: [entries[0], entries[1]], total: 3 });
+        expect(result.structuredContent).toStrictEqual({ dropped: 0, entries: [entries[0], entries[1]], total: 3 });
         // The text block stays, for a client on a pre-2025-06-18 revision.
         expect(JSON.parse(result.content[0]!.text)).toStrictEqual(result.structuredContent);
     });
@@ -135,8 +135,21 @@ describe("lunora_get_logs", () => {
         const mock = mockClient({ [ADMIN_FUNCTIONS.getLogs]: { entries } });
         const result = await callTool(mock.asClient, "lunora_get_logs", { level: "error", limit: 1 }, false, true);
 
-        expect(result.structuredContent).toStrictEqual({ entries: [entries[1]], total: 2 });
+        expect(result.structuredContent).toStrictEqual({ dropped: 0, entries: [entries[1]], total: 2 });
         expect((result.structuredContent as { entries: unknown[] }).entries).toHaveLength(1);
+    });
+
+    it("forwards the ring's dropped counter so a saturated ring is not read as the whole picture", async () => {
+        expect.assertions(2);
+
+        const entries = [logEntry(1, "info"), logEntry(2, "info")];
+        const mock = mockClient({ [ADMIN_FUNCTIONS.getLogs]: { dropped: 49_998, entries } });
+        const result = await callTool(mock.asClient, "lunora_get_logs", {}, false, true);
+
+        // Without this the tool reports `total: 2` for a shard that logged
+        // 50,000 lines, and the model reports it as complete.
+        expect(result.structuredContent).toStrictEqual({ dropped: 49_998, entries, total: 2 });
+        expect(JSON.parse(result.content[0]!.text)).toStrictEqual(result.structuredContent);
     });
 
     it("ignores an unrecognized level rather than filtering everything out", async () => {
@@ -146,7 +159,7 @@ describe("lunora_get_logs", () => {
         const mock = mockClient({ [ADMIN_FUNCTIONS.getLogs]: { entries } });
         const result = await callTool(mock.asClient, "lunora_get_logs", { level: "LOUD" }, false, true);
 
-        expect(result.structuredContent).toStrictEqual({ entries, total: 1 });
+        expect(result.structuredContent).toStrictEqual({ dropped: 0, entries, total: 1 });
     });
 
     it("forwards a shardKey, since these reads are per-shard", async () => {
@@ -166,7 +179,7 @@ describe("lunora_get_logs", () => {
         const result = await callTool(mock.asClient, "lunora_get_logs", {}, false, true);
 
         expect(result.isError).toBeUndefined();
-        expect(result.structuredContent).toStrictEqual({ entries: [], total: 0 });
+        expect(result.structuredContent).toStrictEqual({ dropped: 0, entries: [], total: 0 });
     });
 
     it("maps a bigint / bytes leaf so structuredContent survives the transport's JSON.stringify", async () => {
@@ -182,6 +195,7 @@ describe("lunora_get_logs", () => {
         expect(result.isError).toBeUndefined();
         expect(() => JSON.stringify(result.structuredContent)).not.toThrow();
         expect(result.structuredContent).toStrictEqual({
+            dropped: 0,
             entries: [{ fields: { blob: "AQID", id: "9007199254740993" }, level: "info", message: "m", timestamp: 1 }],
             total: 1,
         });

--- a/packages/mcp/__tests__/paid-wait-until.test.ts
+++ b/packages/mcp/__tests__/paid-wait-until.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPaidMcpServer } from "../src/paid";
+import type { ToolResult } from "../src/tools";
+
+/** Every `deps` the charge middleware was handed, in call order. */
+const handleDeps: ({ waitUntil?: (promise: Promise<unknown>) => void } | undefined)[] = [];
+
+// A charge-middleware double. The real x402 paywall's settle/verify machinery is
+// tested in `@lunora/x402`; what has to be tested HERE is the one thing this
+// package owns — that the Worker's `ctx.waitUntil` reaches `handle`'s third
+// argument, since without it `reportReceipt` floats the `onReceipt` sink with no
+// registration and workerd cancels it at isolate teardown: the money moves
+// on-chain and the receipt row never lands.
+vi.mock(import("@lunora/x402/charge"), () => {
+    return {
+        createChargeMiddleware: () =>
+            Promise.resolve({
+                handle: async (
+                    _request: Request,
+                    runHandler: () => Promise<Response> | Response,
+                    deps?: { readonly waitUntil?: (promise: Promise<unknown>) => void },
+                ): Promise<Response> => {
+                    handleDeps.push(deps);
+
+                    return runHandler();
+                },
+            }),
+    };
+});
+
+const charge = { network: "base", recipient: { evm: "0x1111111111111111111111111111111111111111" } } as const;
+const NO_INPUT = { properties: {}, type: "object" } as const;
+
+const mcpRequest = (body: unknown): Request =>
+    new Request("https://worker.example/mcp", {
+        body: JSON.stringify(body),
+        headers: { accept: "application/json, text/event-stream", "content-type": "application/json" },
+        method: "POST",
+    });
+
+const callBody = (name: string): unknown => {
+    return { id: 2, jsonrpc: "2.0", method: "tools/call", params: { arguments: {}, name } };
+};
+
+const text = (value: string): ToolResult => {
+    return { content: [{ text: value, type: "text" }] };
+};
+
+const paidServer = (): ReturnType<typeof createPaidMcpServer> => {
+    const mcp = createPaidMcpServer({ charge });
+
+    mcp.paidTool({ description: "the paid report", inputSchema: NO_INPUT, name: "premium_report", price: "$0.05" }, () => text("secret"));
+
+    return mcp;
+};
+
+describe("createPaidMcpServer — waitUntil plumbing", () => {
+    it("forwards the Worker execution context's waitUntil to the charge middleware", async () => {
+        expect.assertions(2);
+
+        handleDeps.length = 0;
+
+        const kept: Promise<unknown>[] = [];
+        const context = {
+            waitUntil(promise: Promise<unknown>): void {
+                kept.push(promise);
+            },
+        };
+
+        await paidServer().fetchHandler(mcpRequest(callBody("premium_report")), {}, context);
+
+        const sink = Promise.resolve("receipt row");
+
+        handleDeps[0]?.waitUntil?.(sink);
+
+        expect(handleDeps[0]?.waitUntil).toBeTypeOf("function");
+        expect(kept).toStrictEqual([sink]);
+    });
+
+    // `ExecutionContext.waitUntil` is receiver-bound: called unbound it throws
+    // `TypeError: Illegal invocation`, and `reportReceipt` swallows that — the
+    // paid response still lands while the receipt is silently never registered.
+    it("invokes waitUntil through the context, never as a detached function", async () => {
+        expect.assertions(2);
+
+        handleDeps.length = 0;
+
+        const context = {
+            kept: [] as Promise<unknown>[],
+            waitUntil(this: unknown, promise: Promise<unknown>): void {
+                if (this !== context) {
+                    throw new TypeError("Illegal invocation");
+                }
+
+                context.kept.push(promise);
+            },
+        };
+
+        await paidServer().fetchHandler(mcpRequest(callBody("premium_report")), {}, context);
+
+        const sink = Promise.resolve("receipt row");
+
+        expect(() => handleDeps[0]?.waitUntil?.(sink)).not.toThrow();
+        expect(context.kept).toStrictEqual([sink]);
+    });
+
+    // A non-Workers caller (a test, a plain fetch server) has no execution
+    // context; the middleware must then see no `deps` at all rather than a
+    // `waitUntil` that throws on use.
+    it("passes no deps when the handler is called without an execution context", async () => {
+        expect.assertions(1);
+
+        handleDeps.length = 0;
+
+        await paidServer().fetchHandler(mcpRequest(callBody("premium_report")));
+
+        expect(handleDeps[0]).toBeUndefined();
+    });
+});

--- a/packages/mcp/__tests__/paid.test.ts
+++ b/packages/mcp/__tests__/paid.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { serveStateless } from "../src/http";
 import { createPaidMcpServer } from "../src/paid";
+import { serveStateless } from "../src/serve-stateless";
 import type { ToolResult } from "../src/tools";
 
-vi.mock(import("../src/http"), async (importOriginal) => {
+vi.mock(import("../src/serve-stateless"), async (importOriginal) => {
     const actual = await importOriginal();
 
     return { ...actual, serveStateless: vi.fn<typeof actual.serveStateless>(actual.serveStateless) };
@@ -192,19 +192,69 @@ describe("createPaidMcpServer", () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it("dispatches an unparseable body unchanged when no tool is priced", async () => {
-        expect.assertions(1);
+    it("refuses an unparseable body before dispatch even when no tool is priced", async () => {
+        expect.assertions(2);
 
         stubFacilitator();
 
         const mcp = createPaidMcpServer({ charge });
         mcp.tool({ description: "echo", inputSchema: NO_INPUT, name: "ping" }, () => text("pong"));
 
-        await mcp.fetchHandler(rawMcpRequest("{not json"));
+        const response = await mcp.fetchHandler(rawMcpRequest("{not json"));
 
-        // No paid tools registered → the parse-miss guard never applies, so the
-        // request still reaches the SDK transport exactly as before this change.
-        expect(serveStateless).toHaveBeenCalledTimes(1);
+        // The shared bounded read owns the parse, so the JSON-RPC parse error
+        // is answered here rather than one layer down in the transport.
+        expect(response.status).toBe(400);
+        expect(serveStateless).not.toHaveBeenCalled();
+    });
+
+    it("refuses an oversized body before buffering it, like every other transport", async () => {
+        expect.assertions(3);
+
+        const fetchMock = stubFacilitator();
+
+        const mcp = createPaidMcpServer({ charge });
+        mcp.paidTool({ description: "paid", inputSchema: NO_INPUT, name: "premium_report", price: "$0.05" }, () => text("secret"));
+
+        // Declared oversize: refused on the header, before the body is read.
+        const response = await mcp.fetchHandler(rawMcpRequest("{}", { "content-length": String(64 * 1024 * 1024) }));
+
+        expect(response.status).toBe(413);
+        expect(serveStateless).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("honours a custom maxRequestBytes on the paid transport", async () => {
+        expect.assertions(2);
+
+        stubFacilitator();
+
+        const mcp = createPaidMcpServer({ charge, maxRequestBytes: 16 });
+        mcp.tool({ description: "echo", inputSchema: NO_INPUT, name: "ping" }, () => text("pong"));
+
+        const response = await mcp.fetchHandler(mcpRequest(callBody("ping")));
+
+        expect(response.status).toBe(413);
+        expect(serveStateless).not.toHaveBeenCalled();
+    });
+
+    it("returns a throwing paid tool as an isError result, not a JSON-RPC protocol error", async () => {
+        expect.assertions(3);
+
+        const mcp = createPaidMcpServer({ charge });
+        mcp.tool({ description: "boom", inputSchema: NO_INPUT, name: "explode" }, () => {
+            throw new Error("handler blew up");
+        });
+
+        const response = await mcp.fetchHandler(mcpRequest(callBody("explode")));
+        const payload = (await response.json()) as { error?: unknown; result?: { content: { text: string }[]; isError?: boolean } };
+
+        // Settlement precedes dispatch, so the caller has already paid: a
+        // protocol-level error is invisible to a client that renders only tool
+        // results, and the model is shown nothing for its money.
+        expect(payload.error).toBeUndefined();
+        expect(payload.result?.isError).toBe(true);
+        expect(payload.result?.content[0]?.text).toContain("handler blew up");
     });
 
     it("rejects registering the same tool name twice", () => {

--- a/packages/mcp/__tests__/server.test.ts
+++ b/packages/mcp/__tests__/server.test.ts
@@ -183,7 +183,7 @@ describe("createLunoraMcpServer request handlers", () => {
         })) as CallToolResult;
 
         expect(mock.query).toHaveBeenCalledTimes(1);
-        expect(result.structuredContent).toStrictEqual({ entries: [{ level: "info", message: "hello", timestamp: 1 }], total: 1 });
+        expect(result.structuredContent).toStrictEqual({ dropped: 0, entries: [{ level: "info", message: "hello", timestamp: 1 }], total: 1 });
         expect(JSON.parse((result.content[0] as { text: string }).text)).toStrictEqual(result.structuredContent);
     });
 

--- a/packages/mcp/docs/index.mdx
+++ b/packages/mcp/docs/index.mdx
@@ -411,7 +411,22 @@ list _and_ refused at dispatch unless you enable them. `@lunora/mcp` takes no
 dependency on `@lunora/agent`; it calls the agent's public `agents:agentRun`
 mutation over HTTP RPC like any other function.
 
-Enable it with two env vars (or the matching `createLunoraMcpServer` options):
+Two opt-ins are needed, and they sit on opposite sides of the RPC:
+
+**On the agent**, mark it runnable from outside the deployment:
+
+```ts
+export const support = defineAgent({ name: "support", publicRun: true /* … */ });
+```
+
+`agents:agentRun` throws `FORBIDDEN` for any agent whose handle is not
+`publicRun: true` — starting a durable run is a side effect, so the agent's
+author allows it, not the MCP server. The env vars below cannot grant it: an
+agent exposed here without the flag is advertised in `tools/list` and fails on
+its first call.
+
+**On this server**, the env vars (or the matching `createLunoraMcpServer`
+options):
 
 - `LUNORA_MCP_ALLOW_AGENTS`: `1`/`true`/`yes`/`on` to expose the agent tools.
 - `LUNORA_MCP_AGENTS`: a `;`-separated list of `name:description` pairs

--- a/packages/mcp/src/authed-http.ts
+++ b/packages/mcp/src/authed-http.ts
@@ -56,7 +56,7 @@
 import type { McpFetchHandler } from "./serve-stateless";
 import { serveStateless } from "./serve-stateless";
 import type { LunoraMcpServerOptions } from "./server";
-import { createLunoraMcpServer } from "./server";
+import { createLunoraMcpServer, resolveClient } from "./server";
 
 /**
  * The verified access-token payload better-auth hands a protected handler.
@@ -94,6 +94,9 @@ type McpAuthProtect = (handler: (request: Request, claims: McpAccessTokenClaims)
 type AuthedMcpServerOptions = ((claims: McpAccessTokenClaims) => LunoraMcpServerOptions | Promise<LunoraMcpServerOptions>) | LunoraMcpServerOptions;
 
 interface AuthedMcpFetchHandlerOptions {
+    /** Largest accepted request body, in bytes. Defaults to `DEFAULT_MAX_REQUEST_BYTES` (128 KiB). */
+    maxRequestBytes?: number;
+
     /**
      * The OAuth gate to mount the MCP server behind. Pass
      * `(handler) => requireMcpAuth(auth, handler, opts)` from
@@ -135,13 +138,22 @@ const mcpTokenScopes = (claims: McpAccessTokenClaims): ReadonlySet<string> => {
  * `server` (resolved against the verified claims) and serves it through
  * {@link serveStateless}, exactly as the unprotected `createMcpFetchHandler`
  * does — the transport behaviour is identical, only the gate is new.
+ *
+ * A fixed `server` object names one deployment, so its `LunoraClient` is
+ * resolved once and shared: the public-function registry memo in `./tools` is
+ * keyed by client identity and never hits when each request builds its own. The
+ * `(claims) => …` form is per-request by construction — the claims decide which
+ * deployment and token to use — so it keeps a client per request.
  */
-const createAuthedMcpFetchHandler = (options: AuthedMcpFetchHandlerOptions): McpFetchHandler =>
-    options.protect(async (request: Request, claims: McpAccessTokenClaims): Promise<Response> => {
-        const resolved = typeof options.server === "function" ? await options.server(claims) : options.server;
+const createAuthedMcpFetchHandler = (options: AuthedMcpFetchHandlerOptions): McpFetchHandler => {
+    const sharedClient = typeof options.server === "function" ? undefined : resolveClient(options.server);
 
-        return await serveStateless(createLunoraMcpServer(resolved), request);
+    return options.protect(async (request: Request, claims: McpAccessTokenClaims): Promise<Response> => {
+        const resolved = typeof options.server === "function" ? await options.server(claims) : { ...options.server, client: sharedClient };
+
+        return await serveStateless(createLunoraMcpServer(resolved), request, { maxRequestBytes: options.maxRequestBytes });
     });
+};
 
 export type { AuthedMcpFetchHandlerOptions, AuthedMcpServerOptions, McpAccessTokenClaims, McpAuthProtect };
 export { createAuthedMcpFetchHandler, mcpTokenScopes };

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -18,16 +18,31 @@
 import type { McpFetchHandler } from "./serve-stateless";
 import { serveStateless } from "./serve-stateless";
 import type { LunoraMcpServerOptions } from "./server";
-import { createLunoraMcpServer } from "./server";
+import { createLunoraMcpServer, resolveClient } from "./server";
+
+/** {@link createMcpFetchHandler} options: the server's, plus this transport's body limit. */
+export interface McpFetchHandlerOptions extends LunoraMcpServerOptions {
+    /** Largest accepted request body, in bytes. Defaults to `DEFAULT_MAX_REQUEST_BYTES` (128 KiB). */
+    maxRequestBytes?: number;
+}
 
 /**
  * Build a stateless Streamable-HTTP fetch handler for a Lunora MCP server. Each
  * invocation constructs a fresh proxy server and serves the request through
  * {@link serveStateless}.
+ *
+ * The `LunoraClient` is resolved ONCE, here, and shared by every request: it is
+ * the same deployment on each one, and the public-function registry memo in
+ * `./tools` is keyed by client identity, so a per-request client would re-fetch
+ * that registry on every tool call. A misconfiguration (`url` without `token`)
+ * therefore throws when the handler is built rather than on first request,
+ * which is where `createLunoraMcpServer` already documents reporting it.
  */
-export const createMcpFetchHandler =
-    (options: LunoraMcpServerOptions): McpFetchHandler =>
-    (request: Request): Promise<Response> =>
-        serveStateless(createLunoraMcpServer(options), request);
+export const createMcpFetchHandler = (options: McpFetchHandlerOptions): McpFetchHandler => {
+    const client = resolveClient(options);
 
-export { type McpFetchHandler, serveStateless, type ServeStatelessOptions } from "./serve-stateless";
+    return (request: Request): Promise<Response> =>
+        serveStateless(createLunoraMcpServer({ ...options, client }), request, { maxRequestBytes: options.maxRequestBytes });
+};
+
+export { DEFAULT_MAX_REQUEST_BYTES, type McpFetchHandler, serveStateless, type ServeStatelessOptions } from "./serve-stateless";

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -39,7 +39,16 @@ export type { McpFetchHandler, ServeStatelessOptions } from "./http";
 export { createMcpFetchHandler, serveStateless } from "./http";
 export type { LocalDeployment, LocalDeploymentSource, LocalMcpServerOptions } from "./local";
 export { connectLocalStdio, createLocalMcpServer, LOCAL_SERVER_NAME, localTools, NO_DEPLOYMENT_MESSAGE } from "./local";
-export type { PaidMcpChargeConfig, PaidMcpServer, PaidMcpServerConfig, RegisterPaidToolOptions, RegisterToolOptions, ToolHandler } from "./paid";
+export type {
+    PaidMcpChargeConfig,
+    PaidMcpExecutionContext,
+    PaidMcpFetchHandler,
+    PaidMcpServer,
+    PaidMcpServerConfig,
+    RegisterPaidToolOptions,
+    RegisterToolOptions,
+    ToolHandler,
+} from "./paid";
 export { createPaidMcpServer } from "./paid";
 export type { LunoraMcpServerOptions } from "./server";
 export { connectStdio, createLunoraMcpServer } from "./server";

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -35,8 +35,8 @@ export type { AuthedMcpFetchHandlerOptions, AuthedMcpServerOptions, McpAccessTok
 export { createAuthedMcpFetchHandler, mcpTokenScopes } from "./authed-http";
 export type { McpServerInfo, McpTool } from "./compose";
 export { createToolServer } from "./compose";
-export type { McpFetchHandler, ServeStatelessOptions } from "./http";
-export { createMcpFetchHandler, serveStateless } from "./http";
+export type { McpFetchHandler, McpFetchHandlerOptions, ServeStatelessOptions } from "./http";
+export { createMcpFetchHandler, DEFAULT_MAX_REQUEST_BYTES, serveStateless } from "./http";
 export type { LocalDeployment, LocalDeploymentSource, LocalMcpServerOptions } from "./local";
 export { connectLocalStdio, createLocalMcpServer, LOCAL_SERVER_NAME, localTools, NO_DEPLOYMENT_MESSAGE } from "./local";
 export type {

--- a/packages/mcp/src/observability-tools.ts
+++ b/packages/mcp/src/observability-tools.ts
@@ -128,10 +128,18 @@ const MIGRATION_STATUS_INPUT_SCHEMA: ToolInputSchema = {
  */
 const LOGS_OUTPUT_SCHEMA: ToolInputSchema = {
     properties: {
+        dropped: {
+            description:
+                "Entries the shard's in-memory ring EVICTED before this read — they are gone and cannot be fetched. Non-zero means `entries` + `total` describe only the newest slice of what the deployment logged.",
+            type: "number",
+        },
         entries: { description: "Recent log entries, NEWEST FIRST: { level, message, timestamp, functionPath?, fields? }.", type: "array" },
-        total: { description: "Entries available before `limit`/`level` narrowed them.", type: "number" },
+        total: {
+            description: "Entries still in the ring matching `level`, before `limit` narrowed them. NOT the number of lines logged — see `dropped`.",
+            type: "number",
+        },
     },
-    required: ["entries", "total"],
+    required: ["dropped", "entries", "total"],
     type: "object",
 };
 
@@ -287,8 +295,13 @@ const callObservabilityTool = async (client: LunoraClient, name: string, input: 
             // newest-first, so slicing keeps the most recent.
             const result = await adminRead(client, ADMIN_FUNCTIONS.getLogs, {}, shardKey);
             const entries = rowsOf(result, "entries").filter((entry) => level === undefined || (entry as LogRow).level === level);
+            // The RPC's eviction counter, forwarded: a saturated ring is
+            // otherwise indistinguishable from a shard that logged exactly as
+            // many lines as it still holds, so a model asked "is this the whole
+            // picture?" answers yes on a deployment that dropped 50,000 lines.
+            const { dropped } = (result ?? {}) as { dropped?: unknown };
 
-            return okStructured({ entries: entries.slice(0, limit), total: entries.length });
+            return okStructured({ dropped: typeof dropped === "number" ? dropped : 0, entries: entries.slice(0, limit), total: entries.length });
         }
         case "lunora_get_migration_status": {
             const result = await adminRead(client, ADMIN_FUNCTIONS.migrationStatus, {}, shardKey);

--- a/packages/mcp/src/paid.ts
+++ b/packages/mcp/src/paid.ts
@@ -20,6 +20,12 @@
  * );
  * export default { fetch: mcp.fetchHandler };
  * ```
+ *
+ * `fetchHandler` takes the Worker's `(request, env, ctx)` triple, so mounting it
+ * as the default export above is all that is needed — it forwards `ctx.waitUntil`
+ * to the charge middleware, which is what keeps an `onReceipt` sink alive past
+ * the response. Call it with a bare `Request` and a settled payment's receipt is
+ * cancelled at isolate teardown while the money has already moved on-chain.
  */
 import { LunoraError } from "@lunora/errors";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -27,7 +33,6 @@ import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import { memoizePromise } from "../../../shared/promise-memo";
-import type { McpFetchHandler } from "./http";
 import { serveStateless } from "./http";
 import type { ToolInputSchema, ToolResult } from "./tools";
 
@@ -62,9 +67,15 @@ interface X402ChargeSettings {
     readonly recipient: { readonly evm?: string; readonly svm?: string };
 }
 
+/** Mirrors x402's `ChargeHandlerDeps` — the per-request platform seams `handle` uses. */
+interface ChargeHandlerDeps {
+    /** Keeps the `onReceipt` sink alive past the response — the request's `ctx.waitUntil`. */
+    readonly waitUntil: (promise: Promise<unknown>) => void;
+}
+
 /** Mirrors `ChargeMiddleware` — the one method this module calls. */
 interface ChargeMiddleware {
-    handle: (request: Request, runHandler: () => Promise<Response>, deps?: unknown) => Promise<Response>;
+    handle: (request: Request, runHandler: () => Promise<Response>, deps?: ChargeHandlerDeps) => Promise<Response>;
 }
 
 /** The factory `@lunora/x402/charge` exports, as this module uses it. */
@@ -101,10 +112,33 @@ interface PaidMcpServerConfig {
     serverInfo?: { name: string; version: string };
 }
 
+/**
+ * The Worker execution context, as this module reads it: only `waitUntil`, and
+ * structurally, so the package takes no `@cloudflare/workers-types` dependency.
+ */
+interface PaidMcpExecutionContext {
+    waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/**
+ * The paid server's fetch handler.
+ *
+ * Unlike the free `McpFetchHandler` it takes the Worker's full
+ * `(request, env, ctx)` triple — the shape `export default { fetch }` is called
+ * with — because the x402 receipt sink NEEDS `ctx.waitUntil`: work that is
+ * neither awaited into the response nor registered with it is cancelled when the
+ * request ends, so an async `onReceipt` (inserting the settled payment into a
+ * durable table) frequently never runs while the money has already moved
+ * on-chain. `env` is accepted and ignored so the handler drops straight into the
+ * default export; both are optional, so a non-Workers caller may still invoke it
+ * with a bare `Request` (the middleware then simply sees no `waitUntil`).
+ */
+type PaidMcpFetchHandler = (request: Request, env?: unknown, context?: PaidMcpExecutionContext) => Promise<Response>;
+
 /** A paid MCP server: register free/paid tools, then serve over Streamable HTTP. */
 interface PaidMcpServer {
     /** The Streamable-HTTP fetch handler; gates each paid `tools/call` behind x402. */
-    readonly fetchHandler: McpFetchHandler;
+    readonly fetchHandler: PaidMcpFetchHandler;
     /** Register a **paid** tool: its dispatch runs the x402 charge middleware first. */
     paidTool: (options: RegisterPaidToolOptions, handler: ToolHandler) => void;
     /** Register a **free** tool (coexists with paid tools on the same server). */
@@ -269,7 +303,7 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
             return create({ ...config.charge, price }, { resource: name });
         });
 
-    const fetchHandler: McpFetchHandler = async (request: Request): Promise<Response> => {
+    const fetchHandler: PaidMcpFetchHandler = async (request: Request, _env?: unknown, context?: PaidMcpExecutionContext): Promise<Response> => {
         // Peek the JSON-RPC body from a clone so `request` stays pristine for both
         // the charge middleware (reads headers/URL) and the transport (below).
         let parsedBody: unknown;
@@ -306,7 +340,21 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
 
         const middleware = await gateFor(name, price);
 
-        return middleware.handle(request, dispatch);
+        // Invoked THROUGH the context, never as a detached function.
+        // `ExecutionContext.waitUntil` is receiver-bound and throws
+        // `TypeError: Illegal invocation` when called unbound — and x402's
+        // `reportReceipt` swallows that throw, so the paid response would still
+        // land while the receipt promise was never registered.
+        const deps =
+            typeof context?.waitUntil === "function"
+                ? {
+                      waitUntil: (promise: Promise<unknown>): void => {
+                          context.waitUntil?.(promise);
+                      },
+                  }
+                : undefined;
+
+        return middleware.handle(request, dispatch, deps);
     };
 
     const paidTool = (options: RegisterPaidToolOptions, handler: ToolHandler): void => {
@@ -320,5 +368,14 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
     return { fetchHandler, paidTool, tool };
 };
 
-export type { PaidMcpChargeConfig, PaidMcpServer, PaidMcpServerConfig, RegisterPaidToolOptions, RegisterToolOptions, ToolHandler };
+export type {
+    PaidMcpChargeConfig,
+    PaidMcpExecutionContext,
+    PaidMcpFetchHandler,
+    PaidMcpServer,
+    PaidMcpServerConfig,
+    RegisterPaidToolOptions,
+    RegisterToolOptions,
+    ToolHandler,
+};
 export { createPaidMcpServer };

--- a/packages/mcp/src/paid.ts
+++ b/packages/mcp/src/paid.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/deprecation -- the SDK marks the low-level `Server` @deprecated in favour of the high-level `McpServer`, but explicitly sanctions `Server` for "advanced use cases". Ours qualifies: we dispatch tools defined with plain JSON Schema and bridge structured results ourselves, which avoids McpServer's per-tool zod dependency (matching `server.ts`). */
 
 /**
- * `@lunora/mcp/paid` — x402-gated (paid) MCP tools.
+ * x402-gated (paid) MCP tools, exported from the package root.
  *
  * A Lunora app authors its own MCP tools and prices some of them in USDC. Free
  * `tool()` and `paidTool()` registrations coexist on one server (mirroring
@@ -9,7 +9,11 @@
  * Streamable HTTP (paid tools require an HTTP boundary — an HTTP request can
  * carry `X-PAYMENT`, which stdio cannot), and each `tools/call` for a **paid**
  * tool is gated by the Phase-1 charge middleware: unpaid → `402` +
- * `PAYMENT-REQUIRED`; verified → dispatch, settle, attach `X-PAYMENT-RESPONSE`.
+ * `PAYMENT-REQUIRED`; verified → settle, dispatch, attach `X-PAYMENT-RESPONSE`.
+ * Settlement precedes dispatch (x402's `settleBeforeHandler` default, which this
+ * module does not override), so a tool that throws has already been paid for —
+ * which is why a throwing handler returns an `isError` result rather than a
+ * JSON-RPC protocol error the client may not surface.
  *
  * ```ts
  * const mcp = createPaidMcpServer({ charge: { network: "base", recipient: { evm: env.PAYOUT } } });
@@ -33,7 +37,7 @@ import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import { memoizePromise } from "../../../shared/promise-memo";
-import { serveStateless } from "./http";
+import { readScreenedBody, serveStateless } from "./serve-stateless";
 import type { ToolInputSchema, ToolResult } from "./tools";
 
 /** A tool handler: receives the call's `arguments` bag, returns an MCP tool result. */
@@ -108,6 +112,8 @@ type PaidMcpChargeConfig = X402ChargeSettings;
 interface PaidMcpServerConfig {
     /** The worker-level x402 charge config; each paid tool supplies only its own `price`. */
     charge: PaidMcpChargeConfig;
+    /** Largest accepted request body, in bytes. Defaults to `DEFAULT_MAX_REQUEST_BYTES` (128 KiB). */
+    maxRequestBytes?: number;
     /** Name/version advertised in the MCP `initialize` handshake. Defaults to `lunora-paid-mcp`. */
     serverInfo?: { name: string; version: string };
 }
@@ -215,17 +221,6 @@ const refuseBatch = (): Response =>
     Response.json({ error: "A JSON-RPC batch may not reference a paid MCP tool; send paid tools/call requests individually." }, { status: 400 });
 
 /**
- * Refuse a POST body this module couldn't parse when any tool is priced. This
- * module decides "is this a priced `tools/call`?" from its own parse of the
- * body; on a parse miss it can't tell, and handing the original request to the
- * SDK transport (which re-reads/re-parses it independently) would let a paid
- * tool dispatch with no `X-PAYMENT` check. Fail closed instead — mirrors
- * {@link refuseBatch}'s envelope/status.
- */
-const refuseUnparseableBody = (): Response =>
-    Response.json({ error: "The request body could not be parsed as JSON; a priced MCP tool is registered, so the call cannot be gated." }, { status: 400 });
-
-/**
  * Create a paid MCP server. Register free tools with `tool()` and priced tools
  * with `paidTool()` (they coexist), then serve `fetchHandler` over HTTP.
  *
@@ -280,9 +275,17 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
                 return { content: [{ text: `unknown tool: ${request.params.name}`, type: "text" }], isError: true };
             }
 
-            const result = await entry.handler(request.params.arguments ?? {});
-
-            return result as CallToolResult;
+            try {
+                return (await entry.handler(request.params.arguments ?? {})) as CallToolResult;
+            } catch (error: unknown) {
+                // An `isError` result, not a rejection — the SDK turns a handler
+                // rejection into a JSON-RPC protocol `error`, which a client that
+                // renders only tool results shows the model as nothing at all. On
+                // this transport the payment has ALREADY settled by the time
+                // dispatch runs, so "paid, and the model saw no answer" is the
+                // failure to avoid. Matches `compose.ts` / `tools.ts`.
+                return { content: [{ text: error instanceof Error ? error.message : String(error), type: "text" }], isError: true };
+            }
         });
 
         return server;
@@ -306,24 +309,29 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
     const fetchHandler: PaidMcpFetchHandler = async (request: Request, _env?: unknown, context?: PaidMcpExecutionContext): Promise<Response> => {
         // Peek the JSON-RPC body from a clone so `request` stays pristine for both
         // the charge middleware (reads headers/URL) and the transport (below).
-        let parsedBody: unknown;
+        // Through the SHARED bounded read: a bare `request.clone().json()` here
+        // buffers whatever the caller sent, and handing the result on as
+        // `parsedBody` enters the transport past its size check — which left
+        // this, the one unauthenticated paid surface, with no body limit at all.
+        const screened = await readScreenedBody(request.clone(), config.maxRequestBytes);
 
-        try {
-            parsedBody = await request.clone().json();
-        } catch {
-            parsedBody = undefined;
+        if ("response" in screened) {
+            return screened.response;
         }
+
+        const { parsedBody } = screened;
 
         // Hand the already-parsed body to the transport so it doesn't re-read the
-        // consumed stream; fall back to letting it read `request` on a parse miss.
-        const dispatch = (): Promise<Response> => serveStateless(buildServer(), request, parsedBody === undefined ? undefined : { parsedBody });
-
-        // Scoped to POST: GET (SSE stream open) and DELETE (session termination)
-        // carry no body by spec and reach this same handler, so a method-blind
-        // check would 400 every legitimate handshake.
-        if (parsedBody === undefined && prices.size > 0 && request.method === "POST") {
-            return refuseUnparseableBody();
-        }
+        // consumed stream. `parsedBody` is `undefined` only for a GET/DELETE
+        // handshake, which carries no body: `readScreenedBody` refuses a POST it
+        // could not parse, so this module never has to guess whether an
+        // unreadable body targeted a priced tool.
+        const dispatch = (): Promise<Response> =>
+            serveStateless(
+                buildServer(),
+                request,
+                parsedBody === undefined ? { maxRequestBytes: config.maxRequestBytes } : { maxRequestBytes: config.maxRequestBytes, parsedBody },
+            );
 
         if (Array.isArray(parsedBody)) {
             return parsedBody.some((message) => prices.has(callToolName(message) ?? "")) ? refuseBatch() : dispatch();

--- a/packages/mcp/src/serve-stateless.ts
+++ b/packages/mcp/src/serve-stateless.ts
@@ -52,6 +52,56 @@ const rpcError = (status: number, code: number, message: string): Response =>
 const batchRefusal = (): Response => rpcError(400, -32_600, "batched requests are not supported: send one JSON-RPC message per request");
 
 /**
+ * Read and JSON-parse a POST body, bounded by `maxRequestBytes`.
+ *
+ * The size limit lives HERE rather than inside {@link screenRequest} because a
+ * caller that needs the body before the transport does — the paid-tool gate,
+ * which prices a `tools/call` from its JSON-RPC `method`/`params` — would
+ * otherwise buffer an unbounded body with `request.json()` and hand the result
+ * over as `parsedBody`, entering {@link screenRequest} past every check. One
+ * bounded read, shared by both, is the only shape where every transport in the
+ * package has a body limit.
+ *
+ * Batches are NOT refused here: the paid gate answers them with its own
+ * envelope (a batch may reference a priced tool), so that decision stays with
+ * each caller.
+ */
+const readScreenedBody = async (request: Request, limit?: number): Promise<ScreenedRequest> => {
+    // GET (SSE stream open) and DELETE (session termination) carry no body by
+    // spec, so there is nothing to bound and nothing to parse.
+    if (request.method !== "POST") {
+        return { parsedBody: undefined };
+    }
+
+    const maxRequestBytes = limit ?? DEFAULT_MAX_REQUEST_BYTES;
+    const tooLarge = { response: rpcError(413, -32_600, `request body exceeds ${String(maxRequestBytes)} bytes`) };
+    const declaredLength = Number(request.headers.get("content-length"));
+
+    // Reject on the declared length FIRST, so an oversized body is refused
+    // before it is buffered into the isolate. A chunked request without the
+    // header still has to be read, which is why the authoritative check below
+    // stays — but the common case costs nothing.
+    if (Number.isFinite(declaredLength) && declaredLength > maxRequestBytes) {
+        return tooLarge;
+    }
+
+    const body = await request.text();
+
+    // `String.length` counts UTF-16 code units, so a limit expressed in bytes
+    // has to be measured in bytes: 128 KiB of three-byte UTF-8 is ~43k units,
+    // which a naive length check would wave through.
+    if (byteLength(body) > maxRequestBytes) {
+        return tooLarge;
+    }
+
+    try {
+        return { parsedBody: JSON.parse(body) };
+    } catch {
+        return { response: rpcError(400, -32_700, "parse error: body is not valid JSON") };
+    }
+};
+
+/**
  * Reject what no MCP handler in this package has a reason to accept, before the
  * transport sees it.
  *
@@ -81,45 +131,20 @@ const screenRequest = async (request: Request, options: ServeStatelessOptions | 
     // A caller that already read the body (the paid-tool gate peeks the
     // JSON-RPC message to price the call) hands it over, so re-reading the
     // consumed stream is neither possible nor needed — only the batch refusal
-    // is left to apply.
+    // is left to apply. Such a caller MUST have read it through
+    // {@link readScreenedBody}: this branch is past the size limit, and the one
+    // that skipped it left a public endpoint with no body bound at all.
     if (options?.parsedBody !== undefined) {
         return Array.isArray(options.parsedBody) ? { response: batchRefusal() } : { parsedBody: options.parsedBody };
     }
 
-    const maxRequestBytes = options?.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
-    const tooLarge = { response: rpcError(413, -32_600, `request body exceeds ${String(maxRequestBytes)} bytes`) };
-    const declaredLength = Number(request.headers.get("content-length"));
+    const screened = await readScreenedBody(request, options?.maxRequestBytes);
 
-    // Reject on the declared length FIRST, so an oversized body is refused
-    // before it is buffered into the isolate. A chunked request without the
-    // header still has to be read, which is why the authoritative check below
-    // stays — but the common case costs nothing.
-    if (Number.isFinite(declaredLength) && declaredLength > maxRequestBytes) {
-        return tooLarge;
+    if ("response" in screened) {
+        return screened;
     }
 
-    const body = await request.text();
-
-    // `String.length` counts UTF-16 code units, so a limit expressed in bytes
-    // has to be measured in bytes: 128 KiB of three-byte UTF-8 is ~43k units,
-    // which a naive length check would wave through.
-    if (byteLength(body) > maxRequestBytes) {
-        return tooLarge;
-    }
-
-    let parsed: unknown;
-
-    try {
-        parsed = JSON.parse(body);
-    } catch {
-        return { response: rpcError(400, -32_700, "parse error: body is not valid JSON") };
-    }
-
-    if (Array.isArray(parsed)) {
-        return { response: batchRefusal() };
-    }
-
-    return { parsedBody: parsed };
+    return Array.isArray(screened.parsedBody) ? { response: batchRefusal() } : screened;
 };
 
 /**
@@ -137,7 +162,9 @@ const screenRequest = async (request: Request, options: ServeStatelessOptions | 
  *
  * `options.parsedBody` lets a caller hand over a body it already read (e.g. the
  * paid-tool gate, which peeks the JSON-RPC message to price the call) so the
- * transport doesn't re-read a consumed stream.
+ * transport doesn't re-read a consumed stream. It is trusted as already
+ * screened, so read it with {@link readScreenedBody} — anything else hands this
+ * surface an unbounded body.
  *
  * Teardown runs in a `finally`: a rejection from `connect` or `handleRequest`
  * would otherwise skip it and leak a server + transport per failed request,
@@ -163,4 +190,4 @@ const serveStateless = async (server: Server, request: Request, options?: ServeS
 };
 
 export type { McpFetchHandler, ServeStatelessOptions };
-export { DEFAULT_MAX_REQUEST_BYTES, serveStateless };
+export { DEFAULT_MAX_REQUEST_BYTES, readScreenedBody, serveStateless };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -130,7 +130,14 @@ interface LunoraMcpServerOptions {
     url?: string;
 }
 
-/** Build the `LunoraClient` the tools dispatch against. */
+/**
+ * Build the `LunoraClient` the tools dispatch against.
+ *
+ * Exported for the HTTP handlers, which build one client for the lifetime of
+ * the handler instead of one per request: `listFunctionsCached` in `./tools`
+ * keys its memo on client identity, so a fresh client per request turns every
+ * tool call back into two admin round trips.
+ */
 const resolveClient = (options: LunoraMcpServerOptions): LunoraClient => {
     if (options.client !== undefined) {
         return options.client;
@@ -217,4 +224,4 @@ const connectStdio = async (options: LunoraMcpServerOptions): Promise<Server> =>
 };
 
 export type { LunoraMcpServerOptions };
-export { connectStdio, createLunoraMcpServer };
+export { connectStdio, createLunoraMcpServer, resolveClient };

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -124,7 +124,10 @@ const readFunctionPath = (input: Record<string, unknown>): string => {
     const { functionPath } = input;
 
     if (typeof functionPath !== "string" || functionPath.length === 0) {
-        throw new LunoraError("INTERNAL", '"functionPath" is required and must be a non-empty string');
+        // BAD_REQUEST, not INTERNAL: the value comes from the model's own
+        // `arguments` bag, so it is the caller's mistake — same as the
+        // `readArgumentsBag` refusals below, and what the docs document.
+        throw new LunoraError("BAD_REQUEST", '"functionPath" is required and must be a non-empty string');
     }
 
     return functionPath;

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -39,15 +39,29 @@ Generate a VAPID keypair once: `npx web-push generate-vapid-keys`.
 ```ts
 import { subscribeToPush } from "@lunora/notify/web";
 
-const subscription = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
-await client.mutation("registerDevice", { subscription });
+const { replacedEndpoint, subscription } = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
+await client.mutation("registerDevice", { replacedEndpoint, subscription });
 ```
+
+`replacedEndpoint` is set only after a **VAPID key rotation**: the stale browser
+subscription is dropped and a new one minted, and the new one has a new endpoint
+— hence a new store id — so it never upserts over the old row. Every send to that
+row now answers `403 VapidPkHashMismatch`, which is (correctly) not a "gone"
+signal, so nothing prunes it either. Forward it and unregister it:
 
 ```ts
 // lunora/registerDevice.ts (a mutation — storage write is fine here)
-export const registerDevice = mutation.input({ subscription: v.any() }).mutation(async ({ ctx, args: { subscription } }) => {
-    await ctx.push.register({ subscription, userId: ctx.auth?.userId });
-});
+import { webPushId } from "@lunora/notify";
+
+export const registerDevice = mutation
+    .input({ replacedEndpoint: v.optional(v.string()), subscription: v.any() })
+    .mutation(async ({ ctx, args: { replacedEndpoint, subscription } }) => {
+        if (replacedEndpoint !== undefined) {
+            await ctx.push.unregister(webPushId(replacedEndpoint));
+        }
+
+        await ctx.push.register({ subscription, userId: ctx.auth?.userId });
+    });
 ```
 
 ## Send (from an action)
@@ -87,12 +101,13 @@ await enqueuePushBroadcast(ctx.queues.push, { payload: { title: "New drop", body
 // lunora/notify-fanout.ts — an INTERNAL ACTION, because that is where
 // `ctx.push` and `ctx.queues` exist.
 export const deliverPage = internalAction.input({ job: v.any() }).action(async ({ args: { job }, ctx }) => {
-    const { failedIds, nextCursor } = await runPushBroadcastPage(ctx.push, job);
+    const { failedIds, nextFilter } = await runPushBroadcastPage(ctx.push, job);
 
-    // One message = ONE bounded page. Discarding `nextCursor` delivers only the
+    // One message = ONE bounded page. Discarding `nextFilter` delivers only the
     // first page (default 250 devices) and reports success for the whole audience.
-    if (nextCursor !== undefined) {
-        await enqueuePushBroadcast(ctx.queues.push, { payload: job.payload, filter: { ...job.filter, after: nextCursor } });
+    // Pass it verbatim — it carries the cursor AND the remaining `filter.limit`.
+    if (nextFilter !== undefined) {
+        await enqueuePushBroadcast(ctx.queues.push, { payload: job.payload, filter: nextFilter });
     }
 
     // Redeliver ONLY the recipients that failed — a retry of the whole page would
@@ -144,9 +159,11 @@ client-supplied data, so the facade enforces two boundaries:
 - **No secrets on the app facade.** `ctx.push.list()`
   returns the registered devices with the delivery **secrets stripped** — the Web
   Push `keys` (`auth`/`p256dh`) and the FCM `token`, which together with the
-  endpoint are enough to deliver arbitrary push to a device. The raw rows are
-  reachable only through the internal `SubscriptionStore` (which handlers never
-  hold); the broadcast path uses the store directly.
+  endpoint are enough to deliver arbitrary push to a device. Every other facade
+  read is projected the same way; the broadcast path uses the store directly. The
+  one place a handler does see a raw row is the return of `ctx.push.register(...)`,
+  which echoes back the record the caller just supplied — nothing it did not
+  already hold, and never another device's.
 
 ## Delivery observability
 

--- a/packages/notify/__tests__/inbox.test.ts
+++ b/packages/notify/__tests__/inbox.test.ts
@@ -25,7 +25,7 @@ describe("memoryInboxStore (plan 241 spike — read half prototype)", () => {
         await store.append({ payload: { body: "two" }, userId: "u1" });
         await store.append({ payload: { body: "three" }, userId: "u1" });
 
-        await store.markRead(first.id);
+        await store.markRead("u1", first.id);
 
         await expect(store.unreadCount("u1")).resolves.toBe(2);
 
@@ -40,12 +40,12 @@ describe("memoryInboxStore (plan 241 spike — read half prototype)", () => {
         const store = memoryInboxStore();
         const item = await store.append({ payload: { body: "one" }, userId: "u1" });
 
-        await store.markRead(item.id);
+        await store.markRead("u1", item.id);
 
         const [afterFirst] = await store.list("u1");
         const firstReadAt = afterFirst?.readAt;
 
-        await store.markRead(item.id);
+        await store.markRead("u1", item.id);
 
         const [afterSecond] = await store.list("u1");
 
@@ -53,12 +53,26 @@ describe("memoryInboxStore (plan 241 spike — read half prototype)", () => {
         await expect(store.unreadCount("u1")).resolves.toBe(0);
     });
 
+    it("markRead cannot mark another user's item", async () => {
+        expect.hasAssertions();
+
+        // Every sibling operation is `userId`-scoped; an unscoped `markRead(id)`
+        // lets any caller holding (or guessing) an id clear someone else's
+        // notification — the id is the whole authorisation.
+        const store = memoryInboxStore();
+        const theirs = await store.append({ payload: { body: "theirs" }, userId: "u2" });
+
+        await store.markRead("u1", theirs.id);
+
+        await expect(store.unreadCount("u2")).resolves.toBe(1);
+    });
+
     it("markRead on an unknown id is a safe no-op", async () => {
         expect.hasAssertions();
 
         const store = memoryInboxStore();
 
-        await expect(store.markRead("inbox_does_not_exist")).resolves.toBeUndefined();
+        await expect(store.markRead("u1", "inbox_does_not_exist")).resolves.toBeUndefined();
     });
 
     it("listInbox returns newest-first", async () => {
@@ -120,7 +134,7 @@ describe("memoryInboxStore (plan 241 spike — read half prototype)", () => {
         const first = await store.append({ payload: { body: "one" }, userId: "u1" });
 
         await store.append({ payload: { body: "two" }, userId: "u1" });
-        await store.markRead(first.id);
+        await store.markRead("u1", first.id);
 
         const unread = await store.list("u1", { unreadOnly: true });
 

--- a/packages/notify/__tests__/notify.test.ts
+++ b/packages/notify/__tests__/notify.test.ts
@@ -825,6 +825,19 @@ describe("web-push send-time DNS-rebinding guard", () => {
         expect(inner.sends).toHaveLength(0);
     });
 
+    it("refuses an empty `to` by name instead of blaming an unconfigured channel", async () => {
+        expect.hasAssertions();
+
+        // With no targets both routing branches fall through to the FCM one, so a
+        // webPush-only app was told it "received an FCM token target but no `fcm`
+        // channel is configured" — for a send that named no recipient at all.
+        const inner = mockPushProvider();
+        const router = routingPushProvider({ webPush: inner.provider });
+
+        await expect(router.send({ body: "b", to: [] })).rejects.toThrow(/no recipients/u);
+        expect(inner.sends).toHaveLength(0);
+    });
+
     it("delivers when the host resolves public, and skips the check entirely under allowedPushOrigins", async () => {
         expect.hasAssertions();
 

--- a/packages/notify/__tests__/queue.test.ts
+++ b/packages/notify/__tests__/queue.test.ts
@@ -50,7 +50,7 @@ describe("queue-backed fan-out", () => {
         expect(broadcastPage).toHaveBeenCalledWith(job.payload, undefined);
     });
 
-    it("returns the page (cursor included) instead of throwing when some recipients failed", async () => {
+    it("returns the page (continuation included) instead of throwing when some recipients failed", async () => {
         expect.hasAssertions();
 
         // Regression: throwing discarded `nextCursor`, so one permanently-failing
@@ -75,7 +75,7 @@ describe("queue-backed fan-out", () => {
 
         const outcome = await runPushBroadcastPage(push, job);
 
-        expect(outcome.nextCursor).toBe("wp2_page2");
+        expect(outcome.nextFilter).toStrictEqual({ after: "wp2_page2" });
         expect(outcome.failedIds).toStrictEqual(["b"]);
     });
 
@@ -105,6 +105,58 @@ describe("queue-backed fan-out", () => {
         expect(send).toHaveBeenCalledTimes(1);
     });
 
+    it("a retryIds job that partly recovered does NOT throw, so the recovered ids are never re-sent", async () => {
+        expect.hasAssertions();
+
+        // Throwing on ANY failure re-runs the WHOLE message, and the message
+        // carries every id — so `a` and `b`, which just succeeded, get a second
+        // (and third, and fourth) push on every queue redelivery. Progress must
+        // be kept: return the still-failing ids so the caller enqueues a
+        // narrower retry, exactly as a partially-failed PAGE already does.
+        const send = vi.fn(async (id: string) => {
+            if (id === "c") {
+                throw new Error("403 VapidPkHashMismatch");
+            }
+
+            return { errorMessages: [], successful: true };
+        });
+        const push = { broadcastPage: vi.fn(), send } as unknown as LunoraPush;
+        const job: PushBroadcastJob = { payload: { body: "hi" }, retryIds: ["a", "b", "c"], type: "lunora.push.broadcast" };
+
+        const outcome = await runPushBroadcastPage(push, job);
+
+        expect(outcome.failedIds).toStrictEqual(["c"]);
+        expect(outcome.result).toMatchObject({ failed: 1, sent: 2, total: 3 });
+    });
+
+    it("spends `filter.limit` as an OVERALL cap across messages, not once per message", async () => {
+        expect.hasAssertions();
+
+        // `limit` documents itself as a cap on the total audience reached. On the
+        // queue path the caller re-enqueues the continuation, so the REMAINING
+        // budget has to travel with it — forwarding `filter` verbatim let every
+        // message reach up to `limit` more devices and walk the whole audience.
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: "wp2_page2", result: { failed: 0, outcomes: [], pruned: 0, sent: 4, total: 4 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
+        const job: PushBroadcastJob = { filter: { limit: 10, userId: "u1" }, payload: { body: "hi" }, type: "lunora.push.broadcast" };
+
+        const outcome = await runPushBroadcastPage(push, job);
+
+        expect(outcome.nextFilter).toStrictEqual({ after: "wp2_page2", limit: 6, userId: "u1" });
+    });
+
+    it("stops the walk once `filter.limit` is spent, even with pages remaining", async () => {
+        expect.hasAssertions();
+
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: "wp2_page2", result: { failed: 0, outcomes: [], pruned: 0, sent: 4, total: 4 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
+        const job: PushBroadcastJob = { filter: { limit: 4 }, payload: { body: "hi" }, type: "lunora.push.broadcast" };
+
+        const outcome = await runPushBroadcastPage(push, job);
+
+        expect(outcome.nextFilter).toBeUndefined();
+    });
+
     it("does NOT throw when the whole page was pruned (a successful prune, not a failure)", async () => {
         expect.hasAssertions();
 
@@ -128,7 +180,7 @@ describe("queue-backed fan-out", () => {
         await expect(runPushBroadcastPage(push, job)).resolves.toMatchObject({ result: { total: 0 } });
     });
 
-    it("surfaces nextCursor so the caller can enqueue the continuation page", async () => {
+    it("surfaces the continuation filter so the caller can enqueue the next page", async () => {
         expect.hasAssertions();
 
         const broadcastPage = vi
@@ -139,7 +191,7 @@ describe("queue-backed fan-out", () => {
 
         const outcome = await runPushBroadcastPage(push, job);
 
-        expect(outcome.nextCursor).toBe("wp2_deadbeefdeadbeef");
+        expect(outcome.nextFilter).toStrictEqual({ after: "wp2_deadbeefdeadbeef" });
     });
 
     it("a job carrying a cursor resumes broadcastPage with that cursor as `filter.after`", async () => {

--- a/packages/notify/__tests__/subscriptions.test.ts
+++ b/packages/notify/__tests__/subscriptions.test.ts
@@ -53,6 +53,60 @@ describe("normalizeRegisterInput", () => {
         expect(stored).toMatchObject({ id: fcmId("device-token-1"), kind: "fcm", token: "device-token-1" });
         expect(() => normalizeRegisterInput({ kind: "fcm", token: "" })).toThrow(/non-empty `token`/u);
     });
+
+    it("discriminates on `kind`, not on the mere presence of a `token` key", () => {
+        expect.hasAssertions();
+
+        // `RegisterInput` declares `kind` as the discriminator, but the runtime
+        // branched on `"token" in input`. A web-push registration spread from an
+        // object with an optional token field (`{ ...form, token: undefined }`)
+        // carries the KEY, so it was routed to FCM and rejected as a missing
+        // token — a registration the declared type says is valid.
+        const stored = normalizeRegisterInput({ subscription: webPushSub, token: undefined }, 1000);
+
+        expect(stored.kind).toBe("web-push");
+        expect(stored.id).toBe(webPushId(webPushSub.endpoint));
+    });
+});
+
+describe("normalizeRegisterInput field caps (NOTIFY-02)", () => {
+    it("rejects an oversized web-push endpoint", () => {
+        expect.hasAssertions();
+
+        // `metadata` is capped because a client controls it end-to-end and it
+        // lands in the row unbounded. `endpoint`, `token` and `keys` are exactly
+        // as client-controlled and land in the SAME row — a 1 MB endpoint was
+        // accepted while a 4 KB metadata blob was refused.
+        const endpoint = `https://push.example/${"a".repeat(5000)}`;
+
+        expect(() => normalizeRegisterInput({ subscription: { ...webPushSub, endpoint } })).toThrow(/`endpoint` is \d+ bytes/u);
+    });
+
+    it("rejects oversized web-push keys", () => {
+        expect.hasAssertions();
+
+        expect(() => normalizeRegisterInput({ subscription: { ...webPushSub, keys: { auth: "a".repeat(5000), p256dh: "P256KEY" } } })).toThrow(
+            /`keys\.auth` is \d+ bytes/u,
+        );
+        expect(() => normalizeRegisterInput({ subscription: { ...webPushSub, keys: { auth: "AUTHKEY", p256dh: "p".repeat(5000) } } })).toThrow(
+            /`keys\.p256dh` is \d+ bytes/u,
+        );
+    });
+
+    it("rejects an oversized FCM token", () => {
+        expect.hasAssertions();
+
+        expect(() => normalizeRegisterInput({ kind: "fcm", token: "t".repeat(5000) })).toThrow(/`token` is \d+ bytes/u);
+    });
+
+    it("still accepts realistically-sized values", () => {
+        expect.hasAssertions();
+
+        // A real FCM registration token is ~160 chars and a real push endpoint
+        // ~200; the cap must not be tight enough to refuse a live device.
+        expect(() => normalizeRegisterInput({ kind: "fcm", token: "t".repeat(512) })).not.toThrow();
+        expect(() => normalizeRegisterInput({ subscription: { ...webPushSub, endpoint: `https://push.example/${"a".repeat(800)}` } })).not.toThrow();
+    });
 });
 
 describe("normalizeRegisterInput metadata validation (NOTIFY-02)", () => {
@@ -240,6 +294,24 @@ describe("targetOf / ids / isGoneError", () => {
         expect(isGoneError("HTTP 400: invalid token")).toBe(false);
         expect(isGoneError("503 transient upstream error")).toBe(false);
         expect(isGoneError(undefined)).toBe(false);
+    });
+
+    it("does not apply the FCM-only codes to a web-push failure", () => {
+        expect.hasAssertions();
+
+        // The web-push provider echoes the push service's response BODY into
+        // `HTTP ${status}: ${body}`, so a 4xx whose prose happens to contain
+        // "not registered" matched the FCM-only pattern and permanently deleted
+        // a live subscription. The patterns are documented as provider-specific;
+        // pass the kind so they are applied that way.
+        expect(isGoneError("HTTP 403: sender not registered for this endpoint", "web-push")).toBe(false);
+        expect(isGoneError("HTTP 400: UNREGISTERED sender id", "web-push")).toBe(false);
+
+        // The FCM codes still prune an FCM device, and the shared HTTP 404/410
+        // status still prunes either kind (FCM HTTP v1 answers 404 for a dead token).
+        expect(isGoneError("FCM push failed: UNREGISTERED", "fcm")).toBe(true);
+        expect(isGoneError("HTTP 404: Not Found", "fcm")).toBe(true);
+        expect(isGoneError("HTTP 410: Gone", "web-push")).toBe(true);
     });
 });
 

--- a/packages/notify/__tests__/web.test.ts
+++ b/packages/notify/__tests__/web.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { subscribeToPush } from "../src/web";
+import { isPushSupported, subscribeToPush } from "../src/web";
 
 /**
  * Encode bytes as base64url — the inverse of `web.ts`'s `urlBase64ToUint8Array`,
@@ -26,6 +26,7 @@ const OLD_KEY_BYTES = new Uint8Array([4, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90,
 const VAPID_PUBLIC_KEY = toBase64Url(CURRENT_KEY_BYTES);
 
 interface FakeSubscription {
+    endpoint: string;
     options: { applicationServerKey: ArrayBuffer | null };
     toJSON: () => unknown;
     unsubscribe: () => Promise<boolean>;
@@ -35,6 +36,7 @@ const fakeSubscription = (applicationServerKey: ArrayBuffer | null, label: strin
     let unsubscribed = false;
 
     return {
+        endpoint: `https://push.example/${label}`,
         options: { applicationServerKey },
         toJSON: () => {
             return { endpoint: `https://push.example/${label}`, expirationTime: null, keys: { auth: "a", p256dh: "p" } };
@@ -84,7 +86,7 @@ describe("subscribeToPush — VAPID key rotation", () => {
 
         expect(subscribeCalls).toHaveLength(0);
         expect(existing.unsubscribed()).toBe(false);
-        expect(result).toMatchObject({ endpoint: "https://push.example/existing" });
+        expect(result.subscription).toMatchObject({ endpoint: "https://push.example/existing" });
     });
 
     it("unsubscribes and re-subscribes when the existing key does not match (post-rotation)", async () => {
@@ -97,7 +99,7 @@ describe("subscribeToPush — VAPID key rotation", () => {
 
         expect(existing.unsubscribed()).toBe(true);
         expect(subscribeCalls).toHaveLength(1);
-        expect(result).toMatchObject({ endpoint: "https://push.example/fresh" });
+        expect(result.subscription).toMatchObject({ endpoint: "https://push.example/fresh" });
     });
 
     it("subscribes fresh when there is no existing subscription", async () => {
@@ -108,7 +110,41 @@ describe("subscribeToPush — VAPID key rotation", () => {
         const result = await subscribeToPush({ vapidPublicKey: VAPID_PUBLIC_KEY });
 
         expect(subscribeCalls).toHaveLength(1);
-        expect(result).toMatchObject({ endpoint: "https://push.example/fresh" });
+        expect(result.subscription).toMatchObject({ endpoint: "https://push.example/fresh" });
+        expect(result.replacedEndpoint).toBeUndefined();
+    });
+
+    it("reports the replaced endpoint so the orphaned server row can be unregistered", async () => {
+        expect.hasAssertions();
+
+        // The rotation drops the old browser subscription but mints a NEW
+        // endpoint, hence a new `webPushId`, so the old row is never upserted
+        // over. `403 VapidPkHashMismatch` is correctly not a "gone" signal, so
+        // it is never pruned either — every later broadcast pays a POST and a
+        // write for that orphan forever. Handing the old endpoint back is what
+        // lets the caller unregister it (`ctx.push.unregister(webPushId(e))`).
+        const existing = fakeSubscription(new Uint8Array(OLD_KEY_BYTES).buffer, "existing");
+
+        installBrowser(existing);
+
+        const result = await subscribeToPush({ vapidPublicKey: VAPID_PUBLIC_KEY });
+
+        expect(result.replacedEndpoint).toBe("https://push.example/existing");
+        expect(result.subscription).toMatchObject({ endpoint: "https://push.example/fresh" });
+    });
+
+    it("reports Web Push as unsupported when `Notification` is missing", async () => {
+        expect.hasAssertions();
+
+        // Support detection covered service workers + PushManager but not
+        // `Notification`, which `subscribeToPush` then calls unguarded — so a
+        // browser without it got a bare `ReferenceError` instead of the
+        // documented "not supported" error.
+        installBrowser(null);
+        vi.stubGlobal("Notification", undefined);
+
+        expect(isPushSupported()).toBe(false);
+        await expect(subscribeToPush({ vapidPublicKey: VAPID_PUBLIC_KEY })).rejects.toThrow(/not supported in this browser/u);
     });
 });
 
@@ -161,7 +197,7 @@ describe("subscribeToPush — base64url key decoding (padding lengths + substitu
         // Reused: the round-trip decode matched, so no new subscription was minted.
         expect(subscribeCalls).toHaveLength(0);
         expect(existing.unsubscribed()).toBe(false);
-        expect(result).toMatchObject({ endpoint: "https://push.example/existing" });
+        expect(result.subscription).toMatchObject({ endpoint: "https://push.example/existing" });
     };
 
     // base64url strips `=` padding, so the stripped length is only ever

--- a/packages/notify/src/inbox/memory-store.ts
+++ b/packages/notify/src/inbox/memory-store.ts
@@ -85,8 +85,11 @@ const memoryInboxStore = (): InboxStore => {
         return Promise.resolve(count);
     };
 
-    const markRead = (id: string): Promise<void> => {
-        const item = items.find((candidate) => candidate.id === id);
+    const markRead = (userId: string, id: string): Promise<void> => {
+        // Scoped to `userId` like every sibling operation: an item id is not an
+        // authorisation, so an unscoped lookup would let any caller holding one
+        // clear another user's notification.
+        const item = items.find((candidate) => candidate.id === id && candidate.userId === userId);
 
         if (item !== undefined && item.readAt === undefined) {
             item.readAt = Date.now();

--- a/packages/notify/src/inbox/types.ts
+++ b/packages/notify/src/inbox/types.ts
@@ -83,8 +83,8 @@ export interface InboxStore {
     list: (userId: string, filter?: ListInboxFilter) => Promise<InboxItem[]>;
     /** Mark all of `userId`'s currently-unread items as read; returns how many were changed. */
     markAllRead: (userId: string) => Promise<number>;
-    /** Mark one item as read by id (idempotent — a no-op if already read or unknown). */
-    markRead: (id: string) => Promise<void>;
+    /** Mark one of `userId`'s items as read by id (idempotent — a no-op if already read, unknown, or owned by someone else). */
+    markRead: (userId: string, id: string) => Promise<void>;
     /** Count `userId`'s unread items. */
     unreadCount: (userId: string) => Promise<number>;
 }

--- a/packages/notify/src/notify.ts
+++ b/packages/notify/src/notify.ts
@@ -43,12 +43,12 @@ const receiptError = (receipt: Receipt): string | undefined => (receipt.successf
  * `accepted` on success, `gone` when the endpoint is unregistered (404/410, FCM
  * `UNREGISTERED` — the subscription is pruned), else `failed`.
  */
-const pushDeliveryStatus = (receipt: Receipt, error: string | undefined): NotifyDeliveryStatus => {
+const pushDeliveryStatus = (receipt: Receipt, error: string | undefined, kind: StoredSubscription["kind"]): NotifyDeliveryStatus => {
     if (receipt.successful) {
         return "accepted";
     }
 
-    return isGoneError(error) ? "gone" : "failed";
+    return isGoneError(error, kind) ? "gone" : "failed";
 };
 
 /** Run `task` over `items` with a bounded number in flight (order-independent). */
@@ -336,7 +336,7 @@ export const createNotify = (definition: NotifyDefinition, env: NotifyEnv, optio
         try {
             receipt = await engine.sendToChannel("push", { ...payload, to: targetOf(subscription) });
             error = receiptError(receipt);
-            status = pushDeliveryStatus(receipt, error);
+            status = pushDeliveryStatus(receipt, error, subscription.kind);
         } catch (error_) {
             // A THROW from the send path — a transient provider/store error, or the
             // push router's raw throw for a target whose channel (`webPush`/`fcm`)

--- a/packages/notify/src/providers.ts
+++ b/packages/notify/src/providers.ts
@@ -205,6 +205,15 @@ export const routingPushProvider = (options: RoutingPushOptions): Provider<unkno
             // them. Guarding only `to[0]` would let every later entry walk past
             // the rebinding check — the one place it is enforced.
             const targets = Array.isArray(payload.to) ? payload.to : [payload.to];
+
+            if (targets.length === 0) {
+                // Say what is actually wrong. Routing is per target, so with none
+                // both branches below fall through to `pick(undefined)` and a
+                // webPush-only app was told it "received an FCM token target but
+                // no `fcm` channel is configured" for a send naming no recipient.
+                throw new LunoraError("BAD_REQUEST", "@lunora/notify: push send has no recipients — `to` is an empty array");
+            }
+
             const endpoints = targets.map((entry) => webPushEndpoint(entry));
 
             for (const endpoint of endpoints) {

--- a/packages/notify/src/queue.ts
+++ b/packages/notify/src/queue.ts
@@ -1,6 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
-import type { BroadcastOutcome, BroadcastPageResult, LunoraPush, PushContent, SubscriptionFilter } from "./types";
+import type { BroadcastOutcome, BroadcastResult, LunoraPush, PushContent, SubscriptionFilter } from "./types";
 
 /**
  * A broadcast job body — the JSON-serialisable payload enqueued for off-request
@@ -29,17 +29,35 @@ interface PushBroadcastJob {
 /**
  * One page's outcome plus the ids that need redelivering.
  *
- * The consumer MUST act on BOTH fields: `nextCursor` continues the broadcast and
+ * The consumer MUST act on BOTH fields: `nextFilter` continues the broadcast and
  * `failedIds` redelivers the recipients this page missed. Acking a message while
  * ignoring either silently drops part of the audience.
  */
-interface PushBroadcastPageOutcome extends BroadcastPageResult {
+interface PushBroadcastPageOutcome {
     /**
      * Subscriptions that failed transiently on this run (gone/pruned devices are
      * NOT here — they are deleted, not retried). Re-enqueue a job carrying these
      * as `retryIds` to redeliver to just them.
      */
     failedIds: string[];
+
+    /**
+     * The filter for the CONTINUATION job, or `undefined` when the broadcast is
+     * finished (no further pages, or `filter.limit` is spent). Enqueue it
+     * verbatim — it carries the next page's cursor AND, when the job set
+     * `filter.limit`, the REMAINING budget.
+     *
+     * This replaces the raw `nextCursor` the runner used to return. Rebuilding
+     * the filter at the call site (`{ ...job.filter, after: nextCursor }`)
+     * forwarded the ORIGINAL `limit` to every message, so a `limit` documented
+     * as an overall audience cap (see {@link SubscriptionFilter.limit}, which
+     * `broadcast` honours as one) became a per-message cap and the walk reached
+     * the entire audience anyway.
+     */
+    nextFilter?: SubscriptionFilter;
+
+    /** This page's delivery result. */
+    result: BroadcastResult;
 }
 
 /**
@@ -70,15 +88,13 @@ interface QueueProducerLike {
  * export const deliverPage = internalAction
  *     .input({ job: v.any() })
  *     .action(async ({ args: { job }, ctx }) => {
- *         const { failedIds, nextCursor } = await runPushBroadcastPage(ctx.push, job);
+ *         const { failedIds, nextFilter } = await runPushBroadcastPage(ctx.push, job);
  *
- *         if (nextCursor !== undefined) {
+ *         if (nextFilter !== undefined) {
  *             // More pages remain — enqueue the continuation. Each message still
- *             // does only ONE bounded page of work.
- *             await enqueuePushBroadcast(ctx.queues.push, {
- *                 filter: { ...job.filter, after: nextCursor },
- *                 payload: job.payload,
- *             });
+ *             // does only ONE bounded page of work. Pass `nextFilter` VERBATIM:
+ *             // it carries the cursor and the remaining `limit` budget.
+ *             await enqueuePushBroadcast(ctx.queues.push, { filter: nextFilter, payload: job.payload });
  *         }
  *
  *         if (failedIds.length > 0) {
@@ -106,6 +122,32 @@ interface QueueProducerLike {
 const enqueuePushBroadcast = (queue: QueueProducerLike, job: Omit<PushBroadcastJob, "type">): Promise<void> =>
     queue.send({ ...job, type: "lunora.push.broadcast" });
 
+/**
+ * The filter for the next message of a paged broadcast, or `undefined` when the
+ * walk is over.
+ *
+ * `filter.limit` is an OVERALL audience cap (see its JSDoc; `broadcast` enforces
+ * it as one across its internal pages), so the queue path — where each page is a
+ * separate message — has to SPEND it: the continuation carries
+ * `limit - <reached on this page>`, and a spent budget ends the walk even with
+ * pages remaining. Forwarding the original `limit` unchanged let every message
+ * reach up to `limit` more devices, so an audience of any size was walked in
+ * full.
+ */
+const continuationFilter = (filter: SubscriptionFilter | undefined, nextCursor: string | undefined, reached: number): SubscriptionFilter | undefined => {
+    if (nextCursor === undefined) {
+        return undefined;
+    }
+
+    if (filter?.limit === undefined) {
+        return { ...filter, after: nextCursor };
+    }
+
+    const remaining = filter.limit - reached;
+
+    return remaining > 0 ? { ...filter, after: nextCursor, limit: remaining } : undefined;
+};
+
 /** Redeliver to an explicit set of subscription ids (a previous page's failures). */
 const runRetryIds = async (push: LunoraPush, payload: PushContent, ids: ReadonlyArray<string>): Promise<PushBroadcastPageOutcome> => {
     const outcomes: BroadcastOutcome[] = [];
@@ -128,19 +170,28 @@ const runRetryIds = async (push: LunoraPush, payload: PushContent, ids: Readonly
     const sent = outcomes.length - failedIds.length;
     const result = { failed: failedIds.length, outcomes, pruned: 0, sent, total: outcomes.length };
 
-    if (failedIds.length > 0) {
-        // A retry job carries only the ids that already failed once, so there is
-        // nothing to lose by re-throwing it wholesale: the queue's backoff and,
-        // on exhaustion, its dead-letter queue are what bound a device that never
-        // recovers (a rotated VAPID key, a revoked token). No delivered recipient
-        // is inside this message to be re-sent.
+    if (sent === 0 && failedIds.length > 0) {
+        // NOTHING in this message got through, so re-running it wholesale re-sends
+        // nothing that already landed: the queue's backoff and, on exhaustion, its
+        // dead-letter queue are what bound a device that never recovers (a rotated
+        // VAPID key, a revoked token).
+        //
+        // The throw is deliberately gated on "no recipient recovered". A retry
+        // message carries EVERY id it was built with, so throwing after a partial
+        // recovery re-POSTs the ids that just succeeded on every redelivery
+        // (`a,b,c` → `a,b,c` → `a,b,c`, with only `c` still failing) — a duplicate
+        // notification per redelivery for each recovered device. A partly-recovered
+        // run therefore RESOLVES and reports the still-failing ids, so the caller
+        // enqueues a strictly narrower retry — the same shape a partially-failed
+        // page already uses. A device that never recovers never shrinks the set, so
+        // it keeps throwing and still dead-letters.
         throw new LunoraError(
             "INTERNAL",
             `@lunora/notify: push retry failed for ${failedIds.length.toString()} of ${outcomes.length.toString()} subscription(s) — throwing so the queue retries and eventually dead-letters them`,
         );
     }
 
-    return { failedIds, nextCursor: undefined, result };
+    return { failedIds, nextFilter: undefined, result };
 };
 
 /**
@@ -156,21 +207,26 @@ const runRetryIds = async (push: LunoraPush, payload: PushContent, ids: Readonly
  * keyset-paginated on the subscription `id` (see `SubscriptionFilter.after`)
  * — so per-message work is bounded regardless of total audience size.
  * - A page NEVER throws for a partial failure. Throwing discarded the page's
- * `nextCursor`, which is the only way the broadcast advances: one device that
+ * continuation, which is the only way the broadcast advances: one device that
  * fails permanently (a rotated VAPID keypair leaves a stale device answering
  * `403 VapidPkHashMismatch` forever) would then stall the cursor, re-POST
  * every already-delivered recipient on each retry, dead-letter, and leave
- * every LATER page unreached. The page's `nextCursor` and its `failedIds`
+ * every LATER page unreached. The page's `nextFilter` and its `failedIds`
  * both come back instead.
- * - The CALLER re-enqueues: `filter.after:
- * nextCursor` while more pages remain, and a `retryIds: failedIds` job when
- * any recipient failed. `@lunora/notify` cannot do it itself — it has no
- * `@lunora/queue` dependency (the seam stays structural) and no reference to
- * the producer that enqueued this message. See the consumer example on
- * {@link enqueuePushBroadcast}.
- * - A `retryIds` job redelivers to exactly those ids and DOES throw while any
- * of them still fails, so the queue's backoff/dead-letter bounds it. That
- * message contains no already-delivered recipient, so nothing is re-sent.
+ * - The CALLER re-enqueues: `filter: nextFilter` while more pages remain, and a
+ * `retryIds: failedIds` job when any recipient failed. `@lunora/notify` cannot
+ * do it itself — it has no `@lunora/queue` dependency (the seam stays
+ * structural) and no reference to the producer that enqueued this message. See
+ * the consumer example on {@link enqueuePushBroadcast}.
+ * - `job.filter.limit` is spent across messages, not re-granted to each one:
+ * `nextFilter` carries the REMAINING budget and is `undefined` once it runs
+ * out, so `limit` caps the whole audience here exactly as it does on
+ * {@link LunoraPush.broadcast}.
+ * - A `retryIds` job redelivers to exactly those ids and throws only while ALL
+ * of them still fail, so the queue's backoff/dead-letter bounds a device that
+ * never recovers. Once any recipient recovers the run resolves and reports the
+ * rest in `failedIds`, so the narrower retry never re-sends to a device this
+ * message already reached.
  * - Gone subscriptions (404/410, FCM `UNREGISTERED`) are pruned by the page and
  * never appear in `failedIds` — an all-`pruned` page is a success, not a
  * failure, as is an empty page.
@@ -184,7 +240,7 @@ const runPushBroadcastPage = async (push: LunoraPush, job: PushBroadcastJob): Pr
 
     return {
         failedIds: failedIdsOf(page.result.outcomes),
-        nextCursor: page.nextCursor,
+        nextFilter: continuationFilter(job.filter, page.nextCursor, page.result.total),
         result: page.result,
     };
 };

--- a/packages/notify/src/subscriptions/normalize.ts
+++ b/packages/notify/src/subscriptions/normalize.ts
@@ -21,6 +21,33 @@ interface LooseSubscription {
 const MAX_METADATA_BYTES = 4096;
 
 /**
+ * Cap on each client-controlled DELIVERY field written to the same row
+ * (NOTIFY-02, second half): the Web Push `endpoint`, the FCM `token` and the
+ * RFC 8291 `keys`. These are as client-controlled as `metadata` and land in the
+ * same D1 row, so capping only `metadata` bounded nothing — a 4 KB `metadata`
+ * was refused while a 1 MB `endpoint` and a 2 MB `token` went straight in.
+ *
+ * The caps are generous against reality so no live device is refused: a real
+ * push endpoint is ~200 bytes and an FCM registration token ~160, while the
+ * RFC 8291 keys are fixed-width base64url (`p256dh` 87 chars, `auth` 22).
+ */
+const MAX_ENDPOINT_BYTES = 2048;
+const MAX_TOKEN_BYTES = 2048;
+const MAX_KEY_BYTES = 512;
+
+/** Refuse a client-supplied string field that exceeds its byte cap (see {@link MAX_ENDPOINT_BYTES}). */
+const assertFieldSize = (value: string, max: number, field: string): void => {
+    const byteLength = new TextEncoder().encode(value).length;
+
+    if (byteLength > max) {
+        throw new LunoraError(
+            "BAD_REQUEST",
+            `@lunora/notify: register() \`${field}\` is ${byteLength.toString()} bytes, exceeding the ${max.toString()}-byte cap`,
+        );
+    }
+};
+
+/**
  * Validate a `register()` input's `metadata` (NOTIFY-02) before it is
  * STORED: must be a plain object (not an array, class instance, or
  * primitive — those are legal `typeof "object"` values a client could send
@@ -233,12 +260,21 @@ const assertPushEndpoint = (endpoint: string, allowedPushOrigins?: string[]): vo
  * {@link validateMetadata}), and stamps `createdAt`/`lastSeenAt`.
  */
 const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), options: NormalizeOptions = {}): StoredSubscription => {
-    if ("token" in input) {
-        const { token } = input;
+    // `kind` is the DECLARED discriminator (see `RegisterInput`), so branch on it
+    // and fall back to the token's presence only when it is absent. Branching on
+    // `"token" in input` alone routed `{ ...spread, token: undefined }` — a
+    // web-push registration whose source object merely declares an optional token
+    // field — into the FCM path, where it was rejected as a missing token.
+    const isFcm = input.kind === undefined ? (input as { token?: unknown }).token !== undefined : input.kind === "fcm";
+
+    if (isFcm) {
+        const { token } = input as { token?: unknown };
 
         if (typeof token !== "string" || token === "") {
             throw new LunoraError("BAD_REQUEST", "@lunora/notify: register() fcm input requires a non-empty `token`");
         }
+
+        assertFieldSize(token, MAX_TOKEN_BYTES, "token");
 
         return {
             createdAt: now,
@@ -251,7 +287,7 @@ const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), 
         };
     }
 
-    const subscription = parseSubscription(input.subscription);
+    const subscription = parseSubscription((input as { subscription?: unknown }).subscription);
     const { endpoint } = subscription;
     const p256dh = subscription.keys?.p256dh;
     const auth = subscription.keys?.auth;
@@ -260,6 +296,9 @@ const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), 
         throw new LunoraError("BAD_REQUEST", "@lunora/notify: register() web-push subscription requires `endpoint` and `keys.{p256dh, auth}`");
     }
 
+    assertFieldSize(endpoint, MAX_ENDPOINT_BYTES, "endpoint");
+    assertFieldSize(auth, MAX_KEY_BYTES, "keys.auth");
+    assertFieldSize(p256dh, MAX_KEY_BYTES, "keys.p256dh");
     assertPushEndpoint(endpoint, options.allowedPushOrigins);
 
     return {
@@ -318,18 +357,30 @@ const GONE_TEXT_FALLBACK = /\bsubscription (?:is )?(?:gone|expired|no longer val
  * (the browser/device unsubscribed) and should be pruned — as opposed to a
  * transient failure worth retrying.
  *
- * Gates on STRUCTURED signals first: a Web Push `HTTP 404/410` status or an FCM
- * `UNREGISTERED`/`NOT_REGISTERED` code, both of which the providers surface in
- * their failure receipts. The free-text {@link GONE_TEXT_FALLBACK} is a tightened
- * last resort only, so a transient error that happens to contain `expired`
- * (a cert/session expiry) can never permanently drop a valid subscription.
+ * Gates on STRUCTURED signals first: an `HTTP 404/410` status (both providers
+ * answer one for a dead endpoint/token) or, for FCM only, an
+ * `UNREGISTERED`/`NOT_REGISTERED` code. The free-text
+ * {@link GONE_TEXT_FALLBACK} is a tightened last resort only, so a transient
+ * error that happens to contain `expired` (a cert/session expiry) can never
+ * permanently drop a valid subscription.
+ *
+ * `kind` scopes the PROVIDER-SPECIFIC patterns to the provider that emits them.
+ * The web-push provider echoes the push service's response body into
+ * `HTTP ${status}: ${body}`, so a 4xx whose prose merely contains "not
+ * registered" matched the FCM-only codes and permanently deleted a live
+ * subscription. Omit `kind` (the third-party/unknown-provider case) to test
+ * every pattern, as before.
  */
-const isGoneError = (message: string | undefined): boolean => {
+const isGoneError = (message: string | undefined, kind?: StoredSubscription["kind"]): boolean => {
     if (message === undefined) {
         return false;
     }
 
-    return WEB_PUSH_GONE_PATTERN.test(message) || FCM_GONE_PATTERN.test(message) || GONE_TEXT_FALLBACK.test(message);
+    if (WEB_PUSH_GONE_PATTERN.test(message) || GONE_TEXT_FALLBACK.test(message)) {
+        return true;
+    }
+
+    return kind !== "web-push" && FCM_GONE_PATTERN.test(message);
 };
 
 export { fcmId, isGoneError, legacyFcmId, legacyIdFor, legacyWebPushId, normalizeRegisterInput, targetOf, webPushId };

--- a/packages/notify/src/types.ts
+++ b/packages/notify/src/types.ts
@@ -275,11 +275,15 @@ export interface LunoraPush {
      * List stored subscriptions (optionally filtered), with the delivery
      * **secrets** stripped — the Web Push `keys` (RFC 8291 `auth`/`p256dh`) and the
      * FCM `token`. Those, plus the endpoint, are enough to deliver arbitrary push to
-     * a device, so they never cross the app-facing facade; the raw rows are
+     * a device, so no READ on this facade returns them; the raw rows are otherwise
      * reachable only through the internal `SubscriptionStore`.
+     *
+     * {@link LunoraPush.register} is the one exception, and deliberately so: it
+     * echoes back the record the caller just supplied, so it discloses nothing
+     * the caller did not already hold and never another device's row.
      */
     list: (filter?: SubscriptionFilter) => Promise<PushSubscriptionDevice[]>;
-    /** Register (upsert) a device subscription and return the stored record. */
+    /** Register (upsert) a device subscription and return the stored record (the caller's own row, secrets included). */
     register: (input: RegisterInput) => Promise<StoredSubscription>;
     /** Send a push to a single stored subscription (by id or record); `to` is derived from it. */
     send: (target: StoredSubscription | string, payload: PushContent) => Promise<Receipt>;

--- a/packages/notify/src/web.ts
+++ b/packages/notify/src/web.ts
@@ -7,8 +7,10 @@
  * ```ts
  * import { subscribeToPush } from "@lunora/notify/web";
  *
- * const subscription = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
- * await client.mutation("registerDevice", { subscription });
+ * const { replacedEndpoint, subscription } = await subscribeToPush({ serviceWorkerUrl: "/sw.js", vapidPublicKey });
+ * // `replacedEndpoint` is set after a VAPID rotation — pass it on so the server
+ * // can drop the stale row (`ctx.push.unregister(webPushId(replacedEndpoint))`).
+ * await client.mutation("registerDevice", { replacedEndpoint, subscription });
  * ```
  * @packageDocumentation
  */
@@ -20,6 +22,30 @@ interface SerializedPushSubscription {
     endpoint: string;
     expirationTime: number | null;
     keys: { auth: string; p256dh: string };
+}
+
+/**
+ * What {@link subscribeToPush} returns: the (new or reused) subscription, plus
+ * the endpoint of the one it replaced, when it replaced one.
+ */
+interface SubscribeToPushResult {
+    /**
+     * The endpoint of the subscription this call dropped — set ONLY on the
+     * VAPID-rotation path, where the stale subscription is unsubscribed and a
+     * new one minted under the current key.
+     *
+     * Send it to the server and unregister it
+     * (`ctx.push.unregister(webPushId(replacedEndpoint))`). The new subscription
+     * carries a NEW endpoint, hence a new store id, so it never upserts over the
+     * old row — and `403 VapidPkHashMismatch`, which every send to that row now
+     * answers, is correctly not a "gone" signal, so nothing prunes it either.
+     * Dropped instead of returned, the row is billed a POST and a write on every
+     * later broadcast, forever.
+     */
+    replacedEndpoint?: string;
+
+    /** The active subscription, in the serialisable shape `ctx.push.register` accepts. */
+    subscription: SerializedPushSubscription;
 }
 
 /** Options for {@link subscribeToPush}. */
@@ -69,19 +95,26 @@ const matchesVapidKey = (existing: PushSubscription, vapidPublicKey: string): bo
 };
 
 /** A loose view of the browser globals, so support detection reads them without type-narrowing lint. */
-const browserGlobals = globalThis as { navigator?: { serviceWorker?: unknown }; PushManager?: unknown };
+const browserGlobals = globalThis as { navigator?: { serviceWorker?: unknown }; Notification?: unknown; PushManager?: unknown };
 
-/** Whether the current browser supports the Web Push flow (service workers + Push API). */
-const isPushSupported = (): boolean => browserGlobals.navigator?.serviceWorker !== undefined && browserGlobals.PushManager !== undefined;
+/**
+ * Whether the current browser supports the Web Push flow (service workers +
+ * Push API + the Notifications API). `Notification` is part of the check because
+ * {@link subscribeToPush} calls `Notification.requestPermission()` — without it
+ * a browser missing the API got a bare `ReferenceError` rather than the
+ * "not supported" error this predicate exists to produce.
+ */
+const isPushSupported = (): boolean =>
+    browserGlobals.navigator?.serviceWorker !== undefined && browserGlobals.PushManager !== undefined && browserGlobals.Notification !== undefined;
 
 /**
  * Register (or reuse) a service worker and subscribe the browser to Web Push,
  * returning the subscription in serialisable form. Reuses an existing subscription
  * when present. Throws if push is unsupported or the user denies permission.
  */
-const subscribeToPush = async (options: SubscribeToPushOptions): Promise<SerializedPushSubscription> => {
+const subscribeToPush = async (options: SubscribeToPushOptions): Promise<SubscribeToPushResult> => {
     if (!isPushSupported()) {
-        throw new Error("@lunora/notify: Web Push is not supported in this browser (needs service workers + PushManager)");
+        throw new Error("@lunora/notify: Web Push is not supported in this browser (needs service workers + PushManager + Notification)");
     }
 
     let registration: ServiceWorkerRegistration;
@@ -106,11 +139,16 @@ const subscribeToPush = async (options: SubscribeToPushOptions): Promise<Seriali
     // VapidPkHashMismatch` forever — so drop the stale one and re-subscribe.
     const existing = await registration.pushManager.getSubscription();
     let reusable: null | PushSubscription = null;
+    let replacedEndpoint: string | undefined;
 
     if (existing !== null) {
         if (matchesVapidKey(existing, options.vapidPublicKey)) {
             reusable = existing;
         } else {
+            // Read the endpoint BEFORE unsubscribing: it is the only handle on
+            // the server row this rotation orphans — see the result type's
+            // `replacedEndpoint` field for why nothing else ever clears it.
+            replacedEndpoint = existing.endpoint;
             await existing.unsubscribe();
         }
     }
@@ -122,7 +160,7 @@ const subscribeToPush = async (options: SubscribeToPushOptions): Promise<Seriali
             userVisibleOnly: true,
         }));
 
-    return subscription.toJSON() as SerializedPushSubscription;
+    return { replacedEndpoint, subscription: subscription.toJSON() as SerializedPushSubscription };
 };
 
 /** Unsubscribe the browser's current Web Push subscription. Returns whether one was removed. */
@@ -137,5 +175,5 @@ const unsubscribeFromPush = async (): Promise<boolean> => {
     return subscription === null ? false : subscription.unsubscribe();
 };
 
-export type { SerializedPushSubscription, SubscribeToPushOptions };
+export type { SerializedPushSubscription, SubscribeToPushOptions, SubscribeToPushResult };
 export { isPushSupported, subscribeToPush, unsubscribeFromPush };

--- a/packages/queue/docs/index.mdx
+++ b/packages/queue/docs/index.mdx
@@ -40,15 +40,10 @@ import { defineQueue } from "@lunora/queue";
 import { api } from "./_generated/api";
 
 export const emailQueue = defineQueue<{ to: string }>({
-    handler: async (ctx, batch) => {
+    handler: async (_ctx, batch) => {
         for (const message of batch.messages) {
-            try {
-                await message.run(api.email.send, { to: message.body.to });
-                message.ack();
-            } catch (error) {
-                ctx.log.error("send failed", message.id, error);
-                message.retry();
-            }
+            await message.run(api.email.send, { to: message.body.to });
+            message.ack();
         }
     },
     // Push-consumer tuning (optional):
@@ -58,6 +53,8 @@ export const emailQueue = defineQueue<{ to: string }>({
 
 The handler runs inside a Lunora context: call any query/mutation/action with `message.run(api.x.y, args)` (the dispatch goes through the same path the scheduler and workflows use). Each `message` is `ack`/`retry`-able for at-least-once processing.
 
+Note the loop does **not** wrap `message.run(...)` in a `try`/`catch`. Letting the failure propagate is what the consumer needs to isolate a poison message — see below.
+
 ## Poison messages
 
 `message.run(...)` is `ctx.run(...)` pinned to that one message, and the pin is what keeps one bad message from taking its whole batch down.
@@ -66,9 +63,9 @@ Cloudflare delivers up to 100 messages per batch and redelivers the **whole batc
 
 When a call made through `message.run(...)` fails **deterministically** (the dispatched function answered `400`, `403`, `404` or `422` — a retry would fail identically), the consumer attributes the failure to that message: it is acked and taken out of the queue, every message the handler had not yet decided is explicitly retried, and the batch as a whole resolves. Messages the handler already `ack`ed or `retry`ed keep the decision it made. Transient failures (`408`, `429`, `5xx`, a timeout) are unchanged — the batch still throws and workerd retries it.
 
-Attribution needs the pin. A bare `ctx.run(api.x.y, args)` inside the loop carries no message id, so its failure is unattributable and the whole batch retries — which is why the loop should call `message.run`. Isolation does not depend on the dev capture sink; it applies in production too.
+Attribution needs the pin **and the throw**. A bare `ctx.run(api.x.y, args)` inside the loop carries no message id, so its failure is unattributable and the whole batch retries — which is why the loop should call `message.run`. And a `try`/`catch` around `message.run(...)` that swallows the error and calls `message.retry()` opts the message out entirely: the consumer only attributes a failure the handler let propagate, and an explicit `retry()` is a decision it never overrides. The poison message then burns its retry budget and dead-letters exactly as if isolation did not exist. If you need to log the failure yourself, re-throw after logging. Isolation does not depend on the dev capture sink; it applies in production too.
 
-Because an isolated message is acked, it never reaches the dead-letter queue. It is recorded with outcome `error` (and the failure message) in the Studio **Queues** log, which is where you see it — so keep dev capture on, or log it yourself in a `catch`.
+Because an isolated message is acked, it never reaches the dead-letter queue. It is recorded with outcome `error` (and the failure message) in the Studio **Queues** log, which is where you see it — so keep dev capture on, or log it in a `catch` that re-throws.
 
 ## Enqueue from a mutation or action
 

--- a/packages/replica/__tests__/event-log-do-client.test.ts
+++ b/packages/replica/__tests__/event-log-do-client.test.ts
@@ -377,6 +377,61 @@ describe("eventLogDOClient + MaterializerRuntime", () => {
         expect(runtime.appliedSeq).toBe(1501);
     });
 
+    it("appendEvent leaves its entry unapplied when the catch-up cannot close the gap", async () => {
+        expect.assertions(6);
+
+        // The gap the walk cannot close in one call. `#catchUp` is bounded by
+        // MAX_CATCHUP_PAGES (1000), so a backlog deeper than the bound is STILL
+        // open when the walk returns — the previous fixture kept the remainder
+        // under the bound and so could not tell the two behaviours apart.
+        // Applying the appended entry here would advance every lagging
+        // watermark to `entry.seq + 1`, and the events in between would never
+        // be fetched by anyone again. The entry is persisted either way; it
+        // waits for the backlog ahead of it instead.
+        const client = {
+            append: async () => [{ seq: 2500, type: "increment", payload: {}, timestamp: 2500 }],
+            getSince: async (sinceSeq: number) => {
+                return {
+                    cursor: sinceSeq + 1,
+                    entries: [{ seq: sinceSeq, type: "increment", payload: {}, timestamp: sinceSeq }],
+                    truncated: sinceSeq < 2500,
+                };
+            },
+        } as unknown as EventLogDOClient;
+
+        const counter = defineMaterializer({
+            name: "counter",
+            initial: () => {
+                return { total: 0 };
+            },
+            handle: (state, entry) => {
+                if (entry.type === "increment") {
+                    return { total: state.total + 1 };
+                }
+                return state;
+            },
+        });
+
+        const runtime = new MaterializerRuntime([counter], { doClient: client });
+
+        // First pass: 0..999, one page each, then the budget runs out.
+        await expect(runtime.initialize()).resolves.toBe(1000);
+
+        const entry = await runtime.appendEvent({ type: "increment", payload: {} });
+
+        // The append still persisted and still reports its seq.
+        expect(entry.seq).toBe(2500);
+        // A second budget carried 1000..1999. Seqs 2000..2500 are still ahead of
+        // the watermark — NOT stepped over — so nothing is lost.
+        expect(counter.state).toEqual({ total: 2000 });
+        expect(runtime.appliedSeq).toBe(2000);
+
+        // The backlog is still reachable: the next pass reads 2000..2500,
+        // including the appended entry, in seq order.
+        await expect(runtime.initialize()).resolves.toBe(501);
+        expect(counter.state).toEqual({ total: 2501 });
+    });
+
     it("appendEvent throws when no doClient configured", async () => {
         expect.assertions(1);
 

--- a/packages/replica/src/define-materializer.ts
+++ b/packages/replica/src/define-materializer.ts
@@ -449,7 +449,8 @@ class MaterializerRuntime {
      * This is a convenience over calling `doClient.append(...)` +
      * `runtime.applyEntries(...)` yourself — it persists the event
      * **then** applies the returned entry (with its assigned seq).
-     * @returns The persisted entry with its DO-assigned `seq`.
+     * @returns The persisted entry with its DO-assigned `seq` — always, whether
+     * or not the entry could be applied to the materializers (see below).
      */
     public async appendEvent(input: AppendEventInput): Promise<EventLogEntry> {
         if (!this.#doClient) {
@@ -471,11 +472,24 @@ class MaterializerRuntime {
         // and skips it permanently: the next `initialize()` starts after the
         // gap and nothing ever reads those entries. The walk re-fetches this
         // entry too; `applyEntries` skips it as already applied, so the call
-        // below stays correct either way. It closes the gap only UP TO
-        // MAX_CATCHUP_PAGES — `#catchUp` stops at the same bound `initialize()`
-        // does — so a backlog deeper than that is still stepped over here.
+        // below stays correct either way.
         if (this.#materializers.length > 0 && this.appliedSeq < entry.seq) {
             await this.#catchUp();
+
+            // `#catchUp` is bounded by MAX_CATCHUP_PAGES, so a backlog deeper
+            // than the bound leaves the gap OPEN. Applying the entry now would
+            // do exactly what the walk above exists to prevent — step every
+            // lagging watermark to `entry.seq + 1` over events nothing has read
+            // — and the resulting state is not "slightly behind" but
+            // permanently derived from a subset of the log, with no record that
+            // anything is missing. Leave the entry unapplied instead: it is
+            // durably persisted, the watermarks still point INTO the backlog,
+            // and the next catch-up (this method's own, or `initialize()`)
+            // applies the backlog and this entry in seq order. State converges
+            // late rather than settling wrong.
+            if (this.appliedSeq < entry.seq) {
+                return entry;
+            }
         }
 
         this.applyEntries([entry]);

--- a/packages/search-core/README.md
+++ b/packages/search-core/README.md
@@ -32,7 +32,12 @@ As a package it gets ESLint, its own tests and its own coverage gate. As `privat
 
 **Analysis is stored.** The same analysis must run over a document when it is indexed and over the query when it is searched, forever, or the two stop meeting. That is why `createSearchAnalyzer` carries a `profile` string: it is recorded alongside each companion's backfill progress, so changing a language — or bumping `ANALYZER_VERSION` — is _detected_ and rebuilds the index instead of leaving half of it analyzed the old way.
 
-The recorded profile is `<analyzer>:<field>`, not the analyzer alone — re-pointing an index at another column leaves every stored row holding the text of the column you abandoned, and a profile that only tracked analysis reported such an index complete while searches over the new column returned nothing. Any change to the recorded profile string rebuilds every deployed index once, in place, on the first migration after the change: reads keep being served throughout (a rebuild rewrites each row where it stands, and the coverage flag is latched), so it costs one backfill walk per index, not an outage.
+The recorded profile is `<analyzer>:<field>`, not the analyzer alone — re-pointing an index at another column leaves every stored row holding the text of the column you abandoned, and a profile that only tracked analysis reported such an index complete while searches over the new column returned nothing. Any change to the recorded profile string rebuilds every deployed index once, in place, on the first migration after the change: nothing is ever emptied, the re-walk restarts at the top of the table and rewrites each row where it stands, so it costs one backfill walk per index, not a refill from nothing.
+
+What that rebuild costs a reader depends on which half of the profile moved:
+
+- **The analyzer moved** (a language change, or an `ANALYZER_VERSION` bump). Coverage is latched through the rebuild and **reads keep being served** — under the previous analysis rules, row by row, until each row's turn comes. The stored rows still answer about the column that was asked for.
+- **The field moved.** Coverage is dropped (`searchCoverageSurvives` compares the recorded field, not the analyzer), so **reads refuse with `SEARCH_INDEX_BUILDING` until the re-walk completes** — the stored rows hold another column's text, and serving them would answer confidently with matches from the column the index was pointed away from. The window is bounded by one walk, and `backfillSearch` closes it in a single admin call.
 
 If you change folding, stopwords, the token-length cap, or (one day) stemming, bump `ANALYZER_VERSION`. Not doing so leaves every existing index half-matching, silently, for the rest of its life.
 

--- a/packages/seed/__tests__/client.test.ts
+++ b/packages/seed/__tests__/client.test.ts
@@ -252,4 +252,27 @@ describe("createSeedClient", () => {
         expect(a.users).toEqual(b.users);
         expect(a.users).not.toEqual(c.users);
     });
+
+    // Ids are hashed from `seed` alone, so the determinism the other cases prove
+    // survives an unpinned clock. Time-valued columns do not: without `now` they
+    // fall back to `Date.now()` per call, and two runs of the same seed differ.
+    it("pins time-valued columns to the supplied now", async () => {
+        expect.hasAssertions();
+
+        const temporalSchema = defineSchema({ sessions: defineTable({ expiresAt: v.timestamp() }) });
+        const rowsAt = async (now: number): Promise<ReadonlyArray<Record<string, unknown>>> => {
+            const seed = createSeedClient<{ sessions: { expiresAt: number } }>(temporalSchema, { now, seed: 5 });
+
+            await seed.sessions(3);
+
+            return seed.$store.sessions ?? [];
+        };
+
+        const pinned = await rowsAt(1_700_000_000_000);
+        const earlier = await rowsAt(1_600_000_000_000);
+
+        expect(pinned).toStrictEqual(await rowsAt(1_700_000_000_000));
+        expect(pinned.map((row) => row.expiresAt)).not.toStrictEqual(earlier.map((row) => row.expiresAt));
+        expect(pinned.every((row) => typeof row.expiresAt === "number" && row.expiresAt <= 1_700_000_000_000)).toBe(true);
+    });
 });

--- a/packages/seed/__tests__/generate-value.test.ts
+++ b/packages/seed/__tests__/generate-value.test.ts
@@ -129,6 +129,67 @@ describe("generateValue — bytes wire representation", () => {
     });
 });
 
+describe("generateValue — v.date() / v.timestamp()", () => {
+    const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
+
+    it.each([
+        ["date", v.date()],
+        ["timestamp", v.timestamp()],
+    ])("anchors a v.%s() column on the caller's `now` rather than a generator-local window", (kind, validator) => {
+        expect.assertions(2);
+
+        // Regression: this arm drew from faker's hard-coded 1980–2020 window and
+        // ignored `now` entirely, so `expiresAt: v.timestamp()` seeded 2012 while
+        // `expiresAt: v.timestamp().unique()` (which uses `now`) seeded 2026.
+        const value = generateValue(validator, "expiresAt", `${kind}-input`, NOW) as number;
+
+        expect(value).toBeLessThanOrEqual(NOW);
+        expect(value).toBeGreaterThanOrEqual(NOW - SIX_MONTHS_MS);
+    });
+
+    it("shifts with `now` instead of staying pinned to a fixed calendar window", () => {
+        expect.assertions(1);
+
+        const later = NOW + 10 * 365 * 24 * 60 * 60 * 1000;
+
+        expect(generateValue(v.timestamp(), "expiresAt", "same-input", later)).toBe(
+            (generateValue(v.timestamp(), "expiresAt", "same-input", NOW) as number) + (later - NOW),
+        );
+    });
+});
+
+describe("generateValue — refined string columns", () => {
+    it("refuses a pattern-constrained column by name instead of seeding a value its own validator rejects", () => {
+        expect.assertions(2);
+
+        // The `.unique()` twin (`stringDeal`) and the `v.from()` arm both refuse
+        // loudly for this reason; the ordinary path used to emit a bare lorem
+        // word — `sku` → "audeo", `safeParse().ok === false`.
+        const sku = v.string().pattern(/^SKU-\d{4}$/u);
+
+        expect(() => generateValue(sku, "sku", "input", NOW)).toThrow(/sku/u);
+        expect(() => generateValue(sku, "sku", "input", NOW)).toThrow(/pattern/u);
+    });
+
+    it("refuses a column declaring a format it has no generator for", () => {
+        expect.assertions(1);
+
+        expect(() => generateValue(withConstraints(v.string(), { format: "ipv6" }), "peer", "input", NOW)).toThrow(/format "ipv6"/u);
+    });
+
+    it.each([
+        ["homepage", v.string().url(), (value: string) => new URL(value).protocol],
+        ["contact", v.string().email(), (value: string) => (/^[^@\s]+@[^@\s]+$/u.test(value) ? "https:" : "")],
+    ])("generates a conforming value for a declared format on %s, whose name no heuristic matches", (field, validator, probe) => {
+        expect.assertions(1);
+
+        // A declared format outranks the field-name heuristics: neither
+        // `homepage` nor `contact` matches a keyword, so both used to fall
+        // through to `copycat.word` — "tremo", "audeo".
+        expect(probe(generateValue(validator, field, `${field}-input`, NOW) as string)).toBe("https:");
+    });
+});
+
 describe("generateValue — time-named number columns", () => {
     const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
 

--- a/packages/seed/__tests__/plan.test.ts
+++ b/packages/seed/__tests__/plan.test.ts
@@ -450,6 +450,48 @@ describe("seedPlan — unique columns beyond enums and strings", () => {
         expect(distinct(rows, "contact")).toBe(50);
     });
 
+    it("deals a unique literal union without replacement and refuses past its domain", () => {
+        expect.hasAssertions();
+
+        // The same split the `.unique()` FK had: a union of literals is a closed
+        // domain, but the generator picked a member per row WITH replacement, so
+        // eight rows over two literals simply repeated — the exact case the docs
+        // name as refused at plan time.
+        const shape = { u: v.union(v.literal("a"), v.literal("b")).unique() };
+
+        expect(new Set(rowsOf(shape, 2).map((row) => row.u))).toStrictEqual(new Set(["a", "b"]));
+        expect(() => rowsOf(shape, 8)).toThrow(/unique column "u" has only 2 possible values/);
+    });
+
+    it("honours declared bigint bounds on the plain path, not just the unique one", () => {
+        expect.hasAssertions();
+
+        // `v.bigint()` drew from its default [0, 1_000_000] whatever the column
+        // declared, while the `.unique()` twin walked the declared range — so the
+        // plain spelling seeded values the column's own validator rejects.
+        const bounded = v.bigint().check(() => true, { schema: { maximum: 5, minimum: 1 } });
+
+        expect(rowsOf({ b: bounded }, 20).every((row) => (row.b as number) >= 1 && (row.b as number) <= 5)).toBe(true);
+    });
+
+    it("seeds v.timestamp() and its .unique() twin into the same era", () => {
+        expect.hasAssertions();
+
+        // Regression: the plain arm drew from a hard-coded 1980–2020 window while
+        // the `.unique()` arm stepped back from `now`, so the two spellings of one
+        // column landed four decades apart and the plain one read as long past.
+        const now = Date.parse("2026-09-03T00:00:00.000Z");
+        const { rows } = seedPlan(defineSchema({ events: defineTable({ expiresAt: v.timestamp(), uniqueAt: v.timestamp().unique() }) }), {
+            counts: { events: 20 },
+            now,
+            seed: 5,
+        }).find((entry) => entry.table === "events")!;
+        const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
+
+        expect(rows.every((row) => (row.expiresAt as number) <= now && (row.expiresAt as number) >= now - SIX_MONTHS_MS)).toBe(true);
+        expect(rows.every((row) => (row.uniqueAt as number) <= now && (row.uniqueAt as number) >= now - SIX_MONTHS_MS)).toBe(true);
+    });
+
     it("refuses unique columns whose declared shape an index tag would violate", () => {
         expect.hasAssertions();
 
@@ -465,5 +507,79 @@ describe("seedPlan — unique columns beyond enums and strings", () => {
             ),
         ).toThrow(/pattern-constrained/);
         expect(() => rowsOf({ s: v.string().url().unique() }, 5)).toThrow(/format "uri"/);
+    });
+});
+
+describe("seedPlan — unique foreign keys", () => {
+    const relationSchema = defineSchema({
+        profiles: defineTable({ userId: v.id("users").unique() }),
+        users: defineTable({ name: v.string() }),
+    });
+
+    it("deals parent ids without replacement for a .unique() foreign key", () => {
+        expect.hasAssertions();
+
+        // Regression: `planUniqueDeals` skipped every FK column, so a `.unique()`
+        // `v.id("users")` — the natural way to spell a 1:1 — fell through to
+        // `copycat.oneOf`, a uniform draw WITH replacement: 7 distinct parents
+        // across 10 rows, then a raw UNIQUE-constraint error on insert.
+        const plan = seedPlan(relationSchema, { counts: { profiles: 50, users: 50 }, now: 1_700_000_000_000, seed: 1 });
+        const userIds = new Set(plan.find((entry) => entry.table === "users")!.rows.map((row) => row._id));
+        const linked = plan.find((entry) => entry.table === "profiles")!.rows.map((row) => row.userId);
+
+        expect(new Set(linked).size).toBe(50);
+        expect(linked.every((id) => userIds.has(id))).toBe(true);
+    });
+
+    it("refuses a batch larger than the parent pool, naming the column", () => {
+        expect.hasAssertions();
+
+        const run = (): unknown => seedPlan(relationSchema, { counts: { profiles: 10, users: 4 }, now: 1_700_000_000_000, seed: 1 });
+
+        expect(run).toThrow('unique column "userId"');
+        expect(run).toThrow(/only 4 possible values/);
+    });
+
+    it("counts pre-existing parent ids toward the pool", () => {
+        expect.hasAssertions();
+
+        // The studio's generate-rows dialog seeds one table and passes the live
+        // parent ids as `existingIds`, so those have to be part of the domain.
+        const { rows } = seedPlan(relationSchema, {
+            counts: { profiles: 3 },
+            existingIds: { users: ["u1", "u2", "u3"] },
+            now: 1_700_000_000_000,
+            only: ["profiles"],
+            seed: 1,
+        }).find((entry) => entry.table === "profiles")!;
+
+        expect(new Set(rows.map((row) => row.userId))).toStrictEqual(new Set(["u1", "u2", "u3"]));
+    });
+
+    it("keeps a .unique() self-reference distinct by pointing each row at its predecessor", () => {
+        expect.hasAssertions();
+
+        // A self-reference's pool is the rows generated before it, so there is
+        // nothing to deal from at plan time; the preceding row is the one choice
+        // distinct for every row.
+        const { rows } = seedPlan(defineSchema({ nodes: defineTable({ previousId: v.optional(v.id("nodes").unique()) }) }), {
+            counts: { nodes: 30 },
+            now: 1_700_000_000_000,
+            seed: 1,
+        }).find((entry) => entry.table === "nodes")!;
+        const links = rows.slice(1).map((row) => row.previousId);
+
+        expect(rows[0]!.previousId).toBeUndefined();
+        expect(links).toStrictEqual(rows.slice(0, -1).map((row) => row._id));
+    });
+
+    it("leaves an ordinary foreign key drawing with replacement", () => {
+        expect.hasAssertions();
+
+        // Only `.unique()` changes: a plain `v.id("users")` is a many-to-one and
+        // must stay free to repeat a parent.
+        const plan = seedPlan(schema, { counts: { posts: 40, users: 3 }, now: 1_700_000_000_000, seed: 1 });
+
+        expect(new Set(plan.find((entry) => entry.table === "posts")!.rows.map((row) => row.authorId)).size).toBeLessThanOrEqual(3);
     });
 });

--- a/packages/seed/__tests__/plan.test.ts
+++ b/packages/seed/__tests__/plan.test.ts
@@ -389,6 +389,37 @@ describe("seedPlan — unique columns", () => {
         expect(rows[0]).toStrictEqual({ _id: "d84cf143-978e-4b60-9832-481cdfa76ce2", age: 460, email: "bryan79@hotmail.com", name: "Ada Fritsch DVM" });
         expect(rows[1]).toStrictEqual({ _id: "730f300b-1bf5-4730-9340-429bb785ee9b", age: 509, email: "courtney51@hotmail.com", name: "Griffin Towne" });
     });
+
+    // The tag budget for an email column is the whole fallback domain, not the
+    // one-character suffix separator: counting the cheap form let a narrow
+    // column claim a billion possible values and then seed one its own
+    // validator rejects.
+    it("refuses a unique email column too narrow to hold a tagged address", () => {
+        expect.hasAssertions();
+
+        const narrow = defineSchema({ people: defineTable({ contact: v.string().email().max(10).unique() }) });
+        const run = (): unknown => seedPlan(narrow, { counts: { people: 3 }, now: 1_700_000_000_000, seed: 3 });
+
+        expect(run).toThrow('unique column "contact"');
+        expect(run).toThrow(/only 0 possible values/);
+    });
+
+    // The narrowest column that can still hold `<tag>@example.com` deals exactly
+    // ten values — one per single-digit tag — and no more.
+    it("budgets a unique email column's capacity by the domain the tag has to fit around", () => {
+        expect.hasAssertions();
+
+        const boundary = defineSchema({ people: defineTable({ contact: v.string().email().max(13).unique() }) });
+        const seedRows = (count: number): ReadonlyArray<Record<string, unknown>> =>
+            seedPlan(boundary, { counts: { people: count }, now: 1_700_000_000_000, seed: 3 }).find((entry) => entry.table === "people")!.rows;
+
+        const rows = seedRows(10);
+
+        expect(new Set(rows.map((row) => row.contact)).size).toBe(10);
+        expect(rows.every((row) => String(row.contact).length <= 13)).toBe(true);
+        expect(() => seedRows(11)).toThrow(/cannot seed 11 rows into "people"/);
+        expect(() => seedRows(11)).toThrow(/only 10 possible values/);
+    });
 });
 
 describe("seedPlan — unique columns beyond enums and strings", () => {

--- a/packages/seed/docs/index.mdx
+++ b/packages/seed/docs/index.mdx
@@ -135,6 +135,11 @@ Without codegen, pass the type yourself: `createSeedClient<InsertModel>(schema)`
     type={{
         defaultCount: { type: "number", default: "10", description: "Row count when a table call passes no spec." },
         seed: { type: "number", default: "0", description: "Deterministic mapping selector." },
+        now: {
+            type: "number",
+            default: "Date.now()",
+            description: "Epoch-ms reference for time-valued columns. Pin it alongside `seed` for a byte-identical run.",
+        },
         persist: {
             type: "(table, rows) => Promise<void> | void",
             description: "Called with each generated batch (parents first). The client is pure when omitted.",

--- a/packages/seed/docs/index.mdx
+++ b/packages/seed/docs/index.mdx
@@ -162,7 +162,8 @@ Other flags: `--batch-size` (rows per HTTP request, default 500), `--url` (worke
 
 ## Limitations
 
-- **`.unique()` columns are dealt distinct values by construction.** Each value is a function of the row's absolute index, not a hash of the row, so two rows in the same run never collide — including across the several calls `indexOffset` exists to support. A column whose domain is too small to cover the requested count (a boolean, a three-literal `v.union()`) is refused at plan time, with the column named, before anything is inserted.
+- **`.unique()` columns are dealt distinct values by construction.** Each value is a function of the row's absolute index, not a hash of the row, so two rows in the same run never collide — including across the several calls `indexOffset` exists to support. A `.unique()` foreign key (`v.id("users").unique()`, the way to spell a 1:1) is dealt from its parent pool without replacement, so the pool's size is its domain. A column whose domain is too small to cover the requested count (a boolean, a three-literal `v.union()`, a parent table with fewer rows than the child) is refused at plan time, with the column named, before anything is inserted.
+- **A column the generator cannot satisfy is refused, not guessed at.** `v.from(externalSchema)`, a `.pattern()` column, and any `format` with no generator behind it (only `email` and `uri` have one) fail at plan time with the column named, rather than seeding a value the column's own validator rejects on insert. Supply those through `overrides`, or skip the table with `only`.
 - Seeding is deterministic by design. Re-running with the same `seed` regenerates identical `_id`s, which the import path skips as conflicts. Use a different `seed` for fresh rows, or `--reset` to wipe local state first.
 
 ## Related

--- a/packages/seed/src/client.ts
+++ b/packages/seed/src/client.ts
@@ -61,6 +61,15 @@ type SeedClient<InsertModel> = SeedClientState & {
 interface SeedClientOptions {
     /** Default row count when a table call passes no spec (default `10`). */
     defaultCount?: number;
+
+    /**
+     * Wall-clock reference for time-valued columns (`createdAt`, `expiresAt`, a
+     * `.unique()` date, …), in epoch-ms. Defaults to `Date.now()` **per call**,
+     * which is the one input that otherwise drifts between runs — pin it and the
+     * client is deterministic in the full sense the docs promise, not merely in
+     * its ids.
+     */
+    now?: number;
     /** Persist each generated batch (e.g. insert through the test harness). Pure when omitted. */
     persist?: (table: string, rows: ReadonlyArray<Record<string, unknown>>) => Promise<void> | void;
     /** Deterministic mapping selector — same seed ⇒ same rows and ids. Default `0`. */
@@ -140,7 +149,7 @@ const buildOverrides = <Row>(
  * // posts.authorId values are drawn from `users`.
  */
 const createSeedClient = <InsertModel = Record<string, Record<string, unknown>>>(schema: Schema, options: SeedClientOptions = {}): SeedClient<InsertModel> => {
-    const { defaultCount = 10, persist, seed = 0 } = options;
+    const { defaultCount = 10, now, persist, seed = 0 } = options;
 
     const store: Record<string, Record<string, unknown>[]> = {};
     const idsByTable: Record<string, string[]> = {};
@@ -158,6 +167,7 @@ const createSeedClient = <InsertModel = Record<string, Record<string, unknown>>>
             counts: { [table]: count },
             existingIds: idsByTable,
             indexOffset: { [table]: offset },
+            now,
             only: [table],
             overrides: { [table]: buildOverrides(partials, callOptions?.overrides, offset) },
             seed,

--- a/packages/seed/src/copycat/index.ts
+++ b/packages/seed/src/copycat/index.ts
@@ -54,14 +54,6 @@ const copycat = {
         return seeded(input, () => faker.location.country());
     },
 
-    /** ISO-8601 date string between `min`/`max` (default years 1980–2020). */
-    dateString(input: unknown, options?: { max?: Date; min?: Date }): string {
-        const min = options?.min ?? new Date("1980-01-01T00:00:00.000Z");
-        const max = options?.max ?? new Date("2020-01-01T00:00:00.000Z");
-
-        return seeded(input, () => faker.date.between({ from: min, to: max }).toISOString());
-    },
-
     email(input: unknown): string {
         return seeded(input, () => faker.internet.email().toLowerCase());
     },

--- a/packages/seed/src/generate-value.ts
+++ b/packages/seed/src/generate-value.ts
@@ -124,11 +124,66 @@ const isTimestampField = (fieldName: string): boolean => {
  */
 const generateTimestamp = (input: unknown, now: number): number => now - copycat.int(input, { max: TIMESTAMP_WINDOW_MS, min: 0 });
 
-/** Heuristic string generation by column name (mirrors the studio data generator). */
-const generateString = (fieldName: string, input: unknown, constraints: Constraints): string => {
+/**
+ * Refuse a column the seeder cannot invent a conforming value for, naming it.
+ *
+ * Falling through to the generic `copycat.word` would produce a value the very
+ * next `ctx.db.insert` rejects, reported as a validation failure on a row
+ * nobody wrote by hand. The `.unique()` twin (`planUniqueDeal`) refuses the
+ * same shapes for the same reason, so the two paths agree on which columns are
+ * seedable at all.
+ */
+const refuseColumn = (fieldName: string, why: string): never => {
+    throw new LunoraError(
+        "INTERNAL",
+        `@lunora/seed: column "${fieldName}" ${why}. ` +
+            `Supply a value via \`overrides\` (\`{ <table>: { ${fieldName}: … } }\`) or restrict the run with \`only\` so the table is skipped.`,
+    );
+};
+
+/**
+ * Generators for the JSON Schema `format` keywords a string column can declare
+ * (`v.string().email()` → `email`, `v.string().url()` → `uri`). A declared
+ * format is authoritative over the field-name heuristics below — the column's
+ * own validator re-checks it on insert, and it is the same rule the `number`
+ * arm applies to declared bounds ("a schema that says `minimum: 0, maximum: 5`
+ * means a rating, whatever the column is called").
+ */
+const FORMAT_GENERATORS: Readonly<Record<string, (input: unknown) => string>> = {
+    email: (input) => copycat.email(input),
+    uri: (input) => copycat.url(input),
+};
+
+/**
+ * Generate the base string for a column, honouring a declared shape over the
+ * field-name heuristics and refusing outright when the shape is one the seeder
+ * cannot satisfy.
+ */
+const generateStringBody = (fieldName: string, input: unknown, constraints: Constraints): string => {
+    const { format, pattern } = constraints;
+
+    if (pattern !== undefined) {
+        return refuseColumn(
+            fieldName,
+            `is constrained to the pattern /${pattern}/, and the seeder cannot invent a value matching an arbitrary regular expression`,
+        );
+    }
+
+    if (format !== undefined) {
+        const generate = FORMAT_GENERATORS[format];
+
+        return generate === undefined ? refuseColumn(fieldName, `declares format "${format}", which the seeder has no generator for`) : generate(input);
+    }
+
     const lower = fieldName.toLowerCase();
     const rule = STRING_HEURISTICS.find((entry) => entry.keywords.some((keyword) => lower.includes(keyword)));
-    const value = rule === undefined ? copycat.word(input) : rule.generate(input);
+
+    return rule === undefined ? copycat.word(input) : rule.generate(input);
+};
+
+/** Heuristic string generation by column name (mirrors the studio data generator). */
+const generateString = (fieldName: string, input: unknown, constraints: Constraints): string => {
+    const value = generateStringBody(fieldName, input, constraints);
 
     const { maxLength, minLength } = constraints;
 
@@ -176,10 +231,12 @@ const generateValue = (validator: Validator, fieldName: string, input: unknown, 
         case "bigint": {
             // Emit a plain number so the value survives JSON serialisation on every
             // adapter path (CLI NDJSON, studio JSON response, testing harness). The
-            // range [0, 1_000_000] is well within Number.MAX_SAFE_INTEGER, so no
-            // integer precision is lost. Adapters that write to the DO's SQLite
-            // layer must coerce this back to BigInt before insert (see testing.ts).
-            return copycat.int(input, { max: BIGINT_RANGE.max, min: BIGINT_RANGE.min });
+            // default range [0, 1_000_000] is well within Number.MAX_SAFE_INTEGER,
+            // so no integer precision is lost. Adapters that write to the DO's
+            // SQLite layer must coerce this back to BigInt before insert (see
+            // testing.ts). Declared bounds win over the default, the same as the
+            // `number` arm and the `.unique()` twin's `boundedNumeric`.
+            return copycat.int(input, { max: constraints.maximum ?? BIGINT_RANGE.max, min: constraints.minimum ?? BIGINT_RANGE.min });
         }
 
         case "boolean": {
@@ -198,21 +255,23 @@ const generateValue = (validator: Validator, fieldName: string, input: unknown, 
 
         case "date":
         case "timestamp": {
-            // Lunora stores dates as epoch-ms numbers.
-            return new Date(copycat.dateString(input)).getTime();
+            // Lunora stores dates as epoch-ms numbers, anchored on the caller's
+            // `now` like every other time-valued column — the `number` arm's
+            // `isTimestampField` branch below, and the `.unique()` twin's
+            // `temporalDeal`. A generator-local window would put two spellings
+            // of the same column (`v.timestamp()` and `v.timestamp().unique()`)
+            // decades apart, and would ignore the one input `SeedOptions.now`
+            // exists to pin.
+            return generateTimestamp(input, now);
         }
 
         case "from": {
             // `v.from(externalSchema)` delegates to a Standard Schema library, and
             // there is nothing here to introspect — the seeder cannot know whether
-            // it wants a UUID, an ISO date, or a 20-field object. Falling through
-            // to the generic `copycat.word` would produce a value the very next
-            // `ctx.db.insert` rejects, reported as a validation failure on a row
-            // nobody wrote by hand. Refuse by name instead.
-            throw new LunoraError(
-                "INTERNAL",
-                `@lunora/seed: column "${fieldName}" is a v.from() validator, whose external Standard Schema the seeder cannot introspect to invent a conforming value. ` +
-                    `Supply one via \`overrides\` (\`{ <table>: { ${fieldName}: … } }\`), restrict the run with \`only\` so the table is skipped, or give the column a concrete v.* type.`,
+            // it wants a UUID, an ISO date, or a 20-field object.
+            return refuseColumn(
+                fieldName,
+                "is a v.from() validator, whose external Standard Schema the seeder cannot introspect to invent a conforming value (give the column a concrete v.* type instead)",
             );
         }
 

--- a/packages/seed/src/plan.ts
+++ b/packages/seed/src/plan.ts
@@ -6,7 +6,7 @@ import { generateValue } from "./generate-value";
 import type { FieldSpec } from "./introspect";
 import { fkParentClosure, introspectSchema, orderTables } from "./introspect";
 import type { UniqueDeal } from "./unique-value";
-import { planUniqueDeal } from "./unique-value";
+import { planUniqueDeal, planUniqueFkDeal } from "./unique-value";
 
 /**
  * The pure, I/O-free core of seeding. {@link seedPlan} introspects a schema,
@@ -170,7 +170,18 @@ const generateField = (field: FieldSpec, context: RowContext): unknown => {
             return fkFallback(field, input);
         }
 
-        return copycat.oneOf(input, pool);
+        if (!field.unique) {
+            return copycat.oneOf(input, pool);
+        }
+
+        const fkDeal = uniqueDeals.get(field.name);
+
+        // A self-reference's pool is the rows generated earlier in this same
+        // batch, so there is nothing to deal from at plan time and it carries no
+        // deal (see `planUniqueDeals`). Its last entry — the immediately
+        // preceding row — is the one choice that is distinct for every row by
+        // construction, and row 0 has no parent at all (handled above).
+        return fkDeal === undefined ? pool.at(-1) : fkDeal.valueAt(index, () => copycat.oneOf(input, pool));
     }
 
     // Columns the server fills (.default()/.$defaultFn()) are left out so the
@@ -202,10 +213,16 @@ const generateField = (field: FieldSpec, context: RowContext): unknown => {
  * batches of 2 over a 3-value domain pass and then collide (index 3 wraps onto
  * index 0), which is the exact scenario the offset feature enables.
  *
- * FK and server-defaulted columns are skipped entirely (their values never come
- * from the generator). An overridden column still gets a deal — an override may
- * resolve to `undefined` and defer back to the generator — but its capacity is
- * not asserted, since the caller supplying the values decides their uniqueness.
+ * Server-defaulted columns are skipped (their values never reach the generator)
+ * — but a FOREIGN KEY does reach it, default or not, since `generateField`
+ * resolves the FK before it consults the default. A foreign key is dealt from
+ * its parent pool, whose size is the capacity; a SELF-referencing one is
+ * skipped because its pool is the rows this very batch has yet to generate, and
+ * `generateField` deals it the preceding row instead.
+ *
+ * An overridden column still gets a deal — an override may resolve to
+ * `undefined` and defer back to the generator — but its capacity is not
+ * asserted, since the caller supplying the values decides their uniqueness.
  */
 const planUniqueDeals = (
     fields: ReadonlyArray<FieldSpec>,
@@ -214,15 +231,26 @@ const planUniqueDeals = (
     offset: number,
     now: number,
     tableOverrides: Record<string, unknown>,
+    poolOf: (field: FieldSpec) => ReadonlyArray<string>,
 ): ReadonlyMap<string, UniqueDeal> => {
     const deals = new Map<string, UniqueDeal>();
 
     for (const field of fields) {
-        if (!field.unique || field.fkTable !== undefined || field.hasServerDefault) {
+        if (!field.unique || (field.hasServerDefault && field.fkTable === undefined) || field.fkTable === table) {
             continue;
         }
 
-        const deal = planUniqueDeal(field, { now, table });
+        const pool = field.fkTable === undefined ? undefined : poolOf(field);
+
+        // An FK with no parent to point at never reaches the pool: every row
+        // takes `fkFallback`, which is a fresh uuid (distinct), or an absent /
+        // null cell (which no UNIQUE constraint counts). Nothing to deal, and
+        // nothing to refuse.
+        if (pool?.length === 0) {
+            continue;
+        }
+
+        const deal = pool === undefined ? planUniqueDeal(field, { now, table }) : planUniqueFkDeal(pool, table, field.name);
         const required = offset + count;
 
         if (required > deal.capacity && !Object.hasOwn(tableOverrides, field.name)) {
@@ -297,7 +325,12 @@ const seedPlan = (schema: Schema, options: SeedOptions = {}): ReadonlyArray<Tabl
         // Absolute index base — lets a client seed the same table across calls
         // without colliding ids (each id/value hashes from the absolute index).
         const offset = indexOffset[table] ?? 0;
-        const uniqueDeals = planUniqueDeals(spec.fields, table, count, offset, now, tableOverrides);
+        // A parent table is fully generated before its children (`orderTables`),
+        // so a non-self FK's pool is already final here — `localIndex` only
+        // matters for the self-reference `planUniqueDeals` skips.
+        const uniqueDeals = planUniqueDeals(spec.fields, table, count, offset, now, tableOverrides, (field) =>
+            fkPool(field, table, 0, idsByTable, existingIds),
+        );
 
         const ids: string[] = [];
         idsByTable.set(table, ids);

--- a/packages/seed/src/unique-value.ts
+++ b/packages/seed/src/unique-value.ts
@@ -85,9 +85,17 @@ const uniquifyString = (value: string, index: number, constraints: Constraints):
     if (at > 0) {
         const local = value.slice(0, at);
         const domain = value.slice(at);
-        const room = maxLength === undefined ? local.length : Math.max(0, maxLength - domain.length - tag.length - 1);
+        const room = maxLength === undefined ? local.length : maxLength - domain.length - tag.length - 1;
 
-        return `${local.slice(0, room)}+${tag}${domain}`;
+        // A generated address whose own domain fills the column leaves no room
+        // for a plus-tag: clamping to zero here would emit `+7@a-very-long.example`
+        // OVER `maxLength`, which is the overflow this reservation exists to
+        // prevent. Fall through instead — an `email` column rebuilds the address
+        // around the fixed fallback domain {@link stringCapacity} budgeted for,
+        // and anything else takes the plain index suffix.
+        if (room >= 0) {
+            return `${local.slice(0, room)}+${tag}${domain}`;
+        }
     }
 
     // The column declares `format: "email"` but the field-name heuristics didn't
@@ -185,13 +193,28 @@ const refuse = (table: string, column: string, why: string): never => {
  * How many distinct values a string column can hold once every value has to
  * carry an index tag. A narrow column runs out long before the alphabet does:
  * `maxLength` of 1 leaves no room for even `-0`.
+ *
+ * The overhead an `email` column pays is the whole {@link FALLBACK_EMAIL_DOMAIN},
+ * not the one-character separator: {@link uniquifyString} rebuilds the address
+ * around that domain whenever the generated one leaves no room for a plus-tag,
+ * so it is the fixed cost the tag has to fit around. Budgeting the cheaper
+ * suffix form is what let `v.string().email().max(10).unique()` report a
+ * billion possible values and then seed `0@example.com` — thirteen characters
+ * into a ten-character column, rejected by the column's own validator on
+ * insert, which is exactly the outcome the capacity check exists to pre-empt.
+ *
+ * With this budget the largest index the planner admits is `10 ** (maxLength -
+ * overhead) - 1`, whose tag is at most `maxLength - overhead` characters — so
+ * `tag + overhead` always fits.
  */
-const stringCapacity = (maxLength: number | undefined): number => {
+const stringCapacity = ({ format, maxLength }: Constraints): number => {
     if (maxLength === undefined) {
         return Number.POSITIVE_INFINITY;
     }
 
-    return maxLength <= 1 ? 0 : 10 ** (maxLength - 1);
+    const overhead = format === "email" ? FALLBACK_EMAIL_DOMAIN.length : "-".length;
+
+    return maxLength <= overhead ? 0 : 10 ** (maxLength - overhead);
 };
 
 /**
@@ -215,7 +238,7 @@ const stringDeal = (constraints: Constraints, table: string, column: string): Un
     }
 
     return {
-        capacity: stringCapacity(constraints.maxLength),
+        capacity: stringCapacity(constraints),
         valueAt: (index, generate) => uniquifyString(String(generate()), index, constraints),
     };
 };

--- a/packages/seed/src/unique-value.ts
+++ b/packages/seed/src/unique-value.ts
@@ -149,6 +149,13 @@ const temporalDeal = (now: number): UniqueDeal => {
 const countingDeal: UniqueDeal = { capacity: Number.POSITIVE_INFINITY, valueAt: (index) => index };
 
 /**
+ * The deal for a column whose value is built from the per-cell hash (a uuid, or
+ * a composite of them): already distinct per row, so the generator's own value
+ * stands and there is no capacity to refuse past.
+ */
+const anonymousDeal: UniqueDeal = { capacity: Number.POSITIVE_INFINITY, valueAt: (_index, generate) => generate() };
+
+/**
  * Pick the numeric deal for a column: the declared range when it has one (the
  * range is then a hard capacity the planner must refuse past), otherwise an
  * ascending count. A partially-declared range is completed with the generator's
@@ -212,6 +219,21 @@ const stringDeal = (constraints: Constraints, table: string, column: string): Un
         valueAt: (index, generate) => uniquifyString(String(generate()), index, constraints),
     };
 };
+
+/**
+ * The deal a `.unique()` FOREIGN KEY takes: the parent pool drawn without
+ * replacement, in a fixed shuffled order.
+ *
+ * A foreign key's value comes from the plan layer rather than the generator,
+ * but it comes from a finite domain like any other — so it is dealt like one.
+ * The uniform draw the ordinary path uses (`copycat.oneOf`) picks WITH
+ * replacement, which is exactly the collision `.unique()` promises not to make:
+ * `v.id("users").unique()`, the natural way to spell a 1:1 relation, produced 7
+ * distinct parents across 10 rows. The pool's size is a real capacity, so a
+ * batch larger than the parent table is refused at plan time with the column
+ * named, the same as a boolean or a three-value enum.
+ */
+const planUniqueFkDeal = (pool: ReadonlyArray<string>, table: string, column: string): UniqueDeal => domainDeal(pool, table, column);
 
 /**
  * Decide how one `.unique()` column deals its values.
@@ -285,14 +307,30 @@ const planUniqueDeal = (field: FieldSpec, options: UniqueDealOptions): UniqueDea
             return boundedNumeric(constraints, NUMBER_RANGE);
         }
 
+        case "union": {
+            // A union of literals is a closed domain — the same shape as an
+            // enum, and the very case `docs/index.mdx` names ("a three-literal
+            // `v.union()` … is refused at plan time"). The generator picks a
+            // member per row WITH replacement, so without a deal here eight rows
+            // over a two-literal union simply repeat and nothing refuses.
+            const members = metaOf(field.validator).members ?? [];
+            const literals = members.filter((member) => member.kind === "literal").map((member) => metaOf(member).value);
+
+            if (literals.length > 0 && literals.length === members.length) {
+                return domainDeal(literals, table, field.name);
+            }
+
+            return anonymousDeal;
+        }
+
         default: {
-            // `id`, `storage`, `array`, `object`, `record`, `union` — every one
-            // of these derives from the per-cell hash (a uuid, or a composite
-            // built from uuids), so it is already distinct per row.
-            return { capacity: Number.POSITIVE_INFINITY, valueAt: (_index, generate) => generate() };
+            // `id`, `storage`, `array`, `object`, `record` — every one of these
+            // derives from the per-cell hash (a uuid, or a composite built from
+            // uuids), so it is already distinct per row.
+            return anonymousDeal;
         }
     }
 };
 
-export { planUniqueDeal };
+export { planUniqueDeal, planUniqueFkDeal };
 export type { UniqueDeal };

--- a/packages/storage/__tests__/signed-url.test.ts
+++ b/packages/storage/__tests__/signed-url.test.ts
@@ -429,4 +429,12 @@ describe("signedUrl", () => {
         // shift `key`/`exp` on re-split.
         await expect(buildSignedUrl({ baseUrl: "https://cdn.test", bucketName: "a\nb", key: "x.png", secret: "shh" })).rejects.toThrow(/control character/);
     });
+
+    it("rejects an empty key, as every other storage operation does", async () => {
+        expect.assertions(1);
+
+        // Minting one produced `https://cdn.test/?exp=…`, which verify then
+        // accepted and handed the serving route as `key: ""`.
+        await expect(buildSignedUrl({ baseUrl: "https://cdn.test", bucketName: "default", key: "", secret: "shh" })).rejects.toThrow(/key must not be empty/);
+    });
 });

--- a/packages/storage/src/signed-url.ts
+++ b/packages/storage/src/signed-url.ts
@@ -139,6 +139,15 @@ export const buildSignedUrl = async (
         throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: bucketName must not be empty");
     }
 
+    // Same reason, and the same guard `createStorage`'s `validateKey` applies to
+    // every other key that enters storage: an empty key mints a URL whose
+    // pathname is the bare origin, which `verifySignedUrl` then validates and
+    // hands the serving route as `key: ""`. `buildSignedUrl` is exported, so a
+    // caller reaching it directly is the one path that never met `validateKey`.
+    if (args.key === "") {
+        throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: key must not be empty");
+    }
+
     const exp = Math.floor(Date.now() / 1000) + expiresInSeconds;
     const host = extractHost(args.baseUrl);
     const sig = await signCanonical(args.secret, canonicalize(method, host, args.bucketName, args.key, exp, contentType));

--- a/packages/studio/__tests__/features/data/staged-edits.test.tsx
+++ b/packages/studio/__tests__/features/data/staged-edits.test.tsx
@@ -53,6 +53,34 @@ describe("useStagedEdits", () => {
         expect(result.current.count).toBe(2);
     });
 
+    it("keeps a cell staged as undefined that the patch never wrote", () => {
+        expect.assertions(2);
+
+        // `committed[column]` reads `undefined` for a column the patch never
+        // carried, so a value-only comparison cannot tell "absent from the
+        // patch" from "written as undefined" — and threw away a cell staged
+        // after the snapshot was taken. `stagedValue` already keys off
+        // `column in row`, so the buffer separates the two everywhere else.
+        const { result } = renderHook(() => useStagedEdits());
+
+        act(() => {
+            result.current.stage("m1", "text", "first");
+        });
+
+        const committed = result.current.staged["m1"] ?? {};
+
+        act(() => {
+            result.current.stage("m1", "author", undefined);
+        });
+
+        act(() => {
+            result.current.drop("m1", committed);
+        });
+
+        expect(result.current.stagedValue("m1", "author")).toStrictEqual({ value: undefined });
+        expect(result.current.count).toBe(1);
+    });
+
     it("leaves a partly-committed row where it was in the buffer", () => {
         expect.assertions(2);
 

--- a/packages/studio/__tests__/lib/seed-data.test.ts
+++ b/packages/studio/__tests__/lib/seed-data.test.ts
@@ -101,6 +101,21 @@ describe("requestSeedRows", () => {
         await expect(requestSeedRows(request)).resolves.toStrictEqual({ kind: "error", message: expect.any(String) });
     });
 
+    it("rejects a row list whose entries decode to non-plain objects", async () => {
+        expect.assertions(1);
+
+        // `decodeWire` turns tagged leaves into `Date`/`Map`/`Set`/`Uint8Array`,
+        // all of which are `typeof "object"` and none of which is a row
+        // document — `importShard`'s per-column validators would be handed a
+        // value that cannot satisfy `Record<string, unknown>`.
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => jsonResponse(true, { ok: true, rows: encodeWire([new Date(0), new Map([["a", 1]])]) })),
+        );
+
+        await expect(requestSeedRows(request)).resolves.toStrictEqual({ kind: "error", message: expect.any(String) });
+    });
+
     it("returns an error result when the wire payload cannot be decoded", async () => {
         expect.assertions(1);
 
@@ -111,6 +126,22 @@ describe("requestSeedRows", () => {
         );
 
         await expect(requestSeedRows(request)).resolves.toStrictEqual({ kind: "error", message: expect.any(String) });
+    });
+
+    it("names the parent tables an fk-parents-empty refusal lists", async () => {
+        expect.assertions(1);
+
+        // Only the string entries reach the message — the field is host-supplied
+        // and unvalidated, so a stray non-string must not render as `42`.
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => jsonResponse(false, { error: "fk-parents-empty", ok: false, tables: ["users", 42, "teams"] })),
+        );
+
+        await expect(requestSeedRows(request)).resolves.toStrictEqual({
+            kind: "error",
+            message: expect.stringContaining("users, teams"),
+        });
     });
 
     it("survives an fk-parents-empty refusal whose tables field is not an array", async () => {
@@ -150,5 +181,19 @@ describe("collectUnresolvableFkColumns", () => {
         );
 
         expect(blocked).toStrictEqual(["authorId"]);
+    });
+
+    it("clears an FK column once its parent has sampled rows, and blocks one whose parent was never sampled", () => {
+        expect.assertions(2);
+
+        const columns = [
+            { name: "authorId", optional: false, ref: "users", type: "id" },
+            { name: "teamId", optional: false, ref: "teams", type: "id" },
+        ] as const;
+
+        // `teams` is absent from the pools entirely — the same "nothing to link
+        // against" as an empty pool, so it blocks too.
+        expect(collectUnresolvableFkColumns([...columns], { users: ["u1"] })).toStrictEqual(["teamId"]);
+        expect(collectUnresolvableFkColumns([...columns], { teams: ["t1"], users: ["u1"] })).toStrictEqual([]);
     });
 });

--- a/packages/studio/src/features/data/staged-edits.tsx
+++ b/packages/studio/src/features/data/staged-edits.tsx
@@ -70,7 +70,14 @@ const useStagedEdits = (): StagedEditsModel => {
             // is in flight and `commitStaged` iterates a snapshot, so dropping
             // the whole row entry silently discarded any edit made since —
             // an edit the writer never saw.
-            const pending = Object.fromEntries(Object.entries(row).filter(([column, value]) => !Object.is(value, committed[column])));
+            //
+            // Membership first, then the value: a column ABSENT from `committed`
+            // was never written, and `committed[column]` reads `undefined` for
+            // it — indistinguishable by value alone from a cell written as
+            // `undefined`. Comparing values only threw away a cell staged as
+            // `undefined` after the snapshot was taken, which is exactly the
+            // edit this filter exists to keep.
+            const pending = Object.fromEntries(Object.entries(row).filter(([column, value]) => !(column in committed) || !Object.is(value, committed[column])));
 
             if (Object.keys(pending).length === 0) {
                 return Object.fromEntries(Object.entries(previous).filter(([id]) => id !== rowId));

--- a/packages/studio/src/lib/seed-data.ts
+++ b/packages/studio/src/lib/seed-data.ts
@@ -15,7 +15,7 @@
  * studio's `basePath` — so the client targets it directly. Keep this in sync
  * with `SEED_ENDPOINT` in `@lunora/config/studio-host`.
  */
-import { decodeWire } from "../../../../shared/wire-codec";
+import { decodeWire, isPlainObject } from "../../../../shared/wire-codec";
 import type { ColumnMeta } from "./admin";
 import { errorMessage } from "./internal";
 
@@ -78,9 +78,17 @@ interface SeedResponseBody {
     readonly tables?: unknown;
 }
 
-/** Narrow a decoded reply to the row documents `onInsertRows` can hand to `importShard`. */
-const isRowList = (value: unknown): value is ReadonlyArray<Record<string, unknown>> =>
-    Array.isArray(value) && value.every((row) => typeof row === "object" && row !== null && !Array.isArray(row));
+/**
+ * Narrow a decoded reply to the row documents `onInsertRows` can hand to
+ * `importShard`.
+ *
+ * `isPlainObject` rather than `typeof === "object"`: this runs AFTER
+ * `decodeWire`, which turns tagged leaves into `Date`, `Map`, `Set` and
+ * `Uint8Array` — every one of which is `typeof "object"` and none of which is a
+ * row document. A `!Array.isArray` check is enough for bare `JSON.parse` output
+ * and not for this one.
+ */
+const isRowList = (value: unknown): value is ReadonlyArray<Record<string, unknown>> => Array.isArray(value) && value.every((row) => isPlainObject(row));
 
 /**
  * Request generated rows from the dev host, normalising every outcome.

--- a/packages/workflow/__tests__/fan-out.test.ts
+++ b/packages/workflow/__tests__/fan-out.test.ts
@@ -635,6 +635,60 @@ describe("signalBranchParent", () => {
         expect(JSON.stringify(sent.payload).length).toBeLessThan(1024);
     });
 
+    it("still reports the outcome when the serialization failure cannot be stringified", async () => {
+        expect.assertions(4);
+
+        const parent = makeInstance("parent-1");
+        const env = { WORKFLOW_PARENT: { get: vi.fn<(id: string) => Promise<WorkflowInstanceLike>>(async () => parent) } };
+
+        // A branch handler's own `toJSON` decides what `JSON.stringify` throws, so
+        // the thrown value is as arbitrary as any other user value. Two shapes
+        // defeated the naive `instanceof Error ? .message : String()`: an `Error`
+        // carrying a non-string `message` (`.slice` is not a function) and a
+        // null-prototype object (`String()` throws). Either way the diagnostic
+        // threw INSIDE the guard, `signalBranchParentSafe` swallowed it, and the
+        // parent hibernated to its 24 h join timeout on a finished branch.
+        const numericMessage = Object.assign(new Error("ignored"), { message: 42 });
+
+        await signalBranchParent(
+            { env, step: makeStep() },
+            marker,
+            okOutcome({
+                toJSON: () => {
+                    throw numericMessage;
+                },
+            }),
+        );
+
+        await signalBranchParent(
+            { env, step: makeStep() },
+            marker,
+            okOutcome({
+                toJSON: () => {
+                    // No prototype, so no `toString`: `String(value)` throws
+                    // "Cannot convert object to primitive value".
+                    throw Object.create(null) as unknown;
+                },
+            }),
+        );
+
+        const sends = (parent.sendEvent as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as { payload: BranchOutcome });
+
+        expect(sends).toHaveLength(2);
+
+        for (const sent of sends) {
+            expect(sent.payload).toStrictEqual({
+                error: {
+                    message: expect.stringContaining("cannot be serialised"),
+                    name: "BranchOutputUnserializable",
+                },
+                status: "error",
+            });
+        }
+
+        expect(JSON.stringify(sends[1]?.payload).length).toBeLessThan(1024);
+    });
+
     it("is a no-op when the parent binding is absent (parent falls back to its timeout)", async () => {
         expect.assertions(1);
 

--- a/packages/workflow/src/fan-out.ts
+++ b/packages/workflow/src/fan-out.ts
@@ -470,6 +470,30 @@ const stripBranchMarker = (payload: unknown): unknown => {
 };
 
 /**
+ * A bounded, never-throwing description of whatever `JSON.stringify` threw.
+ *
+ * The obvious `error instanceof Error ? error.message : String(error)` is not
+ * total on this path: `message` is a plain writable property, so an `Error` can
+ * carry a non-string one (`.slice` is then not a function), and a thrown
+ * non-`Error` can have a `toString` that throws or no prototype at all
+ * (`String()` then throws "Cannot convert object to primitive value"). Both come
+ * from a `toJSON` the branch handler wrote, so both are reachable — and a throw
+ * here escapes the very guard that exists to keep the parent off its 24-hour
+ * join timeout, leaving it hibernating on a branch that finished.
+ *
+ * Sliced because V8's cyclic-structure message names a path through the
+ * offending object and is itself unbounded, which would reintroduce the
+ * oversized-payload failure the guard below prevents.
+ */
+const describeSerializationFailure = (error: unknown): string => {
+    try {
+        return String(error instanceof Error ? error.message : error).slice(0, 200);
+    } catch {
+        return "the failure itself could not be described";
+    }
+};
+
+/**
  * Swap an outcome the event channel cannot carry for a bounded failure that it
  * can.
  *
@@ -491,6 +515,7 @@ const stripBranchMarker = (payload: unknown): unknown => {
  * parent again hibernates to its join timeout on a branch that finished. So it
  * gets the same treatment — a bounded error outcome the event channel can carry.
  */
+
 const boundOutcome = (outcome: BranchOutcome): BranchOutcome => {
     let bytes: number;
 
@@ -500,11 +525,7 @@ const boundOutcome = (outcome: BranchOutcome): BranchOutcome => {
         return {
             error: {
                 message:
-                    // Sliced: V8's cyclic-structure message names a path through
-                    // the offending object and is itself unbounded, which would
-                    // reintroduce the oversized-payload failure this guard exists
-                    // one branch below to prevent.
-                    `branch outcome cannot be serialised to JSON (${(encodeError instanceof Error ? encodeError.message : String(encodeError)).slice(0, 200)}) — ` +
+                    `branch outcome cannot be serialised to JSON (${describeSerializationFailure(encodeError)}) — ` +
                     "the parent can never receive it. Return a plain JSON value (no cycles, no BigInt, no class instance that fails to serialise) " +
                     "or a reference the parent can dereference (an R2 key, a row id)",
                 name: "BranchOutputUnserializable",

--- a/packages/x402/docs/index.mdx
+++ b/packages/x402/docs/index.mdx
@@ -140,19 +140,29 @@ const mcp = createPaidMcpServer({ charge: { network: "base", recipient: { evm: e
 mcp.paidTool({ name: "premium_report", description: "the paid report", inputSchema: { properties: {}, type: "object" }, price: "$0.05" }, async () =>
     text(await buildReport()),
 );
+
+export default { fetch: mcp.fetchHandler };
 ```
+
+`fetchHandler` takes the Worker's `(request, env, ctx)` triple, so mounting it as
+the default export is what wires `ctx.waitUntil` through to the charge
+middleware — see Receipts below.
 
 ### Receipts
 
 `onReceipt` is an opt-in, one-way telemetry sink fired once per settled
 payment: best-effort, never blocking the paid response. Use it (with
 `toPaymentEventRow`) to mirror x402 revenue into a durable table or
-`@lunora/payment`'s `events` table so it surfaces in Studio. On Workers, wire
-the request's `ctx.waitUntil` to the gate's `deps.waitUntil` (where the caller
-has one to give, e.g. `@lunora/runtime`'s `x402Charge` seam) so the sink is
-registered with `waitUntil` and survives past the response; otherwise
-workerd cancels the in-flight sink promise at isolate teardown once the
-response returns, before an async sink (e.g. a database insert) resolves.
+`@lunora/payment`'s `events` table so it surfaces in Studio. On Workers, the
+request's `ctx.waitUntil` has to reach the gate's `deps.waitUntil` so the sink is
+registered with it and survives past the response; otherwise workerd cancels the
+in-flight sink promise at isolate teardown once the response returns, before an
+async sink (e.g. a database insert) resolves. Every rail wires this for you as
+long as it can see the execution context — `withX402` reads it off the action
+`ctx`, `@lunora/runtime`'s `x402Charge` seam forwards the request's, and
+`createPaidMcpServer`'s `fetchHandler` takes it as its third argument, so mount
+it as `export default { fetch: mcp.fetchHandler }` rather than calling it with a
+bare `Request`.
 
 ## The pay rail: buy a resource
 


### PR DESCRIPTION
**Do not merge — this exists so CodeRabbit can review code it would otherwise skip.**

All of this is already on #579, which is 300+ files and therefore refused: `Review skipped: N files exceed the limit of 100`. A manual `@coderabbitai full review` accepts the command there and then refuses at review time on the same count, and there is no path-scoped review command. Slicing at a commit boundary is the only thing that works.

**Round 14** — 98 files. Packages that thirteen prior audit rounds never opened: hyperdrive, queue, seed, storage, notify, mcp, advisor, flags, browser, ai, cloudflare-access. 32 defects, the notable ones:

- **The paid MCP gate dropped `deps.waitUntil`** that both x402 siblings pass, so a settled payment's receipt sink was cancelled at isolate teardown — money moved on-chain, receipt row never landed.
- **The advisor's flag-polarity rule was inverted for every kill-switch flag.** `disableRls: true` scored clean while the safe setting was flagged with a remediation telling you to make it unsafe.
- **RAG `index()` hashed only the body**, so moving a document between tenants left the stale `orgId` on every vector.
- **`request.clone().json()` buffered without limit** and then entered the size check.
- **Six `@lunora/seed` divergences** where the `.unique()` path and the ordinary path disagreed — including timestamps seeded four decades apart for two spellings of the same column.
- **The MySQL parity suite had never run in CI**, skipping silently whenever mysqld was absent; it now executes 28 cases.

Four findings were rejected or narrowed with evidence rather than fixed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP handlers support request-size limits, safer body parsing, client reuse, and expanded public types.
  - Push subscription registration reports replaced endpoints after VAPID key rotation.
  - Seed generation supports pinned timestamps and improved unique foreign-key values.
  - Storage worker examples now support CORS and safer content types.

- **Bug Fixes**
  - Improved security-lint detection, flag polarity checks, notification access scoping, email parsing, signed URLs, RAG filtering, browser cleanup, and replication ordering.
  - Added validation for oversized notification values and empty routing targets.
  - MySQL-backed test coverage is now required.

- **Documentation**
  - Clarified MCP opt-in, RAG scoring, browser keep-alive behavior, flag failures, and notification data exposure.

- **Breaking Changes**
  - Removed the seed `dateString` helper.
  - Updated notification and MCP handler interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->