### PR TITLE
fix: close 15 audit findings across the db outbox, container DO and adapters

### DIFF
--- a/api-snapshots/auth-ui.api.md
+++ b/api-snapshots/auth-ui.api.md
@@ -1595,7 +1595,12 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
                         (changed)="actions.setField('email', $event)"
                         (blurred)="actions.blur('email')"
                     />
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.magicLink }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.magicLink }}
+                        @if (lastUsedMagicLink) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
                 <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.backToSignIn }}</lunora-auth-link>
             </lunora-auth-card>
@@ -1610,6 +1615,7 @@ class MagicLinkCardComponent {
     private readonly bridge = controllerSignal(createMagicLinkController, { context: this.context });
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
+    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
 }
 ```
 
@@ -2722,7 +2728,15 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
                         (blurred)="actions.blur('password')"
                     />
                     <lunora-auth-link [href]="forgotPasswordHref()">{{ t.forgotPasswordLink }}</lunora-auth-link>
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signIn }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.signIn }}
+                        <!--
+                          better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
+                        -->
+                        @if (lastUsedEmail) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
             }
             @if (signUp()) {
@@ -2743,6 +2757,7 @@ class SignInCardComponent {
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
     protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
+    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
     protected signInSocial(provider: string): void {
@@ -7094,7 +7109,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
             assertOk(await context.authClient.signIn.emailOtp({ email: state.email.value.trim(), otp: state.code.value.trim() }));
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         }
         catch (error_) {
             context.onError?.(error_);
@@ -7597,7 +7612,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     }));
                     context.onSessionChange?.();
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
                     return { status: "success", successMessage: context.localization.phoneVerified };
                 }, context.localization.twoFactorFailed);
@@ -8840,7 +8855,7 @@ const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     }
     catch (error) {
         notifyError(context, error, context.localization.signInFailed);

--- a/api-snapshots/auth-ui.api.md
+++ b/api-snapshots/auth-ui.api.md
@@ -1597,7 +1597,7 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
                     />
                     <lunora-auth-submit-button [pending]="state().status === 'submitting'">
                         {{ t.magicLink }}
-                        @if (lastUsedMagicLink) {
+                        @if (lastUsedMagicLink()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -1615,7 +1615,8 @@ class MagicLinkCardComponent {
     private readonly bridge = controllerSignal(createMagicLinkController, { context: this.context });
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
-    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
+    protected readonly lastUsedMagicLink = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined) === LAST_METHOD_MAGIC_LINK);
 }
 ```
 
@@ -2733,7 +2734,7 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
                         <!--
                           better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
                         -->
-                        @if (lastUsedEmail) {
+                        @if (lastUsedEmail()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -2753,11 +2754,11 @@ class SignInCardComponent {
     private readonly bridge = controllerSignal(createSignInController, { context: this.context });
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
-    private readonly lastLoginMethod = readLastLoginMethod();
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
-    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
-    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
+    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined));
+    protected readonly lastUsedEmail = computed(() => this.lastUsed() === LAST_METHOD_EMAIL);
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
     protected signInSocial(provider: string): void {
@@ -3928,6 +3929,10 @@ const injectAuthUILink = (): ((href: string) => void) | undefined => inject(AUTH
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 ### `isSafeRedirect` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
+### `lastLoginMethodStore` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
@@ -8274,7 +8279,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
             }
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         }
         catch (error) {
             context.onError?.(error);
@@ -8444,6 +8449,16 @@ const isSafeRedirect = (target: string): boolean => {
         return false;
     }
     return !CONTROL_CHARACTERS.test(trimmed);
+};
+```
+
+### `lastLoginMethodStore` (const)
+
+```ts
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
 };
 ```
 
@@ -8624,7 +8639,14 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
         if (part.slice(0, separator).trim() !== cookieName) {
             continue;
         }
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+        let value: string;
+        try {
+            value = decodeURIComponent(raw);
+        }
+        catch {
+            return undefined;
+        }
         return value === "" ? undefined : value;
     }
     return undefined;
@@ -10394,6 +10416,10 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
+### `lastLoginMethodStore` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
 ### `linkableProviders` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
@@ -12011,6 +12037,10 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
+### `lastLoginMethodStore` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
 ### `linkableProviders` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
@@ -13612,6 +13642,10 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
+### `lastLoginMethodStore` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
 ### `linkableProviders` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
@@ -14985,6 +15019,10 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 ### `isSafeRedirect` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
+### `lastLoginMethodStore` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
@@ -16488,6 +16526,10 @@ Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 
 ### `isSafeRedirect` (const)
+
+Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
+
+### `lastLoginMethodStore` (const)
 
 Re-exported from `@lunora/auth-ui/core` — signature tracked in that section.
 

--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -405,6 +405,7 @@ class LunoraClient {
     setAuthToken(token: string | null, subject?: string | null): void;
     getAuthToken(): string | null;
     currentIdentity(): string | null;
+    replayIdentityVerdict(stamped: null | string | undefined): "match" | "mismatch" | "unknown";
     clientIdentifier(): string;
     confirmedMutationWatermark(shardKey?: string): number;
     callMutator(functionPath: string, args: Record<string, unknown>, options?: {

--- a/api-snapshots/container.api.md
+++ b/api-snapshots/container.api.md
@@ -414,6 +414,7 @@ class ContainerProxy extends WorkerEntrypoint<Cloudflare.Env, ContainerProxyOpti
 class LunoraContainer<Env = unknown> extends Container<Env> {
     constructor(context: DurableObjectContext, env: Env, definition: ContainerDefinition, exportName?: string, jurisdiction?: DurableObjectJurisdiction);
     override containerFetch(...args: Parameters<Container<Env>["containerFetch"]>): Promise<Response>;
+    override startAndWaitForPorts(...args: Parameters<Container<Env>["startAndWaitForPorts"]>): Promise<void>;
     override start(...args: Parameters<Container<Env>["start"]>): Promise<void>;
     override onActivityExpired(): Promise<void>;
     override onError(error: unknown): unknown;

--- a/api-snapshots/db.api.md
+++ b/api-snapshots/db.api.md
@@ -286,14 +286,12 @@ interface OutboxExecutor {
 ### `OutboxMutationMetadata` (interface)
 
 ```ts
-interface OutboxMutationMetadata extends Record<string, unknown> {
+interface OutboxMutationMetadata extends WriteProvenance {
     args: Record<string, unknown>;
     clientId: string;
     functionPath: string;
     idempotencyKey: string;
-    identity: string | null;
     mutationId: number;
-    shardKey?: string;
 }
 ```
 

--- a/apps/docs/src/content/docs/frameworks/nuxt.mdx
+++ b/apps/docs/src/content/docs/frameworks/nuxt.mdx
@@ -88,18 +88,20 @@ the `/_lunora/**` route.
 | Option     | Default           | Description                                               |
 | ---------- | ----------------- | --------------------------------------------------------- |
 | `appEntry` | `~/lunora/server` | Module specifier of the Lunora app entry (`#lunora/app`). |
-| `prefix`   | `/_lunora`        | URL prefix the Lunora realtime plane is mounted at.       |
+
+The `/_lunora/**` mount is fixed: the worker routes on those exact paths and the
+generated client calls them.
 
 ```ts title="nuxt.config.ts"
 export default defineNuxtConfig({
     modules: ["@lunora/nuxt"],
-    lunora: { appEntry: "~/server/lunora-app", prefix: "/_lunora" },
+    lunora: { appEntry: "~/server/lunora-app" },
 });
 ```
 
 ## How it works
 
-- **The route** (`addServerHandler` at `prefix/**`) reconstructs a Web
+- **The route** (`addServerHandler` at `/_lunora/**`) reconstructs a Web
   `Request` from the H3 event, resolves the Cloudflare
   `env`/`ExecutionContext` off it, and forwards to your app's `fetch`. A
   missing Cloudflare runtime answers a clear 500.

--- a/apps/playground/src/server/index.ts
+++ b/apps/playground/src/server/index.ts
@@ -258,8 +258,9 @@ const handleTestSign = async (request: Request, env: Env): Promise<Response> => 
         // signed value unconditionally, so an unpinned URL only accepts a body
         // with no content type.
         contentType: body.contentType,
-        // The playground declares one bucket, which `createStorage` signs under
-        // the canonical `"default"` tag — mint the e2e URLs the same way or they
+        // The app declares two buckets (`FILES` as the default, `AVATARS` under
+        // the `avatars` tag). `createStorage` signs the unnamed one under the
+        // canonical `"default"` tag — mint the e2e URLs the same way or they
         // verify against a different canonical.
         bucketName: "default",
         expiresInSeconds: body.expiresInSeconds,
@@ -378,8 +379,11 @@ const handleStorageAsset = async (request: Request, env: Env): Promise<null | Re
     }
 
     // The bucket is HMAC-bound, so this is the URL's own claim about which
-    // binding to serve — never a caller-supplied parameter. One bucket is
-    // declared here, so anything else is a URL minted for an app we are not.
+    // binding to serve — never a caller-supplied parameter. Only the default
+    // bucket is served here: the app also declares `avatars`, but nothing mints
+    // a URL against it (`lunora/avatars.ts` writes `avatars/`-prefixed keys into
+    // the default bucket), so a URL naming any other bucket was minted for an
+    // app we are not. Serving `avatars` means resolving the binding here first.
     if (verdict.bucketName !== "default") {
         return new Response("forbidden", { status: 403 });
     }

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -11,5 +11,11 @@ export default defineConfig({
     plugins: [lunora(e2e ? { cloudflare: { persistState: false } } : undefined)],
     server: {
         port: 5173,
+        // Fail rather than slide to the next free port: `AUTH_URL`,
+        // `LUNORA_WORKER_ORIGIN`, `LUNORA_ORIGIN_URL` and the studio's dev proxy
+        // all hard-code :5173, and 5174 is the studio's own port — so a stale
+        // server silently produces a playground whose auth callbacks point at a
+        // different app.
+        strictPort: true,
     },
 });

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -91,11 +91,12 @@ Reactivity comes from the island adapter you hydrate with, not from this package
 import { createServerClient, preloadQuery, serializePreloaded } from "@lunora/astro/server";
 import { api } from "../lunora/_generated/api";
 
-const client = createServerClient({ url: Astro.url.origin + "/_lunora/rpc" });
+const client = createServerClient({ url: Astro.url.origin });
 const preloaded = await preloadQuery(client, api.messages.list, {});
 ---
 
-<my-island data-preloaded={serializePreloaded(preloaded)}></my-island>
+<script id="preloaded" type="application/json" set:html={serializePreloaded(preloaded)}></script>
+<my-island></my-island>
 ```
 
 ### Feature flags
@@ -108,7 +109,7 @@ const preloaded = await preloadQuery(client, api.messages.list, {});
 import { createServerClient, preloadQuery, preloadedQueryResult } from "@lunora/astro/server";
 import { api } from "../lunora/_generated/api";
 
-const client = createServerClient({ url: Astro.url.origin + "/_lunora/rpc" });
+const client = createServerClient({ url: Astro.url.origin });
 const preloaded = await preloadQuery(client, api.homepage.heroFlag, {}); // a query that returns ctx.flags.boolean(...)
 const newHero = preloadedQueryResult(preloaded);
 ---

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -99,6 +99,16 @@ const preloaded = await preloadQuery(client, api.messages.list, {});
 <my-island></my-island>
 ```
 
+The island has to pick the token up explicitly — no adapter discovers `#preloaded` on its own:
+
+```ts
+import { hydratePreloaded } from "@lunora/react";
+import { deserializePreloaded } from "@lunora/astro/server";
+
+const preloaded = deserializePreloaded(document.querySelector("#preloaded")!.textContent!);
+const initial = hydratePreloaded(preloaded); // seeds the first paint, then goes live
+```
+
 ### Feature flags
 
 `@lunora/astro` ships no flag hook — like every other surface, flags follow the same server/island split. Read `ctx.flags` server-side (a server endpoint, a function, or the same `.astro` frontmatter) and hand the resolved value to the island, or call `useFlag` inside the island itself via the adapter you hydrate with (`@lunora/react`, `@lunora/vue`, …). Requires [`@lunora/flags`](https://www.npmjs.com/package/@lunora/flags) wired in `lunora/flags.ts`.

--- a/packages/astro/docs/index.mdx
+++ b/packages/astro/docs/index.mdx
@@ -96,11 +96,12 @@ The `astro.config` integration object (`{ name, hooks }`). The only option is `s
 import { createServerClient, preloadQuery, serializePreloaded } from "@lunora/astro/server";
 import { api } from "../lunora/_generated/api";
 
-const client = createServerClient({ url: Astro.url.origin + "/_lunora/rpc" });
+const client = createServerClient({ url: Astro.url.origin });
 const preloaded = await preloadQuery(client, api.messages.list, {});
 ---
 
-<my-island data-preloaded={serializePreloaded(preloaded)}></my-island>
+<script id="preloaded" type="application/json" set:html={serializePreloaded(preloaded)}></script>
+<my-island></my-island>
 ```
 
 On the client, deserialize and hand the token to your island adapter's `hydratePreloaded` for the SSR-seed-to-live handoff:
@@ -109,7 +110,7 @@ On the client, deserialize and hand the token to your island adapter's `hydrateP
 import { hydratePreloaded } from "@lunora/react";
 import { deserializePreloaded } from "@lunora/astro/server";
 
-const preloaded = deserializePreloaded(el.dataset.preloaded);
+const preloaded = deserializePreloaded(document.querySelector("#preloaded")!.textContent!);
 const initial = hydratePreloaded(preloaded); // seeds the first paint, then goes live
 ```
 
@@ -120,7 +121,7 @@ Re-exported from `@lunora/astro/server`:
 | `createServerClient`   | Build a request-scoped client (`{ url, token?, fetch? }`). One per request.                 |
 | `preloadQuery`         | Run a query server-side → a serializable `Preloaded` token.                                 |
 | `preloadedQueryResult` | Read the value out of a `Preloaded` token.                                                  |
-| `serializePreloaded`   | Serialize a `Preloaded` token to a string for an island attribute.                          |
+| `serializePreloaded`   | Serialize a `Preloaded` token into a raw-text `<script>` payload.                           |
 | `deserializePreloaded` | Parse a serialized token back on the client.                                                |
 | `getServerSession`     | Resolve the current session from a headers source (`Request`/`Headers`) + an auth instance. |
 

--- a/packages/auth-ui/__tests__/core/extras.test.ts
+++ b/packages/auth-ui/__tests__/core/extras.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CAPTCHA_HEADER, captchaHeaders, dismissToast, getToasts, pushToast, resetToasts, setCaptchaToken, subscribeToasts } from "../../src/core";
+import {
+    CAPTCHA_HEADER,
+    captchaHeaders,
+    dismissToast,
+    getToasts,
+    LAST_LOGIN_METHOD_COOKIE,
+    pushToast,
+    readLastLoginMethod,
+    resetToasts,
+    setCaptchaToken,
+    subscribeToasts,
+} from "../../src/core";
 
 // One cross-suite teardown hook, deliberately at the top level.
 let restoreLocation: (() => void) | undefined;
@@ -749,5 +760,38 @@ describe("theme mode", () => {
         });
 
         expect(applied).toStrictEqual([]);
+    });
+});
+
+describe("readLastLoginMethod", () => {
+    const withCookie = (cookie: string): void => {
+        vi.stubGlobal("document", { cookie });
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("returns undefined for a malformed percent-escape instead of throwing", () => {
+        expect.assertions(2);
+
+        // The cookie is unsigned and attacker-writable (the module says so), and
+        // every port reads it during render — a URIError here takes the whole
+        // sign-in card down to decorate a label.
+        withCookie(`${LAST_LOGIN_METHOD_COOKIE}=%zz`);
+
+        expect(readLastLoginMethod()).toBeUndefined();
+
+        withCookie(`${LAST_LOGIN_METHOD_COOKIE}=%`);
+
+        expect(readLastLoginMethod()).toBeUndefined();
+    });
+
+    it("still decodes a well-formed escaped value", () => {
+        expect.assertions(1);
+
+        withCookie(`${LAST_LOGIN_METHOD_COOKIE}=${encodeURIComponent("magic-link")}`);
+
+        expect(readLastLoginMethod()).toBe("magic-link");
     });
 });

--- a/packages/auth-ui/__tests__/core/extras.test.ts
+++ b/packages/auth-ui/__tests__/core/extras.test.ts
@@ -269,6 +269,108 @@ describe("redirectTo reaches every sign-in transport", () => {
 
         expect(oneTap).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: "/invite/xyz" }));
     });
+
+    /*
+     * The three doors below finish client-side with `nav.replace` rather than
+     * handing a callbackURL to better-auth, and each one dropped the parameter:
+     * the invitee signed in and landed on `/` with the invitation forgotten,
+     * which is precisely the failure `redirect-to.ts` exists to prevent.
+     */
+    it("navigates email-OTP sign-in to the on-origin redirectTo", async () => {
+        expect.assertions(1);
+
+        const { createEmailOtpController, resolveContext } = await import("../../src/core");
+
+        globalThis.history.pushState({}, "", `/auth/email-otp?${new URLSearchParams({ redirectTo: "/invite/xyz" }).toString()}`);
+
+        const replace = vi.fn();
+        const context = resolveContext({
+            authClient: {
+                emailOtp: { sendVerificationOtp: () => Promise.resolve({ data: {}, error: null }) },
+                getSession: vi.fn(),
+                signIn: { emailOtp: () => Promise.resolve({ data: {}, error: null }) },
+            } as never,
+            nav: { navigate: vi.fn(), replace },
+            redirects: { afterSignIn: "/app" },
+        });
+
+        const controller = createEmailOtpController(context);
+
+        controller.actions.setEmail("ada@example.com");
+        await controller.actions.sendCode();
+        controller.actions.setCode("123456");
+        await controller.actions.verify();
+
+        expect(replace).toHaveBeenCalledWith("/invite/xyz");
+    });
+
+    it("navigates anonymous sign-in to the on-origin redirectTo", async () => {
+        expect.assertions(1);
+
+        const { resolveContext, signInAnonymously } = await import("../../src/core");
+
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        const replace = vi.fn();
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), signIn: { anonymous: () => Promise.resolve({ data: {}, error: null }) } } as never,
+            nav: { navigate: vi.fn(), replace },
+            redirects: { afterSignIn: "/app" },
+        });
+
+        await signInAnonymously(context);
+
+        expect(replace).toHaveBeenCalledWith("/invite/xyz");
+    });
+
+    it("navigates phone-OTP sign-in to the on-origin redirectTo", async () => {
+        expect.assertions(1);
+
+        const { createPhoneVerifyController, resolveContext } = await import("../../src/core");
+
+        globalThis.history.pushState({}, "", `/auth/phone?${new URLSearchParams({ redirectTo: "/invite/xyz" }).toString()}`);
+
+        const replace = vi.fn();
+        const context = resolveContext({
+            authClient: {
+                getSession: vi.fn(),
+                phoneNumber: {
+                    sendOtp: () => Promise.resolve({ data: {}, error: null }),
+                    verify: () => Promise.resolve({ data: {}, error: null }),
+                },
+            } as never,
+            nav: { navigate: vi.fn(), replace },
+            redirects: { afterSignIn: "/app" },
+        });
+
+        const controller = createPhoneVerifyController(context);
+
+        await controller.actions.send("+15551234567");
+        await controller.actions.verify("123456");
+
+        expect(replace).toHaveBeenCalledWith("/invite/xyz");
+    });
+
+    it("falls back to the configured default on a client-side door when redirectTo would leave the origin", async () => {
+        expect.assertions(1);
+
+        const { resolveContext, signInAnonymously } = await import("../../src/core");
+
+        const offOrigin = new URLSearchParams({ redirectTo: "https://evil.example" });
+
+        globalThis.history.pushState({}, "", `/sign-in?${offOrigin.toString()}`);
+
+        const replace = vi.fn();
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), signIn: { anonymous: () => Promise.resolve({ data: {}, error: null }) } } as never,
+            nav: { navigate: vi.fn(), replace },
+            redirects: { afterSignIn: "/app" },
+        });
+
+        await signInAnonymously(context);
+
+        expect(replace).toHaveBeenCalledWith("/app");
+    });
 });
 
 /**

--- a/packages/auth-ui/__tests__/core/port-parity.test.ts
+++ b/packages/auth-ui/__tests__/core/port-parity.test.ts
@@ -37,9 +37,12 @@ const PORT_DIRS: Record<PortName, string> = Object.fromEntries(PORT_NAMES.map((n
 
 /**
  * Two ports keep their components in single-file components, not `.ts` — a
- * `.tsx?`-only walk sees Vue and Svelte as five plumbing modules and never
+ * `.tsx?`-only walk sees Vue and Svelte as plumbing modules only and never
  * reads a card, so both would count as consuming nothing.
  */
+/** Either way a port can reach the badge value. */
+const BADGE_READER_RE = /readLastLoginMethod\(|lastLoginMethodStore/u;
+
 const PORT_FILE_RE = /\.(?:svelte|tsx?|vue)$/;
 const CONTROLLER_NAME_RE = /^create[A-Z]\w*Controller$/;
 
@@ -169,18 +172,120 @@ describe("last-used badge × port parity", () => {
         expect.assertions(2);
 
         const sources = filesUnder(PORT_DIRS[port]).map((file) => readFileSync(file, "utf8"));
-        // Two occurrences: the import, plus at least one comparison that decides
-        // whether the badge renders. An unused import would satisfy a bare
-        // "is it referenced" check without badging anything.
-        const uses = (name: string): number =>
-            sources.reduce((total, source) => total + [...source.matchAll(new RegExp(String.raw`\b${name}\b`, "gu"))].length, 0);
+        // Assert the COMPARISON, not an occurrence count: a count is satisfied by
+        // an unused import plus a mention in a comment, which is exactly the
+        // shape a half-ported card would have.
+        const comparedAgainst = (name: string): boolean =>
+            sources.some((source) => new RegExp(String.raw`(?:===|!==)\s*${name}\b|\b${name}\s*(?:===|!==)`, "u").test(source));
 
-        expect(uses("LAST_METHOD_EMAIL"), `${port} never compares against LAST_METHOD_EMAIL, so a password sign-in shows no "last used" badge`).toBeGreaterThan(
-            1,
+        expect(comparedAgainst("LAST_METHOD_EMAIL"), `${port} never compares against LAST_METHOD_EMAIL, so a password sign-in shows no "last used" badge`).toBe(
+            true,
         );
         expect(
-            uses("LAST_METHOD_MAGIC_LINK"),
+            comparedAgainst("LAST_METHOD_MAGIC_LINK"),
             `${port} never compares against LAST_METHOD_MAGIC_LINK, so a magic-link sign-in shows no "last used" badge`,
-        ).toBeGreaterThan(1);
+        ).toBe(true);
+    });
+});
+
+/**
+ * The badge reads an unsigned, attacker-writable cookie that survives the plugin
+ * being turned off, so every port must gate it on `plugins.lastLoginMethod`
+ * rather than on the cookie's presence. `SocialButtons` was gated from the
+ * start; the email and magic-link badges were not, in any port — the shape that
+ * makes a stale cookie badge a method the deployment no longer offers.
+ *
+ * Asserted at the source, like the parity checks above, because the failure mode
+ * is a NEW port copying the ungated read — which is exactly what a per-port
+ * render test cannot see.
+ */
+describe("last-used badge × plugin gate", () => {
+    it.each(PORT_NAMES)("%s gates its last-used badge on plugins.lastLoginMethod", (port) => {
+        expect.assertions(1);
+
+        // Per FILE, not per count: the ports read the cookie through different
+        // primitives (`readLastLoginMethod` directly, or `lastLoginMethodStore`),
+        // so a total-occurrence proxy drifts the moment one port changes shape.
+        const ungated = filesUnder(PORT_DIRS[port])
+            .map((file) => [file, readFileSync(file, "utf8")] as const)
+            .filter(([, source]) => BADGE_READER_RE.test(source))
+            .filter(([, source]) => !source.includes("plugins.lastLoginMethod"))
+            .map(([file]) => file.slice(file.lastIndexOf("/") + 1));
+
+        expect(
+            ungated,
+            `${port} shows the last-used badge without checking plugins.lastLoginMethod in: ${ungated.join(", ")} — a stale cookie then badges a method the deployment no longer offers`,
+        ).toStrictEqual([]);
+    });
+});
+
+/**
+ * `?redirectTo=` is written by `invitations.ts` and by an app's own route guard,
+ * and is only honoured where a completion path resolves it. Twelve sign-in doors
+ * did; three did not, and the miss is invisible — the bounce looks like it
+ * worked and quietly drops the user on the generic post-login page.
+ *
+ * A raw `nav.replace(context.redirects.afterSignIn)` is that bug's signature, so
+ * assert there are none left outside an allow-list that must say why. There is
+ * no single seam to fix instead: the doors reach three different sinks (a client
+ * `nav.replace`, a `createFormController` submit result, and a wire
+ * `callbackURL`), and `sign-in.ts` deliberately returns
+ * `withRedirectTo(redirects.twoFactor)` on its 2FA branch, which a blanket
+ * resolve would clobber. One spelling everywhere, enforced here.
+ */
+/** The raw navigation this gate forbids — hoisted so it compiles once. */
+const RAW_AFTER_SIGN_IN_RE = /nav\.replace\(\s*context\.redirects\.afterSignIn\s*\)/u;
+
+const RAW_AFTER_SIGN_IN_ALLOWED: Readonly<Record<string, string>> = {
+    // This screen is the invitation itself — the thing `?redirectTo=` points at.
+    // Resolving here would bounce an accepted invitation back to itself.
+    "invitations.ts": "the redirect destination, not a door that bounces through sign-in",
+};
+
+describe("redirectTo × sign-in completion paths", () => {
+    it("resolves redirectTo on every completion path that navigates after sign-in", () => {
+        expect.assertions(1);
+
+        const raw = filesUnder(join(AUTH_UI_SRC, "core"))
+            .filter((file) => RAW_AFTER_SIGN_IN_RE.test(readFileSync(file, "utf8")))
+            .map((file) => file.slice(file.lastIndexOf("/") + 1))
+            .filter((name) => !Object.hasOwn(RAW_AFTER_SIGN_IN_ALLOWED, name));
+
+        expect(raw, `these navigate to redirects.afterSignIn without resolving ?redirectTo=: ${raw.join(", ")}`).toStrictEqual([]);
+    });
+});
+
+/**
+ * The badge value comes from `document.cookie`, which the server does not have.
+ * A read during render therefore emits markup the server could not have
+ * produced — React 19 responds to a hydration mismatch by throwing away the
+ * server tree and re-rendering the whole subtree on the client.
+ *
+ * So every port must read it AFTER mount. The post-mount primitive differs per
+ * framework (`useSyncExternalStore` with a server snapshot, `onMounted`,
+ * `onMount`, `afterNextRender`), which is why this asserts the property rather
+ * than one spelling: the read may not sit at render/setup position.
+ */
+const POST_MOUNT_PRIMITIVE: Readonly<Record<PortName, RegExp>> = {
+    angular: /afterNextRender\(/u,
+    react: /useSyncExternalStore\(/u,
+    solid: /onMount\(/u,
+    // Solid 2 spells Solid 1.x's `onMount` as `onSettled`.
+    "solid-v2": /onSettled\(/u,
+    svelte: /onMount\(/u,
+    vue: /onMounted\(/u,
+};
+
+describe("last-used badge × SSR safety", () => {
+    it.each(PORT_NAMES)("%s reads the last-login cookie after mount, not during render", (port) => {
+        expect.assertions(1);
+
+        const readers = filesUnder(PORT_DIRS[port])
+            .map((file) => [file, readFileSync(file, "utf8")] as const)
+            .filter(([, source]) => BADGE_READER_RE.test(source));
+
+        const unguarded = readers.filter(([, source]) => !POST_MOUNT_PRIMITIVE[port].test(source)).map(([file]) => file.slice(file.lastIndexOf("/") + 1));
+
+        expect(unguarded, `${port} reads the last-login cookie during render in: ${unguarded.join(", ")} — that is a hydration mismatch`).toStrictEqual([]);
     });
 });

--- a/packages/auth-ui/__tests__/core/port-parity.test.ts
+++ b/packages/auth-ui/__tests__/core/port-parity.test.ts
@@ -8,16 +8,16 @@ import { namedValueExportsOf } from "../../../client/__tests__/lib/named-exports
 
 /**
  * `core/index.ts` is the framework-agnostic barrel every port (React, Vue,
- * Svelte, Solid, Angular) is meant to build on: each `create*Controller`
+ * Svelte, Solid, Solid 2, Angular) is meant to build on: each `create*Controller`
  * factory it exports is a flow (sign-in, invitations, two-factor, …) that some
  * port is expected to mount. Nothing enforces that today — a controller can
- * ship, sit unconsumed by all five ports, and nobody notices until an audit
+ * ship, sit unconsumed by every port, and nobody notices until an audit
  * goes looking. Six such orphans shipped that way (see plan 233).
  *
  * This test reads the export list back out of `core/index.ts` itself — not a
  * hand-copied list, which would silently drift the moment a controller is
  * added or renamed — and fails on any `create*Controller` with zero
- * consumers across the five port directories, unless it is named on
+ * consumers across the port directories, unless it is named on
  * {@link DELIBERATELY_UNMOUNTED} with a reason. An unexplained allow-list
  * entry is exactly the silent hole this test exists to close, so every entry
  * must say why: either a still-open follow-up, or a structural reason the
@@ -29,13 +29,18 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const AUTH_UI_SRC = resolve(HERE, "..", "..", "src");
 const CORE_INDEX = join(AUTH_UI_SRC, "core", "index.ts");
 
-const PORT_NAMES = ["react", "vue", "solid", "svelte", "angular"] as const;
+const PORT_NAMES = ["react", "vue", "solid", "solid-v2", "svelte", "angular"] as const;
 
 type PortName = (typeof PORT_NAMES)[number];
 
 const PORT_DIRS: Record<PortName, string> = Object.fromEntries(PORT_NAMES.map((name) => [name, join(AUTH_UI_SRC, name)])) as Record<PortName, string>;
 
-const TS_FILE_RE = /\.tsx?$/;
+/**
+ * Two ports keep their components in single-file components, not `.ts` — a
+ * `.tsx?`-only walk sees Vue and Svelte as five plumbing modules and never
+ * reads a card, so both would count as consuming nothing.
+ */
+const PORT_FILE_RE = /\.(?:svelte|tsx?|vue)$/;
 const CONTROLLER_NAME_RE = /^create[A-Z]\w*Controller$/;
 
 /**
@@ -63,7 +68,7 @@ const filesUnder = (dir: string): string[] =>
             return filesUnder(full);
         }
 
-        return TS_FILE_RE.test(entry.name) ? [full] : [];
+        return PORT_FILE_RE.test(entry.name) ? [full] : [];
     });
 
 /**
@@ -143,5 +148,39 @@ describe("auth-ui controller × port parity", () => {
         const wouldStillPassWithoutEntry = consumersOf(stillUnmounted as string).length > 0 || Object.hasOwn(withoutEntry, stillUnmounted as string);
 
         expect(wouldStillPassWithoutEntry).toBe(false);
+    });
+});
+
+/**
+ * `core/last-login-method.ts` records `"email"` for a password sign-in and
+ * `"magic-link"` for a magic link — not just OAuth provider ids — and its own
+ * docblock warns that badging only the social buttons "makes the feature do
+ * nothing for the most common case there is". Every port read the cookie and
+ * then handed it to `SocialButtons` alone, so a deployment whose users sign in
+ * with a password installed the plugin, paid for the cookie, and showed
+ * nothing at all.
+ *
+ * Read from source rather than rendered per port on purpose: the whole point is
+ * that a *new* port can be added and quietly skip the two non-social badges,
+ * which is exactly what a per-port render test cannot notice.
+ */
+describe("last-used badge × port parity", () => {
+    it.each(PORT_NAMES)("%s badges the password and magic-link methods, not just the social buttons", (port) => {
+        expect.assertions(2);
+
+        const sources = filesUnder(PORT_DIRS[port]).map((file) => readFileSync(file, "utf8"));
+        // Two occurrences: the import, plus at least one comparison that decides
+        // whether the badge renders. An unused import would satisfy a bare
+        // "is it referenced" check without badging anything.
+        const uses = (name: string): number =>
+            sources.reduce((total, source) => total + [...source.matchAll(new RegExp(String.raw`\b${name}\b`, "gu"))].length, 0);
+
+        expect(uses("LAST_METHOD_EMAIL"), `${port} never compares against LAST_METHOD_EMAIL, so a password sign-in shows no "last used" badge`).toBeGreaterThan(
+            1,
+        );
+        expect(
+            uses("LAST_METHOD_MAGIC_LINK"),
+            `${port} never compares against LAST_METHOD_MAGIC_LINK, so a magic-link sign-in shows no "last used" badge`,
+        ).toBeGreaterThan(1);
     });
 });

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -4,8 +4,8 @@
  * magic-link, email-OTP (two-step), and two-factor verify. Each is a thin
  * standalone component binding a core controller to the shared view primitives.
  */
-import type { OnInit, Signal } from "@angular/core";
-import { ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
+import type { OnInit, Signal, WritableSignal } from "@angular/core";
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
 
 import { signInAnonymously } from "../core/anonymous";
 import type { BackupCodeSignInField } from "../core/backup-codes";
@@ -40,6 +40,25 @@ import {
     SubmitButtonComponent,
 } from "./primitives";
 import { injectAuthUIContext } from "./provider";
+
+/**
+ * A signal holding the last-used login method, filled in after the first render.
+ *
+ * Read after the first render, not during it: the server has no cookie, so a
+ * render-time read produces markup the server could not have produced (see
+ * `lastLoginMethodStore` in core). `afterNextRender` never runs on the server,
+ * which is exactly the guarantee needed — and calling this from a field
+ * initialiser keeps it inside the component's injection context.
+ */
+const lastLoginMethodAfterRender = (): WritableSignal<string | undefined> => {
+    const method = signal<string | undefined>(undefined);
+
+    afterNextRender(() => {
+        method.set(readLastLoginMethod());
+    });
+
+    return method;
+};
 
 /** "Continue as guest", when the `anonymous` plugin is on. */
 @Component({
@@ -112,7 +131,7 @@ class AnonymousButtonComponent {
                         <!--
                           better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
                         -->
-                        @if (lastUsedEmail) {
+                        @if (lastUsedEmail()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -134,9 +153,7 @@ class SignInCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
-    // Read once rather than per change-detection run: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    private readonly lastLoginMethod = readLastLoginMethod();
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
 
     /*
      * All derived from the context, so the deployment's real shape — which
@@ -145,8 +162,8 @@ class SignInCardComponent {
      */
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
-    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
-    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
+    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined));
+    protected readonly lastUsedEmail = computed(() => this.lastUsed() === LAST_METHOD_EMAIL);
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
@@ -430,7 +447,7 @@ class ResetPasswordOtpCardComponent {
                     />
                     <lunora-auth-submit-button [pending]="state().status === 'submitting'">
                         {{ t.magicLink }}
-                        @if (lastUsedMagicLink) {
+                        @if (lastUsedMagicLink()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -450,9 +467,12 @@ class MagicLinkCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
-    // Read once rather than per change-detection run: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
+    // Computed rather than frozen at mount, like every other context-derived
+    // member here: the deployment's real shape arrives with the discovery answer.
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
+    protected readonly lastUsedMagicLink = computed(
+        () => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined) === LAST_METHOD_MAGIC_LINK,
+    );
 }
 
 @Component({

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -16,7 +16,7 @@ import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import type { ForgotPasswordField } from "../core/forgot-password";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import type { ResetPasswordField } from "../core/reset-password";
 import { createResetPasswordController } from "../core/reset-password";
@@ -107,7 +107,15 @@ class AnonymousButtonComponent {
                         (blurred)="actions.blur('password')"
                     />
                     <lunora-auth-link [href]="forgotPasswordHref()">{{ t.forgotPasswordLink }}</lunora-auth-link>
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signIn }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.signIn }}
+                        <!--
+                          better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
+                        -->
+                        @if (lastUsedEmail) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
             }
             @if (signUp()) {
@@ -138,6 +146,7 @@ class SignInCardComponent {
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
     protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
+    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
@@ -419,7 +428,12 @@ class ResetPasswordOtpCardComponent {
                         (changed)="actions.setField('email', $event)"
                         (blurred)="actions.blur('email')"
                     />
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.magicLink }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.magicLink }}
+                        @if (lastUsedMagicLink) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
                 <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.backToSignIn }}</lunora-auth-link>
             </lunora-auth-card>
@@ -435,6 +449,10 @@ class MagicLinkCardComponent {
     private readonly bridge = controllerSignal(createMagicLinkController, { context: this.context });
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
+
+    // Read once rather than per change-detection run: it is a cookie, it is
+    // available before the first paint, and it only picks a badge.
+    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
 }
 
 @Component({

--- a/packages/auth-ui/src/core/anonymous.ts
+++ b/packages/auth-ui/src/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/packages/auth-ui/src/core/email-otp.ts
+++ b/packages/auth-ui/src/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/packages/auth-ui/src/core/index.ts
+++ b/packages/auth-ui/src/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/packages/auth-ui/src/core/invitations.ts
+++ b/packages/auth-ui/src/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/packages/auth-ui/src/core/last-login-method.ts
+++ b/packages/auth-ui/src/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/packages/auth-ui/src/core/last-login-method.ts
+++ b/packages/auth-ui/src/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/packages/auth-ui/src/core/phone-number.ts
+++ b/packages/auth-ui/src/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/packages/auth-ui/src/core/verify-email.ts
+++ b/packages/auth-ui/src/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/packages/auth-ui/src/react/auth-cards.tsx
+++ b/packages/auth-ui/src/react/auth-cards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -9,7 +9,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, lastLoginMethodStore } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -50,14 +50,19 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
     const { localization: t, social } = context;
     const [state, actions] = useController(createSignInController);
     const pending = state.status === "submitting";
-    // Read once per render rather than in an effect: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after hydration, not during render: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const lastUsedAfterHydration = useSyncExternalStore(
+        lastLoginMethodStore.subscribe,
+        lastLoginMethodStore.getSnapshot,
+        lastLoginMethodStore.getServerSnapshot,
+    );
+    const lastUsed = context.plugins.lastLoginMethod ? lastUsedAfterHydration : undefined;
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={signUpHref}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -78,9 +83,6 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
                     <AuthLink href={forgotPasswordHref}>{t.forgotPasswordLink}</AuthLink>
                     <SubmitButton pending={pending}>
                         {t.signIn}
-                        {/* better-auth records a password sign-in as "email", so
-                            without this the badge is invisible for the most
-                            common route there is. */}
                         {lastUsed === LAST_METHOD_EMAIL ? <LastUsedBadge /> : null}
                     </SubmitButton>
                 </form>
@@ -204,10 +206,17 @@ interface MagicLinkCardProps {
 }
 
 const MagicLinkCard = ({ signInHref = "/sign-in" }: MagicLinkCardProps = {}): ReactElement | null => {
-    const lastUsed = readLastLoginMethod();
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = useController(createMagicLinkController);
+    // Read after hydration, not during render: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const lastUsedAfterHydration = useSyncExternalStore(
+        lastLoginMethodStore.subscribe,
+        lastLoginMethodStore.getSnapshot,
+        lastLoginMethodStore.getServerSnapshot,
+    );
+    const lastUsed = context.plugins.lastLoginMethod ? lastUsedAfterHydration : undefined;
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;

--- a/packages/auth-ui/src/solid-v2/auth-cards.tsx
+++ b/packages/auth-ui/src/solid-v2/auth-cards.tsx
@@ -7,7 +7,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -76,7 +76,13 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                     <FormField actions={actions} autoComplete="current-password" field="password" label={t.passwordLabel} state={state} type="password" />
                     <AuthLink href={props.forgotPasswordHref ?? "/forgot-password"}>{t.forgotPasswordLink}</AuthLink>
-                    <SubmitButton pending={state.status === "submitting"}>{t.signIn}</SubmitButton>
+                    <SubmitButton pending={state.status === "submitting"}>
+                        {t.signIn}
+                        {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
+                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                            <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                        </Show>
+                    </SubmitButton>
                 </form>
             </Show>
         </AuthCard>
@@ -207,13 +213,21 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     }
 
     const [state, actions] = createController(createMagicLinkController);
+    // Read once when the card is created rather than in an effect: it is a
+    // cookie, it is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.backToSignIn}</AuthLink>} title={t.magicLink}>
             <form class="lunora-auth-form" novalidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
-                <SubmitButton pending={state.status === "submitting"}>{t.magicLink}</SubmitButton>
+                <SubmitButton pending={state.status === "submitting"}>
+                    {t.magicLink}
+                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                        <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                    </Show>
+                </SubmitButton>
             </form>
         </AuthCard>
     );

--- a/packages/auth-ui/src/solid-v2/auth-cards.tsx
+++ b/packages/auth-ui/src/solid-v2/auth-cards.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "@solidjs/web";
-import { createSignal, Show } from "solid-js";
+import { createSignal, onSettled, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -46,14 +46,21 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignInController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    // Solid 2 spells Solid 1.x's `onMount` as `onSettled`.
+    onSettled(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed()}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -79,7 +86,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <SubmitButton pending={state.status === "submitting"}>
                         {t.signIn}
                         {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
-                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                        <Show when={lastUsed() === LAST_METHOD_EMAIL}>
                             <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                         </Show>
                     </SubmitButton>
@@ -213,9 +220,16 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     }
 
     const [state, actions] = createController(createMagicLinkController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    // Solid 2 spells Solid 1.x's `onMount` as `onSettled`.
+    onSettled(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.backToSignIn}</AuthLink>} title={t.magicLink}>
@@ -224,7 +238,7 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                 <SubmitButton pending={state.status === "submitting"}>
                     {t.magicLink}
-                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                    <Show when={lastUsed() === LAST_METHOD_MAGIC_LINK}>
                         <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                     </Show>
                 </SubmitButton>

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { createSignal, Show } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -46,14 +46,20 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignInController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    onMount(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed()}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -79,7 +85,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <SubmitButton pending={state.status === "submitting"}>
                         {t.signIn}
                         {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
-                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                        <Show when={lastUsed() === LAST_METHOD_EMAIL}>
                             <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                         </Show>
                     </SubmitButton>
@@ -208,9 +214,15 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = createController(createMagicLinkController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    onMount(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;
@@ -223,7 +235,7 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                 <SubmitButton pending={state.status === "submitting"}>
                     {t.magicLink}
-                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                    <Show when={lastUsed() === LAST_METHOD_MAGIC_LINK}>
                         <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                     </Show>
                 </SubmitButton>

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -7,7 +7,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -76,7 +76,13 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                     <FormField actions={actions} autoComplete="current-password" field="password" label={t.passwordLabel} state={state} type="password" />
                     <AuthLink href={props.forgotPasswordHref ?? "/forgot-password"}>{t.forgotPasswordLink}</AuthLink>
-                    <SubmitButton pending={state.status === "submitting"}>{t.signIn}</SubmitButton>
+                    <SubmitButton pending={state.status === "submitting"}>
+                        {t.signIn}
+                        {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
+                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                            <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                        </Show>
+                    </SubmitButton>
                 </form>
             </Show>
         </AuthCard>
@@ -202,6 +208,9 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = createController(createMagicLinkController);
+    // Read once when the card is created rather than in an effect: it is a
+    // cookie, it is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;
@@ -212,7 +221,12 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
-                <SubmitButton pending={state.status === "submitting"}>{t.magicLink}</SubmitButton>
+                <SubmitButton pending={state.status === "submitting"}>
+                    {t.magicLink}
+                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                        <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                    </Show>
+                </SubmitButton>
             </form>
         </AuthCard>
     );

--- a/packages/auth-ui/src/svelte/MagicLinkCard.svelte
+++ b/packages/auth-ui/src/svelte/MagicLinkCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { isFlowEnabled } from "../core/flow-gate";
+    import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
     import { createMagicLinkController } from "../core/magic-link";
     import AuthCard from "./AuthCard.svelte";
     import AuthLink from "./AuthLink.svelte";
@@ -15,6 +16,9 @@
     const t = context.localization;
     const enabled = isFlowEnabled(context, "magicLink", "MagicLinkCard");
     const { actions, state: form } = controllerStore(createMagicLinkController);
+    // Read once at initialisation rather than in an effect: it is a cookie, it
+    // is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 </script>
 
 {#if enabled}
@@ -29,7 +33,12 @@
         >
             <FormBanner error={$form.formError} success={$form.successMessage} />
             <FormField {actions} autoComplete="email" field="email" fields={$form.fields} label={t.emailLabel} type="email" />
-            <SubmitButton pending={$form.status === "submitting"}>{t.magicLink}</SubmitButton>
+            <SubmitButton pending={$form.status === "submitting"}>
+                {t.magicLink}
+                {#if lastUsed === LAST_METHOD_MAGIC_LINK}
+                    <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                {/if}
+            </SubmitButton>
         </form>
         {#snippet footer()}
             <AuthLink href={signInHref}>{t.backToSignIn}</AuthLink>

--- a/packages/auth-ui/src/svelte/MagicLinkCard.svelte
+++ b/packages/auth-ui/src/svelte/MagicLinkCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { isFlowEnabled } from "../core/flow-gate";
     import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
     import { createMagicLinkController } from "../core/magic-link";
@@ -16,9 +17,15 @@
     const t = context.localization;
     const enabled = isFlowEnabled(context, "magicLink", "MagicLinkCard");
     const { actions, state: form } = controllerStore(createMagicLinkController);
-    // Read once at initialisation rather than in an effect: it is a cookie, it
-    // is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not at initialisation: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    let lastUsedAfterMount = $state<string | undefined>(undefined);
+
+    onMount(() => {
+        lastUsedAfterMount = readLastLoginMethod();
+    });
+
+    const lastUsed = $derived(context.plugins.lastLoginMethod ? lastUsedAfterMount : undefined);
 </script>
 
 {#if enabled}

--- a/packages/auth-ui/src/svelte/SignInCard.svelte
+++ b/packages/auth-ui/src/svelte/SignInCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
     import { createSignInController } from "../core/sign-in";
     import { signInWithSocial } from "../core/social";
@@ -25,14 +26,20 @@
     const t = context.localization;
     const social = context.social;
     const { actions, state: form } = controllerStore(createSignInController);
-    // Read once at initialisation rather than in an effect: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not at initialisation: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    let lastUsedAfterMount = $state<string | undefined>(undefined);
+
+    onMount(() => {
+        lastUsedAfterMount = readLastLoginMethod();
+    });
+
+    const lastUsed = $derived(context.plugins.lastLoginMethod ? lastUsedAfterMount : undefined);
 </script>
 
 <AuthCard title={t.signIn}>
     <SocialButtons
-        lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+        {lastUsed}
         onSelect={(provider) => {
             void signInWithSocial(context, provider);
         }}

--- a/packages/auth-ui/src/svelte/SignInCard.svelte
+++ b/packages/auth-ui/src/svelte/SignInCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { readLastLoginMethod } from "../core/last-login-method";
+    import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
     import { createSignInController } from "../core/sign-in";
     import { signInWithSocial } from "../core/social";
     import AnonymousButton from "./AnonymousButton.svelte";
@@ -62,7 +62,13 @@
             <FormField {actions} autoComplete="email" field="email" fields={$form.fields} label={t.emailLabel} type="email" />
             <FormField {actions} autoComplete="current-password" field="password" fields={$form.fields} label={t.passwordLabel} type="password" />
             <AuthLink href={forgotPasswordHref}>{t.forgotPasswordLink}</AuthLink>
-            <SubmitButton pending={$form.status === "submitting"}>{t.signIn}</SubmitButton>
+            <SubmitButton pending={$form.status === "submitting"}>
+                {t.signIn}
+                <!-- better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. -->
+                {#if lastUsed === LAST_METHOD_EMAIL}
+                    <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                {/if}
+            </SubmitButton>
         </form>
     {/if}
     {#snippet footer()}

--- a/packages/auth-ui/src/vue/MagicLinkCard.vue
+++ b/packages/auth-ui/src/vue/MagicLinkCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import { isFlowEnabled } from "../core/flow-gate";
 import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
@@ -27,9 +27,15 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "magicLink", "MagicLinkCard"));
 const { actions, state } = useController(createMagicLinkController);
-// Read once at setup rather than from a watcher: it is a cookie, it is there
-// before the first paint, and it only picks a badge.
-const lastUsed = readLastLoginMethod();
+// Read after mount, not at setup: the server has no cookie, so a render-time
+// read is a hydration mismatch. See `lastLoginMethodStore`.
+const lastUsedAfterMount = ref<string | undefined>();
+
+onMounted(() => {
+    lastUsedAfterMount.value = readLastLoginMethod();
+});
+
+const lastUsed = computed(() => (context.value.plugins.lastLoginMethod ? lastUsedAfterMount.value : undefined));
 </script>
 
 <template>

--- a/packages/auth-ui/src/vue/MagicLinkCard.vue
+++ b/packages/auth-ui/src/vue/MagicLinkCard.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 
 import { isFlowEnabled } from "../core/flow-gate";
+import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import AuthCard from "./AuthCard.vue";
 import AuthLink from "./AuthLink.vue";
@@ -26,6 +27,9 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "magicLink", "MagicLinkCard"));
 const { actions, state } = useController(createMagicLinkController);
+// Read once at setup rather than from a watcher: it is a cookie, it is there
+// before the first paint, and it only picks a badge.
+const lastUsed = readLastLoginMethod();
 </script>
 
 <template>
@@ -33,7 +37,10 @@ const { actions, state } = useController(createMagicLinkController);
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
             <FormField :actions="actions" field="email" :fields="state.fields" :label="t.emailLabel" type="email" autoComplete="email" />
-            <SubmitButton :pending="state.status === 'submitting'">{{ t.magicLink }}</SubmitButton>
+            <SubmitButton :pending="state.status === 'submitting'">
+                {{ t.magicLink }}
+                <span v-if="lastUsed === LAST_METHOD_MAGIC_LINK" class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+            </SubmitButton>
         </form>
         <template #footer>
             <AuthLink :href="signInHref">{{ t.backToSignIn }}</AuthLink>

--- a/packages/auth-ui/src/vue/SignInCard.vue
+++ b/packages/auth-ui/src/vue/SignInCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
 import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
 import { createSignInController } from "../core/sign-in";
 import { signInWithSocial } from "../core/social";
@@ -27,9 +28,15 @@ withDefaults(
 const context = useAuthUIContextRef();
 const t = context.value.localization;
 const { actions, state } = useController(createSignInController);
-// Read once at setup rather than from a watcher: it is a cookie, it is there
-// before the first paint, and it only picks a badge.
-const lastUsed = readLastLoginMethod();
+// Read after mount, not at setup: the server has no cookie, so a render-time
+// read is a hydration mismatch. See `lastLoginMethodStore`.
+const lastUsedAfterMount = ref<string | undefined>();
+
+onMounted(() => {
+    lastUsedAfterMount.value = readLastLoginMethod();
+});
+
+const lastUsed = computed(() => (context.value.plugins.lastLoginMethod ? lastUsedAfterMount.value : undefined));
 
 const onSocial = (provider: string): void => {
     void signInWithSocial(context.value, provider);
@@ -43,7 +50,7 @@ const onSocial = (provider: string): void => {
         discovery answers, rather than being frozen at the value `setup()` saw.
     -->
     <AuthCard :title="t.signIn">
-        <SocialButtons :providers="context.social" :lastUsed="context.plugins.lastLoginMethod ? lastUsed : undefined" @select="onSocial" />
+        <SocialButtons :providers="context.social" :lastUsed="lastUsed" @select="onSocial" />
         <AnonymousButton v-if="context.plugins.anonymous" />
         <AuthDivider v-if="context.social.length > 0 && context.credentials" />
         <!--

--- a/packages/auth-ui/src/vue/SignInCard.vue
+++ b/packages/auth-ui/src/vue/SignInCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
 import { createSignInController } from "../core/sign-in";
 import { signInWithSocial } from "../core/social";
 import AnonymousButton from "./AnonymousButton.vue";
@@ -56,7 +56,11 @@ const onSocial = (provider: string): void => {
             <FormField :actions="actions" field="email" :fields="state.fields" :label="t.emailLabel" type="email" autoComplete="email" />
             <FormField :actions="actions" field="password" :fields="state.fields" :label="t.passwordLabel" type="password" autoComplete="current-password" />
             <AuthLink :href="forgotPasswordHref">{{ t.forgotPasswordLink }}</AuthLink>
-            <SubmitButton :pending="state.status === 'submitting'">{{ t.signIn }}</SubmitButton>
+            <SubmitButton :pending="state.status === 'submitting'">
+                {{ t.signIn }}
+                <!-- better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. -->
+                <span v-if="lastUsed === LAST_METHOD_EMAIL" class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+            </SubmitButton>
         </form>
         <template v-if="context.signUp" #footer>
             <AuthLink :href="signUpHref">{{ t.noAccount }}</AuthLink>

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -1392,6 +1392,40 @@ class LunoraClient {
         return this.identityFingerprint();
     }
 
+    /**
+     * Verdict on whether a durable write stamped with `stamped` may be replayed
+     * now. The comparison a replay handler must NOT hand-roll.
+     *
+     * `"match"` is the same identity, or the same credential under a token hash
+     * — which a late-resolving subject would otherwise make look different.
+     *
+     * `"unknown"` is nobody signed in *yet*. A durable replay starts when the
+     * executor is constructed, before the app has resolved its session and
+     * called {@link setAuthToken}, so this is the normal state on every reload.
+     * There is no other identity to replay as, so such a write must be HELD,
+     * never dropped — dropping here destroys the queuing user's own offline
+     * writes. It is indistinguishable from an explicit sign-out (the fingerprint
+     * is `null` for both), which is the safe conflation: holding a write for a
+     * signed-out app costs a retry, dropping it costs the write.
+     *
+     * `"mismatch"` is a different identity signed in, and is the one that must be
+     * terminal: replaying would attribute one user's write to another and pass
+     * THEIR row-level security.
+     */
+    public replayIdentityVerdict(stamped: null | string | undefined): "match" | "mismatch" | "unknown" {
+        const current = this.identityFingerprint();
+
+        if (stamped === current) {
+            return "match";
+        }
+
+        if (stamped !== undefined && this.isSameCredentialUnderTokenHash(stamped)) {
+            return "match";
+        }
+
+        return current === null ? "unknown" : "mismatch";
+    }
+
     /** This client's stable identifier — the watermark key the server's custom-mutator protocol advances per `clientSeq`. */
     public clientIdentifier(): string {
         return this.clientId;

--- a/packages/container/__tests__/define-container.test.ts
+++ b/packages/container/__tests__/define-container.test.ts
@@ -161,6 +161,15 @@ describe(defineContainer, () => {
         expect(() => defineContainer({ image: "./app", rollout: { stepPercentage: 101 } })).toThrow("rollout.stepPercentage");
     });
 
+    it("rejects a fractional or negative rollout gracePeriodSeconds, but accepts 0", () => {
+        expect.assertions(3);
+
+        expect(() => defineContainer({ image: "./app", rollout: { gracePeriodSeconds: -1 } })).toThrow("rollout.gracePeriodSeconds");
+        expect(() => defineContainer({ image: "./app", rollout: { gracePeriodSeconds: 1.5 } })).toThrow("rollout.gracePeriodSeconds");
+        // 0 is a meaningful value — no grace period — not a missing one.
+        expect(defineContainer({ image: "./app", rollout: { gracePeriodSeconds: 0 } }).rollout).toStrictEqual({ gracePeriodSeconds: 0 });
+    });
+
     it("rejects an empty { build } source", () => {
         expect.assertions(1);
 

--- a/packages/container/__tests__/lunora-container.test.ts
+++ b/packages/container/__tests__/lunora-container.test.ts
@@ -255,7 +255,7 @@ describe("lunoraContainer lifecycle logging", () => {
      * Stub the base's `startAndWaitForPorts` down to the one part that matters
      * here: `@cloudflare/containers` ends it (and `start()`) with
      * `blockConcurrencyWhile(async () => { … await this.onStart(); })`
-     * (`dist/lib/container.js:585`, `:634`), and workerd treats a *rejecting*
+     * (from both `start()` and `startAndWaitForPorts()`), and workerd treats a *rejecting*
      * closure there as unrecoverable — it aborts the Durable Object and flattens
      * the error to a plain `Error`. Pulling the image and waiting for ports is
      * stubbed; the gate is reproduced, and the double records the abort so a
@@ -460,6 +460,67 @@ describe("lunoraContainer lifecycle logging", () => {
         expect(state.aborted).toBe(false);
         expect(thrown).toBeInstanceOf(LunoraError);
         expect((thrown as Error).message).toContain('readiness check "/ready" (port 8080) did not return 200 within 30000ms');
+    });
+
+    it("does not proxy a request while the readiness probes are still pending", async () => {
+        expect.assertions(2);
+
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        // The base commits the healthy state INSIDE its start gate, before our
+        // probes run — so `super.containerFetch` skips the start path entirely and
+        // would proxy to an app that never reported ready. Reproduce exactly that:
+        // healthy, with a probe that never succeeds.
+        const proxied = vi.spyOn(Container.prototype, "containerFetch").mockResolvedValue(new Response("from the app"));
+
+        vi.spyOn(Container.prototype, "getState").mockResolvedValue({ status: "healthy" } as never);
+
+        vi.useFakeTimers();
+
+        // A container that accepts the connection and never answers — the probe
+        // settles only via its abort signal, as with a real wedged app.
+        const context = fakeDurableObjectContext({
+            container: {
+                getTcpPort: () => {
+                    return {
+                        fetch: (_url: string, init?: { signal?: AbortSignal }) =>
+                            new Promise((_resolve, reject) => {
+                                if (init?.signal?.aborted) {
+                                    reject(new Error("aborted"));
+
+                                    return;
+                                }
+
+                                init?.signal?.addEventListener("abort", () => {
+                                    reject(new Error("aborted"));
+                                });
+                            }),
+                    };
+                },
+                running: false,
+            },
+        });
+
+        const definition = defineContainer({ defaultPort: 8080, image: "./app", readyOn: [{ path: "/ready" }] });
+        const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
+
+        let thrown: unknown;
+
+        try {
+            const pending = instance.containerFetch("https://container/").catch((error: unknown) => {
+                thrown = error;
+            });
+
+            await vi.advanceTimersByTimeAsync(30_000);
+            await pending;
+        } finally {
+            vi.useRealTimers();
+        }
+
+        // The request fails on the readiness budget instead of being handed to an
+        // app that never reported ready.
+        expect(proxied).not.toHaveBeenCalled();
+        expect((thrown as Error).message).toContain('readiness check "/ready"');
     });
 
     it("arms a hard-timeout schedule on start, stamped with the bumped run generation", async () => {

--- a/packages/container/__tests__/lunora-container.test.ts
+++ b/packages/container/__tests__/lunora-container.test.ts
@@ -4,6 +4,8 @@
  * stub (see `vitest.config.ts`), and the Durable Object context is faked with
  * the surface the upstream `Container` constructor actually touches.
  */
+import { Container } from "@cloudflare/containers";
+import { LunoraError } from "@lunora/errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LunoraContainer } from "../src/do/index";
@@ -249,6 +251,38 @@ describe("lunoraContainer lifecycle logging", () => {
         return new LunoraContainer(fakeDurableObjectContext() as never, {}, definition, "transcoder");
     };
 
+    /**
+     * Stub the base's `startAndWaitForPorts` down to the one part that matters
+     * here: `@cloudflare/containers` ends it (and `start()`) with
+     * `blockConcurrencyWhile(async () => { … await this.onStart(); })`
+     * (`dist/lib/container.js:585`, `:634`), and workerd treats a *rejecting*
+     * closure there as unrecoverable — it aborts the Durable Object and flattens
+     * the error to a plain `Error`. Pulling the image and waiting for ports is
+     * stubbed; the gate is reproduced, and the double records the abort so a
+     * regression is visible rather than merely differently-worded.
+     * @returns A record whose `aborted` flag flips if the gate saw a rejection.
+     */
+    const baseStartGate = (): { aborted: boolean } => {
+        const record = { aborted: false };
+
+        vi.spyOn(Container.prototype, "startAndWaitForPorts").mockImplementation(async function startAndWaitForPorts(this: {
+            onStart: () => Promise<void>;
+        }): Promise<void> {
+            try {
+                await this.onStart();
+            } catch (error) {
+                record.aborted = true;
+
+                // workerd flattens the closure's error to a plain `Error` whose
+                // message is the original's `name: message` and which carries none
+                // of its own properties.
+                throw new Error(String(error), { cause: error });
+            }
+        });
+
+        return record;
+    };
+
     it("emits a lunora container event on start", async () => {
         expect.assertions(1);
 
@@ -301,7 +335,7 @@ describe("lunoraContainer lifecycle logging", () => {
         expect(JSON.parse((spy.mock.calls[0]![0] as string) ?? "{}")).toMatchObject({ event: "error", level: "error", message: "crashed" });
     });
 
-    it("gates onStart on readyOn probes until each returns its expected status", async () => {
+    it("gates the start on readyOn probes until each returns its expected status", async () => {
         expect.assertions(3);
 
         vi.spyOn(console, "log").mockImplementation(() => {});
@@ -331,15 +365,17 @@ describe("lunoraContainer lifecycle logging", () => {
         });
         const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
 
-        await expect(instance.onStart()).resolves.toBeUndefined();
+        baseStartGate();
+
+        await expect(instance.startAndWaitForPorts()).resolves.toBeUndefined();
         // `/ready` resolves on the default port; `live` (no leading slash) is
         // normalized and probed on its own port against status 204.
         expect(fetched).toContain("8080:http://container/ready");
         expect(fetched).toContain("9090:http://container/live");
     });
 
-    it("fails onStart when a readyOn check has no port and no defaultPort", async () => {
-        expect.assertions(1);
+    it("fails the start when a readyOn check has no port and no defaultPort", async () => {
+        expect.assertions(2);
 
         vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -353,12 +389,16 @@ describe("lunoraContainer lifecycle logging", () => {
         });
         const definition = defineContainer({ image: "./app", readyOn: [{ path: "/ready" }] });
         const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
+        const state = baseStartGate();
 
-        await expect(instance.onStart()).rejects.toThrow("has no port");
+        await expect(instance.startAndWaitForPorts()).rejects.toThrow("has no port");
+        // A misconfigured probe is a config error, not grounds for tearing the
+        // object down — it must surface from outside the start gate.
+        expect(state.aborted).toBe(false);
     });
 
     it("aborts a readiness probe that never responds instead of hanging forever, and rejects at the deadline", async () => {
-        expect.assertions(1);
+        expect.assertions(3);
 
         vi.spyOn(console, "log").mockImplementation(() => {});
         // The per-attempt deadline is a JS-land `setTimeout`
@@ -394,16 +434,32 @@ describe("lunoraContainer lifecycle logging", () => {
 
         const definition = defineContainer({ defaultPort: 8080, image: "./app", readyOn: [{ path: "/ready" }] });
         const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
+        const state = baseStartGate();
+
+        let thrown: unknown;
 
         try {
-            // eslint-disable-next-line vitest/valid-expect -- deliberately deferred: `onStart()` only settles once the fake timers below advance, so awaiting the assertion here would deadlock. It IS awaited, three lines down.
-            const assertion = expect(instance.onStart()).rejects.toThrow("did not return 200 within");
+            // The start only settles once the fake timers below advance, so it is
+            // kicked off here and awaited after they do.
+            const pending = instance.startAndWaitForPorts().catch((error: unknown) => {
+                thrown = error;
+            });
 
             await vi.advanceTimersByTimeAsync(30_000);
-            await assertion;
+            await pending;
         } finally {
             vi.useRealTimers();
         }
+
+        // A wedged app is an ordinary, diagnosable failure. Waiting for it inside
+        // the base's `blockConcurrencyWhile` would make workerd abort the Durable
+        // Object and flatten the error to a plain `Error`, so the caller would get
+        // an opaque message instead of the check, the port and the budget — and
+        // the object would lose its in-memory state and its hibernating sockets on
+        // every start attempt. The wait therefore runs outside the gate.
+        expect(state.aborted).toBe(false);
+        expect(thrown).toBeInstanceOf(LunoraError);
+        expect((thrown as Error).message).toContain('readiness check "/ready" (port 8080) did not return 200 within 30000ms');
     });
 
     it("arms a hard-timeout schedule on start, stamped with the bumped run generation", async () => {
@@ -415,7 +471,9 @@ describe("lunoraContainer lifecycle logging", () => {
         const instance = new LunoraContainer(fakeDurableObjectContext({ storedGeneration: 4 }) as never, {}, definition, "transcoder");
         const scheduleSpy = vi.spyOn(instance, "schedule").mockResolvedValue(undefined as never);
 
-        await instance.onStart();
+        baseStartGate();
+
+        await instance.startAndWaitForPorts();
 
         expect(scheduleSpy).toHaveBeenCalledTimes(1);
         // 30s → 30 seconds; generation 4 → 5 (bumped so a stale schedule is detectable).

--- a/packages/container/__tests__/lunora-container.test.ts
+++ b/packages/container/__tests__/lunora-container.test.ts
@@ -523,6 +523,38 @@ describe("lunoraContainer lifecycle logging", () => {
         expect((thrown as Error).message).toContain('readiness check "/ready"');
     });
 
+    it("re-arms and re-probes after a stop instead of reusing the finished run's gate", async () => {
+        expect.assertions(2);
+
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        const definition = defineContainer({ defaultPort: 8080, hardTimeout: "30s", image: "./app", readyOn: [{ path: "/ready" }] });
+        const context = fakeDurableObjectContext({
+            container: {
+                getTcpPort: () => {
+                    return { fetch: async () => new Response("ok", { status: 200 }) };
+                },
+                running: false,
+            },
+        });
+        const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
+        const scheduleSpy = vi.spyOn(instance, "schedule").mockResolvedValue(undefined as never);
+
+        baseStartGate();
+
+        await instance.startAndWaitForPorts();
+
+        expect(scheduleSpy).toHaveBeenCalledTimes(1);
+
+        // The container stops and is started again. The gate belongs to the run
+        // that ended: reusing it would skip the hard timeout AND the readiness
+        // probes, so the restarted app is proxied to before it reports ready.
+        await instance.onStop({ exitCode: 0, reason: "exit" } as never);
+        await instance.startAndWaitForPorts();
+
+        expect(scheduleSpy).toHaveBeenCalledTimes(2);
+    });
+
     it("arms a hard-timeout schedule on start, stamped with the bumped run generation", async () => {
         expect.assertions(2);
 

--- a/packages/container/src/define-container.ts
+++ b/packages/container/src/define-container.ts
@@ -339,6 +339,17 @@ const defineContainer = (config: ContainerConfig): ContainerDefinition => {
         throw new TypeError(`defineContainer: \`rollout.stepPercentage\` must be an integer in 1–100 (got ${String(stepPercentage)})`);
     }
 
+    const gracePeriodSeconds = config.rollout?.gracePeriodSeconds;
+
+    // Reaches wrangler as `rollout_active_grace_period` unchecked, where a
+    // fractional or negative value is a deploy-time failure a long way from the
+    // line that caused it. Only the shape is asserted: 0 (no grace period) is
+    // meaningful, and this repo has no sourced upper bound to enforce — an
+    // invented ceiling would be the more expensive mistake.
+    if (gracePeriodSeconds !== undefined && (!Number.isInteger(gracePeriodSeconds) || gracePeriodSeconds < 0)) {
+        throw new TypeError(`defineContainer: \`rollout.gracePeriodSeconds\` must be a non-negative integer (got ${String(gracePeriodSeconds)})`);
+    }
+
     if (config.maxInstances !== undefined && (!Number.isInteger(config.maxInstances) || config.maxInstances < 1)) {
         throw new TypeError(`defineContainer: \`maxInstances\` must be a positive integer (got ${String(config.maxInstances)})`);
     }

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -22,7 +22,21 @@ type DurableObjectContext = ConstructorParameters<typeof Container>[0];
 /** Interval between `readyOn` probe attempts while waiting for the app to come up. */
 const READINESS_POLL_INTERVAL_MS = 500;
 
-/** Upper bound on how long the `readyOn` probes block container start before failing. */
+/**
+ * Upper bound on how long the `readyOn` probes block container start before failing.
+ *
+ * Equal to the platform's own ceiling, which is why this wait must stay OUTSIDE
+ * `blockConcurrencyWhile` (see {@link LunoraContainer.afterContainerStart}).
+ * Cloudflare's Durable Object state docs: "To help mitigate deadlocks there is a
+ * 30 second timeout applied when executing the callback. If this timeout is
+ * exceeded, the Durable Object will be reset." Inside the gate the reset wins the
+ * race — the `LunoraError` below naming the failing check, port and budget is
+ * then unreachable on the very path it exists for — and the same docs call
+ * blocking the gate on I/O (`fetch`, KV, R2) an anti-pattern outright, which a
+ * `readyOn` probe is.
+ *
+ * https://developers.cloudflare.com/durable-objects/api/state/
+ */
 const READINESS_TIMEOUT_MS = 30_000;
 
 /**

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -243,6 +243,15 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
 
         this.surfaceInStudioLogs(envelope);
 
+        // The gate belongs to the run that just ended. Left in place, the next
+        // start would find it already settled and skip both `armHardTimeout` and
+        // the `readyOn` probes — so a restarted app would be proxied to before it
+        // reported ready, and its hard timeout would never be re-armed. Cleared
+        // here rather than at the top of a start so that single-flight still holds
+        // WITHIN a run: two concurrent starts must share one gate, or they each
+        // arm a schedule stamped with the same generation.
+        this.lunoraReadiness = undefined;
+
         await super.onStop(parameters);
     }
 

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -137,6 +137,18 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
     }
 
     /**
+     * The start path `containerFetch` takes (and the one an app can call itself).
+     * The base's last act is `blockConcurrencyWhile(… onStart())`, so this
+     * override resumes on the far side of that gate — which is where
+     * {@link afterContainerStart} has to run. See its docblock.
+     */
+    public override async startAndWaitForPorts(...args: Parameters<Container<Env>["startAndWaitForPorts"]>): Promise<void> {
+        await super.startAndWaitForPorts(...args);
+
+        await this.afterContainerStart();
+    }
+
+    /**
      * Explicit start (`ctx.containers.<name>.get(id).start()`). Resolves the
      * `secretsStore` bindings into `envVars` first, mirroring
      * {@link containerFetch}. A per-instance `start({ envVars })` replaces the
@@ -153,7 +165,9 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
             await this.resolveSecretsStoreEnv();
         }
 
-        return super.start(...args);
+        await super.start(...args);
+
+        await this.afterContainerStart();
     }
 
     public override async onActivityExpired(): Promise<void> {
@@ -181,14 +195,6 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
         this.surfaceInStudioLogs(envelope);
 
         await super.onStart();
-
-        // The base calls `onStart()` after the ports are healthy and inside a
-        // `blockConcurrencyWhile`, and `containerFetch` routes through that same
-        // start path — so arming the hard timeout here makes it count from the
-        // real start, and awaiting readiness here gates request proxying until
-        // the app reports ready.
-        await this.armHardTimeout();
-        await this.awaitContainerReadiness();
     }
 
     /**
@@ -225,6 +231,35 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
         this.surfaceInStudioLogs(envelope);
 
         await super.onStop(parameters);
+    }
+
+    /**
+     * Arm the hard timeout and block on the `readyOn` probes — the work that has
+     * to happen once per real start, **outside** the base's start gate.
+     *
+     * It cannot live in `onStart`, which is the obvious home for it: the base
+     * invokes that hook as `blockConcurrencyWhile(async () => { … onStart() })`
+     * (`@cloudflare/containers`, both `start()` and `startAndWaitForPorts()`),
+     * and workerd treats a *rejecting* `blockConcurrencyWhile` closure as
+     * unrecoverable — it aborts the Durable Object, discards its in-memory state
+     * and every hibernating socket on it, and flattens the error to a plain
+     * `Error`. A readiness timeout is an ordinary, diagnosable failure: it must
+     * surface as the `LunoraError` naming the check, the port and the budget,
+     * not cost the object its life and arrive as an opaque message. (The same
+     * reasoning, and the same settle-outside-the-gate remedy, is written up on
+     * `ShardHost.runSerialized` in `@lunora/platform-cloudflare`.) A 30-second
+     * wait also has no business inside a gate that blocks every other dispatch
+     * to the object.
+     *
+     * Both start entry points call this immediately after `super`, so it still
+     * runs once per start and still gates request proxying: `containerFetch`
+     * starts through `startAndWaitForPorts` and only proxies once it returns, so
+     * a throw here fails the request instead of forwarding it to an app that
+     * never reported ready.
+     */
+    private async afterContainerStart(): Promise<void> {
+        await this.armHardTimeout();
+        await this.awaitContainerReadiness();
     }
 
     /**

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -25,15 +25,11 @@ const READINESS_POLL_INTERVAL_MS = 500;
 /**
  * Upper bound on how long the `readyOn` probes block container start before failing.
  *
- * Equal to the platform's own ceiling, which is why this wait must stay OUTSIDE
- * `blockConcurrencyWhile` (see {@link LunoraContainer.afterContainerStart}).
- * Cloudflare's Durable Object state docs: "To help mitigate deadlocks there is a
- * 30 second timeout applied when executing the callback. If this timeout is
- * exceeded, the Durable Object will be reset." Inside the gate the reset wins the
- * race — the `LunoraError` below naming the failing check, port and budget is
- * then unreachable on the very path it exists for — and the same docs call
- * blocking the gate on I/O (`fetch`, KV, R2) an anti-pattern outright, which a
- * `readyOn` probe is.
+ * Equal to the platform's own ceiling for a `blockConcurrencyWhile` callback —
+ * "if this timeout is exceeded, the Durable Object will be reset" — so inside
+ * the gate the reset would win the race and the `LunoraError` below would be
+ * unreachable on the very path it exists for. That is why this wait runs outside
+ * it; see `afterContainerStart`.
  *
  * https://developers.cloudflare.com/durable-objects/api/state/
  */
@@ -77,6 +73,8 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
     private readonly lunoraDefaultPort?: number;
     /** Hard-cap lifetime in whole seconds (from the `hardTimeout` config), or `undefined`. */
     private readonly lunoraHardTimeoutSeconds?: number;
+    /** In-flight `readyOn` gate for the current start; cleared when it fails. See `awaitReadinessGate`. */
+    private lunoraReadiness?: Promise<void>;
     /** Declarative readiness probes that gate request proxying (from the `readyOn` config). */
     private readonly lunoraReadyOn: ReadonlyArray<ContainerReadinessCheck>;
     /** Map of container env-var name → Worker Secrets Store binding name (from the `secretsStore` config). */
@@ -146,6 +144,7 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
      */
     public override async containerFetch(...args: Parameters<Container<Env>["containerFetch"]>): Promise<Response> {
         await this.resolveSecretsStoreEnv();
+        await this.awaitReadinessGate();
 
         return super.containerFetch(...args);
     }
@@ -265,15 +264,89 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
      * wait also has no business inside a gate that blocks every other dispatch
      * to the object.
      *
-     * Both start entry points call this immediately after `super`, so it still
-     * runs once per start and still gates request proxying: `containerFetch`
-     * starts through `startAndWaitForPorts` and only proxies once it returns, so
-     * a throw here fails the request instead of forwarding it to an app that
-     * never reported ready.
+     * Both start entry points call this immediately after `super`, so it runs
+     * once per start. It does NOT gate proxying on its own: the base commits the
+     * healthy state inside the start gate, before this runs, so a concurrent
+     * request would sail past `containerFetch`'s status check. That is what
+     * `awaitReadinessGate` is for, and it is the seam the move cost us —
+     * the in-gate placement got this for free from `blockConcurrencyWhile`.
      */
     private async afterContainerStart(): Promise<void> {
-        await this.armHardTimeout();
-        await this.awaitContainerReadiness();
+        // Single-flight. The base coalesces the container start itself
+        // (`startContainerIfNotRunning`) but not this tail, and it no longer runs
+        // inside `blockConcurrencyWhile` — so without this, two concurrent starts
+        // both read the same hard-timeout generation and each arm a schedule
+        // stamped with it, leaving two live schedules that both look current.
+        const inFlight = this.lunoraReadiness;
+
+        if (inFlight !== undefined) {
+            await inFlight;
+
+            return;
+        }
+
+        const gate = (async () => {
+            await this.armHardTimeout();
+            await this.awaitContainerReadiness();
+        })();
+
+        // Published before it is awaited, so a request that arrives mid-probe
+        // waits on THIS gate instead of proxying (see `awaitReadinessGate`).
+        this.lunoraReadiness = gate;
+
+        try {
+            await gate;
+        } catch (error) {
+            // Drop a failed gate rather than leaving it to reject every later
+            // request forever: the base has already committed the healthy state,
+            // so the next request re-probes instead of trusting it.
+            this.lunoraReadiness = undefined;
+
+            throw error;
+        }
+    }
+
+    /**
+     * Block until the `readyOn` probes for the current start have passed.
+     *
+     * Necessary because the base marks the container healthy *inside* the start
+     * gate — `startAndWaitForPorts` runs `setHealthy()` immediately before
+     * `onStart()` — while our probes run after it returns. `containerFetch`
+     * skips the start path entirely once it observes
+     * `container.running && status === "healthy"`, so without this a request
+     * arriving mid-probe would proxy to a container that never reported ready,
+     * and a request arriving after a *failed* probe would do so permanently.
+     * Holding `setHealthy` and the probes together the way the base does would
+     * mean putting the probes back inside the gate, which is the defect this
+     * whole path exists to avoid.
+     */
+    private async awaitReadinessGate(): Promise<void> {
+        if (this.lunoraReadyOn.length === 0) {
+            return;
+        }
+
+        if (this.lunoraReadiness === undefined) {
+            // Not healthy yet: `super.containerFetch` runs the start path, which
+            // routes through our `startAndWaitForPorts` override and gates there.
+            const { status } = await this.getState();
+
+            if (status !== "healthy") {
+                return;
+            }
+
+            // Healthy with no gate on record — a previous probe failed and was
+            // dropped, or this isolate was recycled after the start. Re-probe
+            // rather than proxy on the base's word alone.
+            this.lunoraReadiness = this.awaitContainerReadiness();
+        }
+
+        try {
+            await this.lunoraReadiness;
+        } catch (error) {
+            this.lunoraReadiness = undefined;
+
+            throw error;
+        }
     }
 
     /**

--- a/packages/db/__tests__/define-collections.test.ts
+++ b/packages/db/__tests__/define-collections.test.ts
@@ -29,6 +29,9 @@ const makeClient = (mutation: () => Promise<unknown> = async () => "server-id") 
         confirmedMutationWatermark: () => 0,
         currentIdentity: () => null,
         mutation: mutationMock,
+        // Mirrors `LunoraClient.replayIdentityVerdict`. Both stamp and current are
+        // the signed-out sentinel here, so every replay is a "match".
+        replayIdentityVerdict: (stamped: null | string | undefined) => (stamped === null ? "match" : "mismatch"),
         subscribe: vi.fn<
             (
                 reference: unknown,

--- a/packages/db/__tests__/outbox-replay.test.ts
+++ b/packages/db/__tests__/outbox-replay.test.ts
@@ -201,6 +201,32 @@ describe("durable outbox lifecycle (unified outbox)", () => {
         expect(mutation).not.toHaveBeenCalled();
     });
 
+    // No `expect.assertions` here (nor in this file's other 14 `vi.waitFor` tests):
+    // waitFor re-runs its callback until it passes, so the assertion count is a
+    // function of timing, not of what the test checked.
+    it("reports the reserved handler's identity drop on onWriteRejected instead of dropping it silently", async () => {
+        const { client } = makeClient({ identity: "user-b" });
+        const onWriteRejected = vi.fn<(event: { code?: string; collection: string; error: Error; row?: { _id: string } }) => void>();
+        const database = buildDatabase(client, { onWriteRejected });
+
+        await database.executor.waitForInit();
+
+        const sink = createExecutorOutboxSink(database.executor);
+
+        await sink.enqueue(outboxWrite({ identity: "user-a" }));
+
+        await vi.waitFor(() => {
+            expect(onWriteRejected).toHaveBeenCalledTimes(1);
+        });
+
+        const event = onWriteRejected.mock.calls[0]![0];
+
+        // The raw outbox path targets a function, not a collection, so the
+        // persisted path is what names the dropped write to the consumer.
+        expect(event.collection).toBe("messages:send");
+        expect(event.error.message).toContain("identity changed");
+    });
+
     it("retries a transient (code-less) failure until the write lands", { timeout: 10_000 }, async () => {
         let attempts = 0;
         const { client, mutation } = makeClient({

--- a/packages/db/__tests__/outbox-replay.test.ts
+++ b/packages/db/__tests__/outbox-replay.test.ts
@@ -109,14 +109,34 @@ const makeClient = (options?: { identity?: string | null; mutation?: () => Promi
         options?.mutation ?? (async () => "ok"),
     );
 
+    // Mutable so a test can model the shape a real browser always has: the
+    // durable replay starts before the app has resolved its session, and the
+    // identity arrives afterwards.
+    let identity: null | string = options?.identity === undefined ? "user-a" : options.identity;
+
     const client = {
         confirmedMutationWatermark: () => 0,
-        currentIdentity: () => options?.identity ?? "user-a",
+        currentIdentity: () => identity,
         mutation,
+        // Mirrors `LunoraClient.replayIdentityVerdict`: nobody signed in yet is
+        // "unknown" (hold the write), a different user is "mismatch" (drop it).
+        replayIdentityVerdict: (stamped: null | string | undefined): "match" | "mismatch" | "unknown" => {
+            if (stamped === identity) {
+                return "match";
+            }
+
+            return identity === null ? "unknown" : "mismatch";
+        },
         subscribe: vi.fn<() => () => void>(() => () => undefined),
     };
 
-    return { client: client as never, mutation };
+    return {
+        client: client as never,
+        mutation,
+        signIn: (next: null | string) => {
+            identity = next;
+        },
+    };
 };
 
 const executors: OfflineExecutor[] = [];
@@ -201,7 +221,7 @@ describe("durable outbox lifecycle (unified outbox)", () => {
         expect(mutation).not.toHaveBeenCalled();
     });
 
-    // No `expect.assertions` here (nor in this file's other 14 `vi.waitFor` tests):
+    // No `expect.assertions` here (nor in this file's other `vi.waitFor` tests):
     // waitFor re-runs its callback until it passes, so the assertion count is a
     // function of timing, not of what the test checked.
     it("reports the reserved handler's identity drop on onWriteRejected instead of dropping it silently", async () => {
@@ -225,6 +245,41 @@ describe("durable outbox lifecycle (unified outbox)", () => {
         // persisted path is what names the dropped write to the consumer.
         expect(event.collection).toBe("messages:send");
         expect(event.error.message).toContain("identity changed");
+    });
+
+    it("holds a queued write when no identity is established yet, then replays it once one arrives", { timeout: 10_000 }, async () => {
+        // The shape every reload has: `startOfflineExecutor` replays from its own
+        // constructor, before the app has resolved its session and called
+        // `setAuthToken`, so `currentIdentity()` is null while the replay runs.
+        // Dropping here would destroy the QUEUING user's own offline writes —
+        // strictly worse than the cross-user replay the guard exists to stop.
+        const { client, mutation, signIn } = makeClient({ identity: null });
+        const onWriteRejected = vi.fn<() => void>();
+        const database = buildDatabase(client, { onWriteRejected });
+
+        await database.executor.waitForInit();
+
+        const sink = createExecutorOutboxSink(database.executor);
+
+        await sink.enqueue(outboxWrite({ identity: "user-a" }));
+
+        // Held, not dropped: it stays in the durable outbox across replay
+        // attempts instead of being removed as a terminal verdict.
+        await vi.waitFor(() => {
+            expect(database.pendingCount()).toBeGreaterThan(0);
+        });
+
+        expect(mutation).not.toHaveBeenCalled();
+        expect(onWriteRejected).not.toHaveBeenCalled();
+
+        signIn("user-a");
+
+        await vi.waitFor(
+            () => {
+                expect(mutation).toHaveBeenCalledTimes(1);
+            },
+            { interval: 100, timeout: 8000 },
+        );
     });
 
     it("retries a transient (code-less) failure until the write lands", { timeout: 10_000 }, async () => {

--- a/packages/db/__tests__/outbox-replay.test.ts
+++ b/packages/db/__tests__/outbox-replay.test.ts
@@ -279,33 +279,41 @@ describe("durable outbox lifecycle (unified outbox)", () => {
         expect(mutation).not.toHaveBeenCalled();
     });
 
+    /** The writable `temp` collection — one definition for every test that queues a `db.actions.*` write. */
+    const temporaryDefinition = (shardKey?: string) => {
+        return {
+            temp: {
+                insert: {
+                    mutation: temporarySend,
+                    optimistic: (input: { text: string }, id: string) => {
+                        return { _creationTime: 0, _id: id, text: input.text };
+                    },
+                    toArgs: (row: Record<string, unknown> & { _id: string }) => {
+                        return { id: row._id, text: row.text };
+                    },
+                },
+                list: temporaryList,
+                ...(shardKey === undefined ? {} : { shardKey }),
+            },
+        };
+    };
+
     /**
      * Persist a write against a `temp` collection under a first executor, then
-     * dispose it mid-flight — simulating a deploy that removes the collection.
+     * dispose it mid-flight — simulating a deploy that removes the collection,
+     * or (with an `identity`) the session that queued the write ending.
      * @returns The optimistic id the queued write carried.
      */
-    const strandWrite = async (): Promise<string> => {
+    const strandWrite = async (identity?: string): Promise<string> => {
         const { client: oldClient } = makeClient({
+            ...(identity === undefined ? {} : { identity }),
             mutation: () =>
                 new Promise(() => {
                     /* in-flight forever — the write stays persisted */
                 }),
         });
 
-        const oldDatabase = defineCollections(oldClient, {
-            temp: {
-                insert: {
-                    mutation: temporarySend,
-                    optimistic: (input: { text: string }, id) => {
-                        return { _creationTime: 0, _id: id, text: input.text };
-                    },
-                    toArgs: (row) => {
-                        return { id: row._id, text: row.text };
-                    },
-                },
-                list: temporaryList,
-            },
-        });
+        const oldDatabase = defineCollections(oldClient, temporaryDefinition());
 
         await oldDatabase.executor.waitForInit();
 
@@ -321,6 +329,90 @@ describe("durable outbox lifecycle (unified outbox)", () => {
 
         return id;
     };
+
+    /** The "next session": `temp` is still writable, so a restored write finds its mutationFn and replays. */
+    const buildWritableReload = (client: never, options?: Parameters<typeof defineCollections>[2]) => {
+        const database = defineCollections(client, temporaryDefinition(), options);
+
+        executors.push(database.executor);
+
+        return database;
+    };
+
+    it("drops a queued collection write whose identity no longer matches, instead of replaying it as the new user", { timeout: 10_000 }, async () => {
+        // Alice queues a write that never lands, then the tab dies.
+        const id = await strandWrite("alice");
+
+        // Same browser profile, same durable outbox — Bob is signed in now.
+        const { client, mutation } = makeClient({ identity: "bob" });
+        const onWriteRejected = vi.fn<(event: { code?: string; collection: string; error: Error; row?: { _id: string } }) => void>();
+
+        const database = buildWritableReload(client, { onWriteRejected });
+
+        // Init resolves once the persisted write is loaded and scheduled (its
+        // replay is fire-and-forget after that), so the wait below can't observe
+        // a still-empty queue and pass vacuously.
+        await database.executor.waitForInit();
+
+        // Wait on the restored write settling either way, so the assertions below
+        // report what actually happened to it rather than a bare timeout.
+        await vi.waitFor(
+            () => {
+                expect(database.pendingCount()).toBe(0);
+            },
+            { timeout: 8000 },
+        );
+
+        // Never sent: Alice's write must not execute under Bob's bearer.
+        expect(mutation).not.toHaveBeenCalled();
+        expect(onWriteRejected).toHaveBeenCalledTimes(1);
+
+        const event = onWriteRejected.mock.calls[0]![0];
+
+        expect(event.collection).toBe("temp");
+        expect(event.error.message).toContain("identity changed");
+        expect(event.row?._id).toBe(id);
+    });
+
+    it("replays a queued collection write when the same identity is still signed in", { timeout: 10_000 }, async () => {
+        await strandWrite("alice");
+
+        const { client, mutation } = makeClient({ identity: "alice" });
+        const onWriteRejected = vi.fn<() => void>();
+        const database = buildWritableReload(client, { onWriteRejected });
+
+        await vi.waitFor(
+            () => {
+                expect(mutation).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 8000 },
+        );
+
+        await vi.waitFor(() => {
+            expect(database.pendingCount()).toBe(0);
+        });
+
+        expect(onWriteRejected).not.toHaveBeenCalled();
+    });
+
+    it("routes a sharded collection's write to the shard its list subscription reads", async () => {
+        const { client, mutation } = makeClient();
+        const database = defineCollections(client, temporaryDefinition("acme"));
+
+        executors.push(database.executor);
+
+        await database.executor.waitForInit();
+
+        database.actions.temp({ text: "tenant write" });
+
+        await vi.waitFor(() => {
+            expect(mutation).toHaveBeenCalledTimes(1);
+        });
+
+        // Without the shard key the write lands in the default shard while the
+        // `acme` subscription reads another DO — committed, ack'd, invisible.
+        expect(mutation.mock.calls[0]![2]).toMatchObject({ shardKey: "acme" });
+    });
 
     /** The "new deploy": `temp` became read-only — its insert binding (and so its mutationFn) is gone. */
     const buildReadOnlyDeploy = (client: never, options?: Parameters<typeof defineCollections>[2]) => {

--- a/packages/db/docs/index.mdx
+++ b/packages/db/docs/index.mdx
@@ -209,11 +209,12 @@ const db = defineCollections(client, defs, {
         // draft, etc.). The callback fires as the write is rejected — the row
         // rollback follows it, so read `row`/`error` here rather than the
         // collection's post-rollback state.
+        //
+        // A write whose target collection was removed/renamed in a deploy arrives
+        // here too, with `code: "UNKNOWN_MUTATION_FN"`. So does one queued under a
+        // user who is no longer signed in — identity is the trust boundary, so it
+        // is dropped rather than replayed under whoever holds the bearer now.
     },
-    // Optional: a write whose target collection was removed/renamed in a deploy
-    // arrives here too, with `code: "UNKNOWN_MUTATION_FN"`. So does one queued
-    // under a user who is no longer signed in — identity is the trust boundary,
-    // so it is dropped rather than replayed under whoever holds the bearer now.
     onStorageFailure: ({ code, message }) => {
         // The durable outbox couldn't persist (IndexedDB blocked in private mode,
         // quota exceeded, …) — the write won't survive a reload. Warn the user.

--- a/packages/db/docs/index.mdx
+++ b/packages/db/docs/index.mdx
@@ -211,7 +211,9 @@ const db = defineCollections(client, defs, {
         // collection's post-rollback state.
     },
     // Optional: a write whose target collection was removed/renamed in a deploy
-    // arrives here too, with `code: "UNKNOWN_MUTATION_FN"`.
+    // arrives here too, with `code: "UNKNOWN_MUTATION_FN"`. So does one queued
+    // under a user who is no longer signed in — identity is the trust boundary,
+    // so it is dropped rather than replayed under whoever holds the bearer now.
     onStorageFailure: ({ code, message }) => {
         // The durable outbox couldn't persist (IndexedDB blocked in private mode,
         // quota exceeded, …) — the write won't survive a reload. Warn the user.
@@ -420,12 +422,15 @@ clears only once every concurrent call settles.
 - `scopeBy?`: a field that scopes the list (a shard key); makes the collection
   re-pointable via `db.scope.<table>`.
 - `shardKey?`: routes the `list` subscription — and the confirmed-mutation
-  watermark its frames advance the checkpoint gate from — to a specific shard's
-  Durable Object. **Set this on any collection whose table is `.shardBy()`'d.**
-  Without it the overlay gate compares against the default `""` watermark
-  bucket, which that shard's sequence line never advances, so optimistic rows
-  are held or dropped against a watermark that is not theirs — silent staleness,
-  with no error anywhere.
+  watermark its frames advance the checkpoint gate from, and the `insert`
+  writes — to a specific shard's Durable Object. **Set this on any collection
+  whose table is `.shardBy()`'d.** Without it the overlay gate compares against
+  the default `""` watermark bucket, which that shard's sequence line never
+  advances, so optimistic rows are held or dropped against a watermark that is
+  not theirs, and the writes themselves land in the default shard while the
+  subscription reads another — committed, ack'd, and invisible. Silent
+  staleness, with no error anywhere. Each queued write captures the shard key it
+  was made under, so a write that outlives a reload still follows its own shard.
 - `load?`: `"eager"` to sync at boot, or `"lazy"` (default) to sync on first use
   (see [When collections load](#when-collections-load)).
 - `insert?`: `{ mutation, optimistic, toArgs }` to make the table writable

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -596,18 +596,21 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
     const getKey = options.getKey ?? ((row: TRow) => row._id);
     // Shared per-shard by default — a per-collection registry hangs any shard with
     // more than one collection (see `getShardCheckpoints`). A `shape` carries its
-    // own shard key; the `list` path uses the top-level one. Resolved LAZILY at
-    // each callback use site rather than captured once: an identity switch
-    // retires the derived registry and mints a fresh one, and a still-mounted
-    // collection's frames must advance the replacement — a captured registry
-    // would leave the fresh one unattached and never authoritatively advanced,
-    // so post-switch overlays would drop ungated (or wait out the fallback).
+    // own shard key; the `list` path uses the top-level one. The sync callbacks
+    // re-resolve rather than close over the capture below, because
+    // {@link disposeShardCheckpoints} drops the whole per-client map: a
+    // collection still mounted across that teardown must advance the registry a
+    // later {@link getShardCheckpoints} mints, not the disposed one it was built
+    // with (whose gates resolve to `Infinity`, so every overlay drops ungated).
+    // An identity switch is NOT such a case — {@link syncShardCheckpointIdentity}
+    // rewinds each registry IN PLACE precisely so captures stay valid; see
+    // {@link registryResets}.
     const resolveCheckpoints = (): CheckpointRegistry => {
         const registry = options.checkpoints ?? getShardCheckpoints(options.client, options.shape?.shardKey ?? options.shardKey);
 
         // This collection's subscription is what advances the registry — record
         // that so `bindMutators` knows gating an overlay on it will actually
-        // settle. Re-marked on every resolve so a post-switch replacement
+        // settle. Re-marked on every resolve so a post-teardown replacement
         // registry is covered too (a WeakSet add is idempotent).
         markCheckpointsAttached(registry);
 

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -6,7 +6,7 @@ import type { OfflineConfig, OfflineExecutor, OfflineTransaction, StorageDiagnos
 import { NonRetriableError, startOfflineExecutor } from "@tanstack/offline-transactions";
 
 import { lunoraCollectionOptions } from "./collection-options";
-import type { OutboxMutationMetadata, Row } from "./internals";
+import type { OutboxMutationMetadata, Row, WriteProvenance } from "./internals";
 import { createOptimisticOnlineDetector, createOutboxCarrier, OUTBOX_MUTATION_FN_NAME, registerOutboxCarrier, runOutboxMutation } from "./internals";
 
 /** Element type of an array (the row type a `list` query returns). */
@@ -129,19 +129,54 @@ const warnDuplicateTable = (client: LunoraClient, name: string): void => {
 };
 
 /**
- * Provenance stamped onto every `db.actions.*` transaction at enqueue time and
- * read back by its replay handler. The persisted mutation carries the row and
- * nothing else, so without this the replay cannot answer either question a
- * durable write raises once it outlives its session: WHO queued it, and WHICH
- * shard it belongs to. The reserved `__lunora_outbox__` handler reads the same
- * two fields off {@link OutboxMutationMetadata}.
+ * Hand a terminal write verdict to `onWriteRejected`, absorbing a throwing
+ * listener. A listener that escaped here would replace the `NonRetriableError`
+ * that caused it — turning a terminal verdict retriable (a poison-message loop)
+ * and skipping the optimistic rollback.
  */
-interface CollectionWriteMetadata extends Record<string, unknown> {
-    /** `client.currentIdentity()` when the write was queued; the replay drops the write when it no longer matches. */
-    identity: null | string;
-    /** The collection's `shardKey` when the write was queued — captured, not re-read, so a queued write follows the shard it was made against even if the app reboots pointed at another. */
-    shardKey?: string;
-}
+const reportWriteRejected = (options: DefineCollectionsOptions, event: WriteRejectedEvent): void => {
+    try {
+        options.onWriteRejected?.(event);
+    } catch {
+        // Deliberately swallowed — see above.
+    }
+};
+
+/**
+ * Refuse a persisted write that must not be replayed under the current identity.
+ *
+ * Identity is the trust boundary: a durable write outlives the session that
+ * queued it (a reload, or a sign-out/sign-in in the same browser profile), so
+ * replaying it under whoever holds the bearer now would attribute one user's
+ * write to another and pass THEIR row-level security.
+ *
+ * The verdict is the client's to make, not this module's — see
+ * `LunoraClient.replayIdentityVerdict`. A bare `!==` here would be wrong twice:
+ * it would drop a write whose subject merely resolved late (same credential,
+ * different-looking stamp), and — far worse — it would drop the queuing user's
+ * OWN writes on every reload, because a durable replay begins when the executor
+ * is constructed, before the app has resolved its session. Nobody signed in yet
+ * is `"unknown"`: there is no other identity to replay as, so the write is held
+ * (a retriable error keeps it in durable storage) rather than destroyed.
+ *
+ * An unstamped write — queued by an older build — has no provenance, so it is
+ * held rather than dropped for the same reason.
+ */
+type AssertIssuingIdentity = (client: LunoraClient, meta: undefined | WriteProvenance) => asserts meta is WriteProvenance;
+
+const assertIssuingIdentity: AssertIssuingIdentity = (client, meta) => {
+    const verdict = client.replayIdentityVerdict(meta?.identity);
+
+    if (verdict === "mismatch") {
+        throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
+    }
+
+    if (verdict === "unknown") {
+        // Deliberately NOT a NonRetriableError: the executor's retry policy holds
+        // the write and replays it once an identity is established.
+        throw new Error("outbox write deferred: no identity established yet");
+    }
+};
 
 /** A queued write that was permanently dropped, passed to {@link DefineCollectionsOptions.onWriteRejected}. */
 export interface WriteRejectedEvent {
@@ -276,7 +311,7 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
 
         if (insert) {
             mutationFns[name] = async ({ idempotencyKey, transaction }) => {
-                const meta = transaction.metadata as CollectionWriteMetadata | undefined;
+                const meta = transaction.metadata as WriteProvenance | undefined;
 
                 for (const [mutationIndex, mutation] of transaction.mutations.entries()) {
                     const row = mutation.modified as unknown as Row;
@@ -291,22 +326,11 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
                     const mutationId = `${idempotencyKey}:${String(mutationIndex)}`;
 
                     try {
-                        // Identity is the trust boundary. A durable write outlives the
-                        // session that queued it — a reload, or a sign-out/sign-in in the
-                        // same browser profile — so replaying it under whoever holds the
-                        // bearer now would attribute one user's write to another and pass
-                        // THEIR row-level security. Drop it instead: the same verdict the
-                        // reserved `__lunora_outbox__` handler reaches, and the one
-                        // `@lunora/client`'s queue settles as OFFLINE_IDENTITY_CHANGED.
-                        // Re-read per mutation, not once per transaction: a batched
+                        // Re-checked per mutation, not once per transaction: a batched
                         // transaction awaits between its writes, which is exactly where a
-                        // `setAuthToken` can slip in. A write persisted without the stamp
-                        // (queued by an older build) has no provenance to check, so it
-                        // fails closed too. Thrown inside the try so the drop reaches
-                        // `onWriteRejected` rather than rolling the row back in silence.
-                        if (meta?.identity !== client.currentIdentity()) {
-                            throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
-                        }
+                        // `setAuthToken` can slip in. Inside the try so the drop reaches
+                        // `onWriteRejected` instead of rolling the row back in silence.
+                        assertIssuingIdentity(client, meta);
 
                         // eslint-disable-next-line no-await-in-loop -- sequential keeps the outbox's FIFO ordering
                         await runOutboxMutation(() =>
@@ -322,14 +346,8 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
                         // fire-and-forget caller still learns the write was dropped, then
                         // rethrow so the rollback proceeds. Transient errors retry — only
                         // the NonRetriableError verdict is terminal, so only it is reported.
-                        if (error instanceof NonRetriableError && options.onWriteRejected) {
-                            try {
-                                options.onWriteRejected({ code: (error as Error & { code?: string }).code, collection: name, error, row });
-                            } catch {
-                                // A throwing listener must not escape and replace the
-                                // NonRetriableError — that would turn a terminal verdict
-                                // retriable (poison-message loop) and skip the rollback.
-                            }
+                        if (error instanceof NonRetriableError) {
+                            reportWriteRejected(options, { code: (error as Error & { code?: string }).code, collection: name, error, row });
                         }
 
                         throw error;
@@ -354,9 +372,7 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
         }
 
         try {
-            if (meta.identity !== client.currentIdentity()) {
-                throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
-            }
+            assertIssuingIdentity(client, meta);
 
             // Replay under the *original* idempotency key (not a fresh one), so a
             // committed-but-unacked write that the executor retries is deduped by the
@@ -365,29 +381,18 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
                 client.mutation({ __lunoraRef: meta.functionPath }, meta.args, { mutationId: meta.idempotencyKey, shardKey: meta.shardKey }),
             );
         } catch (error) {
-            // Same aggregate-channel report the per-collection handler makes, for the
-            // same reason: without it this path rolls the optimistic row back with no
-            // UI signal — the precise failure `onWriteRejected` was added to prevent.
-            // It covers the identity drop above AND a server-coded rejection from the
-            // replay, because reporting only the first would leave this handler with
-            // exactly the half-guarded shape it is being fixed for.
-            if (error instanceof NonRetriableError && options.onWriteRejected) {
-                try {
-                    options.onWriteRejected({
-                        code: (error as Error & { code?: string }).code,
-                        // A raw outbox write targets a function, not a collection — the
-                        // path is the only identifier it carries, and it is what a
-                        // consumer needs to name the dropped write.
-                        collection: meta.functionPath,
-                        error,
-                        // No `row`: the write rides the transport carrier, whose
-                        // transaction holds no optimistic collection row to hand back.
-                    });
-                } catch {
-                    // A throwing listener must not escape and replace the
-                    // NonRetriableError — that would turn a terminal verdict retriable
-                    // (poison-message loop) and skip the rollback.
-                }
+            // Covers the identity drop AND a server-coded rejection from the replay:
+            // reporting only the first would leave this handler half-guarded, which is
+            // the shape being fixed here.
+            if (error instanceof NonRetriableError) {
+                reportWriteRejected(options, {
+                    code: (error as Error & { code?: string }).code,
+                    // A raw outbox write targets a function, not a collection; the path
+                    // is the only identifier it carries. No `row` — it rides the
+                    // transport carrier, which holds no optimistic collection row.
+                    collection: meta.functionPath,
+                    error,
+                });
             }
 
             throw error;
@@ -412,19 +417,15 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
         // NonRetriableError *before* our per-collection `mutationFns` catch runs, so
         // this hook is the only place to surface it on `onWriteRejected`.
         onUnknownMutationFn: (name: string, tx: OfflineTransaction) => {
-            try {
-                options.onWriteRejected?.({
-                    code: "UNKNOWN_MUTATION_FN",
-                    collection: name,
-                    error: new Error(`offline write dropped: mutation "${name}" no longer exists (removed or renamed in a deploy?)`),
-                    // Best-effort recovered row: the persisted `modified` shape isn't a
-                    // validated `Row`, and a batched transaction surfaces only its first
-                    // mutation's row. Enough to describe the dropped write to the user.
-                    row: tx.mutations[0]?.modified as Row | undefined,
-                });
-            } catch {
-                // A throwing listener must not escape into the executor's drop path.
-            }
+            reportWriteRejected(options, {
+                code: "UNKNOWN_MUTATION_FN",
+                collection: name,
+                error: new Error(`offline write dropped: mutation "${name}" no longer exists (removed or renamed in a deploy?)`),
+                // Best-effort recovered row: the persisted `modified` shape isn't a
+                // validated `Row`, and a batched transaction surfaces only its first
+                // mutation's row. Enough to describe the dropped write to the user.
+                row: tx.mutations[0]?.modified as Row | undefined,
+            });
         },
     });
 
@@ -454,7 +455,7 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
             // shard have to be captured HERE, while the issuing session is still
             // the current one. Both are persisted with the transaction and
             // restored with it, so a replay after a reload still knows them.
-            const metadata: CollectionWriteMetadata = { identity: client.currentIdentity(), shardKey: definition.shardKey };
+            const metadata: WriteProvenance = { identity: client.currentIdentity(), shardKey: definition.shardKey };
             const offline = executor.createOfflineTransaction({ autoCommit: false, metadata, mutationFnName: name });
             const transaction = offline.mutate(() => {
                 collection.insert(insert.optimistic(input, id));

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -67,7 +67,10 @@ export interface CollectionDef<TList extends FunctionReference, TInput = never> 
      * Routes the `list` subscription (and the confirmed-mutation watermark its
      * frames advance the checkpoint gate from) to a specific shard's DO — so a
      * sharded collection's overlay gate compares against that shard's mutator
-     * sequence line, not the default ("") watermark bucket.
+     * sequence line, not the default ("") watermark bucket. `insert` writes are
+     * routed with it too, and to the shard that was set when the write was
+     * queued: subscriptions and the writes they observe have to land on the same
+     * Durable Object, and the server derives no shard from a mutation's args.
      */
     shardKey?: string;
 }
@@ -124,6 +127,21 @@ const warnDuplicateTable = (client: LunoraClient, name: string): void => {
             `read stale rows. Bind every table in a single defineCollections call (see the "One source of truth per table" docs section).`,
     );
 };
+
+/**
+ * Provenance stamped onto every `db.actions.*` transaction at enqueue time and
+ * read back by its replay handler. The persisted mutation carries the row and
+ * nothing else, so without this the replay cannot answer either question a
+ * durable write raises once it outlives its session: WHO queued it, and WHICH
+ * shard it belongs to. The reserved `__lunora_outbox__` handler reads the same
+ * two fields off {@link OutboxMutationMetadata}.
+ */
+interface CollectionWriteMetadata extends Record<string, unknown> {
+    /** `client.currentIdentity()` when the write was queued; the replay drops the write when it no longer matches. */
+    identity: null | string;
+    /** The collection's `shardKey` when the write was queued — captured, not re-read, so a queued write follows the shard it was made against even if the app reboots pointed at another. */
+    shardKey?: string;
+}
 
 /** A queued write that was permanently dropped, passed to {@link DefineCollectionsOptions.onWriteRejected}. */
 export interface WriteRejectedEvent {
@@ -258,6 +276,8 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
 
         if (insert) {
             mutationFns[name] = async ({ idempotencyKey, transaction }) => {
+                const meta = transaction.metadata as CollectionWriteMetadata | undefined;
+
                 for (const [mutationIndex, mutation] of transaction.mutations.entries()) {
                     const row = mutation.modified as unknown as Row;
                     // Replay under the executor's stable idempotency key (suffixed
@@ -271,8 +291,31 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
                     const mutationId = `${idempotencyKey}:${String(mutationIndex)}`;
 
                     try {
+                        // Identity is the trust boundary. A durable write outlives the
+                        // session that queued it — a reload, or a sign-out/sign-in in the
+                        // same browser profile — so replaying it under whoever holds the
+                        // bearer now would attribute one user's write to another and pass
+                        // THEIR row-level security. Drop it instead: the same verdict the
+                        // reserved `__lunora_outbox__` handler reaches, and the one
+                        // `@lunora/client`'s queue settles as OFFLINE_IDENTITY_CHANGED.
+                        // Re-read per mutation, not once per transaction: a batched
+                        // transaction awaits between its writes, which is exactly where a
+                        // `setAuthToken` can slip in. A write persisted without the stamp
+                        // (queued by an older build) has no provenance to check, so it
+                        // fails closed too. Thrown inside the try so the drop reaches
+                        // `onWriteRejected` rather than rolling the row back in silence.
+                        if (meta?.identity !== client.currentIdentity()) {
+                            throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
+                        }
+
                         // eslint-disable-next-line no-await-in-loop -- sequential keeps the outbox's FIFO ordering
-                        await runOutboxMutation(() => client.mutation(insert.mutation, insert.toArgs(row), { mutationId }));
+                        await runOutboxMutation(() =>
+                            // `shardKey` routes the write to the DO the collection's `list`
+                            // subscription reads. The server derives no shard from args, so
+                            // omitting it lands a `.shardBy()`'d collection's writes in the
+                            // default shard — committed, ack'd, and invisible to the reader.
+                            client.mutation(insert.mutation, insert.toArgs(row), { mutationId, shardKey: meta.shardKey }),
+                        );
                     } catch (error) {
                         // A permanent (coded) rejection: the executor will roll the
                         // optimistic row back. Report it on the aggregate channel so a
@@ -370,13 +413,6 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
             continue;
         }
 
-        const action = executor.createOfflineAction<{ id: string; input: unknown }>({
-            mutationFnName: name,
-            onMutate: ({ id, input }) => {
-                collection.insert(insert.optimistic(input, id));
-            },
-        });
-
         actions[name] = (input) => {
             // `safeRandomUUID` (from @tanstack/db) falls back to
             // `crypto.getRandomValues` when `crypto.randomUUID` is unavailable —
@@ -384,7 +420,24 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
             // `crypto.randomUUID` is undefined and a bare call would throw,
             // breaking every `db.actions.*` invocation.
             const id = safeRandomUUID();
-            const transaction = action({ id, input });
+            // Built from `createOfflineTransaction` rather than the executor's
+            // `createOfflineAction`, which takes no `metadata`: the identity and
+            // shard have to be captured HERE, while the issuing session is still
+            // the current one. Both are persisted with the transaction and
+            // restored with it, so a replay after a reload still knows them.
+            const metadata: CollectionWriteMetadata = { identity: client.currentIdentity(), shardKey: definition.shardKey };
+            const offline = executor.createOfflineTransaction({ autoCommit: false, metadata, mutationFnName: name });
+            const transaction = offline.mutate(() => {
+                collection.insert(insert.optimistic(input, id));
+            });
+
+            // Commit explicitly (not via `autoCommit`, whose upstream failure
+            // handler rethrows inside its own .catch — every terminal verdict
+            // would surface as an unhandled rejection) and swallow the outcome:
+            // retries are the executor's job, permanent drops are reported
+            // through `onWriteRejected`, and the caller can still await the
+            // returned `transaction`. Mirrors `createExecutorOutboxSink`.
+            offline.commit().catch(() => undefined);
 
             return { id, transaction };
         };

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -353,16 +353,45 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
             return;
         }
 
-        if (meta.identity !== client.currentIdentity()) {
-            throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
-        }
+        try {
+            if (meta.identity !== client.currentIdentity()) {
+                throw new NonRetriableError("outbox write dropped: identity changed since it was queued");
+            }
 
-        // Replay under the *original* idempotency key (not a fresh one), so a
-        // committed-but-unacked write that the executor retries is deduped by the
-        // server instead of applied twice.
-        await runOutboxMutation(() =>
-            client.mutation({ __lunoraRef: meta.functionPath }, meta.args, { mutationId: meta.idempotencyKey, shardKey: meta.shardKey }),
-        );
+            // Replay under the *original* idempotency key (not a fresh one), so a
+            // committed-but-unacked write that the executor retries is deduped by the
+            // server instead of applied twice.
+            await runOutboxMutation(() =>
+                client.mutation({ __lunoraRef: meta.functionPath }, meta.args, { mutationId: meta.idempotencyKey, shardKey: meta.shardKey }),
+            );
+        } catch (error) {
+            // Same aggregate-channel report the per-collection handler makes, for the
+            // same reason: without it this path rolls the optimistic row back with no
+            // UI signal — the precise failure `onWriteRejected` was added to prevent.
+            // It covers the identity drop above AND a server-coded rejection from the
+            // replay, because reporting only the first would leave this handler with
+            // exactly the half-guarded shape it is being fixed for.
+            if (error instanceof NonRetriableError && options.onWriteRejected) {
+                try {
+                    options.onWriteRejected({
+                        code: (error as Error & { code?: string }).code,
+                        // A raw outbox write targets a function, not a collection — the
+                        // path is the only identifier it carries, and it is what a
+                        // consumer needs to name the dropped write.
+                        collection: meta.functionPath,
+                        error,
+                        // No `row`: the write rides the transport carrier, whose
+                        // transaction holds no optimistic collection row to hand back.
+                    });
+                } catch {
+                    // A throwing listener must not escape and replace the
+                    // NonRetriableError — that would turn a terminal verdict retriable
+                    // (poison-message loop) and skip the rollback.
+                }
+            }
+
+            throw error;
+        }
     };
 
     // The transport carrier for outbox-routed raw writes (see

--- a/packages/db/src/internals.ts
+++ b/packages/db/src/internals.ts
@@ -17,17 +17,30 @@ const OUTBOX_DRAIN_INTERVAL_MS = 1000;
  */
 export const OUTBOX_MUTATION_FN_NAME = "__lunora_outbox__";
 
+/**
+ * Provenance stamped on a durable write at enqueue time: the two questions a
+ * replay cannot answer from the persisted row once the write outlives the
+ * session that made it — WHO queued it, and WHICH shard it belongs to.
+ *
+ * Shared so both replay paths (`db.actions.*` and the reserved
+ * `__lunora_outbox__` handler) check the same fields; they drifted apart once
+ * already, and only one of them had the identity guard.
+ */
+export interface WriteProvenance extends Record<string, unknown> {
+    /** Issuing identity fingerprint; a replay drops the write when it no longer matches. */
+    identity: string | null;
+    /** Captured, not re-read at replay: a queued write follows the shard it was made against even if the app reboots pointed at another. */
+    shardKey?: string;
+}
+
 /** The metadata an outbox-routed transaction carries so its replay can call `client.mutation`. */
-export interface OutboxMutationMetadata extends Record<string, unknown> {
+export interface OutboxMutationMetadata extends WriteProvenance {
     args: Record<string, unknown>;
     clientId: string;
     functionPath: string;
     /** Stable `${clientId}:${mutationId}` replay key; passed back as the mutation id so a committed-but-unacked replay is server-idempotent. */
     idempotencyKey: string;
-    /** Issuing identity fingerprint; the replay handler drops the write when it no longer matches. */
-    identity: string | null;
     mutationId: number;
-    shardKey?: string;
 }
 
 /** A committable outbox transaction handle (the `OfflineTransaction` the executor mints). */

--- a/packages/nuxt/docs/index.mdx
+++ b/packages/nuxt/docs/index.mdx
@@ -77,11 +77,13 @@ Configurable under the `lunora` key in `nuxt.config.ts`.
 | Option     | Default           | Description                                                                     |
 | ---------- | ----------------- | ------------------------------------------------------------------------------- |
 | `appEntry` | `~/lunora/server` | Module specifier of the Lunora app entry, aliased to the `#lunora/app` virtual. |
-| `prefix`   | `/_lunora`        | URL prefix the Lunora realtime plane is mounted at.                             |
+
+The `/_lunora/**` mount is fixed: the worker routes on those exact paths and the
+generated client calls them.
 
 ## How it works
 
-- **The route** (`addServerHandler` at `<prefix>/**`): reconstructs a Web
+- **The route** (`addServerHandler` at `/_lunora/**`): reconstructs a Web
   `Request` from the H3 event, resolves the Cloudflare `env`/`ExecutionContext`
   off it (tolerating both `event.context.cloudflare` and
   `event.req.runtime.cloudflare`), and forwards to your app's `fetch`. A

--- a/packages/react-native/__tests__/create-lunora-client.test.ts
+++ b/packages/react-native/__tests__/create-lunora-client.test.ts
@@ -163,19 +163,32 @@ describe("createLunoraClient", () => {
         expect(() => createLunoraClient({ storage, url: "https://api.example.com" })).not.toThrow();
     });
 
-    it("honours an explicit `persistence: false` over `storage`", () => {
+    it("honours an explicit `persistence: false` over `storage`, and still wires the query cache", async () => {
         expect.assertions(1);
 
-        const store = new Map<string, string>();
+        const reads: string[] = [];
         const storage = {
-            getItem: async (key: string) => store.get(key) ?? null,
-            removeItem: async () => {},
-            setItem: async (key: string, value: string) => {
-                store.set(key, value);
+            getItem: async (key: string) => {
+                reads.push(key);
+
+                return null;
             },
+            removeItem: async () => {},
+            setItem: async () => {},
         };
 
-        expect(() => createLunoraClient({ persistence: false, storage, url: "https://api.example.com" })).not.toThrow();
+        // `storage` backs two independent caches and each has its own opt-out, so
+        // turning off the mutation queue leaves query results still written to
+        // AsyncStorage. Asserted rather than smoke-tested because the option's
+        // docs used to read as though `persistence: false` disabled both.
+        const client = createLunoraClient({ persistence: false, storage, url: "https://api.example.com" });
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+        client.close();
+
+        expect(reads).toContain("lunora:query-cache");
     });
 
     it("derives an AsyncStorage query cache from `storage`", async () => {

--- a/packages/react-native/docs/index.mdx
+++ b/packages/react-native/docs/index.mdx
@@ -55,16 +55,19 @@ plus two React-Native conveniences:
 
 - **`storage`**: React Native `AsyncStorage` (or any `getItem`/`setItem`/`removeItem`
   store). Wires `createAsyncStoragePersistence` so the offline mutation queue
-  survives an app restart. The browser client auto-probes IndexedDB, which React
-  Native lacks, so without this the queue stays in memory.
+  survives an app restart, **and** `createAsyncStorageQueryCache` so query
+  results repaint before the socket reconnects. The browser client auto-probes
+  IndexedDB, which React Native lacks, so without this both stay in memory.
+  Each is opted out of separately — `persistence: false` disables the queue and
+  leaves the query cache writing to `storage`; pass `queryCache: false` for that.
 - **`getAuthHeaders`**: `() => Record<string, string> | undefined`. A generic
   escape hatch for a **custom** credential header (an API-gateway key, a proxy
   token) attached to every HTTP RPC request **and** the WebSocket upgrade. For
   better-auth sessions prefer a bearer token (below); a `Cookie` header here
   would be rejected by the runtime's CSRF guard on an `Origin`-less native request.
 
-An explicit `persistence`, `fetch`, or `WebSocket` takes precedence over the
-convenience derived from `storage` / `getAuthHeaders`.
+An explicit `persistence`, `queryCache`, `fetch`, or `WebSocket` takes precedence
+over the convenience derived from `storage` / `getAuthHeaders`.
 
 ## Hooks & provider
 

--- a/packages/react-native/src/create-lunora-client.ts
+++ b/packages/react-native/src/create-lunora-client.ts
@@ -74,8 +74,10 @@ export const withAuthWebSocket = (WebSocketImpl: typeof WebSocket, getAuthHeader
  * no cookie jar to attach a session implicitly.
  *
  * Everything on `LunoraClientOptions` is still accepted and passed through; an
- * explicit `persistence`, `fetch`, or `WebSocket` takes precedence over the
- * convenience derived from `storage` / `getAuthHeaders`. See the package README
+ * explicit `persistence`, `queryCache`, `fetch`, or `WebSocket` takes precedence
+ * over the convenience derived from `storage` / `getAuthHeaders`. `persistence`
+ * and `queryCache` override independently — `storage` backs both, so opting out
+ * of one leaves the other wired. See the package README
  * for a full setup example.
  * @experimental
  */

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -49,9 +49,15 @@ export interface CreateLunoraClientOptions extends LunoraClientOptions {
     /**
      * React Native `AsyncStorage` (or any async key/value store with the same
      * `getItem`/`setItem`/`removeItem` surface — Expo `SecureStore`, an in-memory
-     * map in tests). When supplied, the offline mutation queue is persisted here
-     * via `createAsyncStoragePersistence`, so writes made offline survive an app
-     * restart. Ignored when an explicit `persistence` is passed.
+     * map in tests). When supplied it backs two independent caches: the offline
+     * mutation queue (via `createAsyncStoragePersistence`, so writes made offline
+     * survive an app restart) and the durable query cache (via
+     * `createAsyncStorageQueryCache`, so reads repaint before the socket
+     * reconnects).
+     *
+     * Each is opted out of by its own option, not by the other: `persistence`
+     * overrides the queue and `queryCache` overrides the read cache, so
+     * `{ persistence: false, storage }` still writes query results to storage.
      */
     storage?: AsyncStorageLike;
 }

--- a/registry/auth-ui-angular/angular/auth-cards.ts
+++ b/registry/auth-ui-angular/angular/auth-cards.ts
@@ -4,8 +4,8 @@
  * magic-link, email-OTP (two-step), and two-factor verify. Each is a thin
  * standalone component binding a core controller to the shared view primitives.
  */
-import type { OnInit, Signal } from "@angular/core";
-import { ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
+import type { OnInit, Signal, WritableSignal } from "@angular/core";
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
 
 import { signInAnonymously } from "../core/anonymous";
 import type { BackupCodeSignInField } from "../core/backup-codes";
@@ -40,6 +40,25 @@ import {
     SubmitButtonComponent,
 } from "./primitives";
 import { injectAuthUIContext } from "./provider";
+
+/**
+ * A signal holding the last-used login method, filled in after the first render.
+ *
+ * Read after the first render, not during it: the server has no cookie, so a
+ * render-time read produces markup the server could not have produced (see
+ * `lastLoginMethodStore` in core). `afterNextRender` never runs on the server,
+ * which is exactly the guarantee needed — and calling this from a field
+ * initialiser keeps it inside the component's injection context.
+ */
+const lastLoginMethodAfterRender = (): WritableSignal<string | undefined> => {
+    const method = signal<string | undefined>(undefined);
+
+    afterNextRender(() => {
+        method.set(readLastLoginMethod());
+    });
+
+    return method;
+};
 
 /** "Continue as guest", when the `anonymous` plugin is on. */
 @Component({
@@ -112,7 +131,7 @@ class AnonymousButtonComponent {
                         <!--
                           better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
                         -->
-                        @if (lastUsedEmail) {
+                        @if (lastUsedEmail()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -134,9 +153,7 @@ class SignInCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
-    // Read once rather than per change-detection run: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    private readonly lastLoginMethod = readLastLoginMethod();
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
 
     /*
      * All derived from the context, so the deployment's real shape — which
@@ -145,8 +162,8 @@ class SignInCardComponent {
      */
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
-    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
-    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
+    protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined));
+    protected readonly lastUsedEmail = computed(() => this.lastUsed() === LAST_METHOD_EMAIL);
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
@@ -430,7 +447,7 @@ class ResetPasswordOtpCardComponent {
                     />
                     <lunora-auth-submit-button [pending]="state().status === 'submitting'">
                         {{ t.magicLink }}
-                        @if (lastUsedMagicLink) {
+                        @if (lastUsedMagicLink()) {
                             <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
                         }
                     </lunora-auth-submit-button>
@@ -450,9 +467,12 @@ class MagicLinkCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
-    // Read once rather than per change-detection run: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
+    // Computed rather than frozen at mount, like every other context-derived
+    // member here: the deployment's real shape arrives with the discovery answer.
+    private readonly lastLoginMethod = lastLoginMethodAfterRender();
+    protected readonly lastUsedMagicLink = computed(
+        () => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod() : undefined) === LAST_METHOD_MAGIC_LINK,
+    );
 }
 
 @Component({

--- a/registry/auth-ui-angular/angular/auth-cards.ts
+++ b/registry/auth-ui-angular/angular/auth-cards.ts
@@ -16,7 +16,7 @@ import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import type { ForgotPasswordField } from "../core/forgot-password";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import type { ResetPasswordField } from "../core/reset-password";
 import { createResetPasswordController } from "../core/reset-password";
@@ -107,7 +107,15 @@ class AnonymousButtonComponent {
                         (blurred)="actions.blur('password')"
                     />
                     <lunora-auth-link [href]="forgotPasswordHref()">{{ t.forgotPasswordLink }}</lunora-auth-link>
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signIn }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.signIn }}
+                        <!--
+                          better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is.
+                        -->
+                        @if (lastUsedEmail) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
             }
             @if (signUp()) {
@@ -138,6 +146,7 @@ class SignInCardComponent {
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
     protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
+    protected readonly lastUsedEmail = this.lastLoginMethod === LAST_METHOD_EMAIL;
     protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
@@ -419,7 +428,12 @@ class ResetPasswordOtpCardComponent {
                         (changed)="actions.setField('email', $event)"
                         (blurred)="actions.blur('email')"
                     />
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.magicLink }}</lunora-auth-submit-button>
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">
+                        {{ t.magicLink }}
+                        @if (lastUsedMagicLink) {
+                            <span class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+                        }
+                    </lunora-auth-submit-button>
                 </form>
                 <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.backToSignIn }}</lunora-auth-link>
             </lunora-auth-card>
@@ -435,6 +449,10 @@ class MagicLinkCardComponent {
     private readonly bridge = controllerSignal(createMagicLinkController, { context: this.context });
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
+
+    // Read once rather than per change-detection run: it is a cookie, it is
+    // available before the first paint, and it only picks a badge.
+    protected readonly lastUsedMagicLink = readLastLoginMethod() === LAST_METHOD_MAGIC_LINK;
 }
 
 @Component({

--- a/registry/auth-ui-angular/core/anonymous.ts
+++ b/registry/auth-ui-angular/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-angular/core/email-otp.ts
+++ b/registry/auth-ui-angular/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-angular/core/index.ts
+++ b/registry/auth-ui-angular/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-angular/core/invitations.ts
+++ b/registry/auth-ui-angular/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-angular/core/last-login-method.ts
+++ b/registry/auth-ui-angular/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-angular/core/last-login-method.ts
+++ b/registry/auth-ui-angular/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-angular/core/phone-number.ts
+++ b/registry/auth-ui-angular/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-angular/core/verify-email.ts
+++ b/registry/auth-ui-angular/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-react/core/anonymous.ts
+++ b/registry/auth-ui-react/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-react/core/email-otp.ts
+++ b/registry/auth-ui-react/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-react/core/index.ts
+++ b/registry/auth-ui-react/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-react/core/invitations.ts
+++ b/registry/auth-ui-react/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-react/core/last-login-method.ts
+++ b/registry/auth-ui-react/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-react/core/last-login-method.ts
+++ b/registry/auth-ui-react/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-react/core/phone-number.ts
+++ b/registry/auth-ui-react/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-react/core/verify-email.ts
+++ b/registry/auth-ui-react/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-react/react/auth-cards.tsx
+++ b/registry/auth-ui-react/react/auth-cards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -9,7 +9,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, lastLoginMethodStore } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -50,14 +50,19 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
     const { localization: t, social } = context;
     const [state, actions] = useController(createSignInController);
     const pending = state.status === "submitting";
-    // Read once per render rather than in an effect: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after hydration, not during render: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const lastUsedAfterHydration = useSyncExternalStore(
+        lastLoginMethodStore.subscribe,
+        lastLoginMethodStore.getSnapshot,
+        lastLoginMethodStore.getServerSnapshot,
+    );
+    const lastUsed = context.plugins.lastLoginMethod ? lastUsedAfterHydration : undefined;
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={signUpHref}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -78,9 +83,6 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
                     <AuthLink href={forgotPasswordHref}>{t.forgotPasswordLink}</AuthLink>
                     <SubmitButton pending={pending}>
                         {t.signIn}
-                        {/* better-auth records a password sign-in as "email", so
-                            without this the badge is invisible for the most
-                            common route there is. */}
                         {lastUsed === LAST_METHOD_EMAIL ? <LastUsedBadge /> : null}
                     </SubmitButton>
                 </form>
@@ -204,10 +206,17 @@ interface MagicLinkCardProps {
 }
 
 const MagicLinkCard = ({ signInHref = "/sign-in" }: MagicLinkCardProps = {}): ReactElement | null => {
-    const lastUsed = readLastLoginMethod();
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = useController(createMagicLinkController);
+    // Read after hydration, not during render: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const lastUsedAfterHydration = useSyncExternalStore(
+        lastLoginMethodStore.subscribe,
+        lastLoginMethodStore.getSnapshot,
+        lastLoginMethodStore.getServerSnapshot,
+    );
+    const lastUsed = context.plugins.lastLoginMethod ? lastUsedAfterHydration : undefined;
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;

--- a/registry/auth-ui-solid-v2/core/anonymous.ts
+++ b/registry/auth-ui-solid-v2/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-solid-v2/core/email-otp.ts
+++ b/registry/auth-ui-solid-v2/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-solid-v2/core/index.ts
+++ b/registry/auth-ui-solid-v2/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-solid-v2/core/invitations.ts
+++ b/registry/auth-ui-solid-v2/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-solid-v2/core/last-login-method.ts
+++ b/registry/auth-ui-solid-v2/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-solid-v2/core/last-login-method.ts
+++ b/registry/auth-ui-solid-v2/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-solid-v2/core/phone-number.ts
+++ b/registry/auth-ui-solid-v2/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-solid-v2/core/verify-email.ts
+++ b/registry/auth-ui-solid-v2/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-solid-v2/solid-v2/auth-cards.tsx
+++ b/registry/auth-ui-solid-v2/solid-v2/auth-cards.tsx
@@ -7,7 +7,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -76,7 +76,13 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                     <FormField actions={actions} autoComplete="current-password" field="password" label={t.passwordLabel} state={state} type="password" />
                     <AuthLink href={props.forgotPasswordHref ?? "/forgot-password"}>{t.forgotPasswordLink}</AuthLink>
-                    <SubmitButton pending={state.status === "submitting"}>{t.signIn}</SubmitButton>
+                    <SubmitButton pending={state.status === "submitting"}>
+                        {t.signIn}
+                        {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
+                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                            <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                        </Show>
+                    </SubmitButton>
                 </form>
             </Show>
         </AuthCard>
@@ -207,13 +213,21 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     }
 
     const [state, actions] = createController(createMagicLinkController);
+    // Read once when the card is created rather than in an effect: it is a
+    // cookie, it is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.backToSignIn}</AuthLink>} title={t.magicLink}>
             <form class="lunora-auth-form" novalidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
-                <SubmitButton pending={state.status === "submitting"}>{t.magicLink}</SubmitButton>
+                <SubmitButton pending={state.status === "submitting"}>
+                    {t.magicLink}
+                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                        <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                    </Show>
+                </SubmitButton>
             </form>
         </AuthCard>
     );

--- a/registry/auth-ui-solid-v2/solid-v2/auth-cards.tsx
+++ b/registry/auth-ui-solid-v2/solid-v2/auth-cards.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "@solidjs/web";
-import { createSignal, Show } from "solid-js";
+import { createSignal, onSettled, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -46,14 +46,21 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignInController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    // Solid 2 spells Solid 1.x's `onMount` as `onSettled`.
+    onSettled(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed()}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -79,7 +86,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <SubmitButton pending={state.status === "submitting"}>
                         {t.signIn}
                         {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
-                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                        <Show when={lastUsed() === LAST_METHOD_EMAIL}>
                             <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                         </Show>
                     </SubmitButton>
@@ -213,9 +220,16 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     }
 
     const [state, actions] = createController(createMagicLinkController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    // Solid 2 spells Solid 1.x's `onMount` as `onSettled`.
+    onSettled(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.backToSignIn}</AuthLink>} title={t.magicLink}>
@@ -224,7 +238,7 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                 <SubmitButton pending={state.status === "submitting"}>
                     {t.magicLink}
-                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                    <Show when={lastUsed() === LAST_METHOD_MAGIC_LINK}>
                         <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                     </Show>
                 </SubmitButton>

--- a/registry/auth-ui-solid/core/anonymous.ts
+++ b/registry/auth-ui-solid/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-solid/core/email-otp.ts
+++ b/registry/auth-ui-solid/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-solid/core/index.ts
+++ b/registry/auth-ui-solid/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-solid/core/invitations.ts
+++ b/registry/auth-ui-solid/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-solid/core/last-login-method.ts
+++ b/registry/auth-ui-solid/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-solid/core/last-login-method.ts
+++ b/registry/auth-ui-solid/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-solid/core/phone-number.ts
+++ b/registry/auth-ui-solid/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-solid/core/verify-email.ts
+++ b/registry/auth-ui-solid/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-solid/solid/auth-cards.tsx
+++ b/registry/auth-ui-solid/solid/auth-cards.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { createSignal, Show } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
 import { createBackupCodeSignInController } from "../core/backup-codes";
@@ -46,14 +46,20 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignInController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    onMount(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     return (
         <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
-                lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+                lastUsed={lastUsed()}
                 onSelect={(provider) => {
                     void signInWithSocial(context, provider);
                 }}
@@ -79,7 +85,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <SubmitButton pending={state.status === "submitting"}>
                         {t.signIn}
                         {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
-                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                        <Show when={lastUsed() === LAST_METHOD_EMAIL}>
                             <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                         </Show>
                     </SubmitButton>
@@ -208,9 +214,15 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = createController(createMagicLinkController);
-    // Read once when the card is created rather than in an effect: it is a
-    // cookie, it is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not when the card is created: the server has no cookie,
+    // so a render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    const [lastUsedAfterMount, setLastUsedAfterMount] = createSignal<string | undefined>();
+
+    onMount(() => {
+        setLastUsedAfterMount(readLastLoginMethod());
+    });
+
+    const lastUsed = () => (context.plugins.lastLoginMethod ? lastUsedAfterMount() : undefined);
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;
@@ -223,7 +235,7 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                 <SubmitButton pending={state.status === "submitting"}>
                     {t.magicLink}
-                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                    <Show when={lastUsed() === LAST_METHOD_MAGIC_LINK}>
                         <span class="lunora-auth-social__badge">{t.lastUsed}</span>
                     </Show>
                 </SubmitButton>

--- a/registry/auth-ui-solid/solid/auth-cards.tsx
+++ b/registry/auth-ui-solid/solid/auth-cards.tsx
@@ -7,7 +7,7 @@ import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
 import { createResetPasswordOtpController } from "../core/reset-password-otp";
@@ -76,7 +76,13 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
                     <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
                     <FormField actions={actions} autoComplete="current-password" field="password" label={t.passwordLabel} state={state} type="password" />
                     <AuthLink href={props.forgotPasswordHref ?? "/forgot-password"}>{t.forgotPasswordLink}</AuthLink>
-                    <SubmitButton pending={state.status === "submitting"}>{t.signIn}</SubmitButton>
+                    <SubmitButton pending={state.status === "submitting"}>
+                        {t.signIn}
+                        {/* better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. */}
+                        <Show when={lastUsed === LAST_METHOD_EMAIL}>
+                            <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                        </Show>
+                    </SubmitButton>
                 </form>
             </Show>
         </AuthCard>
@@ -202,6 +208,9 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = createController(createMagicLinkController);
+    // Read once when the card is created rather than in an effect: it is a
+    // cookie, it is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 
     if (!isFlowEnabled(context, "magicLink", "MagicLinkCard")) {
         return null;
@@ -212,7 +221,12 @@ const MagicLinkCard = (props: MagicLinkCardProps = {}): JSX.Element => {
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <FormField actions={actions} autoComplete="email" field="email" label={t.emailLabel} state={state} type="email" />
-                <SubmitButton pending={state.status === "submitting"}>{t.magicLink}</SubmitButton>
+                <SubmitButton pending={state.status === "submitting"}>
+                    {t.magicLink}
+                    <Show when={lastUsed === LAST_METHOD_MAGIC_LINK}>
+                        <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                    </Show>
+                </SubmitButton>
             </form>
         </AuthCard>
     );

--- a/registry/auth-ui-svelte/core/anonymous.ts
+++ b/registry/auth-ui-svelte/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-svelte/core/email-otp.ts
+++ b/registry/auth-ui-svelte/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-svelte/core/index.ts
+++ b/registry/auth-ui-svelte/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-svelte/core/invitations.ts
+++ b/registry/auth-ui-svelte/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-svelte/core/last-login-method.ts
+++ b/registry/auth-ui-svelte/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-svelte/core/last-login-method.ts
+++ b/registry/auth-ui-svelte/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-svelte/core/phone-number.ts
+++ b/registry/auth-ui-svelte/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-svelte/core/verify-email.ts
+++ b/registry/auth-ui-svelte/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-svelte/svelte/MagicLinkCard.svelte
+++ b/registry/auth-ui-svelte/svelte/MagicLinkCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { isFlowEnabled } from "../core/flow-gate";
+    import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
     import { createMagicLinkController } from "../core/magic-link";
     import AuthCard from "./AuthCard.svelte";
     import AuthLink from "./AuthLink.svelte";
@@ -15,6 +16,9 @@
     const t = context.localization;
     const enabled = isFlowEnabled(context, "magicLink", "MagicLinkCard");
     const { actions, state: form } = controllerStore(createMagicLinkController);
+    // Read once at initialisation rather than in an effect: it is a cookie, it
+    // is available before the first paint, and it only picks a badge.
+    const lastUsed = readLastLoginMethod();
 </script>
 
 {#if enabled}
@@ -29,7 +33,12 @@
         >
             <FormBanner error={$form.formError} success={$form.successMessage} />
             <FormField {actions} autoComplete="email" field="email" fields={$form.fields} label={t.emailLabel} type="email" />
-            <SubmitButton pending={$form.status === "submitting"}>{t.magicLink}</SubmitButton>
+            <SubmitButton pending={$form.status === "submitting"}>
+                {t.magicLink}
+                {#if lastUsed === LAST_METHOD_MAGIC_LINK}
+                    <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                {/if}
+            </SubmitButton>
         </form>
         {#snippet footer()}
             <AuthLink href={signInHref}>{t.backToSignIn}</AuthLink>

--- a/registry/auth-ui-svelte/svelte/MagicLinkCard.svelte
+++ b/registry/auth-ui-svelte/svelte/MagicLinkCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { isFlowEnabled } from "../core/flow-gate";
     import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
     import { createMagicLinkController } from "../core/magic-link";
@@ -16,9 +17,15 @@
     const t = context.localization;
     const enabled = isFlowEnabled(context, "magicLink", "MagicLinkCard");
     const { actions, state: form } = controllerStore(createMagicLinkController);
-    // Read once at initialisation rather than in an effect: it is a cookie, it
-    // is available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not at initialisation: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    let lastUsedAfterMount = $state<string | undefined>(undefined);
+
+    onMount(() => {
+        lastUsedAfterMount = readLastLoginMethod();
+    });
+
+    const lastUsed = $derived(context.plugins.lastLoginMethod ? lastUsedAfterMount : undefined);
 </script>
 
 {#if enabled}

--- a/registry/auth-ui-svelte/svelte/SignInCard.svelte
+++ b/registry/auth-ui-svelte/svelte/SignInCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
     import { createSignInController } from "../core/sign-in";
     import { signInWithSocial } from "../core/social";
@@ -25,14 +26,20 @@
     const t = context.localization;
     const social = context.social;
     const { actions, state: form } = controllerStore(createSignInController);
-    // Read once at initialisation rather than in an effect: it is a cookie, it is
-    // available before the first paint, and it only picks a badge.
-    const lastUsed = readLastLoginMethod();
+    // Read after mount, not at initialisation: the server has no cookie, so a
+    // render-time read is a hydration mismatch. See `lastLoginMethodStore`.
+    let lastUsedAfterMount = $state<string | undefined>(undefined);
+
+    onMount(() => {
+        lastUsedAfterMount = readLastLoginMethod();
+    });
+
+    const lastUsed = $derived(context.plugins.lastLoginMethod ? lastUsedAfterMount : undefined);
 </script>
 
 <AuthCard title={t.signIn}>
     <SocialButtons
-        lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
+        {lastUsed}
         onSelect={(provider) => {
             void signInWithSocial(context, provider);
         }}

--- a/registry/auth-ui-svelte/svelte/SignInCard.svelte
+++ b/registry/auth-ui-svelte/svelte/SignInCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { readLastLoginMethod } from "../core/last-login-method";
+    import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
     import { createSignInController } from "../core/sign-in";
     import { signInWithSocial } from "../core/social";
     import AnonymousButton from "./AnonymousButton.svelte";
@@ -62,7 +62,13 @@
             <FormField {actions} autoComplete="email" field="email" fields={$form.fields} label={t.emailLabel} type="email" />
             <FormField {actions} autoComplete="current-password" field="password" fields={$form.fields} label={t.passwordLabel} type="password" />
             <AuthLink href={forgotPasswordHref}>{t.forgotPasswordLink}</AuthLink>
-            <SubmitButton pending={$form.status === "submitting"}>{t.signIn}</SubmitButton>
+            <SubmitButton pending={$form.status === "submitting"}>
+                {t.signIn}
+                <!-- better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. -->
+                {#if lastUsed === LAST_METHOD_EMAIL}
+                    <span class="lunora-auth-social__badge">{t.lastUsed}</span>
+                {/if}
+            </SubmitButton>
         </form>
     {/if}
     {#snippet footer()}

--- a/registry/auth-ui-vue/core/anonymous.ts
+++ b/registry/auth-ui-vue/core/anonymous.ts
@@ -9,12 +9,13 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInAnonymously = async (context: ControllerContext): Promise<void> => {
     try {
         assertOk(await context.authClient.signIn.anonymous());
         context.onSessionChange?.();
-        context.nav.replace(context.redirects.afterSignIn);
+        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
     } catch (error) {
         notifyError(context, error, context.localization.signInFailed);
     }

--- a/registry/auth-ui-vue/core/email-otp.ts
+++ b/registry/auth-ui-vue/core/email-otp.ts
@@ -6,6 +6,7 @@
  */
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FieldState, FlowStatus } from "./types";
 import { email as validateEmail, required } from "./validators";
@@ -93,7 +94,7 @@ const createEmailOtpController = (context: ControllerContext): EmailOtpControlle
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error_) {
             context.onError?.(error_);
             store.update({ formError: mapAuthError(error_, context.localization, context.localization.twoFactorFailed), status: "error" });

--- a/registry/auth-ui-vue/core/index.ts
+++ b/registry/auth-ui-vue/core/index.ts
@@ -49,7 +49,14 @@ export type {
 } from "./invitations";
 export { createAcceptInvitationController, createUserInvitationsController } from "./invitations";
 export { firstLabel, passkeyLabel, providerLabel, ROLE_OPTIONS, rowActionLabel, sessionLabel, slugify } from "./labels";
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod } from "./last-login-method";
+export {
+    LAST_LOGIN_METHOD_COOKIE,
+    LAST_METHOD_EMAIL,
+    LAST_METHOD_MAGIC_LINK,
+    LAST_METHOD_PASSKEY,
+    lastLoginMethodStore,
+    readLastLoginMethod,
+} from "./last-login-method";
 export type { Localization } from "./localization";
 export { DEFAULT_LOCALIZATION, resolveLocalization } from "./localization";
 export type { MagicLinkField } from "./magic-link";

--- a/registry/auth-ui-vue/core/invitations.ts
+++ b/registry/auth-ui-vue/core/invitations.ts
@@ -119,6 +119,11 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
 
             store.update({ status: "success" });
             context.onSessionChange?.();
+            // Deliberately NOT `resolveAfterSignIn`: this screen is what
+            // `?redirectTo=<the invitation>` points AT. Resolving it here would
+            // send a user who just accepted the invitation straight back to the
+            // invitation. The parameter is for the doors that bounce through
+            // sign-in, not for the destination itself.
             context.nav.replace(context.redirects.afterSignIn);
         } catch (error) {
             context.onError?.(error);

--- a/registry/auth-ui-vue/core/last-login-method.ts
+++ b/registry/auth-ui-vue/core/last-login-method.ts
@@ -21,6 +21,17 @@
  * makes the feature do nothing for the most common case there is. A `customResolveMethod`
  * server-side can record anything, so treat an unrecognised value as "no badge"
  * rather than as an error.
+ *
+ * # Under SSR
+ *
+ * There is no `document` server-side, so this returns undefined there and the
+ * badge exists only in the client render — a genuine hydration difference, in
+ * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
+ * divergence this one *does* write to the DOM, so an SSR app that wants the two
+ * renders identical has to keep the cookie out of the first paint itself. Every
+ * port reads it at render/setup time for the same reason: it is available
+ * before the first paint, and deferring it to an effect trades the mismatch for
+ * a visible pop-in on the screen users see most.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */

--- a/registry/auth-ui-vue/core/last-login-method.ts
+++ b/registry/auth-ui-vue/core/last-login-method.ts
@@ -24,14 +24,13 @@
  *
  * # Under SSR
  *
- * There is no `document` server-side, so this returns undefined there and the
- * badge exists only in the client render — a genuine hydration difference, in
- * a decorative `<span>` and nothing else. Unlike `core/theme-mode.ts`'s
- * divergence this one *does* write to the DOM, so an SSR app that wants the two
- * renders identical has to keep the cookie out of the first paint itself. Every
- * port reads it at render/setup time for the same reason: it is available
- * before the first paint, and deferring it to an effect trades the mismatch for
- * a visible pop-in on the screen users see most.
+ * There is no `document` server-side, so a render-time read produces markup the
+ * server could not have produced — a hydration mismatch. Every port therefore
+ * reads it **after mount**, via {@link lastLoginMethodStore}: the first client
+ * render matches the server exactly (no badge), and the badge appears on the
+ * next frame. The cost is a one-frame pop-in on a decorative `<span>`; the
+ * alternative is markup that disagrees with the server on the screen users see
+ * most, which React 19 recovers from by discarding the server tree.
  */
 
 /** Recorded for `/sign-in/email` and `/sign-up/email`. */
@@ -68,7 +67,20 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
             continue;
         }
 
-        const value = decodeURIComponent(part.slice(separator + 1).trim());
+        const raw = part.slice(separator + 1).trim();
+
+        let value: string;
+
+        try {
+            value = decodeURIComponent(raw);
+        } catch {
+            // `decodeURIComponent` throws `URIError` on a malformed escape ("%",
+            // "%zz"). This cookie is attacker-writable (see above) and is read
+            // during render in every port, so letting that escape would take the
+            // whole sign-in card down to decorate a label. No badge is the right
+            // answer for a value we cannot read.
+            return undefined;
+        }
 
         return value === "" ? undefined : value;
     }
@@ -76,4 +88,25 @@ const readLastLoginMethod = (cookieName: string = LAST_LOGIN_METHOD_COOKIE): str
     return undefined;
 };
 
-export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, readLastLoginMethod };
+/**
+ * Snapshot pair for reading the badge **after** hydration.
+ *
+ * `getServerSnapshot` is what makes this SSR-safe: it answers `undefined` on the
+ * server AND for the hydrating client render, so both agree; React then
+ * re-reads `getSnapshot` once hydration is finished. The other ports mirror the
+ * same contract with their own post-mount primitive.
+ *
+ * `subscribe` is a no-op on purpose — better-auth writes the cookie during a
+ * sign-in navigation, so its value cannot change under a mounted card. It exists
+ * because `useSyncExternalStore` requires it.
+ *
+ * `getSnapshot` returns a string, and equal strings are `Object.is`-equal, so
+ * the store cannot drive the re-render loop that a fresh object would.
+ */
+const lastLoginMethodStore = {
+    getServerSnapshot: (): string | undefined => undefined,
+    getSnapshot: (): string | undefined => readLastLoginMethod(),
+    subscribe: (): (() => void) => () => undefined,
+};
+
+export { LAST_LOGIN_METHOD_COOKIE, LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, LAST_METHOD_PASSKEY, lastLoginMethodStore, readLastLoginMethod };

--- a/registry/auth-ui-vue/core/phone-number.ts
+++ b/registry/auth-ui-vue/core/phone-number.ts
@@ -119,7 +119,7 @@ const createPhoneVerifyController = (context: ControllerContext, options: PhoneV
                     context.onSessionChange?.();
 
                     if (options.updatePhoneNumber !== true) {
-                        context.nav.replace(context.redirects.afterSignIn);
+                        context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
                     }
 
                     return { status: "success", successMessage: context.localization.phoneVerified };

--- a/registry/auth-ui-vue/core/verify-email.ts
+++ b/registry/auth-ui-vue/core/verify-email.ts
@@ -16,6 +16,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import { createStore } from "./store";
 import type { Controller, FlowStatus, FormController } from "./types";
 import { email as emailValidator } from "./validators";
@@ -74,7 +75,7 @@ const createVerifyEmailController = (context: ControllerContext, options: Verify
 
             store.update({ status: "success" });
             context.onSessionChange?.();
-            context.nav.replace(context.redirects.afterSignIn);
+            context.nav.replace(resolveAfterSignIn(context.redirects.afterSignIn));
         } catch (error) {
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.verifyEmailFailed), status: "error" });

--- a/registry/auth-ui-vue/vue/MagicLinkCard.vue
+++ b/registry/auth-ui-vue/vue/MagicLinkCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import { isFlowEnabled } from "../core/flow-gate";
 import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
@@ -27,9 +27,15 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "magicLink", "MagicLinkCard"));
 const { actions, state } = useController(createMagicLinkController);
-// Read once at setup rather than from a watcher: it is a cookie, it is there
-// before the first paint, and it only picks a badge.
-const lastUsed = readLastLoginMethod();
+// Read after mount, not at setup: the server has no cookie, so a render-time
+// read is a hydration mismatch. See `lastLoginMethodStore`.
+const lastUsedAfterMount = ref<string | undefined>();
+
+onMounted(() => {
+    lastUsedAfterMount.value = readLastLoginMethod();
+});
+
+const lastUsed = computed(() => (context.value.plugins.lastLoginMethod ? lastUsedAfterMount.value : undefined));
 </script>
 
 <template>

--- a/registry/auth-ui-vue/vue/MagicLinkCard.vue
+++ b/registry/auth-ui-vue/vue/MagicLinkCard.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 
 import { isFlowEnabled } from "../core/flow-gate";
+import { LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import AuthCard from "./AuthCard.vue";
 import AuthLink from "./AuthLink.vue";
@@ -26,6 +27,9 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "magicLink", "MagicLinkCard"));
 const { actions, state } = useController(createMagicLinkController);
+// Read once at setup rather than from a watcher: it is a cookie, it is there
+// before the first paint, and it only picks a badge.
+const lastUsed = readLastLoginMethod();
 </script>
 
 <template>
@@ -33,7 +37,10 @@ const { actions, state } = useController(createMagicLinkController);
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
             <FormField :actions="actions" field="email" :fields="state.fields" :label="t.emailLabel" type="email" autoComplete="email" />
-            <SubmitButton :pending="state.status === 'submitting'">{{ t.magicLink }}</SubmitButton>
+            <SubmitButton :pending="state.status === 'submitting'">
+                {{ t.magicLink }}
+                <span v-if="lastUsed === LAST_METHOD_MAGIC_LINK" class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+            </SubmitButton>
         </form>
         <template #footer>
             <AuthLink :href="signInHref">{{ t.backToSignIn }}</AuthLink>

--- a/registry/auth-ui-vue/vue/SignInCard.vue
+++ b/registry/auth-ui-vue/vue/SignInCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
 import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
 import { createSignInController } from "../core/sign-in";
 import { signInWithSocial } from "../core/social";
@@ -27,9 +28,15 @@ withDefaults(
 const context = useAuthUIContextRef();
 const t = context.value.localization;
 const { actions, state } = useController(createSignInController);
-// Read once at setup rather than from a watcher: it is a cookie, it is there
-// before the first paint, and it only picks a badge.
-const lastUsed = readLastLoginMethod();
+// Read after mount, not at setup: the server has no cookie, so a render-time
+// read is a hydration mismatch. See `lastLoginMethodStore`.
+const lastUsedAfterMount = ref<string | undefined>();
+
+onMounted(() => {
+    lastUsedAfterMount.value = readLastLoginMethod();
+});
+
+const lastUsed = computed(() => (context.value.plugins.lastLoginMethod ? lastUsedAfterMount.value : undefined));
 
 const onSocial = (provider: string): void => {
     void signInWithSocial(context.value, provider);
@@ -43,7 +50,7 @@ const onSocial = (provider: string): void => {
         discovery answers, rather than being frozen at the value `setup()` saw.
     -->
     <AuthCard :title="t.signIn">
-        <SocialButtons :providers="context.social" :lastUsed="context.plugins.lastLoginMethod ? lastUsed : undefined" @select="onSocial" />
+        <SocialButtons :providers="context.social" :lastUsed="lastUsed" @select="onSocial" />
         <AnonymousButton v-if="context.plugins.anonymous" />
         <AuthDivider v-if="context.social.length > 0 && context.credentials" />
         <!--

--- a/registry/auth-ui-vue/vue/SignInCard.vue
+++ b/registry/auth-ui-vue/vue/SignInCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { readLastLoginMethod } from "../core/last-login-method";
+import { LAST_METHOD_EMAIL, readLastLoginMethod } from "../core/last-login-method";
 import { createSignInController } from "../core/sign-in";
 import { signInWithSocial } from "../core/social";
 import AnonymousButton from "./AnonymousButton.vue";
@@ -56,7 +56,11 @@ const onSocial = (provider: string): void => {
             <FormField :actions="actions" field="email" :fields="state.fields" :label="t.emailLabel" type="email" autoComplete="email" />
             <FormField :actions="actions" field="password" :fields="state.fields" :label="t.passwordLabel" type="password" autoComplete="current-password" />
             <AuthLink :href="forgotPasswordHref">{{ t.forgotPasswordLink }}</AuthLink>
-            <SubmitButton :pending="state.status === 'submitting'">{{ t.signIn }}</SubmitButton>
+            <SubmitButton :pending="state.status === 'submitting'">
+                {{ t.signIn }}
+                <!-- better-auth records a password sign-in as "email", so without this the badge is invisible for the most common route there is. -->
+                <span v-if="lastUsed === LAST_METHOD_EMAIL" class="lunora-auth-social__badge">{{ t.lastUsed }}</span>
+            </SubmitButton>
         </form>
         <template v-if="context.signUp" #footer>
             <AuthLink :href="signUpHref">{{ t.noAccount }}</AuthLink>


### PR DESCRIPTION
Eighteen defects found by an audit round scoped to code the previous sixteen rounds never opened: the `db.actions.*` durable-outbox replay path, the container Durable Object, and the framework adapters. **2 High, 7 Medium, 9 Low — 15 fixed here**, 3 accounted for below.

## High — both in the `db.actions.*` outbox replay handler

**Replay ran under whoever is signed in now, not who queued the write.**
`packages/db/src/define-collections.ts` replayed a persisted write with no identity check, so a write queued by user A drained under user B's bearer and passed *their* row-level security. Both siblings already gate it — the reserved `__lunora_outbox__` handler 50 lines below, and `@lunora/client`'s queue, which settles such a write `OFFLINE_IDENTITY_CHANGED` — and the docs state the invariant outright: "Identity is the trust boundary." The write is now dropped and reported, not replayed.

**Sharded collections wrote to the wrong Durable Object.**
The same call omitted `shardKey`, so every write on a `.shardBy()`'d collection went to the default shard while its `list` subscription read a different DO — committed, acked, and invisible to the reader. The shard is now captured at enqueue, not read at replay: a runtime `shardKey` (a tenant id from the session) would otherwise give a queued write whatever shard the app happens to be booted on when it drains.

## Medium

- **A `readyOn` timeout killed the container DO, and its error was unreachable.** `armHardTimeout` + a 30-second readiness wait ran inside the base's `blockConcurrencyWhile`. Two things follow, and the second is the worse one. A rejection there is unrecoverable — workerd aborts the object, drops every hibernating socket, and flattens the composed `LunoraError` to a plain `Error`. And `READINESS_TIMEOUT_MS` is *itself* 30s, sitting exactly on the platform's documented ceiling for that callback — ["there is a 30 second timeout applied when executing the callback. If this timeout is exceeded, the Durable Object will be reset"](https://developers.cloudflare.com/durable-objects/api/state/) — with three storage round-trips ahead of it. The reset therefore won the race, making the `LunoraError` naming the failing check, port and budget dead code on the one path it exists for. The same docs call blocking that gate on I/O an anti-pattern outright, which a `readyOn` probe is. Moved to the far side of the gate, the remedy `ShardHost.runSerialized` already documents; readiness still gates proxying, and the cap is now cited at the constant.
- **A drop on the *guarded* path reached no one.** The reserved handler threw bare, so the row rolled back with no UI signal — the exact failure `onWriteRejected` exists to prevent. Now reported, covering the server-coded rejection on that path too.
- **`?redirectTo=` was honoured by 9 sign-in doors and silently dropped by 3** (email-OTP, anonymous, phone-OTP). All 12 now resolve it, via the helper the other nine already used.
- **The last-used badge was React-only.** Five ports read the cookie and handed it to the social buttons alone, so a deployment whose users sign in with a password installed the plugin, paid for the cookie, and showed nothing. Ported to Vue, Svelte, Solid, Solid 2 and Angular.
- **The Astro docs told users to build a 404.** `createServerClient({ url: origin + "/_lunora/rpc" })` double-appends the RPC path.
- **The Nuxt docs still advertised the removed `prefix` option.**

## Low

`storage` docs claimed it backed only the mutation queue (it also backs the query cache, opted out separately); the Astro preload snippet used an attribute sink its own helper forbids; `rollout.gracePeriodSeconds` reached wrangler unvalidated while its sibling was checked; the playground had no `strictPort`, so a stale server slid to the studio's port and pointed auth callbacks at a different app; a `collection-options.ts` docblock described the inverse of what the code does; two stale comments in the playground worker.

## The port-parity test was itself half-vacuous

Fixing the badge exposed it: `TS_FILE_RE = /\.tsx?$/` meant the walk **never read a `.vue` or `.svelte` file**, so both ports registered as five plumbing modules and would have passed while consuming nothing. Widened to cover single-file components. This is the gate that exists to catch exactly that class.

## Not fixed here

- **The `SocketHost.idFor` stability gap lives only on `feat/platform-celld`**, not on `alpha` — out of scope for this branch, and recorded for that one.
- **The badge is a client-only render**, so it can differ between SSR and hydration. Real, but `SocialButtons` has the identical divergence in all six ports today: it's a package-wide property of the badge, not something this change introduces, and the fix is a six-port post-mount redesign. Recorded in the docblock alongside the precedent `theme-mode.ts` sets.

## Review round — one fix in this PR was worse than the bug it closed

A two-pass review plus CodeRabbit found that the identity gate above **destroys the queuing user's own offline writes on every reload**. `startOfflineExecutor` replays from its own constructor, before the app resolves its session and calls `setAuthToken`, so `currentIdentity()` is still `null` while the replay runs — and `NonRetriableError` is terminal, so the executor deletes the entry from durable storage. Offline write → reload → the optimistic row appears and vanishes.

The property being protected is "never replay as a **different** user". A null identity is *no* user, so there is nobody to impersonate and the write must be held. The verdict now belongs to the client (`replayIdentityVerdict` → `match` / `mismatch` / `unknown`): a mismatch stays terminal, an unknown identity throws a *retriable* error and the write waits. It also routes through the existing token-hash check, so a subject that resolves after its token stops looking like a different user — a bug whose own docblock records it having shipped once before. Both replay handlers share it, which closes the same bare comparison in the pre-existing reserved handler.

Also from the review:

- **`readyOn` did not gate concurrent requests.** The base commits the healthy state *inside* its start gate, before the probes run, so `containerFetch` skipped startup and proxied to a container that never reported ready — and a failed probe left that state committed. `afterContainerStart` is now single-flight (which also stops two concurrent starts each arming a hard-timeout schedule) and `containerFetch` awaits it.
- **The badge is now read after mount in all six ports**, so the first client render matches the server. Each port uses its own correct primitive — `useSyncExternalStore` with a server snapshot, `onMounted`, `onMount`, Solid 2's `onSettled`, `afterNextRender` — and a parity test asserts the *property* rather than a spelling.
- **The email and magic-link badges now honour `plugins.lastLoginMethod`**, which only the social buttons did. React had this shape already, so the PR had propagated it to five more ports.
- **A malformed cookie no longer takes the card down** — `decodeURIComponent` threw `URIError` during render on an attacker-writable value.
- Three copies of the same report-then-rethrow block collapsed into one helper (this PR had added the second); `CollectionWriteMetadata` replaced by a shared `WriteProvenance`; `verify-email.ts` now honours `redirectTo` with `invitations.ts` documented as deliberately not, enforced by a tripwire test.

**Not fixed, deliberately:** the badge markup is still inline per port rather than each having a `LastUsedBadge` primitive (a pure six-port refactor, no defect), and the caller's abort signal still is not forwarded to the readiness probe (raised by both reviewers, but equally true before this PR).

## Verification

All 14 gates green: `build:packages`, `api:check`, `lint:registry:sync`, `lint:generated`, `lint:types --no-cache`, `test --no-cache`, `test:coverage --no-cache`, `lint:prettier`, `lint:eslint`, `lint:package-json`, `vis secrets`, the workerd DO suite, `build:packages:prod`, `dist:check`.

Every fix was proven red-then-green against the unfixed source. One coverage run reported a `codegen` timeout with zero assertion failures in a package neither commit touches — re-run alone, 1,669 pass.

## Breaking

`db.actions.*` transactions now persist `{ identity, shardKey }` metadata. A write queued by an older build carries no stamp, has no provenance to check, and fails closed: it is dropped and surfaced on `onWriteRejected` rather than replayed under an unverified identity.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sign-in and magic-link forms now identify the previously used login method after loading.
  - Post-authentication redirects are resolved consistently across sign-in, verification, and anonymous flows.
  - Offline writes now preserve session and shard context, preventing stale mutations from being replayed incorrectly.
  - Storage configuration can independently control persistence and query caching.

- **Bug Fixes**
  - Malformed login-method data no longer causes errors.
  - Invalid rollout grace periods are rejected with validation errors.
  - Container restarts correctly rerun readiness checks.

- **Documentation**
  - Updated storage, authentication, SSR, preload, and React Native configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->