### PR TITLE
docs(cloud): state the celld tenancy boundary in the runtime decision

### DIFF
--- a/apps/cloud/MULTIPLATFORM.md
+++ b/apps/cloud/MULTIPLATFORM.md
@@ -503,7 +503,33 @@ the no-lock-in promise than a fork would be:
   adapters under a celld capability matrix), and it is a real enterprise line
   item against every Workers-shaped competitor.
 - **Fully-managed "Later" (`ROADMAP.md` phase 2).** Operating a celld fleet
-  needs no fork either — Apache-2.0, `celld deploy` works today.
+  needs no fork either — Apache-2.0, `celld deploy` works today. It needs a
+  different shape, though: see the tenancy boundary below.
+
+**The celld tenancy boundary — read before costing a managed tier.** celld's own
+`docs/security.md` is explicit: it "is an alpha", it "is not safe for hostile
+multi-tenant use", and "one fleet runs one application… do not run code from
+mutually distrusting tenants in one fleet". Cell fencing protects storage
+consistency and is _not_ an isolation boundary between hostile applications.
+Security fixes land on the latest release only, so an older alpha build gets
+none.
+
+Two consequences, and the first is a cost model rather than a disclaimer:
+
+- **A managed tier is one fleet per tenant, not one fleet.** Per-tenant nodes
+  plus a per-tenant object store, with no bin-packing across customers — which
+  is most of the margin the "own the runtime" case was arguing for. It also
+  forces continuous upgrades, because only the latest release is patched.
+- **Self-host is the honest tier today**, and it is honest precisely because it
+  is single-tenant by construction: the customer's fleet runs the customer's
+  app, which is the deployment shape celld supports.
+
+So a shared managed deployment is gated, not planned. Two gates before it is
+offered to anyone: celld states a hostile-multi-tenant isolation boundary we can
+point at, and there is a security-fix channel we can meet an SLA with (a
+supported release line, or patches we carry — per "when to revisit" below). This
+sharpens reason 2 above rather than competing with it: on our own fleet the
+isolation boundary is ours to answer for.
 
 **When to revisit.** Two triggers, both concrete: a patch upstream refuses (they
 take `git format-patch` by email under a CLA assigning rights, so friction is


### PR DESCRIPTION
## Summary

Follow-up to #582 (already merged), addressing the one actionable review comment on it: `apps/cloud/MULTIPLATFORM.md` §7.8 described a fully-managed celld tier without stating celld's tenancy boundary.

celld's own [`docs/security.md`](https://github.com/denoland/celld/blob/v0.4.0/docs/security.md) says it "is an alpha", "is not safe for hostile multi-tenant use", and "one fleet runs one application… do not run code from mutually distrusting tenants in one fleet". Cell fencing protects storage consistency and is explicitly *not* an isolation boundary between hostile applications. Security fixes land on the latest release only.

§7.8 as merged said a managed fleet "needs no fork either — Apache-2.0, `celld deploy` works today", which reads as a managed multi-tenant tier being a straightforward *Later*. It isn't, and the interesting part is a cost model rather than a safety footnote:

- **A managed tier is one fleet per tenant, not one fleet** — per-tenant nodes and object store, no bin-packing across customers, which is most of the margin the own-the-runtime case was arguing for. It also forces continuous upgrades, since only the latest release is patched.
- **Self-host stays the honest tier**, precisely because it is single-tenant by construction — the customer's fleet runs the customer's app, which is the shape celld supports.

Also records the two gates before a shared managed deployment is offered to anyone: an upstream isolation boundary we can point at, and a security-fix channel that can carry an SLA.

Area: `apps/cloud` (documentation only). Related framework package: `@lunora/platform-celld` (#359).

## Linked issues

- Refs #582 (addresses the CodeRabbit review comment on `apps/cloud/MULTIPLATFORM.md`)
- Refs #359 (the celld host package this decision governs)

## Test plan

Documentation only — one markdown file, no code, no schema, no dependency change. Nothing to execute beyond formatting.

- [x] `pnpm exec prettier --check apps/cloud/MULTIPLATFORM.md` passes
- [x] Claims verified against celld `docs/security.md` at the `v0.4.0` tag directly, not from the review summary
- [ ] Reviewer re-read of §7.8 for whether the two gates are the right two

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change — n/a, documentation only
- [x] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs) — this change *is* the doc; no user-facing docs affected
- [x] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag — n/a
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry — n/a

## Notes for reviewers

The substantive question is not the caveat but the **one-fleet-per-tenant** consequence. If that is right, it removes a large part of the economic case for ever operating our own fleet, which is worth disagreeing with explicitly if you read it differently.

Two things I deliberately did **not** do:

- I did not soften the decision in row 8. This corroborates it rather than changing it.
- I did not touch `apps/cloud/ROADMAP.md`. Its "optional fully-managed hosting (Later)" line is still accurate — it promises managed hosting, not managed-on-celld — but if you want the tenancy constraint surfaced in the public roadmap too, that is a separate call.

#582 skipped this template; this one follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on celld’s current tenancy and security boundaries.
  * Clarified that deployments should use one fleet per application or tenant, with self-hosting as the current single-tenant option.
  * Documented prerequisites for offering shared managed deployments, including stronger isolation guarantees and an ongoing security-fix channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->