### PR TITLE
chore: open round 16 for review (do not merge)

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -234,13 +234,18 @@ templates:
     - ".github/workflows/test.yml"
     - ".github/file-filters.yml"
 
-# `MAX_BATCH_ENTRIES` in shared/batch-wire.ts vs the literal every non-JS port and
-# protocol/README.md restate. Separate from `sdks` because the reconciliation is a node
-# script, not a conformance suite: it must run on a change to any one of the ten copies
-# without paying for eight toolchains.
+# The two batch caps — `MAX_BATCH_ENTRIES` (shared/batch-wire.ts) and `MAX_BATCH_BYTES`
+# (packages/client/src/replay.ts, derived from the worker's own body cap in
+# packages/runtime/src/body-readers.ts) — vs the literal every non-JS port,
+# protocol/README.md and the offline fixture restate. Separate from `sdks` because the
+# reconciliation is a node script, not a conformance suite: it must run on a change to any
+# one of the copies without paying for eight toolchains.
 batch_cap:
     - "shared/batch-wire.ts"
+    - "packages/client/src/replay.ts"
+    - "packages/runtime/src/body-readers.ts"
     - "protocol/README.md"
+    - "protocol/fixtures/offline-optimistic.json"
     - "sdks/**"
     - "scripts/check-batch-cap-drift.js"
     - ".github/workflows/lint.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -395,11 +395,12 @@
             - "name": "Check node capabilities docs match NODE_CAPABILITIES"
               "run": "pnpm run lint:node-capabilities-docs"
 
-    # `MAX_BATCH_ENTRIES` in shared/batch-wire.ts against the literal each of the eight
-    # non-JS ports and protocol/README.md restates. No conformance suite asserts the
-    # cap — the ports only ever see it as a number they typed once — and a client
-    # chunking above the server's cap has its over-cap chunk refused with a terminal
-    # 400, which discards those durable writes rather than retrying them.
+    # Both batch caps against the literal each of the eight non-JS ports,
+    # protocol/README.md and the offline fixture restate. The ports only ever see a cap
+    # as a number they typed once. Over the entry cap, a client's chunk is refused with a
+    # terminal 400, which discards those durable writes rather than retrying them; the
+    # byte budget is additionally DERIVED from the worker's own request-body cap, so
+    # raising that cap stales all nine clients at once with nothing else noticing.
     "batch-cap":
         "name": "Lint (batch cap)"
         "if": "needs.files-changed.outputs.batch_cap == 'true'"
@@ -425,7 +426,7 @@
                   "run-npm-audit": "false"
                   "run-signatures-audit": "false"
 
-            - "name": "Check every copy of MAX_BATCH_ENTRIES agrees"
+            - "name": "Check every copy of the batch caps agrees"
               "run": "pnpm run lint:batch-cap"
 
     "yaml-lint":

--- a/packages/cli/__tests__/commands/registry-items.test.ts
+++ b/packages/cli/__tests__/commands/registry-items.test.ts
@@ -102,16 +102,31 @@ const bindingsMissingRequiredFields = (): string[] => {
  */
 const CONSUMER_PROVIDED = new Set(["@angular/core", "react", "solid-js", "svelte", "vue"]);
 
-/** Bare package specifiers an item imports without naming them in its `deps`. */
-const undeclaredImports = (): string[] => {
+/**
+ * Source dialects an item can carry an import in. `.vue`/`.svelte` are here
+ * because the Vue and Svelte ports author their view layer as single-file
+ * components: 41 of the registry's bare specifiers live in an SFC, and a sweep
+ * that reads only `.ts`/`.tsx` never opens the 114 files where a Vue- or
+ * Svelte-only dependency would be the one to go undeclared.
+ */
+const SCANNED_DIALECTS = /\.(?:tsx?|vue|svelte)$/u;
+
+/**
+ * Every bare package specifier the items import, and the subset of those an item
+ * does not name in its `deps`.
+ */
+const itemImports = (): { scanned: string[]; undeclared: string[] } => {
+    const scanned: string[] = [];
     const undeclared: string[] = [];
     const declaredBy = new Map(manifests.map(({ manifest, name }) => [name, new Set(Object.keys(manifest.deps ?? {}))]));
 
-    for (const { from, name, source } of itemSources.filter((entry) => /\.tsx?$/u.test(entry.from))) {
+    for (const { from, name, source } of itemSources.filter((entry) => SCANNED_DIALECTS.test(entry.from))) {
         // Bare specifiers only — a relative import or a `#lunora/…` subpath
         // resolves inside the user's own project.
         for (const match of source.matchAll(/from "((?:@[a-z\d-]+\/)?[a-z\d][a-z\d._-]*)(?:\/[^"]*)?"/gu)) {
             const packageName = match[1] as string;
+
+            scanned.push(`${name} → ${packageName} (${from})`);
 
             if (!declaredBy.get(name)?.has(packageName) && !CONSUMER_PROVIDED.has(packageName)) {
                 undeclared.push(`${name} → ${packageName} (${from})`);
@@ -119,7 +134,7 @@ const undeclaredImports = (): string[] => {
         }
     }
 
-    return undeclared;
+    return { scanned, undeclared };
 };
 
 /** Every `createMailerFromEnv(` call site in the registry, split by whether it guards `cloudflareSend`. */
@@ -279,7 +294,7 @@ describe("shipped registry items", () => {
     });
 
     it("every package an item imports is declared in its `deps`", () => {
-        expect.assertions(1);
+        expect.assertions(2);
 
         // `deps` is written verbatim into a USER's package.json by `lunora add`,
         // so a package an item imports but does not declare is simply absent from
@@ -288,7 +303,14 @@ describe("shipped registry items", () => {
         // siblings did, and the Solid 2 port used `@solidjs/web` — its JSX import
         // source, a package that exists only on the 2.x line — in 15 files without
         // naming it anywhere.
-        expect(undeclaredImports()).toStrictEqual([]);
+        const { scanned, undeclared } = itemImports();
+
+        expect(undeclared).toStrictEqual([]);
+        // Guard the guard. This sweep passes by finding nothing, so a filter that
+        // stops matching a dialect — the way it silently skipped every `.vue` and
+        // `.svelte` file — turns it green rather than red. Require positive
+        // evidence that the SFC ports were read.
+        expect(scanned.filter((entry) => /\((?:vue|svelte)\/[^)]+\.(?:vue|svelte)\)$/u.test(entry))).not.toHaveLength(0);
     });
 
     it("no item hands `createMailerFromEnv` an unguarded `cloudflareSend`", () => {

--- a/packages/runtime/__tests__/admin-export-import.test.ts
+++ b/packages/runtime/__tests__/admin-export-import.test.ts
@@ -725,15 +725,27 @@ describe("backup registry snapshot → admin import", () => {
      * Lifting the item's own expression is the point: a re-typed copy here would
      * keep passing after the item drifted, which is exactly the gap that let the
      * header-framed shape ship.
+     *
+     * The item wire-encodes each document through its own `encodeWire` mirror,
+     * which is too large to lift with it (multi-statement, and it closes over two
+     * module constants). The reference encoder is injected instead, because the
+     * question HERE is the NDJSON framing — `table` and `doc` on every line. That
+     * the item's mirror still agrees with the reference is pinned separately, by
+     * `packages/cli/__tests__/commands/registry-backup-item.test.ts`, which builds
+     * its expected bytes from `shared/wire-codec`.
      */
     const itemToNdjson = async (): Promise<(table: string, rows: ReadonlyArray<Record<string, unknown>>) => string> => {
-        const match = /^const toNdjson = (.*);$/mu.exec(readFileSync(itemPath, "utf8"));
+        // Spans lines: the expression is an arrow whose body sits on the next one.
+        const match = /^const toNdjson = ([\s\S]*?);$/mu.exec(readFileSync(itemPath, "utf8"));
 
         if (match?.[1] === undefined) {
             throw new Error("could not locate `toNdjson` in registry/backup/backup.ts");
         }
 
-        const compiled = transformSync(`export const toNdjson = ${match[1]};`, { loader: "ts" }).code;
+        const codecPath = resolvePath(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "shared", "wire-codec.ts");
+        const compiled = transformSync(`import { encodeWire } from ${JSON.stringify(pathToFileURL(codecPath).href)};\nexport const toNdjson = ${match[1]};`, {
+            loader: "ts",
+        }).code;
         const file = join(scratch, `to-ndjson-${randomUUID()}.mjs`);
 
         writeFileSync(file, compiled);

--- a/packages/seed/__tests__/generate-value.test.ts
+++ b/packages/seed/__tests__/generate-value.test.ts
@@ -190,6 +190,59 @@ describe("generateValue — refined string columns", () => {
     });
 });
 
+describe("generateValue — a declared format under declared length bounds", () => {
+    /** Enough rows that the generator's own length variance is guaranteed to cross every bound under test. */
+    const ROWS = 60;
+
+    /** Every value the column would be seeded, so an assertion sees the whole spread rather than one lucky draw. */
+    const seedColumn = (validator: Validator, field: string): ReadonlyArray<string> =>
+        Array.from({ length: ROWS }, (_unused, index) => generateValue(validator, field, [field, index], NOW) as string);
+
+    it.each([
+        ["an address cut to fit", "contact", v.string().email().max(20), 0, 20],
+        ["an address padded to fit", "contact", v.string().email().min(40), 40, Number.POSITIVE_INFINITY],
+        ["an address pinned to one width", "contact", v.string().email().length(24), 24, 24],
+        ["an address in the narrowest column that admits one", "contact", v.string().email().max(13), 0, 13],
+        ["a URL cut to fit", "homepage", v.string().url().max(20), 0, 20],
+        ["a URL padded to fit", "homepage", v.string().url().min(60), 60, Number.POSITIVE_INFINITY],
+        ["a URL in the narrowest column that admits one", "homepage", v.string().url().max(9), 0, 9],
+    ])("seeds %s that the column's own validator accepts", (_label, field, validator, min, max) => {
+        expect.assertions(2);
+
+        // The length axis used to be a blind `slice`/`padEnd` applied AFTER the
+        // format generator ran, so an address in a `max(20)` column arrived with
+        // its domain cut off mid-word and a URL in a `max(8)` one arrived as the
+        // bare scheme — values the column rejects on the very next insert.
+        const values = seedColumn(validator, field);
+
+        expect(values.filter((value) => !validator.safeParse(value).ok)).toStrictEqual([]);
+        expect(values.filter((value) => value.length < min || value.length > max)).toStrictEqual([]);
+    });
+
+    it.each([
+        ["email", "contact", v.string().email().max(12), 13],
+        ["uri", "homepage", v.string().url().max(8), 9],
+    ])("refuses a %s column too narrow for any conforming value, naming it", (format, field, validator, minimum) => {
+        expect.assertions(1);
+
+        // Refusing on the BOUND rather than on the generated value keeps the
+        // outcome deterministic: a per-value check would refuse some rows of the
+        // same column and seed others.
+        expect(() => generateValue(validator, field, [field, 0], NOW)).toThrow(
+            new RegExp(`column "${field}" declares format "${format}".*shortest ${format} value the seeder can build is ${String(minimum)}`, "u"),
+        );
+    });
+
+    it("stretches a shapeless value to its bounds without a format to preserve", () => {
+        expect.assertions(2);
+
+        const values = seedColumn(withConstraints(v.string(), { maxLength: 12, minLength: 9 }), "note");
+
+        expect(values.filter((value) => value.length < 9 || value.length > 12)).toStrictEqual([]);
+        expect(new Set(values).size).toBeGreaterThan(1);
+    });
+});
+
 describe("generateValue — time-named number columns", () => {
     const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
 

--- a/packages/seed/__tests__/plan.test.ts
+++ b/packages/seed/__tests__/plan.test.ts
@@ -481,6 +481,20 @@ describe("seedPlan — unique columns beyond enums and strings", () => {
         expect(distinct(rows, "contact")).toBe(50);
     });
 
+    it("keeps a unique format-email column valid once maxLength also bites", () => {
+        expect.hasAssertions();
+
+        // The two narrowing steps compose: the generator refits the address into
+        // `maxLength`, then the deal reserves room for the index tag inside the
+        // same bound. Either step applied blindly emits an address the column's
+        // own validator rejects.
+        const column = v.string().email().max(24).unique();
+        const rows = rowsOf({ contact: column }, 50);
+
+        expect(rows.filter((row) => !column.safeParse(row.contact).ok)).toStrictEqual([]);
+        expect(distinct(rows, "contact")).toBe(50);
+    });
+
     it("deals a unique literal union without replacement and refuses past its domain", () => {
         expect.hasAssertions();
 

--- a/packages/seed/src/generate-value.ts
+++ b/packages/seed/src/generate-value.ts
@@ -141,26 +141,124 @@ const refuseColumn = (fieldName: string, why: string): never => {
     );
 };
 
+/** The length window a generated string has to land in. `max` is `Infinity` when the column declares no `maxLength`. */
+interface LengthBounds {
+    max: number;
+    min: number;
+}
+
 /**
- * Generators for the JSON Schema `format` keywords a string column can declare
- * (`v.string().email()` → `email`, `v.string().url()` → `uri`). A declared
- * format is authoritative over the field-name heuristics below — the column's
- * own validator re-checks it on insert, and it is the same rule the `number`
- * arm applies to declared bounds ("a schema that says `minimum: 0, maximum: 5`
- * means a rating, whatever the column is called").
+ * The shortest string inside `bounds` that `seed` can reach: repeated until it
+ * clears `bounds.min`, then cut to `bounds.max`. An empty seed repeats `"x"` so
+ * the result is never the empty string.
+ *
+ * Safe on a SHAPELESS value only — repeating or cutting one that has to satisfy
+ * a `format` is what {@link FormatSpec.fit} exists to do properly.
  */
-const FORMAT_GENERATORS: Readonly<Record<string, (input: unknown) => string>> = {
-    email: (input) => copycat.email(input),
-    uri: (input) => copycat.url(input),
+const stretch = (seed: string, bounds: LengthBounds): string => {
+    const base = seed === "" ? "x" : seed;
+    const length = Math.min(Math.max(base.length, bounds.min), bounds.max);
+
+    return base.padEnd(length, base).slice(0, length);
 };
 
 /**
- * Generate the base string for a column, honouring a declared shape over the
- * field-name heuristics and refusing outright when the shape is one the seeder
- * cannot satisfy.
+ * Domain a refitted address is rebuilt around when the generated one leaves no
+ * room for a local part. Shared with `unique-value.ts`, whose `stringCapacity`
+ * budgets for this exact width — the two have to agree, or one path refuses a
+ * column the other happily seeds over its `maxLength`.
  */
-const generateStringBody = (fieldName: string, input: unknown, constraints: Constraints): string => {
-    const { format, pattern } = constraints;
+const FALLBACK_EMAIL_DOMAIN = "@example.com";
+
+/** Scheme a refitted `uri` value is rebuilt on. */
+const URL_SCHEME = "https://";
+
+/** Characters `v.string().email()`'s pattern forbids in the local part. */
+const NOT_EMAIL_LOCAL = /[\s@]/gu;
+
+/** Everything but an ASCII alphanumeric. A purely alphanumeric label is a valid host at EVERY length, so a host reduced to one survives any cut or repeat. */
+const NOT_HOST_ALNUM = /[^a-z\d]/gu;
+
+/**
+ * Rebuild `value` as an address inside `bounds`, keeping its generated domain
+ * when the column is wide enough for it and falling back to
+ * {@link FALLBACK_EMAIL_DOMAIN} when it is not. Only the local part is cut or
+ * repeated — it is the one span whose length the address's shape does not
+ * depend on.
+ */
+const fitEmail = (value: string, bounds: LengthBounds): string => {
+    const at = value.lastIndexOf("@");
+    const generated = at > 0 ? value.slice(at) : "";
+    // A generated domain as wide as the whole column leaves nothing for a local
+    // part, and an address with an empty local part is not one.
+    const domain = generated.length > 0 && generated.length < bounds.max ? generated : FALLBACK_EMAIL_DOMAIN;
+    const local = (at > 0 ? value.slice(0, at) : value).replaceAll(NOT_EMAIL_LOCAL, "");
+
+    return `${stretch(local, { max: bounds.max - domain.length, min: Math.max(1, bounds.min - domain.length) })}${domain}`;
+};
+
+/**
+ * Rebuild `value` as an `https:` URL inside `bounds`. The host is reduced to its
+ * alphanumerics before being cut or repeated, so the result parses at every
+ * length the bounds admit — cutting the generated URL in place instead is what
+ * produced `"https://"` and `"https:/"` for a narrow column.
+ */
+const fitUrl = (value: string, bounds: LengthBounds): string => {
+    const host = URL.canParse(value) ? new URL(value).hostname.replaceAll(NOT_HOST_ALNUM, "") : "";
+
+    return `${URL_SCHEME}${stretch(host, { max: bounds.max - URL_SCHEME.length, min: Math.max(1, bounds.min - URL_SCHEME.length) })}`;
+};
+
+/**
+ * How one JSON Schema `format` keyword a string column can declare
+ * (`v.string().email()` → `email`, `v.string().url()` → `uri`) is generated and,
+ * when the column's length bounds exclude what was generated, rebuilt.
+ *
+ * A declared format is authoritative over the field-name heuristics below — the
+ * column's own validator re-checks it on insert, and it is the same rule the
+ * `number` arm applies to declared bounds ("a schema that says `minimum: 0,
+ * maximum: 5` means a rating, whatever the column is called").
+ */
+interface FormatSpec {
+    /** Rebuild a conforming value inside `bounds`. Called only when the generated one falls outside them. */
+    fit: (value: string, bounds: LengthBounds) => string;
+    /** Produce a conforming value, ignoring length. */
+    generate: (input: unknown) => string;
+    /** Shortest value {@link FormatSpec.fit} can build. A `maxLength` below it admits no conforming value at all. */
+    minimum: number;
+}
+
+const FORMAT_SPECS: Readonly<Record<string, FormatSpec>> = {
+    email: { fit: fitEmail, generate: (input) => copycat.email(input), minimum: FALLBACK_EMAIL_DOMAIN.length + 1 },
+    uri: { fit: fitUrl, generate: (input) => copycat.url(input), minimum: URL_SCHEME.length + 1 },
+};
+
+/** Field-name heuristic generation for a column that declares no `format`. */
+const generateHeuristicString = (fieldName: string, input: unknown): string => {
+    const lower = fieldName.toLowerCase();
+    const rule = STRING_HEURISTICS.find((entry) => entry.keywords.some((keyword) => lower.includes(keyword)));
+
+    return rule === undefined ? copycat.word(input) : rule.generate(input);
+};
+
+/**
+ * Generate a string column's value: a declared shape first, the field-name
+ * heuristics otherwise, then the declared length bounds.
+ *
+ * The bounds are applied THROUGH the shape, never over it. A format-constrained
+ * value has spans whose length carries meaning — an address's domain, a URL's
+ * scheme — and cutting or repeating it blindly emits a value the column's own
+ * validator rejects on the very next insert (`v.string().email().max(20)` seeded
+ * `"preston.crist+0@yaho"`), reported as a validation failure on a row nobody
+ * wrote by hand. A shapeless value has no such spans and is simply stretched.
+ *
+ * A `maxLength` too narrow for ANY conforming value is refused with the column
+ * named, the same as the `.pattern()` and unknown-format cases and for the same
+ * reason: it is a property of the schema, not of the value that happened to be
+ * generated, so the refusal is deterministic rather than a coin flip per row.
+ */
+const generateString = (fieldName: string, input: unknown, constraints: Constraints): string => {
+    const { format, maxLength, minLength, pattern } = constraints;
 
     if (pattern !== undefined) {
         return refuseColumn(
@@ -169,24 +267,6 @@ const generateStringBody = (fieldName: string, input: unknown, constraints: Cons
         );
     }
 
-    if (format !== undefined) {
-        const generate = FORMAT_GENERATORS[format];
-
-        return generate === undefined ? refuseColumn(fieldName, `declares format "${format}", which the seeder has no generator for`) : generate(input);
-    }
-
-    const lower = fieldName.toLowerCase();
-    const rule = STRING_HEURISTICS.find((entry) => entry.keywords.some((keyword) => lower.includes(keyword)));
-
-    return rule === undefined ? copycat.word(input) : rule.generate(input);
-};
-
-/** Heuristic string generation by column name (mirrors the studio data generator). */
-const generateString = (fieldName: string, input: unknown, constraints: Constraints): string => {
-    const value = generateStringBody(fieldName, input, constraints);
-
-    const { maxLength, minLength } = constraints;
-
     if (maxLength !== undefined && minLength !== undefined && minLength > maxLength) {
         throw new LunoraError(
             "INTERNAL",
@@ -194,15 +274,28 @@ const generateString = (fieldName: string, input: unknown, constraints: Constrai
         );
     }
 
-    // Truncate first so we never exceed maxLength.
-    const truncated = maxLength !== undefined && value.length > maxLength ? value.slice(0, maxLength) : value;
+    const bounds: LengthBounds = { max: maxLength ?? Number.POSITIVE_INFINITY, min: minLength ?? 0 };
 
-    // Pad to minLength by repeating the generated value until long enough.
-    if (minLength !== undefined && truncated.length < minLength) {
-        return truncated.padEnd(minLength, truncated.length > 0 ? truncated : "x");
+    if (format === undefined) {
+        return stretch(generateHeuristicString(fieldName, input), bounds);
     }
 
-    return truncated;
+    const spec = FORMAT_SPECS[format];
+
+    if (spec === undefined) {
+        return refuseColumn(fieldName, `declares format "${format}", which the seeder has no generator for`);
+    }
+
+    if (bounds.max < spec.minimum) {
+        return refuseColumn(
+            fieldName,
+            `declares format "${format}" with maxLength ${String(maxLength)}, and the shortest ${format} value the seeder can build is ${String(spec.minimum)} characters`,
+        );
+    }
+
+    const value = spec.generate(input);
+
+    return value.length >= bounds.min && value.length <= bounds.max ? value : spec.fit(value, bounds);
 };
 
 const generateValue = (validator: Validator, fieldName: string, input: unknown, now: number): unknown => {
@@ -361,5 +454,5 @@ const generateValue = (validator: Validator, fieldName: string, input: unknown, 
     }
 };
 
-export { BIGINT_RANGE, constraintsOf, generateValue, isTimestampField, NUMBER_RANGE, TIMESTAMP_WINDOW_MS };
+export { BIGINT_RANGE, constraintsOf, FALLBACK_EMAIL_DOMAIN, generateValue, isTimestampField, NUMBER_RANGE, TIMESTAMP_WINDOW_MS };
 export type { Constraints };

--- a/packages/seed/src/unique-value.ts
+++ b/packages/seed/src/unique-value.ts
@@ -2,7 +2,7 @@ import { LunoraError } from "@lunora/errors";
 
 import { copycat } from "./copycat";
 import type { Constraints } from "./generate-value";
-import { BIGINT_RANGE, constraintsOf, isTimestampField, NUMBER_RANGE, TIMESTAMP_WINDOW_MS } from "./generate-value";
+import { BIGINT_RANGE, constraintsOf, FALLBACK_EMAIL_DOMAIN, isTimestampField, NUMBER_RANGE, TIMESTAMP_WINDOW_MS } from "./generate-value";
 import type { FieldSpec } from "./introspect";
 import { metaOf } from "./introspect";
 
@@ -63,9 +63,6 @@ const shuffleDomain = (domain: ReadonlyArray<unknown>, table: string, column: st
 
     return out;
 };
-
-/** Domain used when a column must hold an address but the generator produced a bare word. */
-const FALLBACK_EMAIL_DOMAIN = "@example.com";
 
 /**
  * Make a generated string row-unique while keeping the shape the generator just

--- a/scripts/check-batch-cap-drift.js
+++ b/scripts/check-batch-cap-drift.js
@@ -1,30 +1,55 @@
 #!/usr/bin/env node
 /**
- * Guards `MAX_BATCH_ENTRIES` — the batch-RPC entry cap — against drifting between
- * `shared/batch-wire.ts` and the ten places that restate it.
+ * Guards the two batch-RPC caps — `MAX_BATCH_ENTRIES` and `MAX_BATCH_BYTES` —
+ * against drifting between their definitions and the places that restate them.
  *
- * The JS client imports the shared constant, so it cannot drift. The eight non-JS
- * ports cannot import anything from this repo, and `protocol/README.md` §4.3 states
- * the number in prose, so all nine hold their own literal. Nothing reconciled them:
- * no conformance case asserts the cap, and the ports only ever see it as a number
+ * The eight non-JS ports cannot import anything from this repo, and
+ * `protocol/README.md` states both numbers in prose, so every one of them holds its
+ * own literal. Nothing reconciled them: the ports only ever see a cap as a number
  * they typed once.
  *
- * That matters more than a stale doc line. The server rejects an over-cap batch with
- * a coded 400, which `protocol/README.md` §4.3 defines as a TERMINAL verdict — a
- * conforming client DISCARDS those entries rather than retrying them. So lowering
- * the shared cap without lowering all eight silently turns durable offline writes
- * into dropped ones on every non-JS client.
+ * That matters more than a stale doc line.
+ *
+ *   - `MAX_BATCH_ENTRIES`: the server rejects an over-cap batch with a coded 400,
+ *     which `protocol/README.md` §4.3 defines as a TERMINAL verdict — a conforming
+ *     client DISCARDS those entries rather than retrying them. Lowering the shared
+ *     cap without lowering all eight silently turns durable offline writes into
+ *     dropped ones on every non-JS client.
+ *   - `MAX_BATCH_BYTES`: a client-side budget, and the only one of the two that is
+ *     DERIVED — it is the worker's own request-body cap (`MAX_BODY_BYTES` in
+ *     `@lunora/runtime`) less a fixed headroom, written as that subtraction in all
+ *     nine clients. So it drifts two ways: a client restating a stale total, and
+ *     the worker's cap moving underneath every client at once. Over-budget costs a
+ *     413, which §4.3 makes a split-and-retry rather than a verdict, so the write
+ *     survives — but the flush pays a wasted round trip per chunk, and an
+ *     under-budget client chunks far more than it needs to.
+ *
+ * Both operands of the byte budget are compared, not just the difference: the first
+ * IS the worker's cap and the second the framing headroom, so a mirror spelling the
+ * same total as `900_000 - 0` would be lying about both.
+ *
+ * The entry cap is ALSO pinned from the other side, by a normative fixture value
+ * (`offlineQueue.batchReplay.maxEntries`) each port reads back in the
+ * `batch_entry_cap_matches_protocol` conformance case. The byte budget deliberately
+ * gets no such twin. That second mechanism buys one thing this script cannot — proof
+ * that each port's RUNNING code reads its own constant — and it is worth eight
+ * hand-written test cases only because an over-entry chunk is settled terminally and
+ * the writes are gone. A stale byte budget costs a round trip, not a write: §4.3
+ * makes the 413 a split-and-retry. Prevention here is what the reconciliation is
+ * for, and the reconciliation is this file.
  *
  * The same `scripts/check-*.js` + `lint:*` + lint.yml shape as
  * `check-node-capabilities-docs.js` and `check-roadmap-tiers.js`, which reconcile a
  * constant against its hand-maintained mirrors for the same reason.
  *
- * Fail-closed twice over:
+ * Fail-closed three times over:
  *   - a pattern that matches NOTHING is an error, not a pass. A renamed or moved
  *     declaration would otherwise quietly reduce this to a check of the copies that
  *     still happen to look the way they did.
- *   - an SDK directory with no entry in MIRRORS is an error, so a ninth port cannot
- *     be added with a tenth hardcoded literal that nothing reads.
+ *   - a pattern capturing a different number of groups than the row claims is an
+ *     error, so a mirror cannot be silently compared against the wrong operand.
+ *   - an SDK directory with no row in a cap's mirrors is an error, so a ninth port
+ *     cannot be added with a tenth hardcoded literal that nothing reads.
  *
  * `pnpm run lint:batch-cap` — deliberately not wired into `postinstall`: that chain
  * fails every CI job at its setup step, with the cause invisible in the job that
@@ -37,31 +62,81 @@ import { fileURLToPath } from "node:url";
 
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-/** The one definition every other copy is measured against. */
-const SOURCE_FILE = "shared/batch-wire.ts";
-const SOURCE_PATTERN = /^const MAX_BATCH_ENTRIES = (\d+);$/mu;
-
 /**
- * Every restatement of the cap, as `file` → the patterns whose first capture group
- * is the number. `sdk` names the `sdks/<name>` directory the row covers, so the
- * coverage check below can tell a port with no row from one that is deliberately
- * not a port.
+ * Every cap this script reconciles.
+ *
+ * `sourcePattern` may capture more than one number (the byte budget captures both
+ * operands of its subtraction); a mirror's `groups` names which of the source's
+ * captures its own captures correspond to, defaulting to all of them in order. A
+ * `scale` multiplies a mirror's captures before comparison, for a mirror that
+ * states the value in a coarser unit than the source does.
  */
-const MIRRORS = [
-    { file: "sdks/python/lunora/submit.py", patterns: [/^MAX_BATCH_ENTRIES = (\d+)$/mu], sdk: "python" },
-    { file: "sdks/go/lunora/submit.go", patterns: [/^const MaxBatchEntries = (\d+)$/mu], sdk: "go" },
-    { file: "sdks/ruby/lib/lunora/client.rb", patterns: [/^ {2}MAX_BATCH_ENTRIES = (\d+)$/mu], sdk: "ruby" },
-    { file: "sdks/rust/src/offline.rs", patterns: [/^pub const MAX_BATCH_ENTRIES: usize = (\d+);$/mu], sdk: "rust" },
-    { file: "sdks/swift/Sources/Lunora/Offline.swift", patterns: [/^public let lunoraMaxBatchEntries = (\d+)$/mu], sdk: "swift" },
-    { file: "sdks/java/src/dev/lunora/Offline.java", patterns: [/^ {4}public static final int MAX_BATCH_ENTRIES = (\d+);$/mu], sdk: "java" },
-    { file: "sdks/kotlin/src/Offline.kt", patterns: [/^const val MAX_BATCH_ENTRIES: Int = (\d+)$/mu], sdk: "kotlin" },
-    { file: "sdks/dart/lib/src/transport.dart", patterns: [/^const int lunoraMaxBatchEntries = (\d+);$/mu], sdk: "dart" },
-    // The normative prose. Both sentences carry the number; §4.3's is the one that
-    // defines the over-cap verdict, so a half-updated README is its own defect.
+const CAPS = [
     {
-        file: "protocol/README.md",
-        patterns: [/capped at \*\*(\d+)\*\* entries/u, /chunking by the (\d+)-entry cap/u],
-        sdk: undefined,
+        consequence: "a client chunking above the server's cap has its over-cap chunk refused with a terminal 400 and\nDISCARDS those durable writes",
+        mirrors: [
+            { file: "sdks/python/lunora/submit.py", patterns: [/^MAX_BATCH_ENTRIES = (\d+)$/mu], sdk: "python" },
+            { file: "sdks/go/lunora/submit.go", patterns: [/^const MaxBatchEntries = (\d+)$/mu], sdk: "go" },
+            { file: "sdks/ruby/lib/lunora/client.rb", patterns: [/^ {2}MAX_BATCH_ENTRIES = (\d+)$/mu], sdk: "ruby" },
+            { file: "sdks/rust/src/offline.rs", patterns: [/^pub const MAX_BATCH_ENTRIES: usize = (\d+);$/mu], sdk: "rust" },
+            { file: "sdks/swift/Sources/Lunora/Offline.swift", patterns: [/^public let lunoraMaxBatchEntries = (\d+)$/mu], sdk: "swift" },
+            { file: "sdks/java/src/dev/lunora/Offline.java", patterns: [/^ {4}public static final int MAX_BATCH_ENTRIES = (\d+);$/mu], sdk: "java" },
+            { file: "sdks/kotlin/src/Offline.kt", patterns: [/^const val MAX_BATCH_ENTRIES: Int = (\d+)$/mu], sdk: "kotlin" },
+            { file: "sdks/dart/lib/src/transport.dart", patterns: [/^const int lunoraMaxBatchEntries = (\d+);$/mu], sdk: "dart" },
+            // The normative prose. Both sentences carry the number; §4.3's is the one
+            // that defines the over-cap verdict, so a half-updated README is its own
+            // defect. The fixture value the conformance suites read is the third.
+            {
+                file: "protocol/README.md",
+                patterns: [/capped at \*\*(\d+)\*\* entries/u, /chunking by the (\d+)-entry cap/u],
+                sdk: undefined,
+            },
+            { file: "protocol/fixtures/offline-optimistic.json", patterns: [/^ {12}"maxEntries": (\d+),$/mu], sdk: undefined },
+        ],
+        name: "MAX_BATCH_ENTRIES",
+        sourceFile: "shared/batch-wire.ts",
+        sourceForm: "const MAX_BATCH_ENTRIES = <n>;",
+        sourcePattern: /^const MAX_BATCH_ENTRIES = (\d+);$/mu,
+    },
+    {
+        consequence:
+            "a client whose budget no longer matches the worker's body cap either wastes a round trip per\nover-budget chunk or chunks far smaller than it needs to",
+        mirrors: [
+            { file: "sdks/python/lunora/submit.py", patterns: [/^MAX_BATCH_BYTES = ([\d_]+) - ([\d_]+)$/mu], sdk: "python" },
+            { file: "sdks/go/lunora/submit.go", patterns: [/^const MaxBatchBytes = ([\d_]+) - ([\d_]+)$/mu], sdk: "go" },
+            { file: "sdks/ruby/lib/lunora/client.rb", patterns: [/^ {2}MAX_BATCH_BYTES = ([\d_]+) - ([\d_]+)$/mu], sdk: "ruby" },
+            { file: "sdks/rust/src/offline.rs", patterns: [/^pub const MAX_BATCH_BYTES: usize = ([\d_]+) - ([\d_]+);$/mu], sdk: "rust" },
+            { file: "sdks/swift/Sources/Lunora/Offline.swift", patterns: [/^public let lunoraMaxBatchBytes = ([\d_]+) - ([\d_]+)$/mu], sdk: "swift" },
+            {
+                file: "sdks/java/src/dev/lunora/Offline.java",
+                patterns: [/^ {4}public static final int MAX_BATCH_BYTES = ([\d_]+) - ([\d_]+);$/mu],
+                sdk: "java",
+            },
+            { file: "sdks/kotlin/src/Offline.kt", patterns: [/^const val MAX_BATCH_BYTES: Int = ([\d_]+) - ([\d_]+)$/mu], sdk: "kotlin" },
+            { file: "sdks/dart/lib/src/transport.dart", patterns: [/^const int lunoraMaxBatchBytes = ([\d_]+) - ([\d_]+);$/mu], sdk: "dart" },
+            // The worker's own request-body cap, which the budget's FIRST operand is
+            // the client-side restatement of. This is the row the entry cap has no
+            // analogue for: raise the server's cap and every client's budget is stale
+            // at once, with nothing else in the repo noticing.
+            {
+                file: "packages/runtime/src/body-readers.ts",
+                groups: [1],
+                patterns: [/^const MAX_BODY_BYTES = ([\d_]+);$/mu],
+                sdk: undefined,
+            },
+            // The normative prose states the same cap in MiB.
+            {
+                file: "protocol/README.md",
+                groups: [1],
+                patterns: [/under the (\d+) MiB cap/u],
+                scale: 1024 * 1024,
+                sdk: undefined,
+            },
+        ],
+        name: "MAX_BATCH_BYTES",
+        sourceFile: "packages/client/src/replay.ts",
+        sourceForm: "const MAX_BATCH_BODY_BYTES = <cap> - <headroom>;",
+        sourcePattern: /^const MAX_BATCH_BODY_BYTES = ([\d_]+) - ([\d_]+);$/mu,
     },
 ];
 
@@ -75,58 +150,77 @@ const IGNORED_SDK_DIRS = new Set(["smoke"]);
 
 const read = (relativePath) => readFileSync(join(rootDir, relativePath), "utf8");
 
-const sourceMatch = SOURCE_PATTERN.exec(read(SOURCE_FILE));
+/** The numeric value of one captured literal, in whatever digit-grouping its language spells. */
+const numberOf = (literal) => Number(literal.replaceAll("_", ""));
 
-if (sourceMatch === null) {
-    process.stderr.write(
-        `${SOURCE_FILE} no longer declares \`const MAX_BATCH_ENTRIES = <n>;\`.\n` +
-            `That declaration is what every other copy of the cap is measured against, so this check\n` +
-            `cannot run. Update SOURCE_PATTERN in scripts/check-batch-cap-drift.js to match its new form.\n`,
-    );
-    process.exit(1);
-}
-
-const expected = sourceMatch[1];
 const problems = [];
 
-for (const { file, patterns } of MIRRORS) {
-    const source = read(file);
+for (const { mirrors, name, sourceFile, sourceForm, sourcePattern } of CAPS) {
+    const sourceMatch = sourcePattern.exec(read(sourceFile));
 
-    for (const pattern of patterns) {
-        const match = pattern.exec(source);
+    if (sourceMatch === null) {
+        process.stderr.write(
+            `${sourceFile} no longer declares \`${sourceForm}\`.\n` +
+                `That declaration is what every other copy of ${name} is measured against, so this check\n` +
+                `cannot run. Update its sourcePattern in scripts/check-batch-cap-drift.js to match its new form.\n`,
+        );
+        process.exit(1);
+    }
 
-        if (match === null) {
-            problems.push(`  ${file} — nothing matches ${String(pattern)}; the declaration moved or was renamed`);
+    const expected = sourceMatch.slice(1).map(numberOf);
+
+    for (const { file, groups = expected.map((_unused, index) => index + 1), patterns, scale = 1 } of mirrors) {
+        const source = read(file);
+
+        for (const pattern of patterns) {
+            const match = pattern.exec(source);
+
+            if (match === null) {
+                problems.push(`  ${name}: ${file} — nothing matches ${String(pattern)}; the declaration moved or was renamed`);
+                continue;
+            }
+
+            const captured = match.slice(1);
+
+            if (captured.length !== groups.length) {
+                problems.push(
+                    `  ${name}: ${file} — ${String(pattern)} captures ${String(captured.length)} number(s) but its row claims ${String(groups.length)}`,
+                );
+                continue;
+            }
+
+            for (const [index, literal] of captured.entries()) {
+                const actual = numberOf(literal) * scale;
+                const want = expected[groups[index] - 1];
+
+                if (actual !== want) {
+                    problems.push(`  ${name}: ${file} — states ${String(actual)}, ${sourceFile} states ${String(want)}`);
+                }
+            }
+        }
+    }
+
+    const covered = new Set(mirrors.map(({ sdk }) => sdk));
+
+    for (const entry of readdirSync(join(rootDir, "sdks"), { withFileTypes: true })) {
+        if (!entry.isDirectory() || IGNORED_SDK_DIRS.has(entry.name)) {
             continue;
         }
 
-        if (match[1] !== expected) {
-            problems.push(`  ${file} — states ${match[1]}, ${SOURCE_FILE} states ${expected}`);
+        if (!covered.has(entry.name)) {
+            problems.push(`  ${name}: sdks/${entry.name} — a port with no row in its mirrors, so its own cap is reconciled by nothing`);
         }
-    }
-}
-
-const covered = new Set(MIRRORS.map(({ sdk }) => sdk));
-
-for (const entry of readdirSync(join(rootDir, "sdks"), { withFileTypes: true })) {
-    if (!entry.isDirectory() || IGNORED_SDK_DIRS.has(entry.name)) {
-        continue;
-    }
-
-    if (!covered.has(entry.name)) {
-        problems.push(`  sdks/${entry.name} — a port with no row in MIRRORS, so its own cap is reconciled by nothing`);
     }
 }
 
 if (problems.length > 0) {
     process.stderr.write(
-        `MAX_BATCH_ENTRIES disagrees across ${String(problems.length)} location(s).\n` +
-            `${SOURCE_FILE} is the source of truth (currently ${expected}); every port and protocol/README.md\n` +
-            `restates it as a literal because they cannot import it. Change all of them together — a client\n` +
-            `chunking above the server's cap has its over-cap chunk refused with a terminal 400 and DISCARDS\n` +
-            `those durable writes:\n${problems.join("\n")}\n`,
+        `The batch caps disagree across ${String(problems.length)} location(s).\n` +
+            `Every port and protocol/README.md restates them as literals because they cannot import them,\n` +
+            `so they have to change together:\n${problems.join("\n")}\n\n` +
+            `${CAPS.map(({ consequence, name, sourceFile }) => `${name} (source of truth: ${sourceFile}) — ${consequence}.`).join("\n\n")}\n`,
     );
     process.exit(1);
 }
 
-process.stdout.write(`✅ MAX_BATCH_ENTRIES is ${expected} in ${SOURCE_FILE} and all ${String(MIRRORS.length)} mirrors.\n`);
+process.stdout.write(`✅ ${CAPS.map(({ mirrors, name }) => `${name} agrees across its ${String(mirrors.length)} mirrors`).join(", ")}.\n`);

--- a/scripts/template-build-smoke.sh
+++ b/scripts/template-build-smoke.sh
@@ -715,9 +715,10 @@ for tname in "${TEMPLATES[@]}"; do
     # the matrix runs at all: an empty result leaves AUTHUI_ADDED="no", which skips
     # `lunora add auth-ui`, every file-landed assertion, the dep-injection check,
     # the per-template typechecker, the typecheck:never-ran guard, the FILE_RE
-    # vacuity guard and the planted-error canary — and the template still records
-    # PASS on `pnpm run build` alone. Swallowing the exit status made a resolution
-    # failure indistinguishable from "this template has no framework".
+    # vacuity guard and the planted-error canary. Swallowing the exit status made a
+    # resolution failure indistinguishable from "this template has no framework".
+    # A template that legitimately has no framework is caught downstream instead:
+    # see the `typecheck:skipped` guard on the build path.
     if [[ ${authui_detect_status:-0} -ne 0 ]]; then
         echo "  FAIL: could not resolve the expected auth-ui view for $tname (node exited ${authui_detect_status})"
         echo "        Everything from \`lunora add auth-ui\` onwards would have been skipped, and $tname would have recorded PASS on its build alone."
@@ -1045,6 +1046,33 @@ for tname in "${TEMPLATES[@]}"; do
         fi
 
         echo "  ==> typecheck OK"
+    else
+        # Fail closed. Reaching here means the detector resolved no view (every
+        # other path out of that block `continue`s), so this template got NO
+        # compiler over its source at all: the block above is the run's only
+        # `tsc`, and `pnpm run build` compiles only what a build entry reaches —
+        # every file under `lunora/` is tree-shaken away before a compiler sees
+        # it. The build-LESS path above typechecks such a template; this one used
+        # to record PASS on the bundler alone.
+        #
+        # Failing here rather than widening the AUTHUI_RESOLVED floor to "all
+        # templates": that floor is a whole-run tripwire, so widening it makes
+        # every verdict depend on the full matrix, while this fires per template
+        # exactly where the coverage is lost. It is unreachable for the templates
+        # on disk — `standalone` is the only one in this matrix that resolves no
+        # view, and it ships no `build` script, so it takes the codegen +
+        # typecheck path above (`expo` also resolves none, and is skipped before
+        # it ever gets here). That is what makes this a guard and not a behaviour
+        # change.
+        echo "  FAIL: $tname resolved no auth-ui view, so nothing typechecked its source"
+        echo "        \`pnpm run build\` bundles only what a build entry reaches, and this run's only"
+        echo "        typechecker is gated on that view — so $tname would have recorded PASS with no"
+        echo "        compiler having read lunora/ at all."
+        echo "        Either teach the detector this template's framework (mirror detectAuthUiItem in"
+        echo "        packages/cli/src/commands/add/features.ts) or drop its \`build\` script, which routes"
+        echo "        it through the codegen + typecheck path instead."
+        FAIL+=("$tname(typecheck:skipped)")
+        continue
     fi
 
     if [[ $build_exit -eq 0 ]]; then


### PR DESCRIPTION
**Do not merge — a review slice of #579.** See #583 for why this is split at all.

**Round 16** — 10 files. Four items earlier rounds fixed only halfway, plus one cross-branch repair:

- **The seed format fix was undone one line later.** A previous round made declared formats drive generation and refuse `.pattern()` at plan time, but the length axis still did a blind `value.slice(0, maxLength)` and a `padEnd`, so `v.string().email().max(20)` seeded an address its own validator rejects. Values that fit are now untouched, those that don't are rebuilt around the format, and a bound admitting no conforming value refuses at plan time naming the column — deterministic, because it is a property of the schema rather than of one generated value.
- **`MAX_BATCH_BYTES` was duplicated across 13 sites** with nothing reconciling them. The existing drift script was extended rather than a second mechanism added, and it compares **both operands**, so raising the worker's own body cap is caught too.
- **The registry deps sweep filtered to `.tsx?`** while the registry ships 114 Vue and Svelte components carrying 41 specifiers it never opened — a guard that passes by finding nothing, so a filter that stops matching a dialect reads as success.
- **The template smoke script recorded PASS with no compiler having read the source** on one path; it now fails closed.
- **A cross-branch repair**: a `@lunora/runtime` test regex-scrapes `toNdjson` out of `registry/backup/backup.ts`, and round 15 made that function span lines. The guard failed to load rather than reporting drift.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ