### PR TITLE
ci: run tests and lint on feat/** PRs, and lint the files the tools cover

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -66,6 +66,13 @@ api_surface:
 frontend_lintable:
     - "**/*.[tj]{s,sx}"
     - "**/*.{cts,mts,cjs,mjs}"
+    # eslint (`packages/auth-ui/eslint.config.js`), `lint:types` (vue-tsc /
+    # svelte-check) and prettier (prettier-plugin-svelte, and `vis.config.ts`
+    # formats md/mdx) all cover these, so a PR touching only them must not skip
+    # the three jobs that check them.
+    - "**/*.{vue,svelte,astro}"
+    - "**/*.{css,html}"
+    - "**/*.{md,mdx}"
     - "**/tsconfig*.json"
     - "**/package.json"
     # A project.json decides whether eslint runs a project at all — an nx-shaped

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@
 "on": # yamllint disable-line rule:truthy
     "pull_request":
         "types": ["opened", "synchronize", "reopened"]
-        "branches": ["main", "alpha", "next", "beta", "fix/**"]
+        "branches": ["main", "alpha", "next", "beta", "feat/**", "fix/**"]
     "merge_group": # yamllint disable-line rule:empty-values
     "workflow_dispatch": # yamllint disable-line rule:empty-values
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@
 "on": # yamllint disable-line rule:truthy
     "pull_request":
         "types": ["opened", "synchronize", "reopened"]
-        "branches": ["main", "alpha", "next", "beta", "fix/**"]
+        "branches": ["main", "alpha", "next", "beta", "feat/**", "fix/**"]
     "merge_group": # yamllint disable-line rule:empty-values
     "workflow_dispatch": # yamllint disable-line rule:empty-values
 


### PR DESCRIPTION
Two gate holes. Both are invisible in the worst way — the checks stay green.

## PRs based on a `feat/**` branch run neither Tests nor Lint

```
.github/workflows/test.yml:9  "branches": ["main", "alpha", "next", "beta", "fix/**"]
.github/workflows/lint.yml:7  "branches": ["main", "alpha", "next", "beta", "fix/**"]
```

`fix/**` is listed; `feat/**` is not. Stacked PRs are the normal working mode in this repo, and a PR whose base is a `feat/*` branch shows the reviewer a complete, all-green check list on which **zero tests and zero lint ran** — only CLA, triage, react-doctor and Semantic PR. #602 (base `feat/invite-only-admin-plane`) is in that state right now.

That `fix/**` was already there is precisely what made this hard to spot: the trigger list looks deliberate and complete.

## `frontend_lintable` misses every file type that isn't JS/TS

The filter gates the **eslint, types and prettier** jobs, but matched only `.ts/.tsx/.js/.jsx/.cts/.mts/.cjs/.mjs` plus a few manifests. All three tools cover considerably more:

- `packages/auth-ui/eslint.config.js` has `files: ["src/vue/**/*.vue", …]` and `files: ["src/svelte/**/*.svelte", …]` blocks
- `packages/auth-ui`'s `lint:types` runs `vue-tsc --noEmit -p tsconfig.vue.json && svelte-check --tsconfig ./tsconfig.svelte.json`
- `prettier.config.js` wires `prettier-plugin-svelte`, and `vis.config.ts` formats `**/*.{md,mdx}` and `**/*.svelte`

There are 57 `.vue` and 57 `.svelte` files under `packages/auth-ui/src` alone, mirrored again into `registry/`. A PR touching only those skipped all three jobs — and the violation then surfaced on somebody else's unrelated PR, as a `prettier --check` failure in a file they never opened.

## Verification

Ran the new globs through **picomatch 4.0.5 with `{dot: true}`**, which is how `dorny/paths-filter` invokes it:

```
MATCH  packages/auth-ui/src/vue/SignInCard.vue
MATCH  packages/auth-ui/src/svelte/SignInCard.svelte
MATCH  packages/auth-ui/src/styles/auth-ui.css
MATCH  packages/runtime/docs/index.mdx
MATCH  apps/docs/src/content/docs/tutorial/realtime-chat.mdx
MATCH  packages/auth-ui/src/react/form.tsx     ← still matches
MATCH  README.md
```

Both workflows re-parsed after the edit; `prettier --check` clean on all three files.

Nothing is currently failing because of this — `prettier --check` over the 248 tracked `.vue/.svelte/.css/.html` files passes today. This closes the hole before it bites, and unblocks the review signal on every stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated linting and testing to run for pull requests targeting feature branches.
  - Improved frontend file coverage so changes to Vue, Svelte, Astro, CSS, HTML, Markdown, and MDX files are included in quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->