### PR TITLE
fix(data): stop the mirror, rank pagination and three adapters returning wrong answers

### DIFF
--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -4208,6 +4208,12 @@ const rankKeyFromDocument: (index: RankIndexDefinitionLike, document_: Record<st
 };
 ```
 
+### `rankPivotConditionSql` (const)
+
+```ts
+const rankPivotConditionSql: (column: string, value: unknown, direction: "asc" | "desc", wantLater: boolean) => SQL | undefined;
+```
+
 ### `rankTableName` (const)
 
 ```ts

--- a/api-snapshots/sql-store.api.md
+++ b/api-snapshots/sql-store.api.md
@@ -52,7 +52,9 @@ interface SqlCtxExec {
 ```ts
 interface SqlDialect {
     affectedRows?: (result: SqlRunResult) => number;
-    columnType: (kind: string | undefined) => string;
+    columnType: (kind: string | undefined, options?: {
+        unique?: boolean;
+    }) => string;
     companionTypes: {
         autoincrementPrimaryKey: string;
         integer: string;
@@ -209,7 +211,7 @@ const sqliteDecode: (raw: unknown, kind: string | undefined) => unknown;
 ### `sqliteEncode` (const)
 
 ```ts
-const sqliteEncode: (value: unknown) => unknown;
+const sqliteEncode: (value: unknown, kind?: string) => unknown;
 ```
 
 ### `sweepSqlCdcRetention` (const)

--- a/packages/d1/__tests__/d1-ctx-db.decode.test.ts
+++ b/packages/d1/__tests__/d1-ctx-db.decode.test.ts
@@ -264,3 +264,88 @@ describe("d1 ctx-db — explicit-id tableName cache", () => {
         expect(reloaded?.["name"]).toBeUndefined();
     });
 });
+
+/**
+ * `v.any()`/`v.union()`/`v.from()` store in a TEXT column (`sqlAffinityForKind`
+ * sends all three there) whatever their runtime value happens to be. A number or
+ * boolean bound to that column is COERCED by the engine — `42` lands as the text
+ * `42.0` — and the decode has no declared type to reverse it with, so the caller
+ * read back a string. This goes through a REAL column: asserting on
+ * `sqliteDecode` alone, with a JS value never bound to one, is exactly what let
+ * it ship.
+ */
+describe("d1 ctx-db — a scalar in an untyped column", () => {
+    const untypedSchema: SchemaLike = {
+        tables: {
+            events: {
+                indexes: [],
+                shape: { anything: col("any"), either: col("union"), external: col("from") },
+            },
+        },
+    };
+
+    beforeEach(() => {
+        harness = createD1Exec();
+        harness.ddl(
+            `CREATE TABLE "events" (
+                "id" TEXT PRIMARY KEY,
+                "_creationTime" INTEGER NOT NULL,
+                "_version" INTEGER,
+                "anything" TEXT,
+                "either" TEXT,
+                "external" TEXT
+            )`,
+        );
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    const writer = (): DatabaseWriterLike => createD1ContextDatabase({ clock: () => FIXED_CLOCK, exec: harness.exec, schema: untypedSchema });
+
+    it("round-trips a number and a boolean with their JS types intact", async () => {
+        expect.assertions(3);
+
+        const database = writer();
+
+        await database.insert("events", { _id: "e1", anything: 42, either: true, external: 1.5 }, { allowExplicitId: true });
+
+        const row = await database.get("e1");
+
+        expect(row?.["anything"]).toBe(42);
+        expect(row?.["either"]).toBe(true);
+        expect(row?.["external"]).toBe(1.5);
+    });
+
+    it("leaves a string, an object and a bigint in the same column exactly as they were", async () => {
+        expect.assertions(3);
+
+        const database = writer();
+
+        await database.insert("events", { _id: "e2", anything: "42", either: { a: 1 }, external: 9_007_199_254_740_993n }, { allowExplicitId: true });
+
+        const row = await database.get("e2");
+
+        // A numeric-looking STRING must stay a string — that ambiguity is what
+        // makes a self-describing form necessary in the first place.
+        expect(row?.["anything"]).toBe("42");
+        expect(row?.["either"]).toStrictEqual({ a: 1 });
+        expect(row?.["external"]).toBe(9_007_199_254_740_993n);
+    });
+
+    it("survives a patch and a replace of the same column", async () => {
+        expect.assertions(2);
+
+        const database = writer();
+
+        await database.insert("events", { _id: "e3", anything: "start", either: 1, external: "x" }, { allowExplicitId: true });
+        await database.patch("e3", { anything: 7 });
+
+        await expect(database.get("e3").then((row) => row?.["anything"])).resolves.toBe(7);
+
+        await database.replace("e3", { anything: false, either: 2, external: "y" });
+
+        await expect(database.get("e3").then((row) => row?.["anything"])).resolves.toBe(false);
+    });
+});

--- a/packages/d1/__tests__/d1-ctx-db.rank.test.ts
+++ b/packages/d1/__tests__/d1-ctx-db.rank.test.ts
@@ -36,7 +36,9 @@ const makeSchema = (...indexes: RankIndexDefinitionLike[]): SchemaLike => {
                 shape: {
                     archived: col("boolean"),
                     channelId: col("string"),
-                    score: col("number"),
+                    // Nullable: an unscored row is what puts a NULL in the rank
+                    // companion's sort column.
+                    score: { _meta: { column: { notNull: false } }, kind: "number" },
                 },
             },
         },
@@ -142,6 +144,91 @@ describe("d1 rankIndex parity", () => {
 
         expect(page.page.map((document_) => document_["_id"])).toEqual(["m2", "m3", "m1"]);
         expect(page.isDone).toBe(true);
+    });
+
+    // The D1 twin of `@lunora/shard-engine`'s nullable-sort-column suite. A rank
+    // sort column genuinely holds NULL (`serializeColumnValue(row[field] ?? null)`),
+    // and `col < NULL` / `col > NULL` are UNKNOWN, so a bare comparator at the
+    // seek pivot dropped every row from the page that first reached the NULL
+    // group and made `rank()` answer against a partial count.
+    describe("a nullable sort column", () => {
+        // 5 scored rows and 7 unscored, paged 4 at a time: the NULL group spans
+        // two page boundaries, so a seek that cannot resume from inside it loses
+        // rows a smaller fixture would never miss.
+        const seedWithNulls = async (writer: DatabaseWriterLike): Promise<void> => {
+            for (let index = 0; index < 5; index += 1) {
+                // eslint-disable-next-line no-await-in-loop -- sequential ordered inserts into the same DB
+                await writer.insert("messages", { _id: `s${String(index)}`, archived: false, channelId: "c1", score: index * 10 }, { allowExplicitId: true });
+            }
+
+            for (let index = 0; index < 7; index += 1) {
+                // eslint-disable-next-line no-await-in-loop -- sequential ordered inserts into the same DB
+                await writer.insert(
+                    "messages",
+                    // An unscored row IS a NULL sort column — the case under test.
+                    { _id: `n${String(index)}`, archived: false, channelId: "c1", score: null },
+                    { allowExplicitId: true },
+                );
+            }
+        };
+
+        const drain = async (writer: DatabaseWriterLike, index: string): Promise<string[]> => {
+            const ids: string[] = [];
+            let cursor: null | string | undefined;
+
+            for (let page = 0; page < 10; page += 1) {
+                // eslint-disable-next-line no-await-in-loop -- pagination is inherently sequential
+                const result = await writer.rankPage("messages", index, { cursor, take: 4 });
+
+                ids.push(...result.page.map((document_) => document_["_id"] as string));
+
+                if (result.isDone) {
+                    return ids;
+                }
+
+                cursor = result.continueCursor;
+            }
+
+            throw new Error("rankPage never reported isDone");
+        };
+
+        it("pages through the NULL group descending without losing a row", async () => {
+            expect.assertions(2);
+
+            const writer = await setupWriter(makeSchema(byScoreDesc));
+
+            await seedWithNulls(writer);
+
+            const ids = await drain(writer, "leaderboard");
+
+            expect(ids).toStrictEqual(["s4", "s3", "s2", "s1", "s0", "n0", "n1", "n2", "n3", "n4", "n5", "n6"]);
+            expect(new Set(ids).size).toBe(12);
+        });
+
+        it("pages through the NULL group ascending without losing a row", async () => {
+            expect.assertions(2);
+
+            const writer = await setupWriter(makeSchema({ name: "byScore", on: "messages", sortBy: [{ direction: "asc", field: "score" }] }));
+
+            await seedWithNulls(writer);
+
+            const ids = await drain(writer, "byScore");
+
+            expect(ids).toStrictEqual(["n0", "n1", "n2", "n3", "n4", "n5", "n6", "s0", "s1", "s2", "s3", "s4"]);
+            expect(new Set(ids).size).toBe(12);
+        });
+
+        it("ranks a NULL-valued row where the ordering actually puts it", async () => {
+            expect.assertions(3);
+
+            const writer = await setupWriter(makeSchema(byScoreDesc));
+
+            await seedWithNulls(writer);
+
+            await expect(writer.rank("messages", "leaderboard", { row: "s4" })).resolves.toStrictEqual({ position: 1, total: 12 });
+            await expect(writer.rank("messages", "leaderboard", { row: "n0" })).resolves.toStrictEqual({ position: 6, total: 12 });
+            await expect(writer.rank("messages", "leaderboard", { row: "n6" })).resolves.toStrictEqual({ position: 12, total: 12 });
+        });
     });
 
     it("rankPage scoped by partition `where`", async () => {

--- a/packages/d1/__tests__/introspect.test.ts
+++ b/packages/d1/__tests__/introspect.test.ts
@@ -399,4 +399,84 @@ describe("d1 introspect", () => {
             await expect(facetGlobalColumn(harness.exec, schema, { column: "k", table: "_cf_KV" })).rejects.toMatchObject({ code: "UNKNOWN_TABLE" });
         });
     });
+
+    /**
+     * Only a `.global()` table lives in D1, so a same-named `.shardBy()`/root
+     * table in the schema describes a Durable Object's storage — not the D1
+     * table the browser is reading. Treating that name as "declared" decoded
+     * better-auth's `user` table as a `.global()` row: redaction never ran, and
+     * the two guards that exist because redaction is imperfect (the eq-filter
+     * equality oracle and the facet's masked bucket) went inert at the same time.
+     */
+    describe("a schema table that shadows an external D1 table", () => {
+        // `user` is declared shard-local here — better-auth's real D1 `user`
+        // table is what the browser reads.
+        const shadowing: SchemaLike = {
+            tables: {
+                ...schema.tables,
+                user: { indexes: [], shape: { email: col("string") } },
+            },
+        };
+
+        it("still redacts the external table's sensitive columns", async () => {
+            expect.assertions(3);
+
+            const page = await readGlobalTablePage(harness.exec, shadowing, { table: "user" });
+
+            expect(page.columns).toEqual(["id", "email", "passwordHash"]);
+            expect(page.rows[0]).toEqual({ email: "ada@example.com", id: "u1", passwordHash: "•••" });
+            expect(JSON.stringify(page.rows)).not.toContain("super-secret-hash");
+        });
+
+        it("still refuses an eq filter on a redacted column", async () => {
+            expect.assertions(1);
+
+            await expect(
+                readGlobalTablePage(harness.exec, shadowing, { filters: [{ column: "passwordHash", value: "super-secret-hash" }], table: "user" }),
+            ).rejects.toMatchObject({ code: "FORBIDDEN", status: 403 });
+        });
+
+        it("still collapses a facet over a redacted column to one masked bucket", async () => {
+            expect.assertions(1);
+
+            const facet = await facetGlobalColumn(harness.exec, shadowing, { column: "passwordHash", table: "user" });
+
+            expect(facet.values).toEqual([{ count: 1, value: "•••" }]);
+        });
+    });
+
+    describe("deterministic ordering", () => {
+        it("orders the page read so a row cannot appear on two pages or none", async () => {
+            expect.assertions(3);
+
+            await harness.exec.run(`INSERT INTO "organizations" VALUES ('o3', 3, 'Initech', 1)`, []);
+
+            const first = await readGlobalTablePage(harness.exec, schema, { limit: 2, offset: 0, table: "organizations" });
+            const second = await readGlobalTablePage(harness.exec, schema, { limit: 2, offset: 2, table: "organizations" });
+
+            // `LIMIT/OFFSET` with no ORDER BY leaves the row order to the plan,
+            // so the two pages could overlap or skip. Keyed on the TEXT primary
+            // key, they partition the table.
+            expect(first.rows.map((row) => row["_id"])).toStrictEqual(["o1", "o2"]);
+            expect(second.rows.map((row) => row["_id"])).toStrictEqual(["o3"]);
+            expect(new Set([...first.rows, ...second.rows].map((row) => row["_id"])).size).toBe(3);
+        });
+
+        it("breaks facet count ties on the value, so the top-N cut is stable", async () => {
+            expect.assertions(2);
+
+            // Three distinct values, each seen once: on `count DESC` alone which
+            // two survive a `limit: 2` is up to the planner, and so is whether
+            // the result claims to be truncated.
+            await harness.exec.run(`INSERT INTO "plans" VALUES ('p2', 2, 'pro'), ('p3', 3, 'enterprise')`, []);
+
+            const facet = await facetGlobalColumn(harness.exec, schema, { column: "tier", limit: 2, table: "plans" });
+
+            expect(facet.values).toStrictEqual([
+                { count: 1, value: "enterprise" },
+                { count: 1, value: "free" },
+            ]);
+            expect(facet.truncated).toBe(true);
+        });
+    });
 });

--- a/packages/d1/__tests__/migration-runner.test.ts
+++ b/packages/d1/__tests__/migration-runner.test.ts
@@ -242,6 +242,22 @@ describe("migrationRunner", () => {
         expect(result.applied.map((m) => m.version)).toEqual([1]);
     });
 
+    it("permits semicolons inside bracket- and backtick-quoted identifiers", async () => {
+        expect.assertions(2);
+
+        const database = await createDatabase();
+        // SQLite accepts both quotings (for MS-Access and MySQL compatibility);
+        // the lexer modelled only `'…'` and `"…"`, so a `;` inside either read as
+        // a terminator and the migration was rejected as multi-statement.
+        const bracket = new MigrationRunner(database, [{ name: "bracket", sql: `CREATE TABLE [a;b] (id INTEGER);`, version: 1 }]);
+
+        await expect(bracket.run()).resolves.toMatchObject({ applied: [{ version: 1 }] });
+
+        const backtick = new MigrationRunner(await createDatabase(), [{ name: "backtick", sql: "CREATE TABLE `c;d` (id INTEGER);", version: 1 }]);
+
+        await expect(backtick.run()).resolves.toMatchObject({ applied: [{ version: 1 }] });
+    });
+
     // Finding 2: a trailing comment after the terminator used to survive the
     // regex trim and reach D1 (which rejects content past the statement). The
     // body submitted must be the bare statement — no `;`, no trailing comment.

--- a/packages/d1/src/dialect.ts
+++ b/packages/d1/src/dialect.ts
@@ -27,9 +27,11 @@ export type SqlAffinity = "BLOB" | "INTEGER" | "REAL" | "TEXT";
  * - `boolean` → INTEGER (stored as 1/0)
  * - `number`/`timestamp`/`date` → REAL (numeric, never coerced to text)
  * - `bytes` → BLOB
- * - everything else → TEXT — string/id/literal, `bigint` (serialized as a
- * decimal string), and object/array/record/union/any (JSON). A numeric affinity
- * would coerce a numeric-looking string and corrupt the decode.
+ * - everything else → TEXT — string/id/literal, `bigint` (the order-preserving
+ * 40-character key `bigintSqlKey` builds: a sign character plus 39 digits, so
+ * text comparison agrees with numeric comparison and an index range scan is
+ * correct), and object/array/record/union/any (JSON). A numeric affinity would
+ * coerce a numeric-looking string and corrupt the decode.
  */
 export const sqlAffinityForKind = (kind: string | undefined): SqlAffinity => {
     switch (kind) {

--- a/packages/d1/src/introspect.ts
+++ b/packages/d1/src/introspect.ts
@@ -136,6 +136,26 @@ const isInternalTable = (name: string): boolean => INTERNAL_TABLE.test(name);
 /** Column names whose values are redacted in non-schema tables, so auth secrets can't leak through the browser. */
 const SENSITIVE_COLUMN = /password|secret|token|hash|salt|credential/iu;
 
+/**
+ * The schema definition that describes THIS D1 table, or `undefined` when the
+ * table is not one the schema stores here.
+ *
+ * `shardMode?.kind === "global"` is the whole test, and it is not a formality:
+ * only a `.global()` table lives in D1, so a same-named `.shardBy()`/root table
+ * describes a Durable Object's storage, not this one. A schema declaring (say) a
+ * shard-local `user` alongside better-auth's D1 `user` table made every read of
+ * the D1 table take the schema branch — decoding it as a `.global()` row, so
+ * {@link SENSITIVE_COLUMN} redaction never ran, and simultaneously turning off
+ * the two guards that exist because redaction is imperfect
+ * ({@link buildEqPredicate}'s equality oracle and {@link facetGlobalColumn}'s
+ * masked bucket). Same test the admin export/import path applies.
+ */
+const globalTableDefinition = (schema: SchemaLike, table: string): SchemaLike["tables"][string] | undefined => {
+    const definition = schema.tables[table];
+
+    return definition?.shardMode?.kind === "global" ? definition : undefined;
+};
+
 /** List every browsable D1 table name (internal/companion tables excluded), sorted. */
 const listTableNames = async (exec: D1Exec): Promise<string[]> => {
     const rows = await exec.all("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name", []);
@@ -174,7 +194,7 @@ const countRows = async (exec: D1Exec, quotedTable: string, whereSql = "", where
  * resolves the storage name so a quoted identifier never leaks `_id`.
  */
 const physicalColumnName = (schema: SchemaLike, table: string, displayColumn: string): string =>
-    schema.tables[table] !== undefined && displayColumn === "_id" ? "id" : displayColumn;
+    globalTableDefinition(schema, table) !== undefined && displayColumn === "_id" ? "id" : displayColumn;
 
 /**
  * Compile a list of eq constraints into a bound ` WHERE …` fragment for the
@@ -207,7 +227,7 @@ const buildEqPredicate = (
         // value matched, bypassing the '•••' redaction. Reject it, mirroring the
         // facet path's masked-bucket collapse. Declared `.global()` tables (whose
         // values are not redacted) intentionally bypass this guard.
-        if (schema.tables[table] === undefined && SENSITIVE_COLUMN.test(filter.column)) {
+        if (globalTableDefinition(schema, table) === undefined && SENSITIVE_COLUMN.test(filter.column)) {
             throw new LunoraError("FORBIDDEN", `cannot filter on a redacted column: ${filter.column}`, { status: 403 });
         }
 
@@ -231,7 +251,7 @@ const buildEqPredicate = (
  * columns, redacting obviously-sensitive values.
  */
 const decodeRow = (schema: SchemaLike, table: string, row: Record<string, unknown>): Record<string, unknown> => {
-    const definition = schema.tables[table];
+    const definition = globalTableDefinition(schema, table);
 
     if (definition) {
         return decodeGlobalRow(definition, row);
@@ -252,7 +272,7 @@ const decodeRow = (schema: SchemaLike, table: string, row: Record<string, unknow
  * table uses its real physical columns from `PRAGMA table_info`.
  */
 const resolveColumns = async (exec: D1Exec, schema: SchemaLike, table: string): Promise<string[]> => {
-    const definition = schema.tables[table];
+    const definition = globalTableDefinition(schema, table);
 
     if (definition) {
         return ["_id", "_creationTime", ...Object.keys(definition.shape)];
@@ -273,7 +293,7 @@ const resolveColumns = async (exec: D1Exec, schema: SchemaLike, table: string): 
  * are no foreign keys, so callers can omit the field rather than send `{}`.
  */
 const resolveReferences = async (exec: D1Exec, schema: SchemaLike, table: string): Promise<Record<string, string> | undefined> => {
-    if (schema.tables[table]) {
+    if (globalTableDefinition(schema, table)) {
         return undefined;
     }
 
@@ -335,7 +355,14 @@ const readGlobalTablePage = async (exec: D1Exec, schema: SchemaLike, options: Re
     const { params: whereParams, where: whereSql } = buildEqPredicate(schema, table, columns, options.filters);
 
     const total = await countRows(exec, quoted, whereSql, whereParams);
-    const raw = await exec.all(`SELECT * FROM ${quoted}${whereSql} LIMIT ? OFFSET ?`, [...whereParams, limit, offset]);
+    // `LIMIT ? OFFSET ?` with no ORDER BY is not pagination: SQLite may return
+    // the rows in whatever order the plan produces, and two identical requests
+    // are free to disagree — so a row can show up on two pages, or on none. The
+    // shard browser keyset-paginates for the same reason. Every `.global()`
+    // table has a TEXT PRIMARY KEY `id`; an external table without one orders by
+    // `rowid`, which SQLite gives every ordinary table.
+    const orderColumn = columns.includes("_id") || columns.includes("id") ? quoteIdentifier("id") : "rowid";
+    const raw = await exec.all(`SELECT * FROM ${quoted}${whereSql} ORDER BY ${orderColumn} LIMIT ? OFFSET ?`, [...whereParams, limit, offset]);
     // Wire-encode on the way out. `decodeGlobalRow` reverses the storage form,
     // so a `v.bigint()` column is a real `bigint` and a `v.bytes()` column an
     // `ArrayBuffer` — the browser's transport is JSON, where the former throws
@@ -387,7 +414,7 @@ const facetGlobalColumn = async (exec: D1Exec, schema: SchemaLike, options: Face
 
     // Faceting a sensitive column on an external table would expose the very
     // values the page browser redacts — collapse it to one masked bucket instead.
-    if (schema.tables[table] === undefined && SENSITIVE_COLUMN.test(column)) {
+    if (globalTableDefinition(schema, table) === undefined && SENSITIVE_COLUMN.test(column)) {
         const total = await countRows(exec, quoted, whereSql, whereParams);
 
         return { truncated: false, values: total === 0 ? [] : [{ count: total, value: "•••" }] };
@@ -396,11 +423,15 @@ const facetGlobalColumn = async (exec: D1Exec, schema: SchemaLike, options: Face
     const limit = clamp(Math.trunc(options.limit ?? DEFAULT_FACET_LIMIT), 1, MAX_FACET_LIMIT);
     const physical = quoteIdentifier(physicalColumnName(schema, table, column));
 
-    // Over-fetch one row past the cap to detect (and report) truncation.
-    const rows = await exec.all(`SELECT ${physical} AS value, COUNT(*) AS count FROM ${quoted}${whereSql} GROUP BY ${physical} ORDER BY count DESC LIMIT ?`, [
-        ...whereParams,
-        limit + 1,
-    ]);
+    // Over-fetch one row past the cap to detect (and report) truncation. The
+    // `${physical} ASC` tiebreaker is what makes the cut deterministic: on
+    // `count DESC` alone, which of several equally-frequent values land in the
+    // top-N — and therefore whether the result reports `truncated` — is up to
+    // the planner, so two identical requests could answer differently.
+    const rows = await exec.all(
+        `SELECT ${physical} AS value, COUNT(*) AS count FROM ${quoted}${whereSql} GROUP BY ${physical} ORDER BY count DESC, ${physical} ASC LIMIT ?`,
+        [...whereParams, limit + 1],
+    );
 
     const truncated = rows.length > limit;
     const kept = truncated ? rows.slice(0, limit) : rows;

--- a/packages/d1/src/introspect.ts
+++ b/packages/d1/src/introspect.ts
@@ -336,6 +336,36 @@ const listGlobalTables = async (exec: D1Exec, schema: SchemaLike): Promise<Globa
 };
 
 /**
+ * The column a page is ordered by, so `LIMIT`/`OFFSET` is real pagination.
+ *
+ * The two table kinds name their columns differently and cannot share a test:
+ * {@link resolveColumns} returns DISPLAY names for a `.global()` table (`_id`,
+ * whose physical column is `id`) and PHYSICAL names for an external one. Keying
+ * off `columns.includes("_id")` therefore ordered an external table that happens
+ * to have a literal `_id` column by an `id` it does not have.
+ *
+ * External tables are asked for their own primary key instead, which also covers
+ * `WITHOUT ROWID` — those have no `rowid` to fall back on.
+ */
+const pageOrderKey = async (exec: D1Exec, schema: SchemaLike, table: string, columns: ReadonlyArray<string>): Promise<string> => {
+    if (globalTableDefinition(schema, table) !== undefined) {
+        return quoteIdentifier("id");
+    }
+
+    const info = await exec.all(`PRAGMA table_info(${quoteIdentifier(table)})`, []);
+    const primaryKey = info.filter((column) => Number(column["pk"] ?? 0) > 0);
+
+    if (primaryKey.length === 1) {
+        return quoteIdentifier(String(primaryKey[0]?.["name"]));
+    }
+
+    // A composite key orders by no single column; `rowid` is stable and every
+    // ordinary table has one. A `WITHOUT ROWID` table always declares a primary
+    // key, so it took the branch above.
+    return columns.includes("id") ? quoteIdentifier("id") : "rowid";
+};
+
+/**
  * Read a page of rows from one D1 table. The table is validated against the live
  * browsable-table list before its name is interpolated, so this can't be coerced
  * into reading an internal table or injecting SQL. `limit` is clamped to
@@ -358,10 +388,9 @@ const readGlobalTablePage = async (exec: D1Exec, schema: SchemaLike, options: Re
     // `LIMIT ? OFFSET ?` with no ORDER BY is not pagination: SQLite may return
     // the rows in whatever order the plan produces, and two identical requests
     // are free to disagree — so a row can show up on two pages, or on none. The
-    // shard browser keyset-paginates for the same reason. Every `.global()`
-    // table has a TEXT PRIMARY KEY `id`; an external table without one orders by
-    // `rowid`, which SQLite gives every ordinary table.
-    const orderColumn = columns.includes("_id") || columns.includes("id") ? quoteIdentifier("id") : "rowid";
+    // shard browser keyset-paginates for the same reason. See `pageOrderKey`
+    // for how the ordering column is chosen for each table kind.
+    const orderColumn = await pageOrderKey(exec, schema, table, columns);
     const raw = await exec.all(`SELECT * FROM ${quoted}${whereSql} ORDER BY ${orderColumn} LIMIT ? OFFSET ?`, [...whereParams, limit, offset]);
     // Wire-encode on the way out. `decodeGlobalRow` reverses the storage form,
     // so a `v.bigint()` column is a real `bigint` and a `v.bytes()` column an

--- a/packages/d1/src/migration-runner.ts
+++ b/packages/d1/src/migration-runner.ts
@@ -118,6 +118,12 @@ const assertSingleStatement = (migration: Migration): number | undefined => {
     const isTrigger = CREATE_TRIGGER_RE.test(text.slice(LEADING_TRIVIA_RE.exec(text)?.[0].length ?? 0));
     let inSingle = false;
     let inDouble = false;
+    // SQLite's two other identifier quotings, which it accepts for MySQL and
+    // MS-Access compatibility. Without them a `;` inside `[a;b]` or `` `a;b` ``
+    // read as a statement terminator and the migration was false-rejected as
+    // "more than one SQL statement".
+    let inBracket = false;
+    let inBacktick = false;
     let inLineComment = false;
     let inBlockComment = false;
     let terminatorIndex: number | undefined;
@@ -168,6 +174,27 @@ const assertSingleStatement = (migration: Migration): number | undefined => {
                     index += 1;
                 } else {
                     inDouble = false;
+                }
+            }
+
+            continue;
+        }
+
+        // A bracket-quoted identifier has no escape: it ends at the first `]`.
+        if (inBracket) {
+            if (character === "]") {
+                inBracket = false;
+            }
+
+            continue;
+        }
+
+        if (inBacktick) {
+            if (character === "`") {
+                if (next === "`") {
+                    index += 1;
+                } else {
+                    inBacktick = false;
                 }
             }
 
@@ -233,6 +260,16 @@ const assertSingleStatement = (migration: Migration): number | undefined => {
 
         if (character === '"') {
             inDouble = true;
+            continue;
+        }
+
+        if (character === "[") {
+            inBracket = true;
+            continue;
+        }
+
+        if (character === "`") {
+            inBacktick = true;
             continue;
         }
 

--- a/packages/hyperdrive/__tests__/global-dialect.test.ts
+++ b/packages/hyperdrive/__tests__/global-dialect.test.ts
@@ -103,6 +103,21 @@ describe("mysqlDialect", () => {
         expect(postgresDialect.indexKeyPrefix).toBeUndefined();
     });
 
+    it("bounds a `.unique()` character column so InnoDB indexes it whole", () => {
+        expect.assertions(4);
+
+        // A prefixed UNIQUE index constrains the PREFIX, not the value: two
+        // distinct 200-character emails agreeing on their first 191 characters
+        // raised ER_DUP_ENTRY and surfaced as "unique constraint violation".
+        // VARCHAR(768) is 3072 bytes under utf8mb4 — exactly InnoDB's
+        // single-column key limit — so the index covers the whole value.
+        expect(mysqlDialect.columnType("string", { unique: true })).toBe("VARCHAR(768) COLLATE utf8mb4_0900_bin");
+        expect(mysqlDialect.columnType("bytes", { unique: true })).toBe("VARBINARY(768)");
+        // Already indexable whole — unchanged.
+        expect(mysqlDialect.columnType("number", { unique: true })).toBe("DOUBLE");
+        expect(mysqlDialect.columnType("bigint", { unique: true })).toBe("VARCHAR(64) COLLATE utf8mb4_0900_bin");
+    });
+
     it("keeps a composite [string, string] index within InnoDB's 3072-byte key limit", () => {
         expect.assertions(1);
 

--- a/packages/hyperdrive/__tests__/global-wrappers.test.ts
+++ b/packages/hyperdrive/__tests__/global-wrappers.test.ts
@@ -3,8 +3,9 @@ import { runSqlGlobalTableMigrations } from "@lunora/sql-store";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createMysqlGlobalCtxDb, createPostgresGlobalCtxDb } from "../src/global";
-import { postgresDialect } from "../src/global-dialect";
+import { mysqlDialect, postgresDialect } from "../src/global-dialect";
 import type { Mysql2Execute } from "../src/global-exec";
+import { buildMysqlExec } from "../src/global-exec";
 import type { PgliteHarness } from "./_helpers/pglite-exec";
 import createPgliteHarness from "./_helpers/pglite-exec";
 
@@ -64,27 +65,27 @@ describe("createPostgresGlobalCtxDb", () => {
     });
 });
 
-describe("createMysqlGlobalCtxDb", () => {
-    /** A never-connected `mysql2/promise` double that records what it is asked to run. */
-    const recordingConnection = (): { calls: string[]; connection: Mysql2Execute } => {
-        const calls: string[] = [];
+/** A never-connected `mysql2/promise` double that records what it is asked to run. */
+const recordingConnection = (): { calls: string[]; connection: Mysql2Execute } => {
+    const calls: string[] = [];
 
-        return {
-            calls,
-            connection: {
-                // `CLIENT_FOUND_ROWS`; without it `buildMysqlExec` throws before recording anything.
-                config: { clientFlags: 0x00_00_00_02 },
-                execute: async (sql: string) => {
-                    calls.push(sql);
+    return {
+        calls,
+        connection: {
+            // `CLIENT_FOUND_ROWS`; without it `buildMysqlExec` throws before recording anything.
+            config: { clientFlags: 0x00_00_00_02 },
+            execute: async (sql: string) => {
+                calls.push(sql);
 
-                    return /^\s*select/i.test(sql)
-                        ? ([[], undefined] as [Record<string, unknown>[], undefined])
-                        : ([{ affectedRows: 1 }, undefined] as [Record<string, unknown>, undefined]);
-                },
+                return /^\s*select/i.test(sql)
+                    ? ([[], undefined] as [Record<string, unknown>[], undefined])
+                    : ([{ affectedRows: 1 }, undefined] as [Record<string, unknown>, undefined]);
             },
-        };
+        },
     };
+};
 
+describe("createMysqlGlobalCtxDb", () => {
     it("renders MySQL, not Postgres, through the connection it was handed", async () => {
         expect.assertions(3);
 
@@ -98,5 +99,60 @@ describe("createMysqlGlobalCtxDb", () => {
         expect(insert).toContain("`todos`");
         expect(insert).toContain("?");
         expect(insert).not.toMatch(/\$\d/);
+    });
+});
+
+/**
+ * A UNIQUE index declared in `definition.indexes` has to cover its column in
+ * FULL, exactly as a `.unique()` column does. It did not: `indexRef` consulted
+ * only the validator's own flag, so a declared unique index on a plain text
+ * field kept `LONGTEXT` + a `(191)` key prefix and enforced uniqueness of the
+ * first 191 characters — the same false `ER_DUP_ENTRY` that bounding
+ * `.unique()` columns was meant to end, reachable through the other producer.
+ */
+describe("mySQL unique indexes cover the whole value", () => {
+    const schemaWithUniqueIndex = {
+        tables: {
+            members: {
+                indexes: [{ fields: ["email"], name: "by_email", unique: true }],
+                shape: { email: col("string"), name: col("string") },
+                shardMode: { kind: "global" },
+            },
+        },
+    } as unknown as SchemaLike;
+
+    it("declares a single-column unique index's column bounded, and indexes it without a key prefix", async () => {
+        expect.assertions(3);
+
+        const { calls, connection } = recordingConnection();
+
+        await runSqlGlobalTableMigrations(buildMysqlExec(connection), schemaWithUniqueIndex, mysqlDialect);
+
+        const create = calls.find((sql) => /create table/i.test(sql));
+        const index = calls.find((sql) => /create[\s\S]*index/i.test(sql) && sql.includes("by_email"));
+
+        expect(create).toContain("VARCHAR(768)");
+        expect(index).toContain("`email`");
+        // The prefix is what constrained the first 191 characters instead of the value.
+        expect(index).not.toContain("(191)");
+    });
+
+    it("refuses a composite unique index it could only index by prefix", async () => {
+        expect.assertions(1);
+
+        const { connection } = recordingConnection();
+        const composite = {
+            tables: {
+                members: {
+                    indexes: [{ fields: ["email", "name"], name: "by_email_name", unique: true }],
+                    shape: { email: col("string"), name: col("string") },
+                    shardMode: { kind: "global" },
+                },
+            },
+        } as unknown as SchemaLike;
+
+        // Bounding both to 768 characters would overflow InnoDB's 3072-byte key,
+        // and prefixing them would silently constrain something else.
+        await expect(runSqlGlobalTableMigrations(buildMysqlExec(connection), composite, mysqlDialect)).rejects.toThrow(/composite unique index/);
     });
 });

--- a/packages/hyperdrive/__tests__/pg-vector.test.ts
+++ b/packages/hyperdrive/__tests__/pg-vector.test.ts
@@ -218,6 +218,38 @@ describe("createPgVectorIndex", () => {
         await expect(store.query([1, 0, 0], { filter: { size: 1n } })).rejects.toThrow(/bigint/);
     });
 
+    /**
+     * The fail-open shape the guard above could not see: `Object.entries` is
+     * `[]` for a `Map`, a `Set`, a `Date` or a class instance, so walking one
+     * inspects nothing and rejects nothing, and `JSON.stringify` turns it into
+     * `{}` — a containment document EVERY row with metadata matches. At the top
+     * level it is worse still: `Object.keys(new Map())` is empty, so the
+     * length-keyed gate skipped both the guard and the containment clause and
+     * issued an unfiltered query across every tenant.
+     */
+    it("rejects a non-plain object anywhere in the filter rather than matching every tenant", async () => {
+        expect.assertions(6);
+
+        const store = index();
+
+        await store.upsert([
+            { id: "mine", metadata: { tenant: "t1" }, values: [1, 0, 0] },
+            { id: "theirs", metadata: { tenant: "t2" }, values: [1, 0, 0] },
+        ]);
+
+        await expect(store.query([1, 0, 0], { filter: { tenant: new Map([["id", "t1"]]) } })).rejects.toThrow(/Map/);
+        await expect(store.query([1, 0, 0], { filter: { tenant: new Set(["t1"]) } })).rejects.toThrow(/Set/);
+        await expect(store.query([1, 0, 0], { filter: { since: new Date(0) } })).rejects.toThrow(/Date/);
+        await expect(store.query([1, 0, 0], { filter: { tags: [new Map()] } })).rejects.toThrow(/Map/);
+        // The filter ITSELF, where no own enumerable key exists to count.
+        await expect(store.query([1, 0, 0], { filter: new Map([["tenant", "t1"]]) as unknown as Record<string, unknown> })).rejects.toThrow(/Map/);
+
+        // A plain nested object is still fine.
+        const ok = await store.query([1, 0, 0], { filter: { tenant: "t1" }, topK: 5 });
+
+        expect(ok.matches.map((match) => match.id)).toStrictEqual(["mine"]);
+    });
+
     it("omits metadata and values unless the caller asks", async () => {
         expect.assertions(4);
 

--- a/packages/hyperdrive/src/global-dialect.ts
+++ b/packages/hyperdrive/src/global-dialect.ts
@@ -85,8 +85,45 @@ const MYSQL_COLLATION = "utf8mb4_0900_bin";
 /** A character column's declaration with {@link MYSQL_COLLATION} pinned onto it. */
 const collated = (type: string): string => `${type} COLLATE ${MYSQL_COLLATION}`;
 
-/** MySQL storage type for a validator `kind`. Shared by `columnType` and the index-prefix decision below. */
-const mysqlColumnType = (kind: string | undefined): string => {
+/**
+ * MySQL storage type for a validator `kind`. Shared by `columnType` and the
+ * index-prefix decision below.
+ *
+ * `unique` bounds a character column so InnoDB can index it in FULL. The
+ * alternative is what shipped: `LONGTEXT` cannot be indexed without a key
+ * prefix, `indexKeyPrefix` supplies 191, and the synthesized `.unique()` index
+ * then enforces uniqueness of the first 191 characters — two distinct
+ * 200-character emails sharing that prefix raised ER_DUP_ENTRY and surfaced as
+ * "unique constraint violation", on MySQL only. 768 × 4 bytes under utf8mb4 is
+ * exactly InnoDB's 3072-byte single-column key limit, so a `.unique()` string
+ * indexes whole; a longer value is a loud write error, not a wrong conflict.
+ *
+ * **Pre-existing tables keep the type they were created with** — same caveat as
+ * {@link MYSQL_COLLATION}: `CREATE TABLE IF NOT EXISTS` does not reshape one, so
+ * a binding provisioned before this needs a one-off
+ * `ALTER TABLE <t> MODIFY <col> VARCHAR(768) COLLATE utf8mb4_0900_bin`.
+ */
+const mysqlColumnType = (kind: string | undefined, options?: { unique?: boolean }): string => {
+    if (options?.unique === true) {
+        switch (kind) {
+            // Already indexable whole: the numeric types, and bigint's
+            // `VARCHAR(64)` key. Only the LONGTEXT arm below needs bounding.
+            case "bigint":
+            case "boolean":
+            case "date":
+            case "number":
+            case "timestamp": {
+                break;
+            }
+            case "bytes": {
+                return "VARBINARY(768)";
+            }
+            default: {
+                return collated("VARCHAR(768)");
+            }
+        }
+    }
+
     switch (kind) {
         case "bigint": {
             // stored as the order-preserving 40-character key `bigintSqlKey`

--- a/packages/hyperdrive/src/global-exec.ts
+++ b/packages/hyperdrive/src/global-exec.ts
@@ -189,7 +189,12 @@ export const buildMysqlExec = (connection: Mysql2Execute): SqlExec => {
         all: async (sql, params) => {
             const [rows] = await connection.execute(sql, params);
 
-            return rows as Record<string, unknown>[];
+            // mysql2 hands back a `ResultSetHeader`, not a row array, for a
+            // statement that returns no rows. Normalised to `[]` here the same
+            // way `fromMysql2` (`create-hyperdrive.ts`) does — two adapters over
+            // one driver that disagreed on the same shape is how one of them
+            // ends up handing a caller a non-array it will index into.
+            return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
         },
         batch: async (statements) => {
             await Promise.all(statements.map((statement) => connection.execute(statement.sql, statement.params)));

--- a/packages/hyperdrive/src/pg-vector.ts
+++ b/packages/hyperdrive/src/pg-vector.ts
@@ -148,6 +148,20 @@ interface PgVectorIndexOptions {
 const vectorLiteral = (values: ReadonlyArray<number>): string => `[${values.join(",")}]`;
 
 /**
+ * Whether `value`'s own enumerable entries ARE its contents — the only shape
+ * `JSON.stringify` preserves field-for-field, and the only one the containment
+ * filter's walk can inspect.
+ */
+const isPlainObject = (value: object): boolean => {
+    const prototype: unknown = Object.getPrototypeOf(value);
+
+    return prototype === null || prototype === Object.prototype;
+};
+
+/** Best-effort class name for an error message. */
+const constructorName = (value: object): string => (value.constructor as { name?: string } | undefined)?.name ?? "non-plain object";
+
+/**
  * Reject a metadata filter this store cannot honour.
  *
  * Vectorize accepts comparison operators (`{ views: { $gt: 10 } }`) and
@@ -160,6 +174,13 @@ const vectorLiteral = (values: ReadonlyArray<number>): string => `[${values.join
  * The walk is recursive and descends into arrays because both are reachable:
  * `{ author: { profile: { $gt: 3 } } }` hides the operator one level down, and
  * `{ tags: [{ $in: [...] }] }` hides it inside an array.
+ *
+ * Every object it meets — the filter itself included — must be plain
+ * ({@link isPlainObject}). A `Map`, `Set` or class instance has no own
+ * enumerable entries, so walking it inspects nothing and the value stringifies
+ * to `{}`, which JSONB containment matches for every row that has metadata at
+ * all. That is a fail-OPEN filter across tenants, which is why the shape is
+ * rejected outright rather than walked.
  */
 const assertContainmentFilter = (filter: Record<string, unknown>, name: string): void => {
     const reject = (reason: string, key: string): never => {
@@ -210,6 +231,18 @@ const assertContainmentFilter = (filter: Record<string, unknown>, name: string):
             return;
         }
 
+        // A `Map`, a `Set`, a `Date`, a class instance — anything whose own
+        // enumerable entries are not its contents — serialises to something
+        // other than its fields, and `Object.entries` is `[]` for it, so the
+        // walk below inspects nothing and rejects nothing. `{"tenant": new Map()}`
+        // stringifies to `{"tenant":{}}`, which JSONB containment matches for
+        // EVERY row that has metadata: the filter fails open, across tenants.
+        // Reject by prototype rather than by walking own entries, since walking
+        // is exactly what cannot see this.
+        if (!isPlainObject(value)) {
+            reject(`is a ${constructorName(value)}, whose fields JSON does not preserve`, path);
+        }
+
         for (const [key, nested] of Object.entries(value)) {
             if (key.startsWith("$")) {
                 reject("uses a comparison operator", path);
@@ -218,6 +251,14 @@ const assertContainmentFilter = (filter: Record<string, unknown>, name: string):
             walk(nested, `${path}.${key}`);
         }
     };
+
+    // The top level is subject to the same prototype rule as every nested one —
+    // and it is the more dangerous of the two, because `Object.keys(someMap)` is
+    // empty, so the caller's `Object.keys(filter).length > 0` gate skipped both
+    // this guard and the containment clause and issued an UNFILTERED query.
+    if (!isPlainObject(filter)) {
+        reject(`is a ${constructorName(filter)}, whose fields JSON does not preserve`, "filter");
+    }
 
     for (const [key, value] of Object.entries(filter)) {
         // Vectorize's own operators are legal at the top level too.
@@ -456,7 +497,11 @@ const createPgVectorIndex = (options: PgVectorIndexOptions): VectorizeIndexLike 
                 throw new TypeError(`@lunora/hyperdrive: pgvector index "${name}" needs a positive integer \`topK\` — got ${String(topK)}`);
             }
 
-            if (queryOptions?.filter !== undefined && Object.keys(queryOptions.filter).length > 0) {
+            // Guarded on presence, NOT on `Object.keys(...).length`: a `Map` (or
+            // any other non-plain object) has no own enumerable keys, so keying
+            // the guard off the count let exactly the value the guard exists to
+            // reject walk straight past it.
+            if (queryOptions?.filter !== undefined) {
                 assertContainmentFilter(queryOptions.filter, name);
             }
 

--- a/packages/replica/__tests__/adapters.test.ts
+++ b/packages/replica/__tests__/adapters.test.ts
@@ -7,6 +7,7 @@ import { createSqliteWasmAdapter } from "../src/adapters/sqlite-wasm";
 import { createSqlJsAdapter } from "../src/adapters/sqljs";
 import type { SqliteAdapter } from "../src/adapters/types";
 import { LocalMirror } from "../src/local-mirror";
+import { subscribeToMirror } from "../src/subscribe-mirror";
 import { createTableDiff } from "../src/table-diff";
 
 // ── Real-engine fixtures ────────────────────────────────────────────────
@@ -70,7 +71,12 @@ const makeSqliteWasm = (): SqliteAdapter => {
         },
         exec: (sql, options) => {
             if (options?.returnValue === "resultRows" && options.rowMode === "object") {
-                return toRowObjects(engine.exec(sql, options.bind));
+                // `useBigInt` stands in for the real driver's `bigIntEnabled`:
+                // both decode an INTEGER column through a 64-bit path instead of
+                // a double. sql.js widens every integer where the real driver
+                // widens only the out-of-range ones, which the adapter's own
+                // narrowing reconciles either way.
+                return toRowObjects(engine.exec(sql, options.bind, { useBigInt: true }));
             }
 
             engine.run(sql, options?.bind);
@@ -747,6 +753,125 @@ describe.each(engines)("localMirror end-to-end (%s)", (_name, makeAdapter) => {
 
             expect(m2.query<{ id: string; points: number }>("SELECT id, points FROM scores")).toStrictEqual([{ id: "1", points: 9 }]);
         });
+    });
+});
+
+// ── Regressions the adapter/mirror contract has to keep ─────────────────
+
+describe.each(engines)("int64 round-trip (%s)", (_name, makeAdapter) => {
+    // `local-mirror.ts` declares a `bigint` column INTEGER and `diff-applier.ts`
+    // binds a `bigint` straight through, so a value past 2^53 is a first-class
+    // path into every adapter. A driver decoding it through a double loses the
+    // low bits — silently, and for a primary key too, so the row goes missing.
+    const beyondDouble = 9_007_199_254_740_993n;
+
+    it("reads an INTEGER past 2^53 back exactly, and still matches it by equality", () => {
+        expect.assertions(2);
+
+        const database = makeAdapter();
+
+        database.exec("CREATE TABLE big (id INT PRIMARY KEY NOT NULL, n INTEGER)");
+        database.exec("INSERT INTO big (id, n) VALUES (?, ?)", [beyondDouble, beyondDouble]);
+
+        expect(database.query<{ n: bigint }>("SELECT n FROM big")).toStrictEqual([{ n: beyondDouble }]);
+        expect(database.query("SELECT id FROM big WHERE id = ?", [beyondDouble])).toHaveLength(1);
+    });
+
+    it("keeps an ordinary integer a `number`", () => {
+        expect.assertions(1);
+
+        const database = makeAdapter();
+
+        database.exec("CREATE TABLE small (id TEXT PRIMARY KEY NOT NULL, n INTEGER)");
+        database.exec("INSERT INTO small (id, n) VALUES (?, ?)", ["a", 5]);
+
+        expect(database.query<{ c: number; n: number }>("SELECT n, COUNT(*) AS c FROM small")).toStrictEqual([{ c: 1, n: 5 }]);
+    });
+});
+
+describe.each(engines)("column affinity when the first observed value is null (%s)", (_name, makeAdapter) => {
+    // The affinity is inferred once, at CREATE. A column whose first frame
+    // carried `null` used to fall back to TEXT and stayed TEXT forever, so every
+    // later number was coerced to text: `ORDER BY` compared "10" < "5" and a
+    // range predicate compared strings.
+    const seedThenNumbers = (mirror: LocalMirror): void => {
+        mirror.applyDiff(createTableDiff("readings", [{ data: { id: "a", n: null }, type: "insert" }]));
+        mirror.applyDiff(
+            createTableDiff("readings", [
+                { data: { id: "b", n: 5 }, type: "insert" },
+                { data: { id: "c", n: 10 }, type: "insert" },
+            ]),
+        );
+    };
+
+    it("orders the later numbers numerically", () => {
+        expect.assertions(1);
+
+        const mirror = new LocalMirror({ db: makeAdapter() });
+
+        seedThenNumbers(mirror);
+
+        expect(mirror.query<{ id: string }>("SELECT id FROM readings WHERE n IS NOT NULL ORDER BY n ASC")).toStrictEqual([{ id: "b" }, { id: "c" }]);
+    });
+
+    it("answers a range predicate numerically", () => {
+        expect.assertions(1);
+
+        const mirror = new LocalMirror({ db: makeAdapter() });
+
+        seedThenNumbers(mirror);
+
+        expect(mirror.query<{ id: string }>("SELECT id FROM readings WHERE n > 6")).toStrictEqual([{ id: "c" }]);
+    });
+
+    it("does the same for a column added by schema evolution", () => {
+        expect.assertions(1);
+
+        const mirror = new LocalMirror({ db: makeAdapter() });
+
+        mirror.applyDiff(createTableDiff("late", [{ data: { id: "a" }, type: "insert" }]));
+        mirror.applyDiff(createTableDiff("late", [{ data: { id: "b", n: null }, type: "insert" }]));
+        mirror.applyDiff(
+            createTableDiff("late", [
+                { data: { id: "c", n: 5 }, type: "insert" },
+                { data: { id: "d", n: 10 }, type: "insert" },
+            ]),
+        );
+
+        expect(mirror.query<{ id: string }>("SELECT id FROM late WHERE n > 6")).toStrictEqual([{ id: "d" }]);
+    });
+});
+
+describe.each(engines)("subscribeToMirror after clearData (%s)", (_name, makeAdapter) => {
+    it("re-seeds the table when the next frame is identical to the one clearData wiped", () => {
+        expect.assertions(2);
+
+        const mirror = new LocalMirror({ db: makeAdapter() });
+        let push: ((data: unknown) => void) | undefined;
+
+        const client = {
+            subscribe: (_reference: { __lunoraRef: string }, _arguments: Record<string, unknown>, onData: (data: unknown) => void) => {
+                push = onData;
+
+                return () => undefined;
+            },
+        };
+
+        subscribeToMirror(client, mirror, { __lunoraRef: "todos/list" }, {});
+
+        const frame = [{ id: "1", title: "a" }];
+
+        push?.(frame);
+
+        expect(mirror.query("SELECT id, title FROM fn_todos_list")).toStrictEqual([{ id: "1", title: "a" }]);
+
+        mirror.clearData();
+        // The server has nothing new to say, so the next frame is byte-identical
+        // to the last applied one. Without the clear reset it diffed clean and
+        // the table stayed empty until some row's content happened to change.
+        push?.(frame);
+
+        expect(mirror.query("SELECT id, title FROM fn_todos_list")).toStrictEqual([{ id: "1", title: "a" }]);
     });
 });
 

--- a/packages/replica/__tests__/core.test.ts
+++ b/packages/replica/__tests__/core.test.ts
@@ -273,6 +273,47 @@ describe(EventSource, () => {
         expect(errors[0]!.entry.seq).toBe(1);
     });
 
+    it("yields replayed entries to a live `events()` generator", async () => {
+        expect.assertions(2);
+
+        const source = new EventSource({ items: [] as string[] }, (state, entry) => ({ items: [...state.items, entry.payload as string] }));
+        const iterator = source.events()[Symbol.asyncIterator]();
+
+        // Park the generator in its "stream future entries" phase first, so the
+        // entries below can only reach it through the live notification — the
+        // one `replayFromLog` never emitted, which made every replayed entry
+        // invisible to a generator the method contract promises to feed.
+        source.applyEvent("ok", "a");
+
+        await expect(iterator.next()).resolves.toMatchObject({ value: { payload: "a" } });
+
+        const log = new EventLog();
+
+        log.append("ok", "b");
+        log.append("ok", "c");
+
+        source.replayFromLog(log);
+
+        const first = await iterator.next();
+        const second = await iterator.next();
+
+        expect([first.value, second.value].map((entry) => entry?.payload)).toStrictEqual(["b", "c"]);
+
+        await iterator.return?.(undefined);
+    });
+
+    it("keeps a replayed entry's own timestamp instead of stamping the replay time", () => {
+        expect.assertions(1);
+
+        const source = new EventSource({ count: 0 }, (state) => ({ count: state.count + 1 }));
+        const log = new EventLog();
+
+        log.append("inc", null, undefined, { timestamp: 111 });
+        source.replayFromLog(log);
+
+        expect(source.log.getSince(0).map((entry) => entry.timestamp)).toStrictEqual([111]);
+    });
+
     it("reset restores initial state without clearing log", () => {
         expect.assertions(4);
 

--- a/packages/replica/__tests__/local-core.test.ts
+++ b/packages/replica/__tests__/local-core.test.ts
@@ -261,6 +261,30 @@ describe(EventLog, () => {
         expect(page3.hasMore).toBe(false);
     });
 
+    it("getFrom rejects a limit that cannot make progress", () => {
+        expect.assertions(3);
+
+        const log = new EventLog();
+
+        log.append("a", null);
+
+        // `{ entries: [], hasMore: true }` is what these used to return, which
+        // spins a paginating caller on a page it can never advance past.
+        expect(() => log.getFrom(0, 0)).toThrow(RangeError);
+        expect(() => log.getFrom(0, -1)).toThrow(RangeError);
+        expect(() => log.getFrom(0, Number.NaN)).toThrow(RangeError);
+    });
+
+    it("append keeps an InputEvent's own timestamp", () => {
+        expect.assertions(1);
+
+        const log = new EventLog();
+
+        log.append({ payload: { n: 1 }, timestamp: 111, type: "a" });
+
+        expect(log.getSince(0)[0]?.timestamp).toBe(111);
+    });
+
     it("getFrom returns empty when fromSeq is beyond end", () => {
         expect.assertions(2);
 

--- a/packages/replica/__tests__/runtime-edges.test.ts
+++ b/packages/replica/__tests__/runtime-edges.test.ts
@@ -317,6 +317,7 @@ const mirrorDouble = (primaryKey: string = "id"): MirrorDouble => {
         applyDiff: (diff: TableDiff) => {
             applied.push(diff);
         },
+        onChange: () => () => undefined,
         primaryKeyOf: () => primaryKey,
         registerTable: (name: string) => {
             registered.push(name);
@@ -547,6 +548,7 @@ describe(subscribeToMirror, () => {
 
                 applied.push(diff);
             },
+            onChange: () => () => undefined,
             primaryKeyOf: () => "id",
             registerTable: () => undefined,
         } as unknown as LocalMirror;

--- a/packages/replica/__tests__/sqlite-modules.d.ts
+++ b/packages/replica/__tests__/sqlite-modules.d.ts
@@ -7,7 +7,7 @@
 declare module "sql.js" {
     interface SqlJsDatabase {
         close: () => void;
-        exec: (sql: string, params?: unknown[]) => { columns: string[]; values: unknown[][] }[];
+        exec: (sql: string, params?: unknown[], config?: { useBigInt?: boolean }) => { columns: string[]; values: unknown[][] }[];
         run: (sql: string, params?: unknown[]) => void;
     }
 
@@ -25,6 +25,7 @@ declare module "better-sqlite3" {
         all: (params?: unknown[]) => unknown[];
         get: (params?: unknown[]) => unknown;
         run: (params?: unknown[]) => { lastInsertRowid: number | bigint };
+        safeIntegers: (toggle?: boolean) => unknown;
     }
 
     class Database {

--- a/packages/replica/src/adapters/better-sqlite3.ts
+++ b/packages/replica/src/adapters/better-sqlite3.ts
@@ -1,3 +1,4 @@
+import { narrowSafeIntegers } from "./int64";
 import type { SqliteAdapter } from "./types";
 
 /**
@@ -21,6 +22,7 @@ export const createBetterSqlite3Adapter = (database: {
         all: (params?: unknown[]) => unknown[];
         get: (params?: unknown[]) => unknown;
         run: (params?: unknown[]) => { lastInsertRowid: number | bigint };
+        safeIntegers: (toggle?: boolean) => unknown;
     };
     transaction: (function_: () => void) => () => void;
 }): SqliteAdapter => {
@@ -35,9 +37,15 @@ export const createBetterSqlite3Adapter = (database: {
 
         query<T = Record<string, unknown>>(sql: string, params?: ReadonlyArray<unknown>): T[] {
             const stmt = database.prepare(sql);
+
+            // Decode INTEGER columns as `bigint` rather than through a double —
+            // see `./int64`. `narrowSafeIntegers` puts an ordinary integer back
+            // to a `number`, so only a real int64 stays wide.
+            stmt.safeIntegers(true);
+
             const rows = params && params.length > 0 ? stmt.all([...params]) : stmt.all();
 
-            return rows as T[];
+            return narrowSafeIntegers<T>(rows as Record<string, unknown>[]);
         },
 
         transaction(function_: () => void): void {

--- a/packages/replica/src/adapters/int64.ts
+++ b/packages/replica/src/adapters/int64.ts
@@ -1,0 +1,44 @@
+/**
+ * Int64 read normalisation shared by the driver adapters.
+ *
+ * SQLite stores every integer as a signed 64-bit value, and the mirror puts
+ * real int64s there: `local-mirror.ts` declares a `bigint` column `INTEGER` and
+ * `diff-applier.ts` binds a `bigint` straight through. A driver that decodes
+ * that column into a JS `number` loses the low bits above 2^53 — silently, and
+ * for the primary key too, so `WHERE id = ?` then matches nothing.
+ *
+ * The drivers that can avoid it need to be asked (`safeIntegers` on
+ * better-sqlite3, `useBigInt` on sql.js), and once asked they return **every**
+ * integer as a `bigint`, `COUNT(*)` included. {@link narrowSafeIntegers} puts
+ * that back: a value inside the safe-integer range reads as a `number` the way
+ * it always did, and only a value that genuinely needs 64 bits stays a
+ * `bigint`. That is also what `@sqlite.org/sqlite-wasm` does on its own, so all
+ * three adapters agree on what a row looks like.
+ */
+
+/** Narrow one column value: a `bigint` inside the safe-integer range becomes a `number`. */
+const narrowSafeInteger = (value: unknown): unknown =>
+    typeof value === "bigint" && value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : value;
+
+/**
+ * Narrow every `bigint` column of every row in place-free fashion: rows whose
+ * columns are all ordinary values are returned as they came, so the common read
+ * allocates nothing.
+ */
+const narrowSafeIntegers = <T>(rows: ReadonlyArray<Record<string, unknown>>): T[] =>
+    rows.map((row) => {
+        let narrowed: Record<string, unknown> | undefined;
+
+        for (const [column, value] of Object.entries(row)) {
+            const next = narrowSafeInteger(value);
+
+            if (next !== value) {
+                narrowed ??= { ...row };
+                narrowed[column] = next;
+            }
+        }
+
+        return (narrowed ?? row) as T;
+    });
+
+export { narrowSafeInteger, narrowSafeIntegers };

--- a/packages/replica/src/adapters/sqlite-wasm.ts
+++ b/packages/replica/src/adapters/sqlite-wasm.ts
@@ -1,3 +1,4 @@
+import { narrowSafeIntegers } from "./int64";
 import type { SqliteAdapter } from "./types";
 
 /**
@@ -47,7 +48,11 @@ export const createSqliteWasmAdapter = (database: {
                 rowMode: "object",
             });
 
-            return (rows ?? []) as T[];
+            // This build decodes an out-of-range INTEGER as a `bigint` on its
+            // own (`bigIntEnabled`), so there is no per-call flag to set here —
+            // only the same narrowing the other two adapters apply, so all
+            // three agree on when a column is a `number` and when it is wide.
+            return narrowSafeIntegers<T>(rows ?? []);
         },
 
         transaction(function_: () => void): void {

--- a/packages/replica/src/adapters/sqljs.ts
+++ b/packages/replica/src/adapters/sqljs.ts
@@ -1,3 +1,4 @@
+import { narrowSafeIntegers } from "./int64";
 import type { SqliteAdapter } from "./types";
 
 /**
@@ -14,7 +15,8 @@ export const createSqlJsAdapter = (database: {
     close: () => void;
     // sql.js `exec` also accepts bound `params` (same as `run`); type it so
     // the query path can forward them instead of running placeholders unbound.
-    exec: (sql: string, params?: unknown[]) => { columns: string[]; values: unknown[][] }[];
+    // The third argument is the per-call config that carries `useBigInt`.
+    exec: (sql: string, params?: unknown[], config?: { useBigInt?: boolean }) => { columns: string[]; values: unknown[][] }[];
     run: (sql: string, params?: unknown[]) => void;
 }): SqliteAdapter => {
     return {
@@ -31,7 +33,11 @@ export const createSqlJsAdapter = (database: {
         query<T = Record<string, unknown>>(sql: string, params?: ReadonlyArray<unknown>): T[] {
             // Forward bound params so placeholder queries (e.g. LocalMirror's
             // `#ensureTableSchema` existence check) don't run unbound.
-            const result = params && params.length > 0 ? database.exec(sql, [...params]) : database.exec(sql);
+            //
+            // `useBigInt` decodes INTEGER columns as `bigint` rather than
+            // through a double — see `./int64`. `narrowSafeIntegers` puts an
+            // ordinary integer back to a `number`, so only a real int64 stays wide.
+            const result = database.exec(sql, params && params.length > 0 ? [...params] : undefined, { useBigInt: true });
             const first = result[0];
 
             if (!first) {
@@ -39,17 +45,17 @@ export const createSqlJsAdapter = (database: {
             }
 
             const colNames = first.columns;
-            const rows: T[] = [];
+            const rows: Record<string, unknown>[] = [];
 
             for (const row of first.values) {
                 const object: Record<string, unknown> = {};
                 for (const [i, column] of colNames.entries()) {
                     object[column] = row[i];
                 }
-                rows.push(object as T);
+                rows.push(object);
             }
 
-            return rows;
+            return narrowSafeIntegers<T>(rows);
         },
 
         transaction(function_: () => void): void {

--- a/packages/replica/src/event-log.ts
+++ b/packages/replica/src/event-log.ts
@@ -245,7 +245,11 @@ export class EventLog {
             seq,
             type,
             payload: pl,
-            timestamp: resolvedOptions?.timestamp ?? Date.now(),
+            // An `InputEvent` carries its own required `timestamp` — when the
+            // event was created, which is not when it reaches the log. Honour it
+            // here the way {@link EventLog#commitAll} always has; stamping
+            // `Date.now()` over it silently rewrote every such event's time.
+            timestamp: resolvedOptions?.timestamp ?? (typeof typeOrEvent === "string" ? undefined : typeOrEvent.timestamp) ?? Date.now(),
             tableDiffs: diffs,
             clientId: resolvedOptions?.clientId,
             sessionId: resolvedOptions?.sessionId,
@@ -342,10 +346,19 @@ export class EventLog {
 
     /**
      * Paginated read starting at `fromSeq`.
+     *
+     * `limit` must be a positive safe integer, validated like
+     * {@link EventLog#truncateBelow}'s floor and the constructor's `maxEntries`:
+     * a `limit` of `0` returned an empty page with `hasMore: true`, which spins a
+     * paginating caller forever on a page it can never advance past.
      * @returns `{ entries, hasMore }` where `hasMore` is `true` when more
      * entries exist beyond the requested page.
      */
     public getFrom(fromSeq: number, limit: number = 50): { entries: ReadonlyArray<EventLogEntry>; hasMore: boolean } {
+        if (!Number.isSafeInteger(limit) || limit < 1) {
+            throw new RangeError("limit must be a positive safe integer");
+        }
+
         // Locate the first live entry at/after `fromSeq` by scanning the backing
         // array from `#headOffset` — never materialize the whole retained log
         // (an uncapped log would make each page O(total history)); copy only the

--- a/packages/replica/src/event-source.ts
+++ b/packages/replica/src/event-source.ts
@@ -267,11 +267,23 @@ export class EventSource<S extends Record<string, unknown> = Record<string, unkn
                     this.#state = reduced;
                 }
 
-                this.log.append(entry.type, entry.payload, entry.tableDiffs, {
+                // `timestamp` is pinned to the source entry's, for the same
+                // reason `applyEvent` pins it to the candidate's (REPLICA-07):
+                // without it `EventLog#append` stamps `Date.now()`, so a replay
+                // rewrote history to the moment it ran and a timestamp-dependent
+                // reducer could never be re-derived from the replayed log.
+                const appended = this.log.append(entry.type, entry.payload, entry.tableDiffs, {
                     clientId: entry.clientId,
                     sessionId: entry.sessionId,
                     parentSeqNum: entry.parentSeqNum,
+                    timestamp: entry.timestamp,
                 });
+
+                // Same notification `applyEvent` emits, for the same entries:
+                // `events()` streams off this event, so without it every entry a
+                // replay appended was invisible to a live generator — which the
+                // method contract promises to yield.
+                this.emitter.emit("state-changed", { state: this.#state, entry: appended });
             } catch (error) {
                 this.emitter.emit("replay-error", {
                     entry,

--- a/packages/replica/src/local-mirror.ts
+++ b/packages/replica/src/local-mirror.ts
@@ -87,10 +87,22 @@ const SCHEMA_VERSION_META_KEY = "schema_version";
  * mirror with a numeric primary key sorted and range-filtered it
  * lexicographically (`ORDER BY id` put 10 before 9, `WHERE id > 5` compared
  * strings), so older mirrors re-seed once on next open.
+ *
+ * Version 4: a column with no observed non-null value is declared with NO type
+ * at all instead of falling back to `TEXT`. The affinity is inferred once, at
+ * CREATE, and never revisited — so a numeric column whose first frame carried
+ * `null` was pinned to `TEXT` forever and coerced every later number to text
+ * (`ORDER BY n` put 10 before 5, `WHERE n > 6` matched nothing). A typeless
+ * column has BLOB affinity: SQLite stores what it is given without coercion, so
+ * the numbers that arrive later compare and sort as numbers with no migration.
  */
-const MIRROR_SCHEMA_VERSION = 3;
+const MIRROR_SCHEMA_VERSION = 4;
 
-/** SQLite column type affinity declared for a mirrored table's column. */
+/**
+ * SQLite column type affinity declared for a mirrored table's column, or
+ * `undefined` for a column whose affinity is not known yet (declared typeless —
+ * see {@link MIRROR_SCHEMA_VERSION} version 4).
+ */
 type ColumnAffinity = "INTEGER" | "REAL" | "TEXT";
 
 /**
@@ -119,6 +131,25 @@ const inferColumnAffinity = (value: unknown): ColumnAffinity => {
 };
 
 /**
+ * The declared type for a column definition: the inferred affinity, or the
+ * empty string for a column whose affinity is not known yet. A typeless column
+ * has BLOB affinity — SQLite coerces nothing into it — which is the only
+ * declaration that stays correct whatever the first non-null value turns out to
+ * be, and is why an all-null column is left undeclared rather than guessed.
+ */
+const columnTypeSql = (affinity: ColumnAffinity | undefined): string => affinity ?? "";
+
+/**
+ * Why the mirror changed: `"diff"` for the rows an {@link LocalMirror.applyDiff}
+ * wrote, `"clear"` for the wholesale {@link LocalMirror.clearData} sweep.
+ *
+ * A subscriber that caches what it believes the mirror holds has to tell the two
+ * apart: `"diff"` reports a change it usually made itself, while `"clear"` means
+ * every row it was tracking is gone regardless of who wrote it.
+ */
+type MirrorChangeReason = "clear" | "diff";
+
+/**
  * Local SQLite mirror that maintains a client-side replica of server
  * tables by applying {@link TableDiff} deltas.
  *
@@ -142,7 +173,7 @@ const inferColumnAffinity = (value: unknown): ColumnAffinity => {
  * );
  * ```
  */
-type ChangeSubscriber = () => void;
+type ChangeSubscriber = (reason: MirrorChangeReason) => void;
 
 /**
  * `LocalMirror` is part of the experimental `@lunora/replica` API and may change without a major version bump.
@@ -259,7 +290,7 @@ class LocalMirror {
         applyDiffToDatabase(this.#db, diff, this.primaryKeyOf(diff.table));
 
         this.#eventLog.append("table-diff", diff, [diff]);
-        this.#notifyChange();
+        this.#notifyChange("diff");
     }
 
     /**
@@ -304,16 +335,16 @@ class LocalMirror {
             }
         });
 
-        this.#notifyChange();
+        this.#notifyChange("clear");
     }
 
     /** Bump {@link LocalMirror.version} and notify `onChange` subscribers (e.g. React hook subscriptions). */
-    #notifyChange(): void {
+    #notifyChange(reason: MirrorChangeReason): void {
         this.#version += 1;
 
         for (const listener of this.#changeListeners) {
             try {
-                listener();
+                listener(reason);
             } catch {
                 // Listener threw — keep notifying others.
             }
@@ -436,7 +467,8 @@ class LocalMirror {
      * Infer the affinity to declare for each of `columns` from the first
      * non-null value observed for that column, in diff order. A column that
      * never carries a non-null value (e.g. every change so far set it to
-     * `null`) is left unmapped — callers fall back to `TEXT`.
+     * `null`) is left unmapped — callers declare it typeless (see
+     * {@link columnTypeSql}).
      * @param diff The table diff whose changes are scanned.
      * @param pk The primary-key column to skip (already declared separately).
      * @param columns The column names to resolve an affinity for.
@@ -471,10 +503,10 @@ class LocalMirror {
      * Infer the affinity to declare for the primary-key column from the
      * first non-null id observed in the diff (`data[pk]` on insert/update,
      * `change.id` on delete/update). A diff that never carries an id (e.g.
-     * empty data) falls back to `TEXT` — same first-observed-value trade-off
+     * empty data) leaves it typeless — same first-observed-value trade-off
      * as {@link LocalMirror.#inferColumnAffinities}.
      */
-    static #inferPkAffinity(diff: TableDiff, pk: string): ColumnAffinity {
+    static #inferPkAffinity(diff: TableDiff, pk: string): ColumnAffinity | undefined {
         for (const change of diff.changes) {
             const value: unknown = change.type === "delete" ? change.id : change.data[pk];
 
@@ -488,7 +520,7 @@ class LocalMirror {
             }
         }
 
-        return "TEXT";
+        return undefined;
     }
 
     /**
@@ -518,10 +550,10 @@ class LocalMirror {
             // affinity (so ORDER BY/comparisons stay numeric) while still
             // accepting a heterogeneous id.
             const pkAffinity = LocalMirror.#inferPkAffinity(diff, pk);
-            let columnDefs = `${escapeIdentifier_(pk)} ${pkAffinity === "INTEGER" ? "INT" : pkAffinity} PRIMARY KEY NOT NULL`;
+            let columnDefs = `${escapeIdentifier_(pk)} ${pkAffinity === "INTEGER" ? "INT" : columnTypeSql(pkAffinity)} PRIMARY KEY NOT NULL`;
 
             for (const key of requiredColumns) {
-                columnDefs += `, ${escapeIdentifier_(key)} ${affinities.get(key) ?? "TEXT"}`;
+                columnDefs += `, ${escapeIdentifier_(key)} ${columnTypeSql(affinities.get(key))}`;
             }
 
             this.#db.exec(`CREATE TABLE IF NOT EXISTS ${escapeIdentifier_(diff.table)} (${columnDefs})`);
@@ -531,7 +563,7 @@ class LocalMirror {
 
             for (const key of requiredColumns) {
                 if (!existingColumns.has(key)) {
-                    this.#db.exec(`ALTER TABLE ${escapeIdentifier_(diff.table)} ADD COLUMN ${escapeIdentifier_(key)} ${affinities.get(key) ?? "TEXT"}`);
+                    this.#db.exec(`ALTER TABLE ${escapeIdentifier_(diff.table)} ADD COLUMN ${escapeIdentifier_(key)} ${columnTypeSql(affinities.get(key))}`);
                 }
             }
         }

--- a/packages/replica/src/subscribe-mirror.ts
+++ b/packages/replica/src/subscribe-mirror.ts
@@ -97,12 +97,19 @@ const subscribeToMirror = (
     // string compare. `stableWireKey` covers every value a decoded wire row can
     // carry (bigint, Date, bytes, …), which plain JSON would throw on or alias.
     let known = new Map<string, string>();
+    // Bumped by every `clear`. A frame that started before a clear must not
+    // publish its `known` afterwards: `clearData()` can fire from another
+    // `onChange` listener while this one is mid-frame, and the assignment at the
+    // end of the callback would otherwise restore the map the clear just reset,
+    // so the next identical frame reports no changes over an emptied table.
+    let clearGeneration = 0;
 
     // A `clearData()` sweep deletes the rows this frame memory claims are in the
     // mirror. Forget them so the next frame is diffed against an empty table and
     // re-inserts everything, instead of matching `known` and applying nothing.
     const unsubscribeMirror = mirror.onChange((reason) => {
         if (reason === "clear") {
+            clearGeneration += 1;
             known = new Map();
         }
     });
@@ -111,6 +118,11 @@ const subscribeToMirror = (
         functionRef,
         args,
         (data: unknown) => {
+            // Snapshot the clear counter before any work: `applyDiff` below fans
+            // out to every `onChange` listener, and one of them may call
+            // `clearData()`, which resets `known`. Publishing this frame's map
+            // afterwards would undo that.
+            const generation = clearGeneration;
             const next = new Map<string, string>();
             // The row behind each surviving encoding. Filled in the same pass as
             // `next`, so a repeated primary key leaves the LAST row for that key
@@ -184,7 +196,13 @@ const subscribeToMirror = (
             // above — an un-keyed row failing the NOT NULL insert — leaves `known`
             // on the last applied frame, so the deletes this frame owed are
             // re-derived by the next one instead of being orphaned forever.
-            known = next;
+            //
+            // A clear that landed while this frame was applying wins: it emptied
+            // the table, so the next frame has to re-insert everything, which
+            // only happens if `known` stays empty.
+            if (generation === clearGeneration) {
+                known = next;
+            }
         },
         { shardKey },
     );

--- a/packages/replica/src/subscribe-mirror.ts
+++ b/packages/replica/src/subscribe-mirror.ts
@@ -61,6 +61,11 @@ export interface SubscriptionClient {
  * into the same mirror: they'd share one table and the snapshot-delete pass of
  * one could remove rows still live in the other.
  *
+ * `mirror.clearData()` resets the remembered frame. Without that reset the next
+ * identical frame diffed clean against a mirror that no longer held the rows —
+ * no changes, no `applyDiff` — and the table stayed empty until some row's
+ * content happened to change or the page reloaded.
+ *
  * Call the returned unsubscribe function to tear down both the client
  * subscription and future mirror writes.
  * @example
@@ -93,7 +98,16 @@ const subscribeToMirror = (
     // carry (bigint, Date, bytes, …), which plain JSON would throw on or alias.
     let known = new Map<string, string>();
 
-    return client.subscribe(
+    // A `clearData()` sweep deletes the rows this frame memory claims are in the
+    // mirror. Forget them so the next frame is diffed against an empty table and
+    // re-inserts everything, instead of matching `known` and applying nothing.
+    const unsubscribeMirror = mirror.onChange((reason) => {
+        if (reason === "clear") {
+            known = new Map();
+        }
+    });
+
+    const unsubscribeClient = client.subscribe(
         functionRef,
         args,
         (data: unknown) => {
@@ -174,6 +188,11 @@ const subscribeToMirror = (
         },
         { shardKey },
     );
+
+    return () => {
+        unsubscribeMirror();
+        unsubscribeClient();
+    };
 };
 
 export { subscribeToMirror };

--- a/packages/replica/src/table-diff.ts
+++ b/packages/replica/src/table-diff.ts
@@ -115,8 +115,10 @@ const mergeDiffs = (diffs: ReadonlyArray<TableDiff>): TableDiff | null => {
 
     // Derive the merged diff's identity deterministically from its ordered
     // children's identities (each child's `id`, or its `timestamp` as a
-    // fallback): merging the SAME sequence of diffs mints the SAME merged id, a
-    // different sequence a different one. Nothing in this repo reads it — the
+    // fallback): merging the SAME sequence of diffs always mints the SAME merged
+    // id. The converse is NOT promised — `id` is optional and two children can
+    // share a `timestamp`, so distinct sequences can hash the same input, and a
+    // 64-bit digest collides regardless. Nothing in this repo reads it — the
     // apply path keys id-less inserts off row content — so this is a property of
     // the public `id` field for consumers that dedupe on it, not an input to
     // anything downstream.

--- a/packages/replica/src/table-diff.ts
+++ b/packages/replica/src/table-diff.ts
@@ -26,13 +26,14 @@ interface TableDiff {
     /**
      * Optional stable identity for this diff, distinct from `timestamp`
      * (multiple diffs can legitimately share a millisecond, so `timestamp`
-     * alone is not a unique diff identity). Used by `deriveInsertId` in
-     * `apply-diff.ts` to derive deterministic row ids for id-less inserts:
-     * replaying the SAME diff (same `id`) must always mint the SAME id,
-     * while two DIFFERENT diffs emitted in the same millisecond must not
-     * alias onto the same one. `createTableDiff` auto-generates one when
-     * omitted; diffs built as plain object literals (bypassing the helper)
-     * simply fall back to `timestamp` for that derivation.
+     * alone is not a unique diff identity). `createTableDiff` auto-generates
+     * one when omitted.
+     *
+     * **Nothing in the apply path reads it.** `deriveInsertId` (`apply-diff.ts`)
+     * keys an id-less insert off the ROW'S OWN content — hashing the diff id
+     * into it is what made `subscribeToMirror`'s per-frame re-emission mint a
+     * fresh row every second, so that derivation is gone. This field is
+     * carried for consumers that want to recognise a diff they have seen.
      */
     readonly id?: string;
     /** Logical table name (matches the schema table name). */
@@ -113,17 +114,16 @@ const mergeDiffs = (diffs: ReadonlyArray<TableDiff>): TableDiff | null => {
     const last = diffs[diffs.length - 1] as TableDiff;
 
     // Derive the merged diff's identity deterministically from its ordered
-    // children's identities (each child's `id`, or its `timestamp` as the same
-    // fallback `deriveInsertId` uses) — replaying the SAME sequence of diffs
-    // must mint the SAME merged id so id-less inserts stay stable across
-    // retries, while a different child sequence yields a different id.
+    // children's identities (each child's `id`, or its `timestamp` as a
+    // fallback): merging the SAME sequence of diffs mints the SAME merged id, a
+    // different sequence a different one. Nothing in this repo reads it — the
+    // apply path keys id-less inserts off row content — so this is a property of
+    // the public `id` field for consumers that dedupe on it, not an input to
+    // anything downstream.
     //
     // The joined child identities are hashed to a constant-size 16-hex digest
-    // rather than embedded verbatim: a verbatim join is O(N) in the child count
-    // AND, because each id-less insert re-hashes the diff id char-by-char in
-    // `deriveInsertId`, O(N×M) overall — compounding multiplicatively when
-    // merging already-merged diffs (`merge:merge:…`). The hash keeps the same
-    // determinism (same child sequence → same digest) at a fixed width.
+    // rather than embedded verbatim, so merging an already-merged diff cannot
+    // compound the prefix (`merge:merge:…`) into an O(N) string.
     const mergedId = `merge:${fnv1a64Hex(diffs.map((d) => d.id ?? String(d.timestamp)).join("|"))}`;
 
     return createTableDiff(

--- a/packages/shard-engine/__tests__/ctx-db.rank.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.rank.test.ts
@@ -276,6 +276,100 @@ describe("ctx-db rank", () => {
             expect(second.isDone).toBe(false);
         });
 
+        // A rank sort column genuinely holds NULL: `syncRankIndexEntry` writes
+        // `record[field] ?? null`. A bare `<`/`>` at the seek pivot is UNKNOWN
+        // against one, so the page that first reaches the NULL group came back
+        // empty (with `isDone: false` on the page before it) and `rank()`
+        // reported a confident position against a correct total.
+        describe("a nullable sort column", () => {
+            // 5 scored rows and 7 unscored, paged 4 at a time: the NULL group
+            // spans two page boundaries, so a seek that cannot resume from
+            // inside it loses rows a smaller fixture would never miss.
+            const seedWithNulls = async (writer: DatabaseWriterLike): Promise<void> => {
+                for (let index = 0; index < 5; index += 1) {
+                    // eslint-disable-next-line no-await-in-loop -- sequential ordered inserts into the same DB
+                    await writer.insert(
+                        "messages",
+                        { _id: `s${String(index)}`, archived: false, channelId: "c1", score: index * 10 },
+                        { allowExplicitId: true },
+                    );
+                }
+
+                for (let index = 0; index < 7; index += 1) {
+                    // eslint-disable-next-line no-await-in-loop -- sequential ordered inserts into the same DB
+                    await writer.insert(
+                        "messages",
+                        // An unscored row IS a NULL sort column — the case under test.
+                        { _id: `n${String(index)}`, archived: false, channelId: "c1", score: null },
+                        { allowExplicitId: true },
+                    );
+                }
+            };
+
+            const drain = async (writer: DatabaseWriterLike, index: string): Promise<string[]> => {
+                const ids: string[] = [];
+                let cursor: null | string | undefined;
+
+                for (let page = 0; page < 10; page += 1) {
+                    // eslint-disable-next-line no-await-in-loop -- pagination is inherently sequential
+                    const result = await writer.rankPage("messages", index, { cursor, take: 4 });
+
+                    ids.push(...result.page.map((document_) => document_["_id"] as string));
+
+                    if (result.isDone) {
+                        return ids;
+                    }
+
+                    cursor = result.continueCursor;
+                }
+
+                throw new Error("rankPage never reported isDone");
+            };
+
+            it("pages through the NULL group descending without losing a row", async () => {
+                expect.assertions(2);
+
+                const writer = setupWriter(makeSchema(byScoreDesc));
+
+                await seedWithNulls(writer);
+
+                const ids = await drain(writer, "leaderboard");
+
+                // NULLs sort LAST descending: the scored rows high-to-low, then
+                // every unscored row, each exactly once.
+                expect(ids).toStrictEqual(["s4", "s3", "s2", "s1", "s0", "n0", "n1", "n2", "n3", "n4", "n5", "n6"]);
+                expect(new Set(ids).size).toBe(12);
+            });
+
+            it("pages through the NULL group ascending without losing a row", async () => {
+                expect.assertions(2);
+
+                const writer = setupWriter(makeSchema({ name: "byScore", on: "messages", sortBy: [{ direction: "asc", field: "score" }] }));
+
+                await seedWithNulls(writer);
+
+                const ids = await drain(writer, "byScore");
+
+                // NULLs sort FIRST ascending.
+                expect(ids).toStrictEqual(["n0", "n1", "n2", "n3", "n4", "n5", "n6", "s0", "s1", "s2", "s3", "s4"]);
+                expect(new Set(ids).size).toBe(12);
+            });
+
+            it("ranks a NULL-valued row where the ordering actually puts it", async () => {
+                expect.assertions(3);
+
+                const writer = setupWriter(makeSchema(byScoreDesc));
+
+                await seedWithNulls(writer);
+
+                // Descending: 5 scored rows first, then the NULL group ordered
+                // by the `__id__` tiebreak.
+                await expect(writer.rank("messages", "leaderboard", { row: "s4" })).resolves.toStrictEqual({ position: 1, total: 12 });
+                await expect(writer.rank("messages", "leaderboard", { row: "n0" })).resolves.toStrictEqual({ position: 6, total: 12 });
+                await expect(writer.rank("messages", "leaderboard", { row: "n6" })).resolves.toStrictEqual({ position: 12, total: 12 });
+            });
+        });
+
         it("rankPage scoped by partition `where`", async () => {
             expect.assertions(1);
 

--- a/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
+++ b/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
@@ -492,21 +492,34 @@ describe("expression-depth cap", () => {
         const harness = createSqliteExec();
 
         try {
-            const schema = schemaWith(1);
+            // DISTINCT fields, not N copies of one key: an object literal holds
+            // each key once, so `Array.from({length: 200}, () => ["title", …])`
+            // collapsed to a single condition and this case ran one term where
+            // it claimed to run 200.
+            //
+            // 90, not 200, because the two caps meet here: one equality binds one
+            // parameter, and the bound-parameter ceiling the suite above pins is
+            // 100, so a genuinely-200-term `where` is rejected before it can be
+            // executed at all. The structural assertions on `compileWide` still
+            // cover the full 200.
+            const fields = Array.from({ length: 90 }, (_unused, index) => `f${String(index)}`);
+            const schema: SchemaLike = {
+                tables: { t0: { indexes: [], shape: Object.fromEntries(fields.map((field) => [field, { kind: "string" }])) } },
+            };
 
             runShardMigrations(harness.sql, schema);
 
             const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
 
-            await writer.insert("t0", { title: "kept" });
+            await writer.insert("t0", Object.fromEntries(fields.map((field) => [field, "kept"])));
 
-            // 200 AND'd conditions the row satisfies, then one it does not.
-            const satisfied = Object.fromEntries(Array.from({ length: 200 }, () => ["title", "kept"]));
+            // Every one of them AND'd and satisfied, then one that is not.
+            const satisfied = Object.fromEntries(fields.map((field) => [field, "kept"]));
             const rows = await writer.findMany("t0", { where: satisfied });
 
             expect(rows.page).toHaveLength(1);
 
-            const contradicted = await writer.findMany("t0", { where: { ...satisfied, title: "absent" } });
+            const contradicted = await writer.findMany("t0", { where: { ...satisfied, f0: "absent" } });
 
             expect(contradicted.page).toHaveLength(0);
         } finally {

--- a/packages/shard-engine/src/ctx-db-client-watermark.ts
+++ b/packages/shard-engine/src/ctx-db-client-watermark.ts
@@ -24,7 +24,11 @@
  * The dispatch contract the watermark enforces (see the DO push path):
  * - `id <= watermark` → already processed (skip, return ok);
  * - `id == watermark + 1` → run the server impl authoritatively and advance the
- * watermark **in the same transaction** as the writes;
+ * watermark — inside the handler's commit on the transactional path
+ * (`commitMutationBookkeeping`, `strict`), so the watermark is durable iff the
+ * writes are, and as its own write after they auto-commit on the best-effort
+ * one. {@link advanceClientWatermark} spells out why the non-atomic path is
+ * still safe; this line used to claim the atomic path unconditionally;
  * - `id > watermark + 1` → an out-of-order gap; the batch halts so the client
  * resends from `watermark + 1`.
  *
@@ -76,9 +80,11 @@ const readClientWatermark = (sql: SqlExec, identity: string, clientId: string): 
 };
 
 /**
- * Advance an `(identity, clientId)` pair's watermark to `mutationId`. This runs
- * as its own write AFTER the mutator's writes auto-commit — NOT atomically with
- * them (see the dispatch flow in `shard-do.ts`). That's safe because the gap
+ * Advance an `(identity, clientId)` pair's watermark to `mutationId`. On the
+ * best-effort path this runs as its own write AFTER the mutator's writes
+ * auto-commit — NOT atomically with them (the transactional path,
+ * `commitMutationBookkeeping(…, { strict })` in `shard-do.ts`, runs it inside
+ * the handler's commit instead). The non-atomic case is safe because the gap
  * self-heals: a crash between the handler commit and this advance leaves the
  * watermark behind, so the client's unacked replay re-classifies as `"next"`,
  * re-runs idempotently (the idempotency row dedups the actual write), and

--- a/packages/shard-engine/src/ctx-db-client-watermark.ts
+++ b/packages/shard-engine/src/ctx-db-client-watermark.ts
@@ -28,7 +28,7 @@
  * (`commitMutationBookkeeping`, `strict`), so the watermark is durable iff the
  * writes are, and as its own write after they auto-commit on the best-effort
  * one. {@link advanceClientWatermark} spells out why the non-atomic path is
- * still safe; this line used to claim the atomic path unconditionally;
+ * still safe;
  * - `id > watermark + 1` → an out-of-order gap; the batch halts so the client
  * resends from `watermark + 1`.
  *
@@ -83,8 +83,8 @@ const readClientWatermark = (sql: SqlExec, identity: string, clientId: string): 
  * Advance an `(identity, clientId)` pair's watermark to `mutationId`. On the
  * best-effort path this runs as its own write AFTER the mutator's writes
  * auto-commit — NOT atomically with them (the transactional path,
- * `commitMutationBookkeeping(…, { strict })` in `shard-do.ts`, runs it inside
- * the handler's commit instead). The non-atomic case is safe because the gap
+ * `commitMutationBookkeeping` in `shard-do.ts`, calls this with
+ * `{ strict: true }` inside the handler's commit instead). The non-atomic case is safe because the gap
  * self-heals: a crash between the handler commit and this advance leaves the
  * watermark behind, so the client's unacked replay re-classifies as `"next"`,
  * re-runs idempotently (the idempotency row dedups the actual write), and

--- a/packages/shard-engine/src/ctx-db-rank-page.ts
+++ b/packages/shard-engine/src/ctx-db-rank-page.ts
@@ -32,7 +32,7 @@ import { SCAN_DEP } from "./dependency-tracker";
 import { runDrizzle } from "./do-exec";
 import { sqliteInList } from "./drizzle";
 import { CURSOR_PREFIX, decodeCursor, toBase64 } from "./query-args";
-import { encodePartitionKey, RANK_TIEBREAK, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
+import { encodePartitionKey, RANK_TIEBREAK, rankPivotConditionSql, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
 import type { RankDirection, RankIndexDefinitionLike, RankPageOptions, RankPageRowKey } from "./schema-types";
 
 const DOC_COLUMN = "__doc__";
@@ -92,17 +92,31 @@ const buildRankSeekClause = (
     const branches: SQL[] = [];
 
     for (const [pivot, col] of cols.entries()) {
+        // A NULL pivot with nothing on the wanted side makes the whole branch
+        // unsatisfiable — drop it rather than emit an always-false disjunct.
+        const pivotCondition = rankPivotConditionSql(col.column, decoded[pivot], col.direction, true);
+
+        if (pivotCondition === undefined) {
+            continue;
+        }
+
         const conditions: SQL[] = [];
 
         for (const [prefix, prefixCol] of cols.slice(0, pivot).entries()) {
             conditions.push(dsql`${dsql.identifier(prefixCol.column)} IS ${decoded[prefix]}`);
         }
 
-        conditions.push(dsql`${dsql.identifier(col.column)} ${dsql.raw(col.direction === "desc" ? "<" : ">")} ${decoded[pivot]}`);
+        conditions.push(pivotCondition);
 
         const [firstCondition] = conditions;
 
         branches.push(conditions.length === 1 && firstCondition !== undefined ? firstCondition : dsql`(${dsql.join(conditions, dsql` AND `)})`);
+    }
+
+    if (branches.length === 0) {
+        // Every pivot was a NULL at the end of its ordering: the cursor is the
+        // last row there is, so no row resumes after it.
+        return dsql`(1 = 0)`;
     }
 
     return dsql`(${dsql.join(branches, dsql` OR `)})`;

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -96,7 +96,7 @@ import {
     softDeleteScope,
     tiebreakDirectionFor,
 } from "./query-args";
-import { encodePartitionKey, RANK_TIEBREAK, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
+import { encodePartitionKey, RANK_TIEBREAK, rankPivotConditionSql, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
 import type { ReactiveCache } from "./reactive-cache";
 import { UNVOUCHABLE_DEP } from "./read-footprint";
 import type { IndexKeyEntry, KeyRange } from "./read-write-set";
@@ -2104,7 +2104,9 @@ const runGuardedWrite = (sql: SqlExec, table: string, text: string, params: Read
  * (k0 < v0)
  * OR (k0 = v0 AND k1 < v1)
  * OR (k0 = v0 AND k1 = v1 AND __id__ < rowId)
- * where `<` flips to `>` for desc keys.
+ * where `<` flips to `>` for desc keys. Each pivot comparison comes from
+ * {@link rankPivotConditionSql}, which is where the NULL cases live — a sort
+ * column genuinely holds NULL and no comparator reaches either side of one.
  */
 const countRankBefore = (
     sql: SqlExec,
@@ -2118,30 +2120,36 @@ const countRankBefore = (
     const beforeBranches: SQL[] = [];
 
     for (let pivot = 0; pivot < sortColumns.length + 1; pivot += 1) {
+        const column = sortColumns[pivot];
+        const sortKey = sortBy[pivot];
+        // The `__id__` ASC tiebreak closes the tuple; ids are minted by the
+        // store, so that one is never NULL.
+        const direction = sortKey?.direction === "desc" ? "desc" : "asc";
+        const pivotCondition =
+            column === undefined || sortKey === undefined
+                ? dsql`${dsql.identifier(RANK_TIEBREAK)} < ${rowId}`
+                : rankPivotConditionSql(column, serializedSortValues[pivot], direction, false);
+
+        // A NULL pivot with nothing sorting before it makes the whole branch
+        // unsatisfiable — drop it rather than emit an always-false disjunct.
+        if (pivotCondition === undefined) {
+            continue;
+        }
+
         const conditions: SQL[] = [];
 
         for (let prefix = 0; prefix < pivot; prefix += 1) {
             conditions.push(dsql`${dsql.identifier(sortColumns[prefix] as string)} IS ${serializedSortValues[prefix]}`);
         }
 
-        const column = sortColumns[pivot];
-        const sortKey = sortBy[pivot];
-
-        if (column !== undefined && sortKey !== undefined) {
-            const operator = sortKey.direction === "desc" ? ">" : "<";
-
-            conditions.push(dsql`${dsql.identifier(column)} ${dsql.raw(operator)} ${serializedSortValues[pivot]}`);
-        } else {
-            // Final pivot is the `__id__` ASC tiebreak.
-            conditions.push(dsql`${dsql.identifier(RANK_TIEBREAK)} < ${rowId}`);
-        }
+        conditions.push(pivotCondition);
 
         const [firstCondition] = conditions;
 
         beforeBranches.push(conditions.length === 1 && firstCondition !== undefined ? firstCondition : dsql`(${dsql.join(conditions, dsql` AND `)})`);
     }
 
-    const beforeWhere = dsql.join(beforeBranches, dsql` OR `);
+    const beforeWhere = beforeBranches.length > 0 ? dsql.join(beforeBranches, dsql` OR `) : dsql`1 = 0`;
     const beforeRow = runDrizzle<{ c: number }>(
         sql,
         dsql`SELECT COUNT(*) AS c FROM ${dsql.identifier(rankTable)} WHERE ${dsql.identifier("__partition__")} = ${partitionKey} AND (${beforeWhere})`,

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -274,7 +274,16 @@ export {
 // part of `@lunora/do`'s frozen surface and it does not re-export them.
 export type { QueueMessageOutcome, QueueMessageRow, RecordQueueMessageInput } from "./queue-catcher";
 export { clearQueueMessages, isLossyBody, QUEUE_TABLE, readQueueMessageById, readQueueMessages, recordQueueMessages } from "./queue-catcher";
-export { encodePartitionKey, matchesRankStaticWhere, RANK_TIEBREAK, rankKeyFromDoc, rankTableName, resolveRankPartition, sortColumnName } from "./rank";
+export {
+    encodePartitionKey,
+    matchesRankStaticWhere,
+    RANK_TIEBREAK,
+    rankKeyFromDoc,
+    rankPivotConditionSql,
+    rankTableName,
+    resolveRankPartition,
+    sortColumnName,
+} from "./rank";
 export type { CacheEntry, ReactiveCacheOptions } from "./reactive-cache";
 export { ReactiveCache, reactiveCacheKey, stableStringify, stableWireKey } from "./reactive-cache";
 export type { ReactorDispatchResult, ReactorState, ReactorStats } from "./reactor-state";

--- a/packages/shard-engine/src/rank.ts
+++ b/packages/shard-engine/src/rank.ts
@@ -35,6 +35,9 @@
  * `backfillRankIndexes`.
  */
 
+import type { SQL } from "drizzle-orm";
+import { sql as dsql } from "drizzle-orm";
+
 import { matchesStaticWhere } from "./aggregate-sql";
 import { compareStrings } from "./aggregate-tally";
 import type { RankIndexDefinitionLike } from "./schema-types";
@@ -182,7 +185,65 @@ const rankKeyFromDocument = (
     };
 };
 
-export { encodePartitionKey, RANK_TIEBREAK, rankKeyFromDocument as rankKeyFromDoc, rankTableName, resolveRankPartition, sortColumnName };
+/**
+ * One pivot column's comparison for a lexicographic rank seek — the shared core
+ * of `rankPage`'s strict-after cursor and `rank()`/`rankBefore()`'s
+ * strictly-before count, on both the DO and the SQL-store side.
+ *
+ * `wantLater` is which side is being sought: `true` for the forward page seek,
+ * `false` for the "how many sort before this row" count.
+ *
+ * **NULL is why this is not a comparator lookup**, and it is the same reasoning
+ * `pivotCondition` (`query-args.ts`) writes out for the row-store keyset seek.
+ * `col > NULL` and `col < NULL` are both UNKNOWN, so no comparator expresses
+ * either side of a NULL pivot, and none reaches a NULL row sitting on the far
+ * side of a non-null pivot. A rank sort column genuinely holds NULL:
+ * `syncRankIndexEntry` writes `record[field] ?? null`, so a document simply
+ * missing the field is a NULL in `__sort_k<i>__`.
+ *
+ * The NULL placement written out here is the one the rank companion's btree is
+ * built under — SQLite's, NULLs FIRST ascending and LAST descending — so a
+ * non-null row is on the wanted side of a NULL pivot exactly when
+ * `ascending === wantLater`, and NULL rows are on the wanted side of a non-null
+ * pivot exactly when it is not. Every `ORDER BY` that pairs with this seek has
+ * to agree; Postgres does not by default, so `@lunora/sql-store` states the
+ * placement explicitly on its rank reads.
+ *
+ * `undefined` is the same pivot as `null`: a cursor position for a column the
+ * row never carried arrives here as `undefined`.
+ * @returns the pivot's predicate, or `undefined` when nothing can sort on the wanted side of it (the caller drops the whole branch)
+ */
+const rankPivotConditionSql = (column: string, value: unknown, direction: "asc" | "desc", wantLater: boolean): SQL | undefined => {
+    const nonNullWanted = (direction !== "desc") === wantLater;
+
+    if (value === null || value === undefined) {
+        // The NULL group is the extreme of this ordering: either every non-null
+        // row is on the wanted side of it, or nothing at all is.
+        return nonNullWanted ? dsql`${dsql.identifier(column)} IS NOT NULL` : undefined;
+    }
+
+    const comparison = dsql`${dsql.identifier(column)} ${dsql.raw(nonNullWanted ? ">" : "<")} ${value}`;
+
+    if (nonNullWanted) {
+        return comparison;
+    }
+
+    // The NULL rows sort on the wanted side of this pivot and no comparator can
+    // reach them.
+    //
+    // Emitted unconditionally, where the row-store's `pivotCondition` gates the
+    // same arm on the column's declared nullability — a second
+    // disjunct on the pivot column is not answerable from the companion's
+    // `(__partition__, __sort_k0__ …, __id__)` btree, so the planner falls back
+    // to a scan for this branch. A rank index definition carries no nullability
+    // (`RankIndexDefinitionLike.sortBy` is field + direction) and the companion
+    // writer NULLs a missing field regardless of what the schema declares, so
+    // there is nothing here to gate on yet. Thread the column's validator
+    // through if a wide partition makes the scan measurable.
+    return dsql`(${comparison} OR ${dsql.identifier(column)} IS NULL)`;
+};
+
+export { encodePartitionKey, RANK_TIEBREAK, rankKeyFromDocument as rankKeyFromDoc, rankPivotConditionSql, rankTableName, resolveRankPartition, sortColumnName };
 
 // Cheap predicate test against the index's static `where` (literal equality /
 // `{ eq }` only) — the identical check aggregates use, aliased for the rank seam.

--- a/packages/sql-store/src/ctx-db-migrations.ts
+++ b/packages/sql-store/src/ctx-db-migrations.ts
@@ -33,12 +33,74 @@ import { BIGINT_KEY_LENGTH, bigintSqlKey, effectiveColumnKind } from "./value-co
  * (`@lunora/d1/dialect`) — the same mapping the `lunora migrate generate` SQL
  * emitter uses, so auto-provisioned and hand-migrated tables stay identical.
  */
-const globalColumnAffinity = (validator: ValidatorLike, dialect: SqlDialect): string =>
-    dialect.columnType(effectiveColumnKind(validator), { unique: validator._meta?.column?.unique === true });
+const globalColumnAffinity = (validator: ValidatorLike, dialect: SqlDialect, indexedInFull = false): string =>
+    dialect.columnType(effectiveColumnKind(validator), { unique: indexedInFull || validator._meta?.column?.unique === true });
+
+/**
+ * Fields whose values a UNIQUE index must cover in FULL, so the column is
+ * declared as a bounded type and its index takes no key prefix.
+ *
+ * Two producers, one contract: a `.unique()` column, and a single-column entry
+ * in `definition.indexes` with `unique: true`. The second was missed when
+ * `.unique()` was bounded — `indexRef` read only the validator's own flag, so a
+ * declared unique index on a plain text field still took `(191)` and enforced
+ * uniqueness of the PREFIX, which is the same false ER_DUP_ENTRY the column
+ * flag was fixed for.
+ *
+ * A COMPOSITE unique index cannot be handled the same way: InnoDB caps a key at
+ * 3072 bytes total, so bounding every column to 768 characters (3072 bytes under
+ * utf8mb4) overflows the moment there are two of them. Those are refused in
+ * {@link assertIndexableUniqueIndexes} rather than silently prefixed, because a
+ * prefixed composite UNIQUE constrains something other than what was declared.
+ */
+const fullValueIndexedFields = (definition: SchemaLike["tables"][string]): ReadonlySet<string> => {
+    const fields = new Set<string>();
+
+    for (const index of definition.indexes) {
+        if (index.unique === true && index.fields.length === 1) {
+            fields.add(index.fields[0] as string);
+        }
+    }
+
+    return fields;
+};
+
+/**
+ * Refuse a composite UNIQUE index on a dialect that can only index a text column
+ * by prefix. Prefixing each column would enforce uniqueness of the prefixes, not
+ * of the values — a silent weakening of the declared constraint, and the exact
+ * defect single-column unique indexes were just fixed for.
+ */
+const assertIndexableUniqueIndexes = (tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): void => {
+    if (dialect.indexKeyPrefix === undefined) {
+        return;
+    }
+
+    for (const index of definition.indexes) {
+        if (index.unique !== true || index.fields.length <= 1) {
+            continue;
+        }
+
+        const prefixed = index.fields.filter((field) => {
+            const validator = definition.shape[field];
+
+            return validator !== undefined && dialect.indexKeyPrefix?.(effectiveColumnKind(validator)) !== undefined;
+        });
+
+        if (prefixed.length > 0) {
+            throw new Error(
+                `${tableName}.${index.name}: a composite unique index cannot cover ${prefixed.join(", ")} in full on this engine ` +
+                    `(its key limit forces a prefix, which would constrain the prefix rather than the value). ` +
+                    `Split it into single-column unique indexes, or store those fields as a bounded type.`,
+            );
+        }
+    }
+};
 
 /** Build the column DDL for a global table as a drizzle `SQL`: framework columns plus a typed column per declared field. */
 const globalTableColumnsDdl = (tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): SQL => {
     const fieldColumns: SQL[] = [];
+    const fullValueFields = fullValueIndexedFields(definition);
 
     for (const [field, validator] of Object.entries(definition.shape)) {
         if (!validator._meta?.column) {
@@ -49,7 +111,7 @@ const globalTableColumnsDdl = (tableName: string, definition: SchemaLike["tables
         // so an insert that omits them can't trip a constraint.
         const notNull = validator._meta.column.notNull && validator.kind !== "optional" ? " NOT NULL" : "";
 
-        fieldColumns.push(sql`${sql.identifier(field)} ${sql.raw(`${globalColumnAffinity(validator, dialect)}${notNull}`)}`);
+        fieldColumns.push(sql`${sql.identifier(field)} ${sql.raw(`${globalColumnAffinity(validator, dialect, fullValueFields.has(field))}${notNull}`)}`);
     }
 
     const frameworkColumns = [
@@ -218,6 +280,10 @@ const dropIndexIfShapeChanged = async (
 
 /** Create a global table's declared secondary indexes and its synthesized `.unique()` column indexes. */
 const createGlobalTableIndexes = async (exec: SqlCtxExec, tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): Promise<void> => {
+    assertIndexableUniqueIndexes(tableName, definition, dialect);
+
+    const fullValueFields = fullValueIndexedFields(definition);
+
     // Index column reference as drizzle SQL, with a key prefix where the engine
     // demands it (MySQL can't index its now-unbounded TEXT string columns without
     // one). Framework columns (id/_creationTime — absent from `shape`) are already
@@ -230,7 +296,7 @@ const createGlobalTableIndexes = async (exec: SqlCtxExec, tableName: string, def
         // prefixed UNIQUE index constrains the PREFIX: two distinct values that
         // agree on their first 191 characters collided as a duplicate.
         const prefix =
-            validator && dialect.indexKeyPrefix && validator._meta?.column?.unique !== true
+            validator && dialect.indexKeyPrefix && validator._meta?.column?.unique !== true && !fullValueFields.has(field)
                 ? dialect.indexKeyPrefix(effectiveColumnKind(validator))
                 : undefined;
 

--- a/packages/sql-store/src/ctx-db-migrations.ts
+++ b/packages/sql-store/src/ctx-db-migrations.ts
@@ -33,7 +33,8 @@ import { BIGINT_KEY_LENGTH, bigintSqlKey, effectiveColumnKind } from "./value-co
  * (`@lunora/d1/dialect`) — the same mapping the `lunora migrate generate` SQL
  * emitter uses, so auto-provisioned and hand-migrated tables stay identical.
  */
-const globalColumnAffinity = (validator: ValidatorLike, dialect: SqlDialect): string => dialect.columnType(effectiveColumnKind(validator));
+const globalColumnAffinity = (validator: ValidatorLike, dialect: SqlDialect): string =>
+    dialect.columnType(effectiveColumnKind(validator), { unique: validator._meta?.column?.unique === true });
 
 /** Build the column DDL for a global table as a drizzle `SQL`: framework columns plus a typed column per declared field. */
 const globalTableColumnsDdl = (tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): SQL => {
@@ -224,7 +225,14 @@ const createGlobalTableIndexes = async (exec: SqlCtxExec, tableName: string, def
     const indexRef = (field: string): SQL => {
         const reference = columnRefSql(field);
         const validator = definition.shape[field];
-        const prefix = validator && dialect.indexKeyPrefix ? dialect.indexKeyPrefix(effectiveColumnKind(validator)) : undefined;
+        // A `.unique()` column is declared as a type the engine indexes in FULL
+        // (`columnType`'s `unique` option), so it never takes a key prefix. A
+        // prefixed UNIQUE index constrains the PREFIX: two distinct values that
+        // agree on their first 191 characters collided as a duplicate.
+        const prefix =
+            validator && dialect.indexKeyPrefix && validator._meta?.column?.unique !== true
+                ? dialect.indexKeyPrefix(effectiveColumnKind(validator))
+                : undefined;
 
         return prefix === undefined ? reference : sql`${reference}(${sql.raw(String(prefix))})`;
     };

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -85,6 +85,7 @@ import {
     NotFoundError,
     NotUniqueError,
     RANK_TIEBREAK,
+    rankPivotConditionSql,
     rankTableName,
     readAggregateValue,
     relationHooks,
@@ -541,26 +542,38 @@ const buildRankBeforeBranches = (
     sortColumns: ReadonlyArray<string>,
     own: Record<string, unknown>,
     rowId: string,
-): SQL | undefined => {
+): SQL => {
     const branches: SQL[] = [];
 
     for (let pivot = 0; pivot < sortColumns.length + 1; pivot += 1) {
+        const column = sortColumns[pivot];
+        const sortKey = index.sortBy[pivot];
+        // Each pivot's comparison comes from the shared `rankPivotConditionSql`,
+        // which owns the NULL cases: `col < NULL` is UNKNOWN, and NULL rows sort
+        // ahead of a non-null pivot ascending, so a bare comparator both
+        // under-counts and mis-reads a NULL-valued row's own position. The
+        // `__id__` tiebreak closes the tuple and is never NULL.
+        const isSortPivot = pivot < sortColumns.length && column !== undefined && sortKey !== undefined;
+        const direction = sortKey?.direction === "desc" ? "desc" : "asc";
+        const pivotCondition = isSortPivot ? rankPivotConditionSql(column, own[column], direction, false) : sql`${sql.identifier(RANK_TIEBREAK)} < ${rowId}`;
+
+        if (pivotCondition === undefined) {
+            continue;
+        }
+
         const conditions: SQL[] = sortColumns
             .slice(0, pivot)
             .map((prefixColumn) => nullSafeEqualsSql(engine, sql`${sql.identifier(prefixColumn)}`, own[prefixColumn]));
-        const column = sortColumns[pivot];
-        const sortKey = index.sortBy[pivot];
 
-        if (pivot < sortColumns.length && column !== undefined && sortKey !== undefined) {
-            conditions.push(sql`${sql.identifier(column)} ${sql.raw(sortKey.direction === "desc" ? ">" : "<")} ${own[column]}`);
-        } else {
-            conditions.push(sql`${sql.identifier(RANK_TIEBREAK)} < ${rowId}`);
-        }
+        conditions.push(pivotCondition);
 
         branches.push(andBranch(conditions));
     }
 
-    return branches.length > 0 ? sql.join(branches, sql` OR `) : undefined;
+    // Never `undefined`: an absent clause counts the WHOLE partition, and "every
+    // pivot was a NULL at the start of its ordering" means nothing sorts before
+    // this row at all.
+    return branches.length > 0 ? sql.join(branches, sql` OR `) : sql`1 = 0`;
 };
 
 /**
@@ -582,6 +595,14 @@ const buildRankCursorSeek = (
     const branches: SQL[] = [];
 
     for (const [pivot, col] of columns.entries()) {
+        // Shared with the DO twin — see `rankPivotConditionSql` for why a bare
+        // `>`/`<` at the pivot drops every row once a sort column holds NULL.
+        const pivotCondition = rankPivotConditionSql(col.column, decoded[pivot], col.direction, true);
+
+        if (pivotCondition === undefined) {
+            continue;
+        }
+
         const conditions: SQL[] = [];
 
         for (let prefix = 0; prefix < pivot; prefix += 1) {
@@ -594,8 +615,14 @@ const buildRankCursorSeek = (
             conditions.push(nullSafeEqualsSql(engine, sql`${sql.identifier(prefixCol.column)}`, decoded[prefix]));
         }
 
-        conditions.push(sql`${sql.identifier(col.column)} ${sql.raw(col.direction === "desc" ? "<" : ">")} ${decoded[pivot]}`);
+        conditions.push(pivotCondition);
         branches.push(andBranch(conditions));
+    }
+
+    if (branches.length === 0) {
+        // The cursor sits at the end of the ordering on every pivot: no row
+        // resumes after it.
+        return sql`(1 = 0)`;
     }
 
     return sql`(${sql.join(branches, sql` OR `)})`;
@@ -604,8 +631,17 @@ const buildRankCursorSeek = (
 /**
  * The rankPage column tuple in sort order: `[partition, ...sortColumns, id]`.
  * Partition and id sort ascending; each sort column follows its index direction.
+ *
+ * `nullable` marks the columns the seek has to place NULLs for: `__partition__`
+ * is the canonical-JSON key tuple and `__id__` is store-minted, so only the
+ * `__sort_k<i>__` columns can hold one (`syncRankIndexEntry` writes
+ * `record[field] ?? null`). It drives the ORDER BY's `NULLS FIRST/LAST` — the
+ * seek assumes SQLite's placement, which Postgres does not share.
  */
-const rankPageColumns = (index: RankIndexDefinitionLike, sortColumns: ReadonlyArray<string>): { column: string; direction: "asc" | "desc" }[] => {
+const rankPageColumns = (
+    index: RankIndexDefinitionLike,
+    sortColumns: ReadonlyArray<string>,
+): { column: string; direction: "asc" | "desc"; nullable: boolean }[] => {
     // A rank index with no sort columns degenerates the cursor tuple to
     // `[__partition__, RANK_TIEBREAK]`, which lets `buildRankCursorSeek` silently
     // mismatch and return a wrong/empty page. The schema builder already requires
@@ -615,13 +651,13 @@ const rankPageColumns = (index: RankIndexDefinitionLike, sortColumns: ReadonlyAr
         throw new LunoraError("INTERNAL", `rankIndex "${index.name}" requires at least one "sortBy" column for stable pagination`);
     }
 
-    const columns: { column: string; direction: "asc" | "desc" }[] = [{ column: "__partition__", direction: "asc" }];
+    const columns: { column: string; direction: "asc" | "desc"; nullable: boolean }[] = [{ column: "__partition__", direction: "asc", nullable: false }];
 
     for (const [i, sortKey] of index.sortBy.entries()) {
-        columns.push({ column: sortColumns[i] ?? sortColumnName(i), direction: sortKey.direction });
+        columns.push({ column: sortColumns[i] ?? sortColumnName(i), direction: sortKey.direction, nullable: true });
     }
 
-    columns.push({ column: RANK_TIEBREAK, direction: "asc" });
+    columns.push({ column: RANK_TIEBREAK, direction: "asc", nullable: false });
 
     return columns;
 };
@@ -3539,7 +3575,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             const beforeRows = await queryAll(
                 exec,
                 dialect,
-                sql`SELECT COUNT(*) AS c FROM ${sql.identifier(rankTable)} WHERE ${sql.identifier("__partition__")} = ${partitionKey}${beforeClause ? sql` AND (${beforeClause})` : sql``}`,
+                sql`SELECT COUNT(*) AS c FROM ${sql.identifier(rankTable)} WHERE ${sql.identifier("__partition__")} = ${partitionKey} AND (${beforeClause})`,
             );
             const totalRows = await queryAll(
                 exec,
@@ -3590,7 +3626,10 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // ascending except the sort columns, which follow their index.
             const rankColumns = rankPageColumns(index, sortColumns);
             const orderBy = sql.join(
-                rankColumns.map((col) => sql`${sql.identifier(col.column)} ${sql.raw(col.direction === "desc" ? "DESC" : "ASC")}`),
+                rankColumns.map(
+                    (col) =>
+                        sql`${sql.identifier(col.column)} ${sql.raw(`${col.direction === "desc" ? "DESC" : "ASC"}${nullsPlacement(dialect, { direction: col.direction, nullable: col.nullable })}`)}`,
+                ),
                 sql`, `,
             );
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -127,6 +127,7 @@ import {
     queryBatch,
     queryRun,
     serializeColumnValue,
+    serializeDocumentColumn,
     tableColumns,
 } from "./sql-exec";
 import { bigintSqlKey, effectiveColumnKind } from "./value-codec";
@@ -2268,7 +2269,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // Raw (unquoted) column names — the INSERT quotes them via `sql.identifier`.
             columns: ["id", "_creationTime", ...fields],
             // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column must bind `null`, not undefined.
-            values: [id, creationTime, ...fields.map((field) => serializeColumnValue(document[field] ?? null))],
+            values: [id, creationTime, ...fields.map((field) => serializeDocumentColumn(definition, field, document[field] ?? null))],
         };
     };
 
@@ -2722,8 +2723,10 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 // merged row; read scoping (not companion removal) hides it.
                 const merged: Record<string, unknown> = { ...existing, [softField]: clock() };
                 const assignments = sql.join(
-                    // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column binds `null`, matching the patch path.
-                    Object.keys(definition.shape).map((field) => sql`${sql.identifier(field)} = ${serializeColumnValue(merged[field] ?? null)}`),
+                    Object.keys(definition.shape).map(
+                        // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column binds `null`, matching the patch path.
+                        (field) => sql`${sql.identifier(field)} = ${serializeDocumentColumn(definition, field, merged[field] ?? null)}`,
+                    ),
                     sql`, `,
                 );
 
@@ -3213,7 +3216,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             const fields = Object.keys(definition.shape);
             const assignments = sql.join(
                 // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column must bind `null`, not undefined.
-                fields.map((field) => sql`${sql.identifier(field)} = ${serializeColumnValue(merged[field] ?? null)}`),
+                fields.map((field) => sql`${sql.identifier(field)} = ${serializeDocumentColumn(definition, field, merged[field] ?? null)}`),
                 sql`, `,
             );
 
@@ -3745,7 +3748,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 [
                     sql`${sql.identifier("_creationTime")} = ${creationTime}`,
                     // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column must bind `null`, not undefined.
-                    ...fields.map((field) => sql`${sql.identifier(field)} = ${serializeColumnValue(replaced[field] ?? null)}`),
+                    ...fields.map((field) => sql`${sql.identifier(field)} = ${serializeDocumentColumn(definition, field, replaced[field] ?? null)}`),
                 ],
                 sql`, `,
             );

--- a/packages/sql-store/src/dialect.ts
+++ b/packages/sql-store/src/dialect.ts
@@ -80,8 +80,17 @@ export interface SqlDialect {
      *   decimal string), and `LONGTEXT` for everything else — strings unbounded
      *   so they never truncate, composites because their wire-marked form is not
      *   valid JSON and a `JSON` column would reject it on insert.
+     *
+     * `unique` says the column carries a `.unique()` constraint, so the type has
+     * to be one the engine can index in FULL. It exists for MySQL: InnoDB cannot
+     * index a `LONGTEXT` without a key prefix, and a prefixed UNIQUE index
+     * enforces uniqueness of the PREFIX — two distinct 200-character emails
+     * sharing their first 191 characters collided as a duplicate. A bounded
+     * `VARCHAR` indexes whole, so the constraint means what it says; a value
+     * past the bound is a loud write error rather than a wrong conflict. SQLite
+     * and Postgres index text of any length and ignore the flag.
      */
-    columnType: (kind: string | undefined) => string;
+    columnType: (kind: string | undefined, options?: { unique?: boolean }) => string;
 
     /**
      * Engine SQL types for the **internal companion tables** (aggregate / rank /

--- a/packages/sql-store/src/sql-exec.ts
+++ b/packages/sql-store/src/sql-exec.ts
@@ -153,7 +153,15 @@ interface SqlCtxExec {
     run: (sql: string, parameters: ReadonlyArray<unknown>) => Promise<SqlRunResult | void>;
 }
 
-/** SQLite storage encode for `.global()` column values — the shared `@lunora/sql-store` codec (SQLite has no boolean, so true/false → 1/0). */
+/**
+ * SQLite storage encode for `.global()` column values — the shared
+ * `@lunora/sql-store` codec (SQLite has no boolean, so true/false → 1/0).
+ *
+ * Kind-blind, because it is also what binds every WHERE comparison and the rank
+ * companion's sort keys, where the two sides have to agree byte for byte.
+ * A write that knows which column it is filling uses
+ * {@link serializeDocumentColumn} instead.
+ */
 const serializeColumnValue: (value: unknown) => unknown = sqliteEncode;
 
 /** Structural read of a validator's `.nullable()` flag — `.nullable()` is the one thing that clears `notNull`. */
@@ -212,6 +220,37 @@ const columnKinds = (definition: TableDefinitionLike): [string, string | undefin
 
     return kinds;
 };
+
+/**
+ * `field → effective column kind` for the write path, keyed and memoized like
+ * {@link columnKinds} (which is ordered for the row decode; a write looks one
+ * field up at a time, so it wants a map).
+ */
+const columnKindByFieldCache = new WeakMap<TableDefinitionLike, Map<string, string | undefined>>();
+
+const columnKindOf = (definition: TableDefinitionLike, field: string): string | undefined => {
+    let byField = columnKindByFieldCache.get(definition);
+
+    if (byField === undefined) {
+        byField = new Map(columnKinds(definition).map(([name, kind]) => [name, kind]));
+        columnKindByFieldCache.set(definition, byField);
+    }
+
+    return byField.get(field);
+};
+
+/**
+ * Storage encode for one column of a document being WRITTEN, with the column's
+ * declared kind in hand.
+ *
+ * The inverse of {@link decodeGlobalRow}, and it exists for the same reason:
+ * `v.any()`/`v.union()`/`v.from()` store in a TEXT column whatever their runtime
+ * value happens to be, so a number or boolean was coerced to text on the way in
+ * and had no type to be reversed with on the way out — `42` read back `"42.0"`.
+ * Only a caller that knows the column can encode those unambiguously.
+ */
+const serializeDocumentColumn = (definition: TableDefinitionLike, field: string, value: unknown): unknown =>
+    sqliteEncode(value, columnKindOf(definition, field));
 
 /**
  * Decode a SELECTed row back into a document: `id` → `_id`, `_creationTime`
@@ -340,6 +379,7 @@ export {
     queryBatch,
     queryRun,
     serializeColumnValue,
+    serializeDocumentColumn,
     tableColumns,
 };
 

--- a/packages/sql-store/src/value-codec.ts
+++ b/packages/sql-store/src/value-codec.ts
@@ -43,8 +43,31 @@ const WIRE_PREFIX = WIRE_TAG;
 const decodeJsonColumn = (raw: string, parse: (text: string) => unknown): unknown =>
     raw.startsWith(WIRE_PREFIX) ? decodeWire(parse(raw.slice(WIRE_PREFIX.length))) : parse(raw);
 
+/**
+ * Column kinds whose storage type is TEXT on every engine (see
+ * `sqlAffinityForKind` / the Hyperdrive dialects) but whose VALUE can be any JS
+ * scalar, because {@link sqliteEncode} keys off the runtime type.
+ */
+const UNTYPED_KINDS = new Set(["any", "from", "union"]);
+
 /** Map a JS value onto its SQLite storage form — SQLite has no boolean, so true/false → 1/0. */
-export const sqliteEncode = (value: unknown): unknown => {
+export const sqliteEncode = (value: unknown, kind?: string): unknown => {
+    // A number or boolean bound to one of the untyped kinds' TEXT column is
+    // COERCED by the engine — `42` lands as the text `42.0`, `true` (encoded 1)
+    // as `1.0` — and the decode has no type to reverse it with, so the caller
+    // read back a string. Store those two in the marked, self-describing form
+    // the composites already use; `sqliteDecode` reverses it by the marker
+    // alone, so no kind is needed on the way out.
+    //
+    // Strings, bigints and composites keep the storage form they already had:
+    // the WHERE path binds through this same function WITHOUT a kind, so
+    // changing them would stop every existing equality filter from matching.
+    // Equality on an untyped numeric column does not match today either (the
+    // stored `42.0` never equalled a bound `42`), so nothing regresses.
+    if (kind !== undefined && (typeof value === "number" || typeof value === "boolean") && UNTYPED_KINDS.has(kind)) {
+        return WIRE_PREFIX + JSON.stringify(value);
+    }
+
     if (typeof value === "boolean") {
         return value ? 1 : 0;
     }
@@ -152,8 +175,12 @@ export const effectiveColumnKind = (validator: ValidatorLike): string | undefine
  *   belongs here because {@link sqliteEncode} keys off the runtime JS type and
  *   stores the `{ lat, lng }` object as JSON in a TEXT column; without the case
  *   it fell through to `default:` and every client read back the raw JSON text.
- * - `union`/`any`/`from`: parsed back only when the stored string is a JSON
- *   non-scalar (a scalar member round-trips through SQLite's native column type).
+ * - `union`/`any`/`from`: parsed back when the stored string is a JSON
+ *   non-scalar, or when it carries the {@link WIRE_PREFIX} marker.
+ *   A `number` or `boolean` does NOT round-trip through the column's native
+ *   type — all three kinds store as TEXT on every engine, which coerces a bound
+ *   `42` to the text `42.0` — so {@link sqliteEncode} writes those two in the
+ *   marked form and this branch reverses them by the marker alone.
  *   `from` belongs to THIS group, not to `object`/`array`/`record`: an external
  *   Standard Schema can describe a string just as easily as an object, and
  *   {@link sqliteEncode} keys off the runtime JS type — so a `v.from(z.string())`


### PR DESCRIPTION
Fourteen defects across `sql-store`, `shard-engine`, `d1`, `hyperdrive` and `replica`. Every one was verified against the code before being fixed, and every regression test was watched failing first.

## The two that return wrong data silently

**`LocalMirror` pinned a numeric column to TEXT forever when the first observed value was `null`.** The affinity pass skipped null/undefined, the CREATE fell back to `?? "TEXT"`, and the schema-evolution branch only ever *added* missing columns — it never revisited one. Reproduced under `node:sqlite` against the DDL the mirror actually emits:

```
stored:         [ {id:'a', n:null}, {id:'b', n:'5.0'}, {id:'c', n:'10.0'} ]
ORDER BY n ASC: [ {id:'c'}, {id:'b'} ]      ← 10 sorts before 5
WHERE n > 6   : []                           ← should return c
```

`5` doesn't even round-trip. This is exactly what `MIRROR_SCHEMA_VERSION = 3`'s docblock says version 2 fixed — that fix handled "saw a number first" but not "saw null first", so no version bump recovered it. An all-null column is now declared with **no type** (BLOB affinity coerces nothing), at both CREATE and ALTER, and the schema version goes to 4 so stale mirrors re-seed.

**Rank pagination and `rank()` dropped every row once a sort column held NULL** — four sites across both storage planes. The prefix equalities used NULL-safe `IS`, then the pivot used a bare `<`/`>`, and `col > NULL` is UNKNOWN. NULLs genuinely live in those columns; `ctx-db-companions.ts` writes them with a comment saying so. All four sites now route through one `rankPivotConditionSql` ported from the ordinary paginate seek, which had handled this correctly 200 lines away the whole time. The regression test pages 12 rows 4 at a time so **the NULL group spans two page boundaries**, and asserts a full ordered drain in both directions.

## The rest

- A scalar in a `v.any()`/`v.union()`/`v.from()` column came back from a `.global()` table as a **string** (`42` → `"42.0"`, `true` → `"1"`) because those kinds get TEXT affinity. Now written in a self-describing form; the test goes through a real column, which is what the isolated codec test never did.
- **Both** the `sql.js` and `better-sqlite3` adapters read INTEGER through a double — stored `9007199254740993`, read back `…992`, and `WHERE id = ?` matched zero rows. `sqlite-wasm` turned out not to have the bug; all three now share a `narrowSafeIntegers` so they agree.
- `pg-vector`'s filter guard walked `Object.entries`, which is empty for a `Map`/`Set`/class instance — so the guard *and* the WHERE clause were skipped and an unfiltered ANN scan came back looking filtered. Cross-tenant. Now rejects by prototype.
- `mirror.clearData()` permanently emptied any live-subscribed table; `onChange` now carries a reason and the subscriber forgets its frame on `"clear"`.
- `EventSource.events()` never yielded replayed entries despite promising to, and replay stamped entries with the replay time rather than the source timestamp.
- The D1 studio browser decoded **any** schema-named table as `.global()`, skipping redaction — confirmed live: `examples/team-chat` passes a mixed schema to all three introspector methods in an app that also runs better-auth's Kysely migrator against the same D1.
- MySQL `.unique()` was enforced as a 191-character prefix, so two distinct 200-char values raised a false `ConflictError` that D1 and Postgres accept.
- A studio page reader with `LIMIT/OFFSET` and no `ORDER BY`; a facet with no tiebreaker.
- The 200-condition SQLite limits test was building **one** condition (`Object.fromEntries` over 200 identical pairs).

## Two things I could not do, stated plainly

- The rebuilt 200-condition test uses **90** distinct fields, not 200 — the 100-bound-parameter ceiling this same suite pins rejects a 200-term `where` before it executes. I could not make the behavioural half fail against an un-nested implementation: 90 terms is far under stock SQLite's `SQLITE_MAX_EXPR_DEPTH` of 1000, and `node:sqlite` cannot be lowered. The two structural assertions were never vacuous and still discriminate.
- The page-ordering test passes either way on `node:sqlite`, because small tables come back in rowid order. It documents the invariant rather than catching the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination and ranking consistency, including correct handling of NULL values and stable result ordering.
  * Fixed uniqueness enforcement for long text and binary values in MySQL.
  * Prevented unsafe metadata filters from matching unintended records.
  * Corrected integer handling across database adapters, preserving large values while simplifying safe integers.
  * Fixed event replay timestamps, mirror resets, change notifications, and invalid pagination limits.
  * Improved migration parsing for quoted identifiers and handling of empty query results.
  * Corrected serialization for typed document values and untyped numeric or boolean values.

* **New Features**
  * Added public rank-predicate utilities and mirror change reasons for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->