### PR TITLE
fix(scheduler,workflow): give a scheduled workflow an idempotency key

### DIFF
--- a/packages/advisor/docs/index.mdx
+++ b/packages/advisor/docs/index.mdx
@@ -171,7 +171,7 @@ Storage, AI, containers & payments:
 | `relation_references_unknown_table`          | `ERROR` | A relation pointing at a table that doesn't exist                                                              |
 | `shape_unknown_table`                        | `ERROR` | A shape bound to a table that doesn't exist                                                                    |
 | `workflow_unknown_target`                    | `ERROR` | A workflow call naming a workflow that doesn't exist                                                           |
-| `workflow_duplicate_step_name`               | `ERROR` | A durable step name reused within one workflow (the second call returns the first's cached result)             |
+| `workflow_duplicate_step_name`               | `ERROR` | A durable step name reused across two call sites in one workflow (which cache each gets becomes positional)    |
 | `external_source_on_global`                  | `ERROR` | A table that is both `.source()` and `.global()` (contradictory tiers)                                         |
 | `external_source_incremental_no_delete_path` | `ERROR` | An `incremental` `.source()` table with no `reconcileEveryMs`/`softDeleteColumn`; upstream deletes never apply |
 | `export_sink_misconfigured`                  | `ERROR` | A CDC export sink missing a required config field, so the tap silently drains nothing                          |

--- a/packages/advisor/src/lints/static/workflow-duplicate-step-name.ts
+++ b/packages/advisor/src/lints/static/workflow-duplicate-step-name.ts
@@ -2,33 +2,53 @@ import emit from "../../finding";
 import type { Lint } from "../../types";
 
 /**
- * Flags a durable step name reused within one workflow.
+ * Flags a durable step name reused across two call sites in one workflow.
  *
- * Cloudflare Workflows memoizes every `step.do` / `step.sleep` / `step.sleepUntil`
- * / `step.waitForEvent` call by its name: on replay the runtime returns the cached
- * result for a name it has already seen. Two distinct steps that share a name are
- * therefore a silent bug — the second call never runs its body and instead yields
- * the first's result, skipping the work (a charge, a write, an external wait)
- * without error. Hence `ERROR`/`INTERNAL`: it is a developer-facing correctness
- * defect in the workflow's own code, not a runtime-data nit.
+ * **The mechanism, precisely.** Cloudflare does not key a step by its name alone:
+ * the engine keeps a per-run occurrence counter per name and caches under
+ * `hash(name-count)-count` (miniflare's `binding.worker.js`, and the public
+ * `WorkflowStepContext.step.count` that exists to expose it). So the second call
+ * under a repeated name is NOT served the first's cached result — it gets
+ * occurrence 2 and runs. That is what makes the documented loop-over-items
+ * pattern legal, and one loop is one call site, so it never reaches this lint.
  *
- * Only the first string-literal argument of each step call is compared; a step
- * named dynamically (`step.do(\`load-${id}\`, …)`) is omitted by the feeder, so a
- * deliberately-parameterized fan-out is never flagged. `ctx.runStep(stepDef, …)`
- * names (which come from `defineStep` in another file) are out of scope here.
+ * What two DISTINCT call sites sharing a name cost instead is that the mapping
+ * from call site to cached result becomes positional. Occurrence 2 is "whichever
+ * of these ran second", so a conditional, an early return, or a reordering
+ * between them re-points a later replay's cache at the other step's stored
+ * output — silently, with the workflow proceeding on the wrong value. They are
+ * also indistinguishable in the step log and the dashboard. Hence
+ * `ERROR`/`INTERNAL`: a developer-facing correctness defect in the workflow's own
+ * code, not a runtime-data nit.
+ *
+ * **Scope — what the feeder can and cannot see.** Only the first string-literal
+ * argument of a NATIVE step call (`ctx.step.<method>` or a destructured
+ * `step.<method>`) is compared. Three classes are therefore invisible here, by
+ * construction rather than by oversight. A dynamically named step
+ * (`step.do(\`load-${id}\`, …)`) is omitted so a deliberately-parameterized
+ * fan-out is never flagged. `ctx.runStep(stepDef, …)` resolves its name to
+ * `options?.name ?? step.name` from a `defineStep` in another file, and
+ * `ctx.waitForEvent(eventDef, …)` to `options?.name ?? \`event:${event.type}\``
+ * from a `defineWorkflowEvent` in another file — both framework-minted, both
+ * needing cross-file resolution to recover.
+ *
+ * Leaving those two out costs nothing that matters: a repeat of either is an
+ * ordinary second occurrence under the engine's counter, so it waits/runs as
+ * written. The remediation below names only the surfaces actually compared.
+ *
  * Only runs when the declaration feeder supplied step evidence
  * (`workflow.steps` present); a runtime caller flags nothing.
  */
 const workflowDuplicateStepName: Lint = {
     categories: ["SCHEMA"],
     description:
-        "Two durable steps in this workflow share a name. Cloudflare memoizes a step by its name, so on replay the second call returns the first step's cached result instead of running its body — silently skipping the work without an error.",
+        "Two durable step call sites in this workflow share a name. Cloudflare caches a step under its name plus its occurrence number within the run, so which cached result each call site gets is decided by the order they ran — a conditional or a reordering between them re-points a later replay at the other step's stored output, silently and without an error. They are also indistinguishable in the step log.",
     facing: "INTERNAL",
     level: "ERROR",
     // eslint-disable-next-line no-secrets/no-secrets -- the lint's rule id, not a credential
     name: "workflow_duplicate_step_name",
     remediation:
-        "Give every `step.do` / `step.sleep` / `step.sleepUntil` / `step.waitForEvent` call in the workflow a unique name. If a step legitimately repeats (e.g. a loop), make the name distinct per iteration by interpolating the item id into the step name.",
+        "Give every `step.do` / `step.sleep` / `step.sleepUntil` / `step.waitForEvent` CALL SITE in the workflow its own name. A single call site that repeats — a loop over items — is fine as written and is not flagged; interpolate the item id into the name only if you want the iterations distinguishable in the step log.",
     run: (context) => {
         // No declaration evidence → nothing to assert (mirrors the other feeders).
         if (context.workflows === undefined) {

--- a/packages/codegen/__tests__/discover/workflows.test.ts
+++ b/packages/codegen/__tests__/discover/workflows.test.ts
@@ -161,6 +161,36 @@ describe("discover/workflows", () => {
         expect(discoverWorkflows(newProject(), workdir)[0]?.steps).toEqual([{ line: 7, method: "do", name: "seed" }]);
     });
 
+    it("omits the framework-minted step names of ctx.runStep and ctx.waitForEvent", () => {
+        expect.assertions(1);
+
+        // The documented scope boundary of the advisor's duplicate-step-name lint,
+        // made executable. `ctx.runStep(stepDef)` resolves its durable step name to
+        // `options?.name ?? step.name` and `ctx.waitForEvent(eventDef)` to
+        // `options?.name ?? \`event:\${event.type}\``, both from a definition in
+        // another file — the receiver here is `ctx`, not `.step`, so neither
+        // reaches the feeder and neither can reach the lint. That is affordable
+        // rather than a hole: the engine caches a step under its name AND its
+        // occurrence number within the run, so a repeated wait gets occurrence 2
+        // and genuinely waits instead of replaying the first payload.
+        writeWorkflows(`
+            import { defineWorkflow } from "@lunora/workflow";
+            import { chargeStep } from "./steps";
+            import { orderApproved } from "./events";
+
+            export const approvals = defineWorkflow({
+                handler: async (ctx) => {
+                    await ctx.step.do("open", () => undefined);
+                    await ctx.waitForEvent(orderApproved);
+                    await ctx.runStep(chargeStep, {});
+                    await ctx.waitForEvent(orderApproved);
+                },
+            });
+        `);
+
+        expect(discoverWorkflows(newProject(), workdir)[0]?.steps).toEqual([{ line: 8, method: "do", name: "open" }]);
+    });
+
     it("ignores non-defineWorkflow exports and unexported definitions", () => {
         expect.assertions(1);
 

--- a/packages/runtime/__tests__/cron-jobs-run.test.ts
+++ b/packages/runtime/__tests__/cron-jobs-run.test.ts
@@ -100,6 +100,34 @@ describe("createWorker — cron-jobs run endpoint", () => {
         expect(created).toStrictEqual([{ params: { region: "eu" } }]);
     });
 
+    it("starts a fresh instance on every cron run — the cron path deliberately passes no instance id", async () => {
+        expect.assertions(2);
+
+        // The scheduler path forwards its record id as the workflow instance id
+        // so an at-least-once re-fire is deduped. The cron path must NOT: there
+        // is no record id, every scheduled fire of the same expression is a
+        // distinct run, and this "Run now" trigger has to be repeatable on
+        // demand. A stable per-job key here would make the second fire a
+        // duplicate and silently never run again.
+        const created: { id?: string; params?: unknown }[] = [];
+        const env = {
+            WORKFLOW_DIGEST: {
+                create: async (options?: { id?: string; params?: unknown }) => {
+                    created.push(options ?? {});
+
+                    return { id: "wf-1" };
+                },
+            },
+        };
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: createShardSpy().namespace });
+
+        await worker.fetch(runRequest("nightly digest"), env, fakeContext);
+        await worker.fetch(runRequest("nightly digest"), env, fakeContext);
+
+        expect(created).toHaveLength(2);
+        expect(created.every((options) => options.id === undefined)).toBe(true);
+    });
+
     it("returns 404 for an unknown job name", async () => {
         expect.assertions(2);
 

--- a/packages/runtime/__tests__/scheduled-workpool.test.ts
+++ b/packages/runtime/__tests__/scheduled-workpool.test.ts
@@ -113,13 +113,13 @@ const dispatchWithEnv = (worker: ReturnType<typeof createWorker>, body: Record<s
     );
 
 describe("createWorker — scheduled workflow/agent dispatch", () => {
-    it("starts a fresh instance of the workflow binding with the job args as params", async () => {
+    it("starts an instance of the workflow binding with the job args as params", async () => {
         expect.assertions(3);
 
-        const created: { params?: Record<string, unknown> }[] = [];
+        const created: { id?: string; params?: Record<string, unknown> }[] = [];
         const env = {
             AGENT_SUPPORT: {
-                create: async (options: { params?: Record<string, unknown> }) => {
+                create: async (options: { id?: string; params?: Record<string, unknown> }) => {
                     created.push(options);
 
                     return { id: "wf-1" };
@@ -132,10 +132,83 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
         const response = await dispatchWithEnv(worker, { args: { prompt: "digest" }, id: "job-3", workflow: "AGENT_SUPPORT" }, env);
 
         expect(response.status).toBe(200);
-        // The binding is `create()`d with the scheduled args as its `params`.
-        expect(created).toStrictEqual([{ params: { prompt: "digest" } }]);
+        // The binding is `create()`d with the scheduled args as its `params`, under
+        // the record id as its instance id.
+        expect(created).toStrictEqual([{ id: "job-3", params: { prompt: "digest" } }]);
         // This job carries no `pool`, so there is no slot to release.
         expect(sched.calls.some((call) => call.path === "/complete")).toBe(false);
+    });
+
+    it("passes the scheduler record id as the workflow instance id so a re-fire is idempotent", async () => {
+        expect.assertions(2);
+
+        // The SchedulerDO's retry loop is at-least-once: a DO eviction, an edge
+        // 502 or a transport blip after the origin already started the workflow
+        // makes `dispatch()` report failure, `recordRetry` re-arms, and the SAME
+        // record fires again — up to MAX_RETRY_ATTEMPTS times. Without an
+        // instance id Cloudflare mints a fresh random one every call, so each
+        // re-fire runs a second full pipeline. The record id is already on the
+        // wire and already constrained to a safe key segment, which is exactly
+        // what `create({ id })` accepts.
+        const created: { id?: string; params?: Record<string, unknown> }[] = [];
+        const env = {
+            AGENT_SUPPORT: {
+                create: async (options: { id?: string; params?: Record<string, unknown> }) => {
+                    created.push(options);
+
+                    return { id: options.id ?? "wf-1" };
+                },
+            },
+        };
+        const sched = schedulerSpy();
+        const worker = createWorker({ adminToken: ADMIN, schedulerDO: sched.namespace, shardDO: okShard() });
+
+        const response = await dispatchWithEnv(worker, { args: { prompt: "digest" }, id: "job-idem", workflow: "AGENT_SUPPORT" }, env);
+
+        expect(response.status).toBe(200);
+        expect(created).toStrictEqual([{ id: "job-idem", params: { prompt: "digest" } }]);
+    });
+
+    it("treats a duplicate-instance rejection as a successful dispatch and still releases the pool slot", async () => {
+        expect.assertions(3);
+
+        // The re-fire itself: the first attempt's create landed, so the second
+        // one is rejected with "already exists". That is the idempotency signal,
+        // not a failure — reporting it as a 500 would send the record back
+        // through `recordRetry` and leave its pool slot held.
+        const env = {
+            AGENT_SUPPORT: {
+                create: async (): Promise<never> => {
+                    throw new Error('instance with id "job-idem" already exists');
+                },
+            },
+        };
+        const sched = schedulerSpy();
+        const worker = createWorker({ adminToken: ADMIN, schedulerDO: sched.namespace, shardDO: okShard() });
+
+        const response = await dispatchWithEnv(worker, { args: {}, id: "job-idem", instanceName: "tenant-a", pool: "digests", workflow: "AGENT_SUPPORT" }, env);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ ok: true });
+        expect(sched.calls.filter((call) => call.path === "/complete")).toHaveLength(1);
+    });
+
+    it("still fails a non-duplicate create rejection so the record stays retryable", async () => {
+        expect.assertions(1);
+
+        const env = {
+            AGENT_SUPPORT: {
+                create: async (): Promise<never> => {
+                    throw new Error("Workflows service unavailable");
+                },
+            },
+        };
+        const sched = schedulerSpy();
+        const worker = createWorker({ adminToken: ADMIN, schedulerDO: sched.namespace, shardDO: okShard() });
+
+        const response = await dispatchWithEnv(worker, { args: {}, id: "job-boom", workflow: "AGENT_SUPPORT" }, env);
+
+        expect(response.status).toBe(500);
     });
 
     it("releases the workpool slot of a POOLED workflow job", async () => {
@@ -224,10 +297,10 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
     it("starts an ordinary scheduled workflow unaffected by the branch-marker guard", async () => {
         expect.assertions(2);
 
-        const created: { params?: Record<string, unknown> }[] = [];
+        const created: { id?: string; params?: Record<string, unknown> }[] = [];
         const env = {
             AGENT_SUPPORT: {
-                create: async (options: { params?: Record<string, unknown> }) => {
+                create: async (options: { id?: string; params?: Record<string, unknown> }) => {
                     created.push(options);
 
                     return { id: "wf-1" };
@@ -240,6 +313,6 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
         const response = await dispatchWithEnv(worker, { args: { prompt: "digest" }, id: "job-6", workflow: "AGENT_SUPPORT" }, env);
 
         expect(response.status).toBe(200);
-        expect(created).toStrictEqual([{ params: { prompt: "digest" } }]);
+        expect(created).toStrictEqual([{ id: "job-6", params: { prompt: "digest" } }]);
     });
 });

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -6,6 +6,7 @@ import type { BatchEntry } from "../../../shared/batch-wire";
 import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { collectPages } from "../../../shared/collect-pages";
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
+import { isDuplicateInstanceError } from "../../../shared/duplicate-instance";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
@@ -2846,14 +2847,40 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     /**
-     * Start a fresh durable-workflow instance: resolve `binding` off `env` and
+     * Start a durable-workflow instance: resolve `binding` off `env` and
      * `create()` it with `args` as its `params`. A missing/malformed binding is a
      * hard failure (the job can't run) surfaced as a 500, so the caller's
      * invocation fails rather than silently no-op'ing. Shared by cron-fire
      * ({@link runOneCronJob}) and one-shot scheduler dispatch
      * ({@link handleSchedulerDispatch}); `label` names the caller in the error.
+     *
+     * `instanceId` is the idempotency key, and the two callers answer it
+     * differently on purpose.
+     *
+     * **Scheduler dispatch passes the record id.** That path is at-least-once: a
+     * DO eviction, an edge 502 or a transport blip after this origin already
+     * started the workflow makes `SchedulerDO.dispatch()` report failure, and
+     * `recordRetry` re-fires the SAME record up to `MAX_RETRY_ATTEMPTS` times
+     * (`reindexOrphanedRecords` and `drainRecord`'s swallowed post-success cleanup
+     * re-fire it too). Without an id Cloudflare mints a fresh random instance for
+     * each of those, so one scheduled job runs its whole pipeline up to five times
+     * — while two scheduler docblocks justify the retry loop with "idempotent
+     * dispatch keyed by record id". The record id is already on the wire and
+     * already constrained to a safe key segment by `resolveScheduleId`, which is
+     * exactly what `create({ id })` accepts.
+     *
+     * **The cron path passes nothing.** There is no record id there, every
+     * scheduled fire of an expression is a distinct run, and the admin "Run now"
+     * trigger has to be repeatable on demand — a stable per-job key would make the
+     * second fire a duplicate and silently never run again. Cron has no re-fire
+     * loop to dedupe against, so a fresh instance per fire is the correct
+     * semantics rather than a gap.
+     *
+     * A duplicate-instance rejection is therefore SUCCESS: it is the proof that a
+     * previous attempt's create already landed. Every other rejection propagates,
+     * so the record stays retryable.
      */
-    const startWorkflowInstance = async (binding: string, args: Record<string, unknown>, env: unknown, label: string): Promise<void> => {
+    const startWorkflowInstance = async (binding: string, args: Record<string, unknown>, env: unknown, label: string, instanceId?: string): Promise<void> => {
         const candidate = (env as Record<string, unknown> | null | undefined)?.[binding];
 
         if (!candidate || typeof (candidate as { create?: unknown }).create !== "function") {
@@ -2875,7 +2902,13 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             });
         }
 
-        await (candidate as WorkflowBindingLike).create({ params: args });
+        try {
+            await (candidate as WorkflowBindingLike).create(instanceId === undefined ? { params: args } : { id: instanceId, params: args });
+        } catch (error: unknown) {
+            if (!isDuplicateInstanceError(error)) {
+                throw error;
+            }
+        }
     };
 
     /**
@@ -3108,9 +3141,22 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         const args = (candidate.args ?? {}) as Record<string, unknown>;
 
-        // A workflow/agent target starts a fresh durable instance (the args become
-        // its `params`) rather than dispatching a function to a shard — the
+        // Forward the scheduler record id as the idempotency key so an at-least-once
+        // re-fire (a retry after the origin response was lost but the side effect
+        // already committed) is deduped rather than double-applying the job. This
+        // makes the scheduler's "idempotent dispatch keyed by record id" contract
+        // actually hold. Derived BEFORE the workflow branch below, which returns:
+        // that branch is exactly the one the scheduler's retry loop re-fires, and
+        // leaving it without an id let one scheduled workflow run its whole
+        // pipeline once per retry attempt.
+        const recordId = typeof candidate.id === "string" && candidate.id.length > 0 ? candidate.id : undefined;
+
+        // A workflow/agent target starts a durable instance (the args become its
+        // `params`) rather than dispatching a function to a shard — the
         // `WORKFLOW_*`/`AGENT_*` binding lives on the runtime's `env`, not the DO.
+        // The record id becomes the INSTANCE id, so a re-fire attaches to the
+        // running instance instead of starting a second one; the function path
+        // below spends the same id as the shard's replay-dedup `mutationId`.
         //
         // It still releases its pool slot. `Scheduler.runAt` accepts a
         // `WorkflowReference` alongside `RunOptions.pool`, and `reservePoolSlot`
@@ -3118,7 +3164,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // hold a slot, and returning before the release below wedged the pool for
         // good at the default `maxConcurrency: 1`.
         if (typeof candidate.workflow === "string" && candidate.workflow.length > 0) {
-            await startWorkflowInstance(candidate.workflow, args, env, "scheduled workflow");
+            await startWorkflowInstance(candidate.workflow, args, env, "scheduled workflow", recordId);
 
             await releasePoolSlot(candidate);
 
@@ -3130,12 +3176,6 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         }
 
         const shardKey = typeof candidate.shardKey === "string" && candidate.shardKey.length > 0 ? candidate.shardKey : defaultShard;
-        // Forward the scheduler record id as the idempotency key so an at-least-once
-        // re-fire (a retry after the origin response was lost but the side effect
-        // already committed) is deduped by the DO rather than double-applying the
-        // job. This makes the scheduler's "idempotent dispatch keyed by record id"
-        // contract actually hold.
-        const mutationId = typeof candidate.id === "string" && candidate.id.length > 0 ? candidate.id : undefined;
 
         // A server-initiated dispatch may forward a verified caller identity on the
         // `x-lunora-userid` / `x-lunora-identity` headers (e.g. a voice session
@@ -3144,7 +3184,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // headers pass through to the shard alongside the system flag for RLS.
         const identity = readForwardedIdentity(request);
 
-        const response = await dispatchToShard(candidate.functionPath, args, shardKey, mutationId, identity);
+        const response = await dispatchToShard(candidate.functionPath, args, shardKey, recordId, identity);
 
         // Workpool jobs hold a concurrency slot until the action settles; release
         // it. Best-effort only in that a failure can't fail this dispatch — a

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -621,7 +621,10 @@ class SchedulerDO {
             // any other 4xx, or a 5xx is NOT treated as done — the caller
             // (alarm()) keeps the record and routes it through recordRetry()
             // rather than deleting it. Idempotent dispatch keyed by record id
-            // makes a re-fire safe.
+            // makes a re-fire safe: the receiver spends `id` as the shard's
+            // replay-dedup `mutationId` for a function target and as the
+            // WORKFLOW INSTANCE id for a `workflow` target, so neither runs
+            // twice.
             return response.ok;
         } catch {
             return false;
@@ -1449,9 +1452,10 @@ class SchedulerDO {
      * `/dead`. The at-least-once contract `drainRecordGuarded` documents covers
      * a thrown storage op, not a lost instance.
      *
-     * Re-firing is safe: the dispatch carries the record id as
-     * `x-lunora-mutation-id`, which the receiver dedups on, so a job that DID
-     * reach the origin before the crash is not run twice.
+     * Re-firing is safe: the dispatch carries the record id, which the receiver
+     * spends as `x-lunora-mutation-id` for a function target and as the workflow
+     * INSTANCE id for a `workflow` target, so a job that DID reach the origin
+     * before the crash is not run twice either way.
      *
      * Two bounded walks (all `t:` values, then all `id:` headers) rather than a
      * per-header `get`, so the cost is one pass over each prefix.

--- a/packages/workflow/__tests__/fan-out.test.ts
+++ b/packages/workflow/__tests__/fan-out.test.ts
@@ -124,9 +124,18 @@ const makeLog = (): { debug: ReturnType<typeof vi.fn>; error: ReturnType<typeof 
     };
 };
 
-/** Build fan-out deps over a single shared binding double, with a deterministic id counter. */
+/**
+ * Build fan-out deps over a single shared binding double, with a deterministic id
+ * counter.
+ *
+ * `parentId` mirrors the run context's own allocator exactly — it returns an
+ * explicit id verbatim and otherwise appends `-c<n>` with NO ceiling of its own —
+ * so a long host-issued parent produces the same over-long derived child here as it
+ * does in production.
+ */
 const makeDeps = (
     step: WorkflowStepLike,
+    parentId = "parent-1",
 ): {
     create: Mock<(options?: { id?: string; params?: Record<string, unknown> }) => Promise<WorkflowInstanceLike>>;
     deps: FanOutDeps;
@@ -140,13 +149,13 @@ const makeDeps = (
         create,
         deps: {
             env: {},
-            instanceId: "parent-1",
+            instanceId: parentId,
             nextChildId: (explicit?: string) => {
                 if (explicit !== undefined) {
                     return explicit;
                 }
 
-                const id = `parent-1-c${String(counter)}`;
+                const id = `${parentId}-c${String(counter)}`;
                 counter += 1;
 
                 return id;
@@ -376,7 +385,7 @@ describe("createParallel", () => {
         //
         // The parent here is a SHORT synthetic id, so this case only exercises the
         // character class. The engine checks length first and the ids are
-        // caller-controlled up to that ceiling — see the near-ceiling case below.
+        // caller-controlled up to that ceiling — see the two over-ceiling cases below.
         const step = makeStep([okOutcome({ a: 1 }), okOutcome({ b: 2 }), errorOutcome(new Error("boom"))]);
         const { create, deps } = makeDeps(step);
 
@@ -390,6 +399,63 @@ describe("createParallel", () => {
 
         expect(ids).toHaveLength(5);
         expect(ids.filter((id) => engineRejectsInstanceId(id))).toStrictEqual([]);
+    });
+
+    it("spawns branches of a 98-character parent, whose derived `-c<n>` ids overflow the ceiling", async () => {
+        expect.assertions(4);
+
+        // The fold was applied to the compensation id but not to the CHILD id it
+        // derives from. The run context's allocator appends `-c<n>` with no ceiling
+        // of its own, so a 98-character host-issued parent (the id shapes hosts
+        // actually mint run long) yields a 101-character child. The
+        // engine checks length FIRST, so `create` rejects it outright — and the
+        // spawn `Promise.all` sits OUTSIDE `createParallel`'s try, so that
+        // rejection is not a `BranchJoinFailure`: the whole group-saga rollback is
+        // skipped and the raw engine error surfaces instead.
+        const parentId = `p${"0".repeat(97)}`;
+        const step = makeStep([okOutcome({ a: 1 }), okOutcome({ b: 2 })]);
+        const { create, deps } = makeDeps(step, parentId);
+
+        const results = await createParallel(deps)([branch("first", { x: 1 }), branch("second")]);
+
+        expect(results).toStrictEqual([{ a: 1 }, { b: 2 }]);
+
+        const ids = create.mock.calls.map((call) => call[0]?.id);
+
+        expect(ids).toHaveLength(2);
+        expect(ids.filter((id) => engineRejectsInstanceId(id))).toStrictEqual([]);
+        // Folded, not truncated: siblings of one over-long parent stay distinct, or
+        // both branches share a spawn step name and one silently never runs.
+        expect(new Set(ids).size).toBe(2);
+    });
+
+    it("folds an over-long explicit `branch(…, { id })` and still compensates it", async () => {
+        expect.assertions(4);
+
+        // The other half of the same gap: `nextChildId` returns an explicit id
+        // VERBATIM, with no length check at all, so a caller-supplied 150-character
+        // branch id reaches `create` as-is. Its rollback is unreachable for the
+        // same reason — and on a saga that took payment, that unrun rollback is the
+        // refund.
+        const longId = `b${"9".repeat(149)}`;
+        const step = makeStep([okOutcome({ paid: true }), errorOutcome(new Error("boom"))]);
+        const { create, deps } = makeDeps(step);
+        const log = makeLog();
+
+        await createParallel({ ...deps, log: log as unknown as FanOutDeps["log"] })([
+            branch("charge", undefined, { compensateWith: "refund", id: longId }),
+            branch("second"),
+        ]).catch(() => undefined);
+
+        const ids = create.mock.calls.map((call) => call[0]?.id);
+
+        // charge, second, and charge's rollback.
+        expect(ids).toHaveLength(3);
+        expect(ids.filter((id) => engineRejectsInstanceId(id))).toStrictEqual([]);
+        expect(ids.filter((id) => String(id).endsWith("-compensate"))).toHaveLength(1);
+        // A swallowed create rejection leaves the group failing exactly as it does
+        // here, with only this log to show for it.
+        expect(log.error).not.toHaveBeenCalled();
     });
 
     it("compensates a branch whose own id sits just under the engine's 100-character ceiling", async () => {
@@ -623,6 +689,25 @@ describe("createSpawn", () => {
         expect(create).toHaveBeenCalledWith({ id: "parent-1-c0", params: { y: 2 } });
         expect(get).toHaveBeenCalledWith("parent-1-c0");
         expect(instance.id).toBe("parent-1-c0");
+    });
+
+    it("folds an over-long child id and returns the handle for the id it actually created", async () => {
+        expect.assertions(3);
+
+        // `ctx.spawn` shares the same allocator, so it shares the same gap. The
+        // handle must address the FOLDED id — a `get()` on the unfolded one points
+        // at an instance that was never created.
+        const longId = `s${"7".repeat(149)}`;
+        const step = makeStep();
+        const { create, deps, get } = makeDeps(step);
+
+        const instance = await createSpawn(deps)("child", { y: 2 }, { id: longId });
+
+        const created = create.mock.calls[0]?.[0]?.id;
+
+        expect(engineRejectsInstanceId(created)).toBe(false);
+        expect(get).toHaveBeenCalledWith(created);
+        expect(instance.id).toBe(created);
     });
 
     it("rejects a caller-supplied reserved branch marker without touching the step API", async () => {

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -103,40 +103,11 @@ const raiseNonRetryable = (message: string, cause: unknown, NativeNonRetryableEr
     return convertNonRetryableError(nonRetryable, NativeNonRetryableError);
 };
 
-/**
- * Matches Cloudflare Workflows' "instance already exists" rejection (hoisted).
- *
- * Deliberately separator-agnostic. The local harness cannot pin the exact
- * production text — miniflare's `WorkflowBinding.create` never rejects a
- * duplicate id at all (it calls `stub.init(...)` unconditionally and
- * `Engine.init` returns early for an instance that already has metadata), so
- * the attach branch below is unreachable LOCALLY: in Node and under
- * `wrangler dev`/workerd alike. Production Workflows does reject it, which is
- * the whole reason `createOrAttach` exists — so this is a gap in what the
- * harness can prove, never evidence that the branch is dead code. That makes
- * the *shape* of the message the only thing we can defend, and a
- * `already_exists` / `already-exists` spelling must not read as a transient
- * failure and cost the caller its whole retry budget.
- */
-const DUPLICATE_INSTANCE = /already[\s_-]?exists/iu;
-
-/**
- * Whether a `WorkflowBinding.create()` rejection is a duplicate-instance-id
- * error — the idempotency signal that a *previous* attempt's create already
- * applied — as opposed to a transient or config failure (Workflows service
- * error, instance-creation quota, bad params).
- *
- * `step.do` memoizes a step's RESULT, not its side effects: a spawn body that
- * fails after `create` landed is re-run, and only this rejection means the
- * child is already there to attach to. Every other failure MUST surface, so the
- * durable step retries or fails visibly rather than silently attaching to an
- * unrelated instance.
- *
- * Lives here, in the package that owns the Workflows binding contract, so the
- * fan-out spawn and `@lunora/agent`'s sub-agent/channel dispatch cannot drift
- * apart on what counts as "already exists".
- */
-const isDuplicateInstanceError = (error: unknown): boolean => DUPLICATE_INSTANCE.test(error instanceof Error ? error.message : String(error));
-
 export type { NativeNonRetryableErrorConstructor };
-export { convertNonRetryableError, isDuplicateInstanceError, isNonRetryableError, NonRetryableError, raiseNonRetryable, toNativeNonRetryableError };
+export { convertNonRetryableError, isNonRetryableError, NonRetryableError, raiseNonRetryable, toNativeNonRetryableError };
+// `isDuplicateInstanceError` lives in `shared/` rather than here: `@lunora/runtime`'s
+// scheduler dispatcher makes the same idempotency decision about the same rejection,
+// but reaches the Workflows binding structurally and keeps no runtime dependency on
+// this package. This package still OWNS the predicate as public API — the fan-out
+// spawn and `@lunora/agent`'s sub-agent/channel dispatch import it from here.
+export { isDuplicateInstanceError } from "../../../shared/duplicate-instance";

--- a/packages/workflow/src/fan-out.ts
+++ b/packages/workflow/src/fan-out.ts
@@ -55,50 +55,52 @@ const SIGNAL_STEP_PREFIX = "lunora:signal:";
 /** Durable-step name prefix for a completed branch's group-saga compensation spawn. */
 const COMPENSATE_STEP_PREFIX = "lunora:compensate:";
 
+/** `-<16 hex>` — the width the fold below spends on its disambiguating digest. */
+const DIGEST_WIDTH = 17;
+
 /**
- * The child instance id a completed branch's `compensateWith` rollback is spawned
- * under.
+ * The instance id this package hands to `create`: `id` with `suffix` appended,
+ * folded back under the engine's ceiling when the two together overflow it.
  *
- * The suffix is deliberately `[A-Za-z0-9_-]` only. Cloudflare's engine validates
- * an instance id on `create` — at most 100 characters matching
- * `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`, in which `:` is NOT allowed — so a suffix
- * outside that class turns every rollback into a permanent create rejection. This
- * shipped once as `<childId>:compensate` and made the whole group-saga feature
- * inert; `__tests__/fan-out.test.ts` now applies the engine's own check to every
- * id the package mints.
+ * **Every id minted here routes through this**, because the engine's create-time
+ * check is `id.length > 100` FIRST and only then the character pattern. Both halves
+ * of the id are caller-controlled right up to that ceiling — an explicit
+ * `branch(…, { id })` / `ctx.spawn(…, { id })` is taken verbatim by the run
+ * context's allocator, and its derived `<parentId>-c<n>` form appends to a parent id
+ * the host issued at whatever length it likes. So a plain `<parentId>-c<n>` under a
+ * 98-character parent is already 101, and `+ "-compensate"` puts a rollback over the
+ * line at 90. Every one of those is a hard `create` rejection, and neither surfaces
+ * as one. For a CHILD, the spawn `Promise.all` sits outside {@link createParallel}'s
+ * try, so the rejection is not a `BranchJoinFailure` and the group-saga rollback is
+ * skipped entirely. For a ROLLBACK, {@link compensateCompleted} logs it and moves
+ * on, and the completed branch is never rolled back — on a saga that took payment,
+ * that unrun rollback is the refund.
  *
- * Only the SUFFIX is ours to constrain. The parent id these are derived from
- * belongs to the host: `@lunora/platform-node` runs this same orchestrator on
- * `@visulima/workflow`, whose `generateRunId` mints `<definitionId>:<uuid>` and
- * accepts no override. Validating a derived id against Cloudflare's grammar here
- * would refuse ids the running host had just issued.
+ * The fold keeps a digest of the WHOLE input (siblings of one over-long parent stay
+ * distinct rather than truncating to the same head) and keeps `suffix` intact so it
+ * stays readable in a dashboard. Deterministic, so a parent replay re-attaches to
+ * the same instance instead of spawning a second one.
  *
- * The LENGTH half of that check is ours to keep too, and it is the half the engine
- * tests FIRST (`id.length > 100` short-circuits before the pattern). The parent id
- * is not ours to shorten, but the derived one is: a branch id may legitimately run
- * right up to the engine's own 100-character ceiling — an explicit
- * `branch(…, { id })`, or `<parentId>-c<n>` under a long host-issued parent — and
- * `+ "-compensate"` then puts the ROLLBACK over it. That create is rejected,
- * {@link compensateCompleted} logs it and moves on, and the completed branch is
- * never rolled back; on a saga that took payment, the unrun rollback is the refund.
- * So an over-long id is folded back under the ceiling, keeping a hash of the WHOLE
- * child id (siblings stay distinct) and the `-compensate` suffix (it stays readable
- * in a dashboard). Deterministic, so a parent replay re-attaches to the same
- * rollback instance.
+ * The CHARACTER class is deliberately NOT enforced. Only a suffix of ours is ours to
+ * constrain — hence `-compensate` and not the `<childId>:compensate` that shipped
+ * once and made the whole group-saga feature inert, since `:` is outside
+ * `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`. The ids themselves belong to the host:
+ * `@lunora/platform-node` runs this same orchestrator on `@visulima/workflow`, whose
+ * `generateRunId` mints `<definitionId>:<uuid>` and accepts no override, so
+ * validating against Cloudflare's grammar here would refuse ids the running host had
+ * just issued. `__tests__/fan-out.test.ts` applies the engine's own check to every id
+ * this package mints.
  *
  * Step names are a different, far laxer validator (`isValidStepName`: only control
  * characters and >256 characters are rejected), so the `lunora:*` step prefixes
  * above are fine as they are.
  */
-const compensationInstanceId = (childId: string): string => {
-    const id = `${childId}-compensate`;
-
-    if (id.length <= MAX_INSTANCE_ID_LENGTH) {
-        return id;
+const boundInstanceId = (id: string, suffix = ""): string => {
+    if (id.length + suffix.length <= MAX_INSTANCE_ID_LENGTH) {
+        return `${id}${suffix}`;
     }
 
-    // `-<16 hex>-compensate` is 28 characters, so the head keeps the first 72.
-    return `${childId.slice(0, MAX_INSTANCE_ID_LENGTH - 28)}-${fnv1a64Hex(childId)}-compensate`;
+    return `${id.slice(0, MAX_INSTANCE_ID_LENGTH - suffix.length - DIGEST_WIDTH)}-${fnv1a64Hex(id)}${suffix}`;
 };
 
 /**
@@ -137,7 +139,7 @@ interface FanOutDeps {
     instanceId: string;
     /** Optional structured logger — used to surface best-effort failures (e.g. a stranded group-saga compensation) without aborting the flow. */
     log?: WorkflowLogger;
-    /** Allocate the next deterministic child instance id (replay-stable; honors an explicit id). */
+    /** Allocate the next deterministic child instance id (replay-stable; honors an explicit id). Free to return any length — every result is folded through {@link boundInstanceId} before it reaches `create`. */
     nextChildId: (explicit?: string) => string;
     /** The running workflow's own `WORKFLOW_*` binding name — passed to children so they can signal back. */
     parentBinding: string;
@@ -406,7 +408,7 @@ const compensateCompleted = async (
 
             // eslint-disable-next-line no-await-in-loop -- reverse-order group-saga compensation, one durable spawn per completed branch
             await deps.step.do(`${COMPENSATE_STEP_PREFIX}${done.plan.childId}`, async (): Promise<string> => {
-                const compensateId = compensationInstanceId(done.plan.childId);
+                const compensateId = boundInstanceId(done.plan.childId, "-compensate");
                 const compensationParams: BranchCompensationParams = {
                     branch: done.plan.item.workflow,
                     error,
@@ -467,7 +469,7 @@ const createParallel = (deps: FanOutDeps): WorkflowParallelFunction => {
         // order, BEFORE any await — so a parent replay reproduces the exact same
         // ids and re-attaches to the existing children rather than spawning new ones.
         const planned: PlannedBranch[] = branches.map((item, index) => {
-            const childId = deps.nextChildId(item.id);
+            const childId = boundInstanceId(deps.nextChildId(item.id));
 
             return { childId, eventType: `${BRANCH_EVENT_PREFIX}${childId}`, index, item };
         });
@@ -608,7 +610,7 @@ const createSpawn =
             throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params ${BRANCH_MARKER_REJECTION}`);
         }
 
-        const childId = deps.nextChildId(options?.id);
+        const childId = boundInstanceId(deps.nextChildId(options?.id));
 
         await deps.step.do(`${SPAWN_STEP_PREFIX}${childId}`, async (): Promise<string> => {
             const binding = deps.resolveBinding(workflow);

--- a/packages/workflow/src/run-context.ts
+++ b/packages/workflow/src/run-context.ts
@@ -60,6 +60,14 @@ const createWorkflowRunContext = <Params = Record<string, unknown>>(options: Run
     // Deterministic child-id allocator: the handler replays in the same order, so
     // a per-invocation counter yields replay-stable ids and `step.do` memoization
     // re-attaches to the existing children instead of double-spawning.
+    //
+    // Deliberately unbounded: `options.event.instanceId` is the HOST's id, at
+    // whatever length and in whatever alphabet it mints (`@lunora/platform-node`
+    // issues `<definitionId>:<uuid>`), and an explicit id is returned verbatim.
+    // The engine's 100-character ceiling is applied where the id reaches `create`
+    // — `boundInstanceId` in `fan-out.ts` — so both `ctx.parallel` and `ctx.spawn`
+    // fold through one place and neither this allocator nor any other
+    // `nextChildId` implementation has to restate the rule.
     let childCounter = 0;
     const nextChildId = (explicit?: string): string => {
         if (explicit !== undefined) {

--- a/shared/duplicate-instance.ts
+++ b/shared/duplicate-instance.ts
@@ -1,0 +1,42 @@
+/**
+ * The one definition of "a `WorkflowBinding.create()` rejection means the
+ * instance is already there".
+ *
+ * It is deliberately **not** a package. `@lunora/workflow` owns the Workflows
+ * binding contract and re-exports this as `isDuplicateInstanceError`, but
+ * `@lunora/runtime`'s scheduler/cron dispatcher reaches the same binding through
+ * a purely structural `WorkflowBindingLike` — it keeps no runtime dependency on
+ * `@lunora/workflow`, so it inlines this file instead. Two spellings of the same
+ * regex is exactly the drift that would let one caller retry forever on what the
+ * other already treats as success.
+ */
+
+/**
+ * Matches Cloudflare Workflows' "instance already exists" rejection.
+ *
+ * Deliberately separator-agnostic. The local harness cannot pin the exact
+ * production text — miniflare's `WorkflowBinding.create` never rejects a
+ * duplicate id at all (it calls `stub.init(...)` unconditionally and
+ * `Engine.init` returns early for an instance that already has metadata), so the
+ * duplicate branch is unreachable LOCALLY: in Node and under `wrangler
+ * dev`/workerd alike. Production Workflows does reject it, which is the whole
+ * reason the attach/idempotency paths exist — so this is a gap in what the
+ * harness can prove, never evidence that those branches are dead code. That
+ * makes the *shape* of the message the only thing we can defend, and a
+ * `already_exists` / `already-exists` spelling must not read as a transient
+ * failure and cost the caller its whole retry budget.
+ */
+const DUPLICATE_INSTANCE = /already[\s_-]?exists/iu;
+
+/**
+ * Whether a `WorkflowBinding.create()` rejection is a duplicate-instance-id
+ * error — the idempotency signal that a *previous* attempt's create already
+ * applied — as opposed to a transient or config failure (Workflows service
+ * error, instance-creation quota, bad params).
+ *
+ * Every other failure MUST surface, so the caller retries or fails visibly
+ * rather than silently reporting success for work that never started.
+ */
+const isDuplicateInstanceError = (error: unknown): boolean => DUPLICATE_INSTANCE.test(error instanceof Error ? error.message : String(error));
+
+export { isDuplicateInstanceError };


### PR DESCRIPTION
Two defects fixed, one finding rejected with evidence.

## A scheduled *workflow* had no idempotency at all — and two docblocks said it did

`handleSchedulerDispatch`'s workflow branch returned **before** the dispatch id was derived, and `startWorkflowInstance` called `create({ params })` with no instance id, so Cloudflare minted a fresh one every time. Meanwhile `scheduler-do.ts:620-624` justifies the retry loop with "Idempotent dispatch keyed by record id makes a re-fire safe", and `:1452-1454` repeats it for orphan reindexing.

Any at-least-once re-fire — the retry loop after a dropped response, the orphan reindex, `drainRecord`'s swallowed post-success cleanup — started the whole pipeline again, up to 5 times. On a payment or fulfilment workflow that is the money path.

The record id was already on the wire and already constrained to `^[\w-]{1,64}$`, so it is exactly what `create({ id })` wants. It is now hoisted above the branch, a duplicate-instance rejection counts as success, and every other rejection still propagates.

**The cron path deliberately passes nothing.** No record id exists, each fire of an expression is a distinct run, and the admin "Run now" trigger must stay repeatable. That decision is documented in the docblock and pinned by a test, so it reads as a choice rather than an oversight.

`isDuplicateInstanceError` moved to `shared/duplicate-instance.ts` so the runtime gets the predicate without a runtime dependency on `@lunora/workflow`; the public surface is unchanged.

## The 100-char id fold was applied to the rollback id but not to the id it derives from

`nextChildId` returned an explicit `branch(…, { id })` verbatim with no check, and appended `-c<n>` with no ceiling. Both reach `create({ id })`. Cloudflare rejects an instance id over 100 characters, **checking length first** — and that call sits outside the try that produces a `BranchJoinFailure`, so the rejection skipped the group-saga rollback entirely.

The compensation fold is generalised into `boundInstanceId(id, suffix)` and all three id sites route through it. Compensation output is byte-identical (`100 − 11 − 17 == 100 − 28`). **No charset assertion was added** — a previous attempt at one had to be reverted because it rejected `platform-node`'s `<definitionId>:<uuid>` ids. Length only.

The old test admitted its own gap: *"The parent here is a SHORT synthetic id, so this case only exercises the character class."* The fan-out double now takes a `parentId` and mirrors the real allocator, and the new cases use a 98-char parent and an over-long explicit branch id — both threw `Workflow instance has invalid id` before the fix.

## Rejected: the `ctx.waitForEvent` duplicate-step finding

The reported failure mode — "Cloudflare memoizes by step name, so a second `waitForEvent` returns the first payload" — **is false**. The engine keys steps by name *and* per-run occurrence:

```js
// miniflare workflows binding.worker.js:13851
let count = this.#getCount("waitForEvent-" + name),
    cacheKey = `${await computeHash(`${name}-${count}`)}-${count}`,
```

Same at `:13286` for `step.do` and `:13787` for `sleep`, and Cloudflare's public `WorkflowStepContext` exposes `step.count` for exactly this. A runtime collision check would have broken the loop pattern `@lunora/workflow`'s own run-context test already documents as legal.

What was real is the **lint's description of itself**: the feeder only sees native `ctx.step.<method>` string literals, so `ctx.runStep` *and* `ctx.waitForEvent` are both invisible — while the old scope note excluded only the former and the remediation text implied both were covered. Docblock, description, remediation and the docs row are corrected; lint behaviour is unchanged, and a test makes the corrected scope executable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated scheduler deliveries from starting duplicate workflow instances.
  * Improved reliability for parallel, background, and rollback workflow tasks by ensuring generated instance identifiers remain within supported limits.
  * Standardized handling of duplicate-instance responses so legitimate retries complete successfully while unrelated errors remain visible.

* **Documentation**
  * Clarified duplicate workflow step-name lint guidance, including affected call patterns and recommended fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->