### PR TITLE
fix(errors,values,server): close the gates that were failing open

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -240,6 +240,31 @@ const ERROR_CATALOG: {
         readonly status: 502;
         readonly title: "Cloudflare Workflows REST API error";
     };
+    readonly CONFIG_INVALID: {
+        readonly internal: true;
+        readonly status: 500;
+        readonly title: "Payment configuration invalid";
+    };
+    readonly CURRENCY_MISMATCH: {
+        readonly status: 400;
+        readonly title: "Currency mismatch";
+    };
+    readonly PROVIDER_ERROR: {
+        readonly status: 502;
+        readonly title: "Payment provider error";
+    };
+    readonly WEBHOOK_EVENT_ID_MISSING: {
+        readonly status: 400;
+        readonly title: "Webhook event id missing";
+    };
+    readonly WEBHOOK_SIGNATURE_INVALID: {
+        readonly status: 400;
+        readonly title: "Webhook signature invalid";
+    };
+    readonly WEBHOOK_TIMESTAMP_INVALID: {
+        readonly status: 400;
+        readonly title: "Webhook timestamp outside tolerance";
+    };
     readonly ADMIN_FORBIDDEN: {
         readonly status: 403;
         readonly title: "Admin access forbidden";

--- a/api-snapshots/values.api.md
+++ b/api-snapshots/values.api.md
@@ -203,6 +203,7 @@ interface SchemaNodeReader<TNode> {
     constraints: (node: TNode) => JsonSchema | undefined;
     inner: (node: TNode) => TNode | undefined;
     isNullable: (node: TNode) => boolean;
+    keyChild: (node: TNode) => TNode | undefined;
     kind: (node: TNode) => ValidatorKind;
     literalSchema: (node: TNode) => JsonSchema;
     members: (node: TNode) => ReadonlyArray<TNode>;

--- a/apps/docs/scripts/check-doc-imports.mjs
+++ b/apps/docs/scripts/check-doc-imports.mjs
@@ -1,13 +1,26 @@
 /**
- * Doc snippet import gate.
+ * Doc snippet API gate.
  *
  * Twoslash can't type-check the doc snippets: apps/docs doesn't depend on the
  * @lunora/* packages and the app-local `@/lunora/_generated/*` modules don't
- * exist here, so nothing resolves. This lighter check catches the bug class
- * that actually shipped — importing a symbol from a package that doesn't export
- * it (e.g. `import { query } from "@lunora/server"`, where the builders live in
- * the generated server). It parses every ```ts/```tsx fence across the docs and
- * verifies each named import against the target module's real exports.
+ * exist here, so nothing resolves. This lighter check catches the two bug
+ * classes that actually shipped:
+ *
+ *   1. importing a symbol from a package that doesn't export it (e.g.
+ *      `import { query } from "@lunora/server"`, where the builders live in the
+ *      generated server) — checked against the target module's real exports;
+ *   2. a symbol that IS exported, used with a shape it does not have — see
+ *      {@link NONEXISTENT_API}. Names alone can't see this class, and it is the
+ *      worse of the two: the flagship tutorial taught `useMutation` as a
+ *      callable for as long as the hook has returned an object, so a reader
+ *      following it got `TypeError: send is not a function`.
+ *
+ * It parses every ```ts/```tsx fence across the docs and applies both.
+ *
+ * A deny-table, not a type checker: it holds only shapes that were WRONG in
+ * shipped docs, each with the correct form in its message. Type-checking the
+ * samples for real needs the packages installed here plus synthesized
+ * `_generated` modules — worth doing, but not what this file is.
  *
  * Usage: node scripts/check-doc-imports.mjs   (exit 1 on any violation)
  */
@@ -18,7 +31,9 @@ import { fileURLToPath } from "node:url";
 const ROOT = fileURLToPath(new URL("../../../", import.meta.url));
 const PKGS = join(ROOT, "packages");
 
-const DOC_DIRS = [join(ROOT, "apps/docs/src/content/docs")];
+// `blog/` is in scope for the same reason `docs/` is: its posts carry full
+// runnable snippets, and two of them taught `useMutation` as a callable.
+const DOC_DIRS = [join(ROOT, "apps/docs/src/content/docs"), join(ROOT, "apps/docs/src/content/blog")];
 // Package doc sources (apps/docs/src/content/docs/packages is a generated copy).
 for (const pkg of readdirSync(PKGS)) {
     const d = join(PKGS, pkg, "docs");
@@ -48,6 +63,29 @@ const GENERATED = {
     // codegen emits alongside `api` / `internal` when the project declares them.
     "@/lunora/_generated/api": new Set(["agents", "api", "FunctionReference", "internal", "workflows"]),
 };
+
+/**
+ * Uses of a real export with a shape it does not have, as
+ * `[pattern, what to write instead]`. Add an entry when a doc snippet is found
+ * teaching an API the runtime never had; keep the correction in the message so
+ * the failure is actionable without opening this file.
+ */
+const NONEXISTENT_API = [
+    [
+        // `const send = useMutation(fn)` then `send(args)`. The hook returns
+        // `{ data, error, isError, mutate, pending, reset, withOptimisticUpdate }`.
+        // A destructuring `const { mutate: send } = …` is the correct form and
+        // does not match (`{` is not `\w`).
+        /\bconst\s+\w+\s*=\s*useMutation\(/,
+        "`useMutation(fn)` returns `{ mutate, pending, … }` and is not itself callable — write `const { mutate: send } = useMutation(fn)`",
+    ],
+    [
+        // Present on the untyped runtime writer, absent from the generated
+        // typed `ctx.db`, so it may run but never type-checks in a user project.
+        /\bctx\.db\.findMany\(\s*["']/,
+        '`ctx.db.findMany("table")` is not on the generated `ctx.db` — write `ctx.db.<table>.findMany()` or `ctx.db.query("table").collect()`',
+    ],
+];
 
 // Umbrella `lunorash/<sub>` re-exports the base packages.
 const UMBRELLA = new Set(["client", "do", "runtime", "server", "values"]);
@@ -155,6 +193,12 @@ for (const dir of DOC_DIRS) {
             }
             if (!inTs) return;
 
+            for (const [pattern, correction] of NONEXISTENT_API) {
+                if (pattern.test(line)) {
+                    violations.push(`${file.replace(ROOT, "")}:${index + 1}  ${correction}`);
+                }
+            }
+
             const imp = line.match(/import\s+(?:type\s+)?\{([^}]*)\}\s+from\s+["']([^"']+)["']/);
             if (!imp) return;
 
@@ -177,10 +221,10 @@ for (const dir of DOC_DIRS) {
 }
 
 if (violations.length > 0) {
-    console.error(`✗ ${violations.length} doc import violation(s):\n`);
+    console.error(`✗ ${violations.length} doc snippet violation(s):\n`);
     for (const v of violations) console.error(`  ${v}`);
-    console.error("\nFix the import, or extend GENERATED/SUBPATH_ENTRY in scripts/check-doc-imports.mjs.");
+    console.error("\nFix the snippet, or extend GENERATED/SUBPATH_ENTRY/NONEXISTENT_API in scripts/check-doc-imports.mjs.");
     process.exit(1);
 }
 
-console.log("✓ doc snippet imports check out");
+console.log("✓ doc snippets check out");

--- a/apps/docs/scripts/check-doc-imports.mjs
+++ b/apps/docs/scripts/check-doc-imports.mjs
@@ -75,8 +75,12 @@ const NONEXISTENT_API = [
         // `const send = useMutation(fn)` then `send(args)`. The hook returns
         // `{ data, error, isError, mutate, pending, reset, withOptimisticUpdate }`.
         // A destructuring `const { mutate: send } = …` is the correct form and
-        // does not match (`{` is not `\w`).
-        /\b(?:const|let|var)\s+\w+\s*=\s*useMutation\(/,
+        // does not match (`{` is not `\w`) — and neither does the other correct
+        // form, `const m = useMutation(fn)` then `m.mutate(args)`, which is why
+        // the bound name has to be seen CALLED (the backreference) rather than
+        // merely bound. That is also why these run per FENCE, not per line: the
+        // binding and the call are on different lines.
+        /\b(?:const|let|var)\s+(\w+)\s*=\s*useMutation\([\s\S]*?\b\1\s*\(/,
         "`useMutation(fn)` returns `{ mutate, pending, … }` and is not itself callable — write `const { mutate: send } = useMutation(fn)`",
     ],
     [
@@ -95,7 +99,17 @@ const NONEXISTENT_API = [
 // falsifiable independently of what the docs currently say.
 const SELF_CHECK = [
     // [pattern index, must match, must NOT match]
-    [0, ["const send = useMutation(api.x);", "let send = useMutation(api.x);", "var send = useMutation(api.x);"], ["const { mutate: send } = useMutation(api.x);", "const { mutate } = useMutation(api.x);"]],
+    [
+        0,
+        ["const send = useMutation(api.x);\nawait send(args);", "let send = useMutation(api.x);\nsend(args);", "var send = useMutation(api.x);\nsend(args);"],
+        [
+            "const { mutate: send } = useMutation(api.x);\nawait send(args);",
+            "const { mutate } = useMutation(api.x);\nawait mutate(args);",
+            // The non-destructuring form is CORRECT too — the hook's object is
+            // kept and its `mutate` called off it. Flagging this blocks valid docs.
+            "const m = useMutation(api.x);\nawait m.mutate(args);",
+        ],
+    ],
     [1, ['ctx.db.findMany("posts")', "ctx.db.findMany('posts')", "ctx.db.findMany(`posts`)"], ["ctx.db.posts.findMany()", 'ctx.db.query("posts").collect()']],
 ];
 
@@ -211,23 +225,45 @@ for (const dir of DOC_DIRS) {
     for (const file of walk(dir)) {
         const lines = readFileSync(file, "utf8").split("\n");
         let inTs = false;
+        // A fence is the unit for NONEXISTENT_API: a misuse spans the line that
+        // binds and the line that calls, so a per-line match cannot tell the
+        // wrong form from the right one. Buffered here, checked when it closes.
+        let fenceBody = [];
+        let fenceStart = 0;
+
+        const checkFence = () => {
+            if (fenceBody.length === 0) return;
+
+            const body = fenceBody.join("\n");
+
+            for (const [pattern, correction] of NONEXISTENT_API) {
+                const match = pattern.exec(body);
+
+                if (match) {
+                    const line = fenceStart + body.slice(0, match.index).split("\n").length;
+                    violations.push(`${file.replace(ROOT, "")}:${line}  ${correction}`);
+                }
+            }
+
+            fenceBody = [];
+        };
+
         lines.forEach((line, index) => {
             const fence = line.match(/^```(\w+)/);
             if (fence) {
+                checkFence();
                 inTs = /^(ts|tsx|typescript)$/.test(fence[1]);
+                fenceStart = index + 1;
                 return;
             }
             if (line.startsWith("```")) {
+                checkFence();
                 inTs = false;
                 return;
             }
             if (!inTs) return;
 
-            for (const [pattern, correction] of NONEXISTENT_API) {
-                if (pattern.test(line)) {
-                    violations.push(`${file.replace(ROOT, "")}:${index + 1}  ${correction}`);
-                }
-            }
+            fenceBody.push(line);
 
             const imp = line.match(/import\s+(?:type\s+)?\{([^}]*)\}\s+from\s+["']([^"']+)["']/);
             if (!imp) return;

--- a/apps/docs/scripts/check-doc-imports.mjs
+++ b/apps/docs/scripts/check-doc-imports.mjs
@@ -118,14 +118,18 @@ for (const [index, shouldMatch, shouldNotMatch] of SELF_CHECK) {
 
     for (const sample of shouldMatch) {
         if (!pattern.test(sample)) {
-            console.error(`✗ self-check: NONEXISTENT_API[${index}] (${pattern}) no longer matches ${JSON.stringify(sample)} — the pattern was narrowed and now catches nothing.`);
+            console.error(
+                `✗ self-check: NONEXISTENT_API[${index}] (${pattern}) no longer matches ${JSON.stringify(sample)} — the pattern was narrowed and now catches nothing.`,
+            );
             process.exit(1);
         }
     }
 
     for (const sample of shouldNotMatch) {
         if (pattern.test(sample)) {
-            console.error(`✗ self-check: NONEXISTENT_API[${index}] (${pattern}) matches the CORRECT form ${JSON.stringify(sample)} — it would reject valid docs.`);
+            console.error(
+                `✗ self-check: NONEXISTENT_API[${index}] (${pattern}) matches the CORRECT form ${JSON.stringify(sample)} — it would reject valid docs.`,
+            );
             process.exit(1);
         }
     }

--- a/apps/docs/scripts/check-doc-imports.mjs
+++ b/apps/docs/scripts/check-doc-imports.mjs
@@ -76,16 +76,46 @@ const NONEXISTENT_API = [
         // `{ data, error, isError, mutate, pending, reset, withOptimisticUpdate }`.
         // A destructuring `const { mutate: send } = …` is the correct form and
         // does not match (`{` is not `\w`).
-        /\bconst\s+\w+\s*=\s*useMutation\(/,
+        /\b(?:const|let|var)\s+\w+\s*=\s*useMutation\(/,
         "`useMutation(fn)` returns `{ mutate, pending, … }` and is not itself callable — write `const { mutate: send } = useMutation(fn)`",
     ],
     [
         // Present on the untyped runtime writer, absent from the generated
         // typed `ctx.db`, so it may run but never type-checks in a user project.
-        /\bctx\.db\.findMany\(\s*["']/,
+        /\bctx\.db\.findMany\(\s*["'`]/,
         '`ctx.db.findMany("table")` is not on the generated `ctx.db` — write `ctx.db.<table>.findMany()` or `ctx.db.query("table").collect()`',
     ],
 ];
+
+// The deny-table's own gate. Every entry here was added because a shipped doc
+// matched it — and once that doc is fixed the pattern matches nothing, forever.
+// From then on a narrowed or broken regex is indistinguishable from a clean
+// repo: the run stays green either way, which is the same failure mode the
+// error-catalog scanner grew a self-check for. These fixtures keep each entry
+// falsifiable independently of what the docs currently say.
+const SELF_CHECK = [
+    // [pattern index, must match, must NOT match]
+    [0, ["const send = useMutation(api.x);", "let send = useMutation(api.x);", "var send = useMutation(api.x);"], ["const { mutate: send } = useMutation(api.x);", "const { mutate } = useMutation(api.x);"]],
+    [1, ['ctx.db.findMany("posts")', "ctx.db.findMany('posts')", "ctx.db.findMany(`posts`)"], ["ctx.db.posts.findMany()", 'ctx.db.query("posts").collect()']],
+];
+
+for (const [index, shouldMatch, shouldNotMatch] of SELF_CHECK) {
+    const [pattern] = NONEXISTENT_API[index];
+
+    for (const sample of shouldMatch) {
+        if (!pattern.test(sample)) {
+            console.error(`✗ self-check: NONEXISTENT_API[${index}] (${pattern}) no longer matches ${JSON.stringify(sample)} — the pattern was narrowed and now catches nothing.`);
+            process.exit(1);
+        }
+    }
+
+    for (const sample of shouldNotMatch) {
+        if (pattern.test(sample)) {
+            console.error(`✗ self-check: NONEXISTENT_API[${index}] (${pattern}) matches the CORRECT form ${JSON.stringify(sample)} — it would reject valid docs.`);
+            process.exit(1);
+        }
+    }
+}
 
 // Umbrella `lunorash/<sub>` re-exports the base packages.
 const UMBRELLA = new Set(["client", "do", "runtime", "server", "values"]);

--- a/apps/docs/src/content/blog/build-a-realtime-chat-on-cloudflare.mdx
+++ b/apps/docs/src/content/blog/build-a-realtime-chat-on-cloudflare.mdx
@@ -75,7 +75,7 @@ import { api } from "../lunora/_generated/api";
 
 export function Chat() {
     const messages = useQuery(api.messages.list) ?? [];
-    const send = useMutation(api.messages.send);
+    const { mutate: send } = useMutation(api.messages.send);
     const [draft, setDraft] = useState("");
 
     return (

--- a/apps/docs/src/content/blog/introducing-lunora.mdx
+++ b/apps/docs/src/content/blog/introducing-lunora.mdx
@@ -72,7 +72,7 @@ import { api } from "../lunora/_generated/api";
 
 function Chat() {
     const messages = useQuery(api.messages.list) ?? [];
-    const send = useMutation(api.messages.send);
+    const { mutate: send } = useMutation(api.messages.send);
     // `messages` is fully typed and stays live. Optimistic writes and an
     // offline queue come for free.
 }

--- a/apps/docs/src/content/blog/realtime-by-default.mdx
+++ b/apps/docs/src/content/blog/realtime-by-default.mdx
@@ -26,7 +26,7 @@ channels to wire up, no cache to invalidate by hand.
 
 ```ts
 const messages = useQuery(api.messages.list, { roomId });
-const send = useMutation(api.messages.send);
+const { mutate: send } = useMutation(api.messages.send);
 ```
 
 That's the whole surface area. Reactivity isn't a feature you opt into here. It's just how reads

--- a/apps/docs/src/content/docs/concepts/error-handling.mdx
+++ b/apps/docs/src/content/docs/concepts/error-handling.mdx
@@ -115,16 +115,17 @@ try {
 For rendering, the React hooks expose error state directly so you don't manage a
 separate `useState`.
 
-`useMutation` returns a callable with a `.pending` flag for in-flight UI; await
-it and `catch` to handle failure:
+`useMutation` returns `{ mutate, pending, ... }`, not a callable: destructure
+`mutate` to invoke the mutation and `pending` for in-flight UI. Await `mutate`
+and `catch` to handle failure:
 
 ```tsx
 import { useMutation } from "@lunora/react";
 import { api } from "@/lunora/_generated/api";
 
-const send = useMutation(api.messages.send);
+const { mutate: send, pending } = useMutation(api.messages.send);
 
-// send.pending is true while a call is in flight
+// pending is true while a call is in flight
 await send({ channelId, text });
 ```
 
@@ -150,7 +151,7 @@ failure), those closures fire and the cache reverts. You don't write any
 rollback code; a rejected mutation leaves the UI as it was.
 
 ```tsx
-const send = useMutation(api.messages.send);
+const { mutate: send } = useMutation(api.messages.send);
 
 await send({ channelId, text }, { optimistic: (current) => [...(current ?? []), draft] });
 // If this rejects, `draft` is removed from the list automatically.

--- a/apps/docs/src/content/docs/concepts/masking.mdx
+++ b/apps/docs/src/content/docs/concepts/masking.mdx
@@ -15,7 +15,7 @@ import { mask } from "lunorash/server";
 
 import { query } from "./_generated/server";
 
-export const listUsers = query.use(mask({ users: { email: "redact" } })).query(async ({ ctx }) => ctx.db.findMany("users"));
+export const listUsers = query.use(mask({ users: { email: "redact" } })).query(async ({ ctx }) => ctx.db.users.findMany());
 // every `email` in the result comes back as null
 ```
 
@@ -40,7 +40,7 @@ export const listUsers = query
             },
         }),
     )
-    .query(async ({ ctx }) => ctx.db.findMany("users"));
+    .query(async ({ ctx }) => ctx.db.users.findMany());
 ```
 
 ## Roles and bypass
@@ -68,7 +68,7 @@ export const listUsers = query
             },
         ),
     )
-    .query(async ({ ctx }) => ctx.db.findMany("users"));
+    .query(async ({ ctx }) => ctx.db.users.findMany());
 ```
 
 A `MaskFn` also sees the **original, un-masked row** as `context.row`, so it can

--- a/apps/docs/src/content/docs/concepts/realtime.mdx
+++ b/apps/docs/src/content/docs/concepts/realtime.mdx
@@ -19,7 +19,7 @@ import { useMutation, useQuery } from "@lunora/react";
 
 export const Chat = ({ channelId }: { channelId: string }) => {
     const messages = useQuery(api.messages.list, { channelId });
-    const send = useMutation(api.messages.send);
+    const { mutate: send } = useMutation(api.messages.send);
 
     if (!messages) return <p>Loading…</p>;
     return (

--- a/apps/docs/src/content/docs/concepts/rls.mdx
+++ b/apps/docs/src/content/docs/concepts/rls.mdx
@@ -22,7 +22,7 @@ const ownDocuments = definePolicy({
     when: ({ auth }) => ({ ownerId: auth.userId }),
 });
 
-export const listDocuments = query.use(rls(definePolicies([ownDocuments]))).query(async ({ ctx }) => ctx.db.findMany("documents"));
+export const listDocuments = query.use(rls(definePolicies([ownDocuments]))).query(async ({ ctx }) => ctx.db.documents.findMany());
 ```
 
 ## Policies

--- a/apps/docs/src/content/docs/frameworks/react.mdx
+++ b/apps/docs/src/content/docs/frameworks/react.mdx
@@ -96,8 +96,10 @@ function Messages({ channelId }: { channelId: string }) {
 
 ## Mutations
 
-`useMutation(fn)` returns a callable with a `.pending` flag. You pass optimistic
-updates per call, and they roll back automatically if the server rejects.
+`useMutation(fn)` returns `{ mutate, pending, data, error, isError, reset,
+withOptimisticUpdate }` — `mutate` is the callable, the hook result itself is
+not. You pass optimistic updates per call, and they roll back automatically if
+the server rejects.
 
 ```tsx
 import { useMutation } from "@lunora/react";
@@ -105,11 +107,11 @@ import { useMutation } from "@lunora/react";
 import { api } from "@/lunora/_generated/api";
 
 function Composer({ channelId }: { channelId: string }) {
-    const send = useMutation(api.messages.send);
+    const { mutate: send, pending } = useMutation(api.messages.send);
 
     return (
         <button
-            disabled={send.pending}
+            disabled={pending}
             onClick={() => void send({ channelId, text: "hi" }, { optimistic: (current) => [...(current ?? []), { _id: "tmp", text: "hi" }] })}
         >
             Send

--- a/apps/docs/src/content/docs/frameworks/reactive-loaders.mdx
+++ b/apps/docs/src/content/docs/frameworks/reactive-loaders.mdx
@@ -95,7 +95,7 @@ import { useMutation, usePreloadedQuery } from "@lunora/react";
 function ChannelView() {
     const { preloaded } = Route.useLoaderData();
     const messages = usePreloadedQuery(preloaded); // SSR value first, then live
-    const send = useMutation(api.messages.send);
+    const { mutate: send } = useMutation(api.messages.send);
 
     return (
         <ul>

--- a/apps/docs/src/content/docs/migrating/from-firebase.mdx
+++ b/apps/docs/src/content/docs/migrating/from-firebase.mdx
@@ -166,7 +166,7 @@ Lunora:
 ```ts
 // client
 import { useMutation } from "@lunora/react";
-const send = useMutation(api.messages.send);
+const { mutate: send } = useMutation(api.messages.send);
 await send({ channelId, text });
 ```
 

--- a/apps/docs/src/content/docs/migrating/from-supabase.mdx
+++ b/apps/docs/src/content/docs/migrating/from-supabase.mdx
@@ -161,7 +161,7 @@ Lunora:
 ```ts
 // client
 import { useMutation } from "@lunora/react";
-const send = useMutation(api.messages.send);
+const { mutate: send } = useMutation(api.messages.send);
 await send({ channelId, text });
 ```
 

--- a/apps/docs/src/content/docs/tutorial/realtime-chat.mdx
+++ b/apps/docs/src/content/docs/tutorial/realtime-chat.mdx
@@ -136,7 +136,7 @@ import { useState } from "react";
 
 export const Chat = ({ channelId }: { channelId: string }) => {
     const messages = useQuery(api.messages.list, { channelId });
-    const send = useMutation(api.messages.send);
+    const { mutate: send } = useMutation(api.messages.send);
     const [text, setText] = useState("");
 
     if (!messages) return <p>Loading...</p>;

--- a/apps/playground/__tests__/smoke.test.ts
+++ b/apps/playground/__tests__/smoke.test.ts
@@ -37,6 +37,29 @@ describe("playground compose smoke (Phase 7)", () => {
         expect(result.generated.api).toContain("messages");
     });
 
+    it("keeps the inbound-email sink off the public api", () => {
+        expect.assertions(3);
+
+        // `inbound:onEmail` is reached by the worker's `email()` export over the
+        // root shard's ADMIN RPC, behind a DMARC/SPF/DKIM `verify` gate that only
+        // the mail path crosses. Registered as a plain `mutation` it was ALSO on
+        // the public `api`, so any signed-in client could call it directly with a
+        // freely chosen `from` — the forged-sender case the gate exists to stop,
+        // reached by walking around the gate instead of through it.
+        //
+        // `internalMutation` is the sibling pattern (`cleanup.ts`), and the mail
+        // dispatcher already sends `x-lunora-system: 1`, which is exactly what
+        // lets an internal target answer a server-initiated dispatch.
+        const { api } = runCodegen({ projectRoot }).generated;
+        const internalAt = api.indexOf("export interface InternalApiTypes");
+
+        expect(internalAt).toBeGreaterThan(-1);
+        // Not in the public `ApiTypes` block…
+        expect(api.slice(0, internalAt)).not.toContain("onEmail");
+        // …and present in the internal one.
+        expect(api.slice(internalAt)).toContain("onEmail");
+    });
+
     it("validateWranglerProject finds no problems for the shipped wrangler.jsonc", () => {
         expect.assertions(3);
 
@@ -86,5 +109,27 @@ describe("playground compose smoke (Phase 7)", () => {
         // origin, so a `text/html` body becomes stored XSS.
         expect(text).toContain("if (contentType !== verdict.contentType) {");
         expect(text).not.toContain("verdict.contentType !== undefined");
+    });
+
+    /* Source assertion for the same reason as the one above — the worker entry
+     * is not importable under this pool. */
+    it("does not claim a Durable Object reset it cannot perform", () => {
+        expect.assertions(2);
+
+        const text = readFileSync(join(projectRoot, "src/server/index.ts"), "utf8");
+
+        // `/test/reset` used to POST `https://do/internal/reset` at a DO named
+        // `__e2e_reset__`, inside a swallowing `catch`. `ShardDO.fetch` answers
+        // 404 to anything but `/rpc` and its WS/relay routes, and that name is
+        // neither `__root__` nor any channel shard — so even a real route would
+        // have reset the wrong DO. A best-effort call to a route that does not
+        // exist is worse than no call: the e2e fixtures and the `workers: 1`
+        // argument were both written as if DO state were being cleared.
+        //
+        // Matched on the QUOTED forms, so the handler's own docblock — which
+        // names the deleted route in prose to explain why it is gone — does not
+        // trip the check that the CALL is absent.
+        expect(text).not.toContain('"https://do/internal/reset"');
+        expect(text).not.toContain('idFromName("__e2e_reset__")');
     });
 });

--- a/apps/playground/lunora/inbound.ts
+++ b/apps/playground/lunora/inbound.ts
@@ -4,7 +4,7 @@ import { dbRateLimit } from "@lunora/ratelimit";
 // eslint-disable-next-line unicorn/prevent-abbreviations -- "Doc" is the generated dataModel type name; aliasing it breaks codegen
 import type { Doc } from "./_generated/dataModel.js";
 import type { Id } from "./_generated/server.js";
-import { mutation, query, v } from "./_generated/server.js";
+import { internalMutation, query, v } from "./_generated/server.js";
 
 // A global cap (no per-key bucket) on inbound-email ingestion — 100/minute.
 const limits = { onEmail: { kind: "fixed window", period: 60_000, rate: 100 } } satisfies RateLimitConfigMap;
@@ -19,6 +19,15 @@ const limits = { onEmail: { kind: "fixed window", period: 60_000, rate: 100 } } 
  * playground's `resolveArgs` projects — a mutation validates its args strictly,
  * so the dispatcher narrows the parsed message to exactly these.
  *
+ * An `internalMutation`, NOT a `mutation`. The worker entry gates this path on
+ * `verify: authenticatesFrom` because Cloudflare Email Routing authenticates the
+ * recipient domain and never the sender; as a public mutation the same sink sat
+ * on the client `api` as well, so any signed-in caller could invoke it with a
+ * `from` of their choosing and skip the gate entirely. Internal costs the mail
+ * path nothing: `@lunora/mail`'s shard dispatcher already sends
+ * `x-lunora-system: 1`, which is what admits a server-initiated dispatch to an
+ * internal target.
+ *
  * The write lands on the root DO's SQLite, so it *is* on the change-feed: the
  * {@link list} query below re-runs for any live subscriber when new mail arrives.
  *
@@ -26,7 +35,7 @@ const limits = { onEmail: { kind: "fixed window", period: 60_000, rate: 100 } } 
  * mutation handler must be deterministic, so the worker entry's `resolveArgs`
  * stamps the receive time (the correct place for the ambient clock call).
  */
-export const onEmail = mutation
+export const onEmail = internalMutation
     .input({
         from: v.string().max(320),
         messageId: v.optional(v.string().max(256)),
@@ -55,7 +64,16 @@ export const onEmail = mutation
         return inboxId;
     });
 
-/** Most-recently-received inbox messages, newest first via the `by_received` index. */
+/**
+ * Most-recently-received inbox messages, newest first via the `by_received` index.
+ *
+ * Public on purpose, unlike {@link onEmail}: it demonstrates that the write
+ * above lands on the change-feed, so a live subscriber re-runs when mail
+ * arrives. It is also ONE shared demo inbox rather than per-user mail — the
+ * `inbox` table has no owner column to scope a read by. A real app routes mail
+ * to a tenant and gates this with an `rls()` policy on that column; leaving it
+ * open is the demo's choice, not the pattern to copy.
+ */
 export const list = query.input({ limit: v.optional(v.number()) }).query(async ({ args, ctx }): Promise<Doc<"inbox">[]> =>
     ctx.db
         .query("inbox")

--- a/apps/playground/src/server/index.ts
+++ b/apps/playground/src/server/index.ts
@@ -216,16 +216,20 @@ const clearD1 = async (database: D1Reset): Promise<void> => {
     }
 };
 
+/**
+ * `/test/reset` — clears the **D1** state the e2e suite shares (users, channels
+ * and every other `.global()` table). Gated by `LUNORA_E2E === "true"`.
+ *
+ * It does NOT reset Durable Object state, and does not pretend to. It used to
+ * POST `https://do/internal/reset` at a DO named `__e2e_reset__` behind a
+ * swallowing `catch`: `ShardDO.fetch` 404s anything that is not `/rpc` or its
+ * WS/relay routes, and that name is neither `__root__` nor any channel shard, so
+ * the call cleared nothing and reported success either way. Deleted rather than
+ * implemented — shard-local rows (`messages`) are reachable only through their
+ * channel, and every spec mints a fresh channel, so nothing depends on clearing
+ * them. A spec that ever does needs a real per-shard admin op, not this.
+ */
 const handleTestReset = async (env: Env): Promise<Response> => {
-    try {
-        const id = env.SHARD.idFromName("__e2e_reset__");
-        const stub = env.SHARD.get(id);
-
-        await stub.fetch(new Request("https://do/internal/reset", { method: "POST" }));
-    } catch {
-        // best-effort
-    }
-
     try {
         await clearD1(env.DB);
     } catch {

--- a/examples/auth-playground/lunora/_generated/openapi.json
+++ b/examples/auth-playground/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "organizationId": {
                         "type": "string"
@@ -143,7 +142,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "organizationId": {
                         "type": "string"

--- a/examples/auth-playground/lunora/_generated/openapi.ts
+++ b/examples/auth-playground/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "organizationId": {
                                                 "type": "string"
@@ -146,7 +145,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "organizationId": {
                                                 "type": "string"

--- a/examples/blog/lunora/_generated/openapi.json
+++ b/examples/blog/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -129,7 +128,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"drafts\">",
@@ -200,7 +198,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"posts\">",
@@ -264,7 +261,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -320,7 +316,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "title": {
                         "type": "string"
@@ -389,7 +384,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "contentType": {
                         "type": "string"
@@ -451,7 +445,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "text": {
                         "type": "string"

--- a/examples/blog/lunora/_generated/openapi.ts
+++ b/examples/blog/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -132,7 +131,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"drafts\">",
@@ -203,7 +201,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"posts\">",
@@ -267,7 +264,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -323,7 +319,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "title": {
                                                 "type": "string"
@@ -392,7 +387,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "contentType": {
                                                 "type": "string"
@@ -454,7 +448,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "text": {
                                                 "type": "string"

--- a/examples/chess/lunora/_generated/openapi.json
+++ b/examples/chess/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -137,7 +136,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -193,7 +191,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -268,7 +265,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -324,7 +320,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -388,7 +383,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -452,7 +446,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -516,7 +509,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "gameId": {
                         "description": "Id<\"games\">",
@@ -584,7 +576,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "lobbyId": {
                         "description": "Id<\"lobbies\">",
@@ -648,7 +639,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "isPrivate": {
                         "type": "boolean"
@@ -710,7 +700,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "lobbyId": {
                         "description": "Id<\"lobbies\">",
@@ -777,7 +766,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "inviteCode": {
                         "type": "string"
@@ -839,7 +827,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "lobbyId": {
                         "description": "Id<\"lobbies\">",
@@ -903,7 +890,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -959,7 +945,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -1015,7 +1000,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -1071,7 +1055,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "displayName": {
                         "type": "string"
@@ -1131,7 +1114,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -1187,7 +1169,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -1243,7 +1224,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"

--- a/examples/chess/lunora/_generated/openapi.ts
+++ b/examples/chess/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -140,7 +139,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -196,7 +194,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -271,7 +268,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -327,7 +323,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -391,7 +386,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -455,7 +449,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -519,7 +512,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "gameId": {
                                                 "description": "Id<\"games\">",
@@ -587,7 +579,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "lobbyId": {
                                                 "description": "Id<\"lobbies\">",
@@ -651,7 +642,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "isPrivate": {
                                                 "type": "boolean"
@@ -713,7 +703,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "lobbyId": {
                                                 "description": "Id<\"lobbies\">",
@@ -780,7 +769,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "inviteCode": {
                                                 "type": "string"
@@ -842,7 +830,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "lobbyId": {
                                                 "description": "Id<\"lobbies\">",
@@ -906,7 +893,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -962,7 +948,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -1018,7 +1003,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -1074,7 +1058,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "displayName": {
                                                 "type": "string"
@@ -1134,7 +1117,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -1190,7 +1172,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -1246,7 +1227,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"

--- a/examples/expo/lunora/_generated/openapi.json
+++ b/examples/expo/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -129,7 +128,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "authorName": {
                         "type": "string"

--- a/examples/expo/lunora/_generated/openapi.ts
+++ b/examples/expo/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -132,7 +131,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "authorName": {
                                                 "type": "string"

--- a/examples/feedback-board/lunora/_generated/openapi.json
+++ b/examples/feedback-board/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "feedbackId": {
                         "description": "Id<\"feedback\">",
@@ -151,7 +150,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "feedbackId": {
                         "description": "Id<\"feedback\">",
@@ -215,7 +213,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "title": {
                         "type": "string"
@@ -294,7 +291,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"feedback\">",
@@ -358,7 +354,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "status": {
                         "anyOf": [
@@ -455,7 +450,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "voterEmail": {
                         "type": "string"
@@ -517,7 +511,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"feedback\">",
@@ -581,7 +574,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"feedback\">",
@@ -674,7 +666,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "feedbackId": {
                         "description": "Id<\"feedback\">",
@@ -742,7 +733,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "limit": {
                         "type": "number"
@@ -802,7 +792,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -858,7 +847,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"summaries\">",

--- a/examples/feedback-board/lunora/_generated/openapi.ts
+++ b/examples/feedback-board/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "feedbackId": {
                                                 "description": "Id<\"feedback\">",
@@ -154,7 +153,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "feedbackId": {
                                                 "description": "Id<\"feedback\">",
@@ -218,7 +216,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "title": {
                                                 "type": "string"
@@ -297,7 +294,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"feedback\">",
@@ -361,7 +357,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "status": {
                                                 "anyOf": [
@@ -458,7 +453,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "voterEmail": {
                                                 "type": "string"
@@ -520,7 +514,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"feedback\">",
@@ -584,7 +577,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"feedback\">",
@@ -677,7 +669,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "feedbackId": {
                                                 "description": "Id<\"feedback\">",
@@ -745,7 +736,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "limit": {
                                                 "type": "number"
@@ -805,7 +795,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -861,7 +850,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"summaries\">",

--- a/examples/kanban-board/lunora/_generated/openapi.json
+++ b/examples/kanban-board/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "title": {
                         "type": "string"
@@ -155,7 +154,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -211,7 +209,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"tasks\">",
@@ -300,7 +297,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"tasks\">",
@@ -364,7 +360,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"tasks\">",

--- a/examples/kanban-board/lunora/_generated/openapi.ts
+++ b/examples/kanban-board/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "title": {
                                                 "type": "string"
@@ -158,7 +157,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -214,7 +212,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"tasks\">",
@@ -303,7 +300,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"tasks\">",
@@ -367,7 +363,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"tasks\">",

--- a/examples/notify-demo/lunora/_generated/openapi.json
+++ b/examples/notify-demo/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "body": {
                         "type": "string"
@@ -139,7 +138,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "body": {
                         "type": "string"
@@ -205,7 +203,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -261,19 +258,16 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "replacedEndpoint": {
                         "type": "string"
                       },
                       "subscription": {
-                        "additionalProperties": false,
                         "properties": {
                           "endpoint": {
                             "type": "string"
                           },
                           "keys": {
-                            "additionalProperties": false,
                             "properties": {
                               "auth": {
                                 "type": "string"

--- a/examples/notify-demo/lunora/_generated/openapi.ts
+++ b/examples/notify-demo/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "body": {
                                                 "type": "string"
@@ -142,7 +141,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "body": {
                                                 "type": "string"
@@ -208,7 +206,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -264,19 +261,16 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "replacedEndpoint": {
                                                 "type": "string"
                                             },
                                             "subscription": {
-                                                "additionalProperties": false,
                                                 "properties": {
                                                     "endpoint": {
                                                         "type": "string"
                                                     },
                                                     "keys": {
-                                                        "additionalProperties": false,
                                                         "properties": {
                                                             "auth": {
                                                                 "type": "string"

--- a/examples/offline-rejections/lunora/_generated/openapi.json
+++ b/examples/offline-rejections/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -129,7 +128,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "text": {
                         "type": "string"

--- a/examples/offline-rejections/lunora/_generated/openapi.ts
+++ b/examples/offline-rejections/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -132,7 +131,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "text": {
                                                 "type": "string"

--- a/examples/payment-demo/lunora/_generated/openapi.json
+++ b/examples/payment-demo/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -129,7 +128,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "priceId": {
                         "type": "string"
@@ -191,7 +189,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -247,7 +244,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -303,7 +299,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"

--- a/examples/payment-demo/lunora/_generated/openapi.ts
+++ b/examples/payment-demo/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -132,7 +131,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "priceId": {
                                                 "type": "string"
@@ -194,7 +192,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -250,7 +247,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -306,7 +302,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"

--- a/examples/realtime-cursors/lunora/_generated/openapi.json
+++ b/examples/realtime-cursors/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "roomId": {
                         "type": "string"
@@ -147,7 +146,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "roomId": {
                         "type": "string"
@@ -209,7 +207,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "roomId": {
                         "type": "string"

--- a/examples/realtime-cursors/lunora/_generated/openapi.ts
+++ b/examples/realtime-cursors/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "roomId": {
                                                 "type": "string"
@@ -150,7 +149,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "roomId": {
                                                 "type": "string"
@@ -212,7 +210,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "roomId": {
                                                 "type": "string"

--- a/examples/tanstack-start/lunora/_generated/openapi.json
+++ b/examples/tanstack-start/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "limit": {
                         "type": "number"
@@ -133,7 +132,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "author": {
                         "type": "string"

--- a/examples/tanstack-start/lunora/_generated/openapi.ts
+++ b/examples/tanstack-start/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "limit": {
                                                 "type": "number"
@@ -136,7 +135,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "author": {
                                                 "type": "string"

--- a/examples/team-chat/lunora/_generated/openapi.json
+++ b/examples/team-chat/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "name": {
                         "type": "string"
@@ -135,7 +134,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -191,7 +189,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -257,7 +254,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -319,7 +315,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -385,7 +380,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -451,7 +445,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -523,7 +516,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -593,7 +585,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -659,7 +650,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "type": "string"
@@ -721,7 +711,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "key": {
                         "type": "string"
@@ -783,7 +772,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -839,7 +827,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "contentType": {
                         "type": "string"
@@ -901,7 +888,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "name": {
                         "type": "string"

--- a/examples/team-chat/lunora/_generated/openapi.ts
+++ b/examples/team-chat/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "name": {
                                                 "type": "string"
@@ -138,7 +137,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -194,7 +192,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -260,7 +257,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -322,7 +318,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -388,7 +383,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -454,7 +448,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -526,7 +519,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -596,7 +588,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -662,7 +653,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "type": "string"
@@ -724,7 +714,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "key": {
                                                 "type": "string"
@@ -786,7 +775,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -842,7 +830,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "contentType": {
                                                 "type": "string"
@@ -904,7 +891,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "name": {
                                                 "type": "string"

--- a/examples/todo-app/lunora/_generated/openapi.json
+++ b/examples/todo-app/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "text": {
                         "type": "string"
@@ -135,7 +134,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {},
                     "required": [],
                     "type": "object"
@@ -191,7 +189,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"todos\">",
@@ -255,7 +252,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "description": "Id<\"todos\">",

--- a/examples/todo-app/lunora/_generated/openapi.ts
+++ b/examples/todo-app/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "text": {
                                                 "type": "string"
@@ -138,7 +137,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {},
                                         "required": [],
                                         "type": "object"
@@ -194,7 +192,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"todos\">",
@@ -258,7 +255,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "id": {
                                                 "description": "Id<\"todos\">",

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openapi.json
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openapi.json
@@ -73,7 +73,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "body": {
                         "type": "string"
@@ -139,7 +138,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "boardId": {
                         "type": "string"

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openapi.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openapi.ts
@@ -76,7 +76,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "body": {
                                                 "type": "string"
@@ -142,7 +141,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "boardId": {
                                                 "type": "string"

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openrpc.json
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openrpc.json
@@ -121,7 +121,6 @@
           "name": "args",
           "required": true,
           "schema": {
-            "additionalProperties": false,
             "properties": {
               "body": {
                 "type": "string"
@@ -268,7 +267,6 @@
           "name": "args",
           "required": true,
           "schema": {
-            "additionalProperties": false,
             "properties": {
               "boardId": {
                 "type": "string"

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openrpc.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/openrpc.ts
@@ -124,7 +124,6 @@ export const openRpcSpec: Record<string, unknown> = {
                     "name": "args",
                     "required": true,
                     "schema": {
-                        "additionalProperties": false,
                         "properties": {
                             "body": {
                                 "type": "string"
@@ -271,7 +270,6 @@ export const openRpcSpec: Record<string, unknown> = {
                     "name": "args",
                     "required": true,
                     "schema": {
-                        "additionalProperties": false,
                         "properties": {
                             "boardId": {
                                 "type": "string"

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/openapi.json
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/openapi.json
@@ -71,7 +71,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
                   "properties": {
                     "channelId": {
                       "description": "Id<\"channels\">",
@@ -170,7 +169,6 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": false,
                 "properties": {
                   "text": {
                     "type": "string"
@@ -211,7 +209,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "description": "Id<\"channels\">",
@@ -278,7 +275,6 @@
                 "additionalProperties": false,
                 "properties": {
                   "args": {
-                    "additionalProperties": false,
                     "properties": {
                       "channelId": {
                         "description": "Id<\"channels\">",
@@ -302,6 +298,9 @@
                       },
                       "tags": {
                         "additionalProperties": {
+                          "type": "string"
+                        },
+                        "propertyNames": {
                           "type": "string"
                         },
                         "type": "object"

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/openapi.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/openapi.ts
@@ -74,7 +74,6 @@ export const openApiSpec: Record<string, unknown> = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "additionalProperties": false,
                                     "properties": {
                                         "channelId": {
                                             "description": "Id<\"channels\">",
@@ -173,7 +172,6 @@ export const openApiSpec: Record<string, unknown> = {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "additionalProperties": false,
                                 "properties": {
                                     "text": {
                                         "type": "string"
@@ -214,7 +212,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "description": "Id<\"channels\">",
@@ -281,7 +278,6 @@ export const openApiSpec: Record<string, unknown> = {
                                 "additionalProperties": false,
                                 "properties": {
                                     "args": {
-                                        "additionalProperties": false,
                                         "properties": {
                                             "channelId": {
                                                 "description": "Id<\"channels\">",
@@ -305,6 +301,9 @@ export const openApiSpec: Record<string, unknown> = {
                                             },
                                             "tags": {
                                                 "additionalProperties": {
+                                                    "type": "string"
+                                                },
+                                                "propertyNames": {
                                                     "type": "string"
                                                 },
                                                 "type": "object"

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/openrpc.json
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/openrpc.json
@@ -121,7 +121,6 @@
           "name": "args",
           "required": true,
           "schema": {
-            "additionalProperties": false,
             "properties": {
               "channelId": {
                 "description": "Id<\"channels\">",
@@ -269,7 +268,6 @@
           "name": "args",
           "required": true,
           "schema": {
-            "additionalProperties": false,
             "properties": {
               "channelId": {
                 "description": "Id<\"channels\">",
@@ -293,6 +291,9 @@
               },
               "tags": {
                 "additionalProperties": {
+                  "type": "string"
+                },
+                "propertyNames": {
                   "type": "string"
                 },
                 "type": "object"

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/openrpc.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/openrpc.ts
@@ -124,7 +124,6 @@ export const openRpcSpec: Record<string, unknown> = {
                     "name": "args",
                     "required": true,
                     "schema": {
-                        "additionalProperties": false,
                         "properties": {
                             "channelId": {
                                 "description": "Id<\"channels\">",
@@ -272,7 +271,6 @@ export const openRpcSpec: Record<string, unknown> = {
                     "name": "args",
                     "required": true,
                     "schema": {
-                        "additionalProperties": false,
                         "properties": {
                             "channelId": {
                                 "description": "Id<\"channels\">",
@@ -296,6 +294,9 @@ export const openRpcSpec: Record<string, unknown> = {
                             },
                             "tags": {
                                 "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "propertyNames": {
                                     "type": "string"
                                 },
                                 "type": "object"

--- a/packages/codegen/__tests__/schema-ir.test.ts
+++ b/packages/codegen/__tests__/schema-ir.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The IR-backed schema-node reader must produce the SAME JSON Schema the
+ * runtime `@lunora/values` reader produces for the same validator — that
+ * equivalence is the whole reason both plug into one shared mapper, and the
+ * OpenAPI/OpenRPC emitters trust it.
+ *
+ * Each case here is one place the two had drifted, or one place the schema
+ * contradicted the runtime parser. `to-json-schema.test.ts` in `@lunora/values`
+ * pins the runtime half of the same pairs.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ValidatorIR } from "../src/ir";
+import { objectSchema, validatorIrToJsonSchema } from "../src/schema-ir";
+
+describe("the IR-backed JSON Schema reader", () => {
+    it("carries a bigint literal the same way the bigint scalar does", () => {
+        expect.assertions(2);
+
+        // The IR records a literal as SOURCE text, so `5n` reached the numeric
+        // fallback (`Number("5n")` is NaN) and emitted `{ const: "5n" }` — a
+        // THIRD spelling, next to the runtime reader's `{ const: "5" }` and the
+        // scalar's int64. One decimal-string carrier for all of them.
+        expect(validatorIrToJsonSchema({ kind: "bigint" })).toStrictEqual({ format: "int64", type: "string" });
+        expect(validatorIrToJsonSchema({ kind: "literal", literalValue: "5n" })).toStrictEqual({
+            const: "5",
+            format: "int64",
+            type: "string",
+        });
+    });
+
+    it("reflects a record's key validator as propertyNames", () => {
+        expect.assertions(1);
+
+        // The reader read `valueType` and ignored `keyType`, so a key constraint
+        // the runtime enforces was inexpressible in the generated spec.
+        const record: ValidatorIR = {
+            keyType: { kind: "string" },
+            kind: "record",
+            valueType: { kind: "number" },
+        };
+
+        expect(validatorIrToJsonSchema(record)).toStrictEqual({
+            additionalProperties: { type: "number" },
+            propertyNames: { type: "string" },
+            type: "object",
+        });
+    });
+
+    it("leaves an object open and requires only what cannot be absent", () => {
+        expect.assertions(1);
+
+        // `additionalProperties: false` contradicted a parser that STRIPS
+        // unknown keys, and `required` listed `v.any()` and unions with an
+        // optional member — both of which parse happily when absent.
+        const shape: Record<string, ValidatorIR> = {
+            anything: { kind: "any" },
+            maybe: { inner: { kind: "number" }, kind: "optional" },
+            name: { kind: "string" },
+            unionWithOptional: { kind: "union", members: [{ kind: "string" }, { inner: { kind: "number" }, kind: "optional" }] },
+        };
+
+        expect(objectSchema(shape)).toStrictEqual({
+            properties: {
+                anything: {},
+                maybe: { type: "number" },
+                name: { type: "string" },
+                unionWithOptional: { anyOf: [{ type: "string" }, { type: "number" }] },
+            },
+            required: ["name"],
+            type: "object",
+        });
+    });
+});

--- a/packages/codegen/src/schema-ir.ts
+++ b/packages/codegen/src/schema-ir.ts
@@ -3,10 +3,14 @@ import { jsonSchemaFromNode, objectSchemaFromNodes } from "@lunora/values";
 
 import type { ValidatorIR } from "./ir";
 
+/** A bigint literal as the IR records its source text — digits with the `n` suffix, optionally signed. */
+const BIGINT_LITERAL = /^-?\d+n$/u;
+
 /**
  * Render a `v.literal(...)` value as a JSON Schema `const`. The IR carries the
- * literal as verbatim source text (`"admin"`, `42`, `true`, `null`), so parse it
- * back to a JSON value; a bigint-style literal is carried as its decimal string.
+ * literal as verbatim source text (`"admin"`, `42`, `true`, `null`, `5n`), so
+ * parse it back to a JSON value; a bigint literal is carried as its decimal
+ * string, matching both the runtime reader and the `bigint` scalar node.
  */
 const literalConst = (literalValue: string | undefined): JsonSchema => {
     if (literalValue === undefined) {
@@ -43,6 +47,14 @@ const literalConst = (literalValue: string | undefined): JsonSchema => {
         return { const: trimmed.slice(1, -1), type: "string" };
     }
 
+    // A bigint literal reaches here as its SOURCE text (`5n`), which is not a
+    // number and not JSON — it used to fall through to `{ const: "5n" }`, a
+    // third spelling of a value the runtime reader emits as `{ const: "5" }`
+    // and the `bigint` scalar as an int64 string. One carrier for all three.
+    if (BIGINT_LITERAL.test(trimmed)) {
+        return { const: trimmed.slice(0, -1), format: "int64", type: "string" };
+    }
+
     const asNumber = Number(trimmed);
 
     if (!Number.isNaN(asNumber)) {
@@ -66,6 +78,7 @@ const irReader: SchemaNodeReader<ValidatorIR> = {
     constraints: () => undefined,
     inner: (validator) => validator.inner,
     isNullable: (validator) => validator.column?.notNull === false,
+    keyChild: (validator) => validator.keyType,
     // `ValidatorIR.kind` is a loose `string` (build-time AST); narrow it to the
     // shared reader's `ValidatorKind`. Unknown kinds fall through the mapper's
     // `default` branch to an empty schema, exactly as before.

--- a/packages/do/__tests__/sql-assistant.test.ts
+++ b/packages/do/__tests__/sql-assistant.test.ts
@@ -61,6 +61,24 @@ describe("generateSql", () => {
         expect(result.degraded ? result.reason : undefined).toBe("unsafe-response");
     });
 
+    it("logs the gate's rejection code, so a systematic false refusal is diagnosable", async () => {
+        expect.assertions(2);
+
+        // The discard is correct; its silence was not. An operator only ever
+        // saw "unsafe-response", which reads identically whether the model
+        // wrote a real `DELETE` or the gate misclassified a read-only shape.
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        try {
+            await generateSql(binding("DELETE FROM messages"), { prompt: "remove everything" }, SCHEMA);
+
+            expect(warn).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+            expect(warn.mock.calls[0]?.[0]).toContain("SQL_NOT_READONLY");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     it("retries once before giving up, so one bad completion is not fatal", async () => {
         expect.assertions(2);
 

--- a/packages/do/src/sql-assistant.ts
+++ b/packages/do/src/sql-assistant.ts
@@ -426,7 +426,10 @@ const modelFor = (rawArgs: Record<string, unknown>): string => capped(rawArgs.mo
  *
  * A response that fails the read-only gate is retried once and then DISCARDED —
  * returning unvalidated SQL, even labelled, would put model output inside a
- * security boundary it has no business in.
+ * security boundary it has no business in. Each discard is warned to the
+ * server console with the gate's rejection code, because the caller only learns
+ * `unsafe-response` and could not otherwise tell a bad completion from a gate
+ * that refuses a legitimate shape.
  */
 const generateSql = async (binding: unknown, rawArgs: Record<string, unknown>, schema: ReadonlyArray<SchemaFact>): Promise<GenerateSqlResult> => {
     const args: GenerateSqlArgs = {
@@ -448,7 +451,26 @@ const generateSql = async (binding: unknown, rawArgs: Record<string, unknown>, s
         (raw) => {
             const statement = extractStatement(raw);
 
-            return statement !== "" && classifyStatement(statement) === undefined ? statement : undefined;
+            if (statement === "") {
+                return undefined;
+            }
+
+            const rejection = classifyStatement(statement);
+
+            if (rejection === undefined) {
+                return statement;
+            }
+
+            // Discarding is the posture; discarding SILENTLY was the bug. The
+            // operator only ever sees `unsafe-response`, which reads the same
+            // whether the model really wrote a `DELETE` or the gate misread a
+            // read-only shape as a write — so a systematic false refusal was
+            // undiagnosable. Server-side only, and only on an admin-gated
+            // surface.
+            // eslint-disable-next-line no-console -- intentional operational notice: the caller only learns "unsafe-response", so without this a gate that refuses a legitimate shape is indistinguishable from a bad completion
+            console.warn(`[@lunora/do] sql-assistant: discarded a generated statement (${rejection.code}): ${statement}`);
+
+            return undefined;
         },
     );
 

--- a/packages/errors/__tests__/catalog-registration.test.ts
+++ b/packages/errors/__tests__/catalog-registration.test.ts
@@ -39,22 +39,45 @@ const SKIP_DIRECTORIES = new Set([
     "test-results",
 ]);
 
-// Matches the two shapes a Lunora package mints an error code in: the
-// `{ code: "X", ... }` structured-error/options shape, and a direct
-// `new LunoraError("X", ...)` first-argument literal. Deliberately textual
-// (not AST-based) — this is meant to catch a *future* uncatalogued code the
-// same cheap way a reviewer would grep for one.
+// The shapes a Lunora package mints an error code in. Each pattern captures the
+// code in group 1; a code found by more than one is deduped by the caller.
 //
-// The `new LunoraError(...)` group's first argument is unambiguously a code,
-// so it tolerates any case (`badRequest`, `BadRequest`, ...) — a mint doesn't
-// have to be SCREAMING_SNAKE_CASE to reach `isInternalCode`. The `code:`
-// object-literal group stays SCREAMING_SNAKE_CASE-only: widening it the same
-// way would flag every unrelated `code: "Enter"` (key events), `code: "en"`
-// (locale tags), `code: "P2002"` (driver errors), and similar repo-wide,
-// which is what makes the textual heuristic viable at all. A template-literal
-// code (`` `CODE_${x}` ``) is undetectable by a textual gate either way — an
-// accepted limitation, not a silent one.
-const CODE_PATTERN = /code:\s*"([A-Z][A-Z0-9_]*)"|new LunoraError\(\s*"([A-Za-z]\w*)"/g;
+// Deliberately textual (not AST-based) — this is meant to catch a *future*
+// uncatalogued code the same cheap way a reviewer would grep for one. Three
+// separate patterns rather than one alternation: the combined form is past the
+// regex-complexity budget, and each shape's case rule reads next to it.
+//
+// A template-literal code (`` `CODE_${x}` ``) is undetectable by a textual gate
+// either way — an accepted limitation, not a silent one.
+const CODE_PATTERNS: ReadonlyArray<RegExp> = [
+    // The `{ code: "X", ... }` structured-error/options shape.
+    //
+    // SCREAMING_SNAKE_CASE-only: widening it would flag every unrelated
+    // `code: "Enter"` (key events), `code: "en"` (locale tags), `code: "P2002"`
+    // (driver errors) repo-wide, which is what makes the heuristic viable.
+    /code:\s*"([A-Z][A-Z0-9_]*)"/g,
+
+    // A direct `new LunoraError("X", ...)`. Its first argument is unambiguously
+    // a code, so any case goes (`badRequest`, `BadRequest`, ...) — a mint
+    // doesn't have to be SCREAMING_SNAKE_CASE to reach `isInternalCode`.
+    /new LunoraError\(\s*"([A-Za-z]\w*)"/g,
+
+    // An INDIRECT mint: `new <Anything>Error("X", ...)` (a `LunoraError`
+    // subclass such as the payment package's), `raise("X", ...)`, and the
+    // `super("X", ...)` a subclass constructor forwards with.
+    //
+    // This is what makes the gate see past the base class. `isInternalCode`
+    // keys off the *code*, not the constructor, so a code minted through a
+    // subclass reaches the wire mappers exactly like a base-class one — and a
+    // pattern pinned to the literal name `LunoraError` classes every subclass
+    // mint as unregistered-therefore-client-safe. Six payment codes shipped
+    // that way.
+    //
+    // SCREAMING_SNAKE_CASE-only, because unlike the group above these shapes
+    // also take a plain MESSAGE first (`new TypeError("some message")`,
+    // `super("message")`) and the case restriction is what tells the two apart.
+    /(?:new\s+\w*Error|raise|super)\(\s*"([A-Z][A-Z0-9_]*)"/g,
+];
 
 /**
  * Codes the gate would otherwise flag as unregistered but that are not
@@ -157,11 +180,13 @@ describe("error catalog registration", () => {
         for (const filePath of collectSourceFiles(REPO_ROOT)) {
             const content = readFileSync(filePath, "utf8");
 
-            for (const match of content.matchAll(CODE_PATTERN)) {
-                const code = match[1] ?? match[2];
+            for (const pattern of CODE_PATTERNS) {
+                for (const match of content.matchAll(pattern)) {
+                    const code = match[1];
 
-                if (code !== undefined && !catalogKeys.has(code) && !missing.has(code)) {
-                    missing.set(code, filePath.replace(`${REPO_ROOT}/`, ""));
+                    if (code !== undefined && !catalogKeys.has(code) && !missing.has(code)) {
+                        missing.set(code, filePath.replace(`${REPO_ROOT}/`, ""));
+                    }
                 }
             }
         }
@@ -172,6 +197,38 @@ describe("error catalog registration", () => {
             unexpected.map(([code, file]) => `${code} (first seen in ${file})`),
             "Found error code(s) minted outside ERROR_CATALOG. Register each with a status/title (and internal: true if its message can carry backend detail) in packages/errors/src/catalog.ts.",
         ).toStrictEqual([]);
+    });
+
+    // Guards the *scanner*, not the catalog. The repo-wide `it` above only goes
+    // red while an uncatalogued code happens to exist, so once the catalog is
+    // complete a narrowing of CODE_PATTERN back to the literal `LunoraError`
+    // name would land green — and every future subclass mint would again be
+    // treated as client-safe by `isInternalCode`.
+    it("the scanner sees indirect mints, not just `new LunoraError(...)`", () => {
+        expect.assertions(1);
+
+        const source = [
+            `throw new SubError("SUBCLASS_MINT", "d");`,
+            `raise("RAISE_MINT", "d");`,
+            `super("SUPER_MINT", message, { name: "X" });`,
+            `new LunoraError("baseMint", "d");`,
+            `const options = { code: "OBJECT_MINT" };`,
+            // Not codes: a plain message-first construction, and a lowercase
+            // `code:` value from an unrelated union.
+            `throw new TypeError("expected a string");`,
+            `super("plain message");`,
+            `const key = { code: "Enter" };`,
+        ].join("\n");
+
+        const found = new Set<string>();
+
+        for (const pattern of CODE_PATTERNS) {
+            for (const match of source.matchAll(pattern)) {
+                found.add(match[1] as string);
+            }
+        }
+
+        expect([...found].toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["baseMint", "OBJECT_MINT", "RAISE_MINT", "SUBCLASS_MINT", "SUPER_MINT"]);
     });
 
     it("every KNOWN_NON_LUNORA_CODES entry still occurs in its expected file", () => {

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -229,7 +229,16 @@ export const ERROR_CATALOG = {
      * already have.
      */
     PROVIDER_ERROR: { status: 502, title: "Payment provider error" },
-    /** Webhook rejections, addressed to the provider posting the hook; the messages are fixed and name no internal state. */
+    /**
+     * Webhook rejections, addressed to the provider posting the hook, so NOT
+     * `internal`. Five of the six mint sites are fixed strings ("no matching
+     * signature", "missing creem-signature header"). The sixth,
+     * `providers/stripe.ts`, passes the Stripe SDK's own verification message
+     * through — "No signatures found matching…", "Timestamp outside the
+     * tolerance zone" — which still describes the REQUEST the poster sent, not
+     * this server's state. Keep that true of anything added here: an upstream
+     * message is only safe to forward while it is about the caller's input.
+     */
     WEBHOOK_EVENT_ID_MISSING: { status: 400, title: "Webhook event id missing" },
     WEBHOOK_SIGNATURE_INVALID: { status: 400, title: "Webhook signature invalid" },
     WEBHOOK_TIMESTAMP_INVALID: { status: 400, title: "Webhook timestamp outside tolerance" },

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -229,6 +229,7 @@ export const ERROR_CATALOG = {
      * already have.
      */
     PROVIDER_ERROR: { status: 502, title: "Payment provider error" },
+
     /**
      * Webhook rejections, addressed to the provider posting the hook, so NOT
      * `internal`. Five of the six mint sites are fixed strings ("no matching

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -197,7 +197,7 @@ export const ERROR_CATALOG = {
     R2_SQL_ERROR: { status: 502, title: "R2 SQL API error" },
     WORKFLOWS_REST_ERROR: { status: 502, title: "Cloudflare Workflows REST API error" },
 
-    /**
+    /*
      * `@lunora/payment` codes, minted through `LunoraPaymentError` — a
      * `LunoraError` subclass. They shipped uncatalogued because the
      * registration gate's scanner only matched the literal `new LunoraError(`,

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -206,6 +206,14 @@ export const ERROR_CATALOG = {
      * package's own `STATUS_BY_CODE`. The remaining payment codes — `FORBIDDEN`,
      * `INVALID_TRANSITION`, `NOT_FOUND`, `VALIDATION_ERROR` — are the generic
      * entries above and keep their existing verdicts.
+     *
+     * `CONFIG_INVALID` is `internal` because its messages name server wiring
+     * ("webhook secret not configured", a duplicate/absent adapter), and the
+     * caller can do nothing with them. That verdict only holds while the code
+     * is reserved for server configuration: `check()`'s argument-shape guard
+     * used to mint it for "requires a featureId or priceId", which is the
+     * caller's own mistake and now mints `VALIDATION_ERROR` instead. Keep new
+     * caller-fixable failures off this code rather than widening it.
      */
 
     /** Server-side payment wiring is wrong or missing (`webhook secret not configured`, a duplicate/absent adapter). A 500 that names internal configuration — redact on the wire. */

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -198,6 +198,35 @@ export const ERROR_CATALOG = {
     WORKFLOWS_REST_ERROR: { status: 502, title: "Cloudflare Workflows REST API error" },
 
     /**
+     * `@lunora/payment` codes, minted through `LunoraPaymentError` — a
+     * `LunoraError` subclass. They shipped uncatalogued because the
+     * registration gate's scanner only matched the literal `new LunoraError(`,
+     * so every subclass mint was invisible to it and `isInternalCode` (which
+     * fails OPEN) classed all six as client-safe. `status` mirrors the
+     * package's own `STATUS_BY_CODE`. The remaining payment codes — `FORBIDDEN`,
+     * `INVALID_TRANSITION`, `NOT_FOUND`, `VALIDATION_ERROR` — are the generic
+     * entries above and keep their existing verdicts.
+     */
+
+    /** Server-side payment wiring is wrong or missing (`webhook secret not configured`, a duplicate/absent adapter). A 500 that names internal configuration — redact on the wire. */
+    CONFIG_INVALID: { internal: true, status: 500, title: "Payment configuration invalid" },
+    /** Arithmetic across two currencies. The message names only the two currency codes the caller supplied. */
+    CURRENCY_MISMATCH: { status: 400, title: "Currency mismatch" },
+
+    /**
+     * A payment provider refused or answered unusably. NOT `internal`, matching
+     * the upstream-API 502s above: the messages are fixed capability text
+     * ("<provider> does not support refundPayment") or echo back the malformed
+     * id the CALLER passed in, so none of them reveals state the caller did not
+     * already have.
+     */
+    PROVIDER_ERROR: { status: 502, title: "Payment provider error" },
+    /** Webhook rejections, addressed to the provider posting the hook; the messages are fixed and name no internal state. */
+    WEBHOOK_EVENT_ID_MISSING: { status: 400, title: "Webhook event id missing" },
+    WEBHOOK_SIGNATURE_INVALID: { status: 400, title: "Webhook signature invalid" },
+    WEBHOOK_TIMESTAMP_INVALID: { status: 400, title: "Webhook timestamp outside tolerance" },
+
+    /**
      * Admin-gated `/_lunora/admin/*` and `__lunora_admin__:*` codes. Registered
      * here (plan 230, ERRORS-01) after an audit found them minted with `code:`
      * but never added to the catalog — `isInternalCode` fails OPEN for an

--- a/packages/payment/__tests__/create-payment.test.ts
+++ b/packages/payment/__tests__/create-payment.test.ts
@@ -983,6 +983,31 @@ describe("createPayment", () => {
         await expect(response.json()).resolves.toEqual({ error: "upstream provider timed out" });
     });
 
+    it("redacts CONFIG_INVALID's message, which names server-side wiring", async () => {
+        expect.assertions(2);
+
+        // `LunoraPaymentError` is a `LunoraError` SUBCLASS, and the catalog gate
+        // that keeps every minted code registered could not see subclass mints —
+        // so all six payment codes were unregistered, and `isInternalCode` treats
+        // an unregistered code as client-safe. This 500 therefore echoed "webhook
+        // secret not configured" (and elsewhere the adapter/provider names) to
+        // whoever POSTed the webhook. Registered `internal: true`, the status
+        // still travels and the message does not.
+        const adapter = fakeAdapter({
+            parseWebhook: async () => {
+                const { LunoraPaymentError } = await import("../src/errors");
+
+                throw new LunoraPaymentError("CONFIG_INVALID", "webhook secret not configured");
+            },
+        });
+        const payment = createPayment({ adapter, store: new MemoryPaymentStore() });
+
+        const response = await payment.handleWebhook(new Request("https://app.test/payment/webhook", { body: "{}", method: "POST" }));
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({ error: "Internal error" });
+    });
+
     it("masks an unrecognized webhook-parsing throw behind a generic 400 (unchanged, non-LunoraPaymentError branch)", async () => {
         expect.assertions(2);
 

--- a/packages/payment/__tests__/create-payment.test.ts
+++ b/packages/payment/__tests__/create-payment.test.ts
@@ -1312,7 +1312,7 @@ describe("createPayment — attach / check / track", () => {
 
         const payment = createPayment({ adapter: fakeAdapter(), entitlements, store: new MemoryPaymentStore() });
 
-        await expect(payment.check({ referenceId: "user_1" })).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+        await expect(payment.check({ referenceId: "user_1" })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
     });
 
     it("listBalances resolves every configured feature in one call", async () => {

--- a/packages/payment/__tests__/providers/autumn.test.ts
+++ b/packages/payment/__tests__/providers/autumn.test.ts
@@ -481,8 +481,8 @@ describe("autumn adapter", () => {
                 store: new MemoryPaymentStore(),
             });
 
-            // Neither featureId nor priceId — must throw CONFIG_INVALID, not reach Autumn unscoped.
-            await expect(payment.check({ referenceId: "user_1" })).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+            // Neither featureId nor priceId — must throw VALIDATION_ERROR, not reach Autumn unscoped.
+            await expect(payment.check({ referenceId: "user_1" })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
         });
     });
 });

--- a/packages/payment/src/create-payment.ts
+++ b/packages/payment/src/create-payment.ts
@@ -389,7 +389,7 @@ export const createPayment = (options: CreatePaymentOptions): LunoraPayment => {
             // provider — otherwise a `check({ referenceId })` with neither `featureId` nor `priceId`
             // would reach a provider-owned adapter unscoped and could fail open ("customer exists").
             if (input.featureId === undefined && input.priceId === undefined) {
-                throw new LunoraPaymentError("CONFIG_INVALID", "check() requires a featureId or priceId");
+                throw new LunoraPaymentError("VALIDATION_ERROR", "check() requires a featureId or priceId");
             }
 
             // When the provider owns entitlement truth (e.g. Autumn), delegate the whole decision to
@@ -409,7 +409,7 @@ export const createPayment = (options: CreatePaymentOptions): LunoraPayment => {
             // Unreachable at runtime — the arg-shape guard above already rejected "neither", and the
             // priceId branch returned. This narrows `featureId` to `string` for `evaluateFeature` below.
             if (input.featureId === undefined) {
-                throw new LunoraPaymentError("CONFIG_INVALID", "check() requires a featureId or priceId");
+                throw new LunoraPaymentError("VALIDATION_ERROR", "check() requires a featureId or priceId");
             }
 
             if (!options.entitlements) {

--- a/packages/shard-engine/__tests__/sql-console.test.ts
+++ b/packages/shard-engine/__tests__/sql-console.test.ts
@@ -236,6 +236,20 @@ describe("classifyStatement offsets", () => {
         // batch scan fixes a rule nobody chose; this one someone did.
         expect(classifyStatement("SELECT 'DROP TABLE x'")?.code).toBe("SQL_NOT_READONLY");
     });
+
+    it("allows SQLite's read-only `replace()` scalar but still refuses `REPLACE INTO`", () => {
+        expect.assertions(4);
+
+        // `replace` is a write only in the `REPLACE INTO` statement form. As a
+        // scalar it is a core string function, and refusing it broke a plain
+        // SELECT with a message that named no rule the operator had broken.
+        expect(classifyStatement("SELECT REPLACE(name, 'a', 'b') FROM users")).toBeUndefined();
+        expect(classifyStatement("SELECT replace(name, 'a', 'b') AS n FROM users")).toBeUndefined();
+        // The statement form is still refused — including from inside a CTE,
+        // which is the reason the keyword scan exists at all.
+        expect(classifyStatement("REPLACE INTO t VALUES (1)")?.code).toBe("SQL_NOT_READONLY");
+        expect(classifyStatement("WITH x AS (SELECT 1) REPLACE INTO t SELECT * FROM x")?.code).toBe("SQL_NOT_READONLY");
+    });
 });
 
 describe("lintReadonlySql", () => {

--- a/packages/values/__tests__/to-json-schema.test.ts
+++ b/packages/values/__tests__/to-json-schema.test.ts
@@ -17,10 +17,10 @@ describe("toJsonSchema", () => {
             expect(toJsonSchema(v.null())).toStrictEqual({ type: "null" });
         });
 
-        it("carries bigint as an int64 integer", () => {
+        it("carries bigint as an int64 decimal string", () => {
             expect.assertions(1);
 
-            expect(toJsonSchema(v.bigint())).toStrictEqual({ format: "int64", type: "integer" });
+            expect(toJsonSchema(v.bigint())).toStrictEqual({ format: "int64", type: "string" });
         });
 
         it("schemas date and timestamp as epoch-millisecond integers", () => {
@@ -74,7 +74,11 @@ describe("toJsonSchema", () => {
         it("maps a record to additionalProperties", () => {
             expect.assertions(1);
 
-            expect(toJsonSchema(v.record(v.string(), v.number()))).toStrictEqual({ additionalProperties: { type: "number" }, type: "object" });
+            expect(toJsonSchema(v.record(v.string(), v.number()))).toStrictEqual({
+                additionalProperties: { type: "number" },
+                propertyNames: { type: "string" },
+                type: "object",
+            });
         });
 
         it("maps a union to anyOf", () => {
@@ -95,7 +99,6 @@ describe("toJsonSchema", () => {
             );
 
             expect(schema).toStrictEqual({
-                additionalProperties: false,
                 properties: {
                     age: { type: "number" },
                     name: { type: "string" },
@@ -112,10 +115,8 @@ describe("toJsonSchema", () => {
             const schema = toJsonSchema(v.object({ author: v.object({ id: v.id("users") }) }));
 
             expect(schema).toStrictEqual({
-                additionalProperties: false,
                 properties: {
                     author: {
-                        additionalProperties: false,
                         properties: { id: { description: 'Id<"users">', type: "string", "x-lunora-table": "users" } },
                         required: ["id"],
                         type: "object",
@@ -197,7 +198,6 @@ describe("argsToJsonSchema", () => {
         });
 
         expect(schema).toStrictEqual({
-            additionalProperties: false,
             properties: {
                 cursor: { type: "string" },
                 limit: { type: "number" },
@@ -211,7 +211,7 @@ describe("argsToJsonSchema", () => {
     it("yields an empty object schema for a no-arg function", () => {
         expect.assertions(1);
 
-        expect(argsToJsonSchema({})).toStrictEqual({ additionalProperties: false, properties: {}, required: [], type: "object" });
+        expect(argsToJsonSchema({})).toStrictEqual({ properties: {}, required: [], type: "object" });
     });
 });
 
@@ -221,7 +221,7 @@ describe("literal const carrier", () => {
 
         // The `typeof value === "bigint"` branch of validatorReader.literalSchema —
         // JSON Schema `const` must be JSON-serializable, so a bigint is stringified.
-        expect(toJsonSchema(v.literal(9_007_199_254_740_993n))).toStrictEqual({ const: "9007199254740993", type: "string" });
+        expect(toJsonSchema(v.literal(9_007_199_254_740_993n))).toStrictEqual({ const: "9007199254740993", format: "int64", type: "string" });
     });
 });
 
@@ -246,6 +246,7 @@ describe("jsonSchemaFromNode over an IR-style reader", () => {
             constraints: () => undefined,
             inner: () => undefined,
             isNullable: () => false,
+            keyChild: () => undefined,
             kind: (node) => node.kind,
             literalSchema: () => {
                 return { const: undefined };
@@ -301,9 +302,72 @@ describe("jsonSchemaFromNode over an IR-style reader", () => {
         const schema: JsonSchema = objectSchemaFromNodes(shape, reader);
 
         expect(schema).toStrictEqual({
-            additionalProperties: false,
             properties: { flag: { type: "boolean" }, maybe: {} },
             required: ["flag"],
+            type: "object",
+        });
+    });
+});
+
+// Every case here pairs the emitted schema with the RUNTIME verdict on the same
+// value. The emitter shipped four claims the parser contradicted, and each only
+// shows up when the two are asserted side by side: a client generated from the
+// spec refused bodies the server accepts, and could not express what the server
+// requires.
+describe("schema agrees with the runtime parser", () => {
+    it("does not close an object the parser leaves open", () => {
+        expect.assertions(2);
+
+        // `v.object` STRIPS an undeclared key by default (`.output()`'s
+        // rejectUnknownKeys mode is the only thing that refuses one), so
+        // `additionalProperties: false` had a generated client rejecting a body
+        // the server accepts.
+        const validator = v.object({ a: v.string() });
+
+        expect(validator.safeParse({ a: "x", b: 1 }).ok).toBe(true);
+        expect(toJsonSchema(validator)).toStrictEqual({
+            properties: { a: { type: "string" } },
+            required: ["a"],
+            type: "object",
+        });
+    });
+
+    it("omits from `required` every field the parser accepts as absent", () => {
+        expect.assertions(4);
+
+        // `v.any()` accepts `undefined`, and a union with an optional member
+        // does too — neither has `kind === "optional"`, which was the whole test
+        // for requiredness.
+        expect(v.object({ a: v.any() }).safeParse({}).ok).toBe(true);
+        expect(argsToJsonSchema({ a: v.any() }).required).toStrictEqual([]);
+        expect(v.object({ a: v.union(v.string(), v.optional(v.number())) }).safeParse({}).ok).toBe(true);
+        expect(argsToJsonSchema({ a: v.union(v.string(), v.optional(v.number())) }).required).toStrictEqual([]);
+    });
+
+    it("describes bigint with one lossless carrier, scalar and literal alike", () => {
+        expect.assertions(3);
+
+        // `type: "integer"` advertised the one JSON form the parser refuses (a
+        // number), and lost precision past 2^53 besides. A bigint rides as its
+        // decimal string everywhere else in the system — the wire codec's tagged
+        // payload, and `v.literal(5n)`'s own `const` — so the schema says string
+        // too, exactly as `bytes` already says base64 string for an ArrayBuffer.
+        expect(v.bigint().safeParse(5).ok).toBe(false);
+        expect(toJsonSchema(v.bigint())).toStrictEqual({ format: "int64", type: "string" });
+        expect(toJsonSchema(v.literal(5n))).toStrictEqual({ const: "5", format: "int64", type: "string" });
+    });
+
+    it("reflects a record's key constraint the parser enforces", () => {
+        expect.assertions(2);
+
+        // The key validator was read for nothing: the parser rejects a
+        // non-matching key, but the schema said any key would do.
+        const validator = v.record(v.string().pattern(/^k_/u), v.number());
+
+        expect(validator.safeParse({ nope: 1 }).ok).toBe(false);
+        expect(toJsonSchema(validator)).toStrictEqual({
+            additionalProperties: { type: "number" },
+            propertyNames: { pattern: "^k_", type: "string" },
             type: "object",
         });
     });

--- a/packages/values/__tests__/v.test.ts
+++ b/packages/values/__tests__/v.test.ts
@@ -663,6 +663,45 @@ describe(".nullable() runtime parsing", () => {
         expect(validator.parse(7)).toBe(7);
         expect(() => validator.parse("7")).toThrow(ValidationError);
     });
+
+    it("chain order decides whether a refinement sees null, and the type says which", () => {
+        expect.assertions(3);
+
+        // `.nullable().check(p)` refines the WIDENED type, so `p` runs on null —
+        // and its parameter is typed `string | null`, which is what makes that
+        // safe to rely on. A predicate that dereferences the value here is a
+        // compile error, not a runtime surprise:
+        //
+        //     v.string().nullable().check((s) => s.length > 0)
+        //     //                                 ^ TS18047: 's' is possibly 'null'
+        const seen: unknown[] = [];
+
+        expect(
+            v
+                .string()
+                .nullable()
+                .check((value) => {
+                    seen.push(value);
+
+                    return true;
+                })
+                .parse(null),
+        ).toBeNull();
+        expect(seen).toStrictEqual([null]);
+
+        // `.check(p).nullable()` wraps the refined parser instead, so null
+        // short-circuits ahead of `p`. Same two calls, opposite semantics —
+        // pick the order that states the invariant you mean.
+        expect(
+            v
+                .string()
+                .check(() => {
+                    throw new Error("predicate must not run for null");
+                })
+                .nullable()
+                .parse(null),
+        ).toBeNull();
+    });
 });
 
 describe("v.optional() standalone parsing", () => {

--- a/packages/values/src/json-schema-core.ts
+++ b/packages/values/src/json-schema-core.ts
@@ -18,7 +18,7 @@ interface JsonSchema {
  * no runtime metadata — so `constraints`/`isNullable` may be inert there).
  *
  * A reader normalizes a `TNode` to the small set of children/leaves the mapper
- * recurses over. Composite accessors (`inner`/`shape`/`members`/`valueChild`)
+ * recurses over. Composite accessors (`inner`/`shape`/`members`/`keyChild`/`valueChild`)
  * return the same `TNode` type so the mapper can recurse uniformly; leaf concerns
  * that differ between the two sources — how a literal's `const` is computed,
  * whether a `.check()`/`.meta()` constraint fragment exists, whether `.nullable()`
@@ -38,6 +38,13 @@ interface SchemaNodeReader<TNode> {
 
     /** Whether `.nullable()` was applied (runtime: `_meta.column.notNull === false`). */
     isNullable: (node: TNode) => boolean;
+
+    /**
+     * Key-child of a `record` node, mapped to `propertyNames`. May be absent on
+     * the IR side (and on a `v.record(v.string(), …)` whose key validator adds
+     * no constraint beyond `type: "string"` it is merely redundant, not wrong).
+     */
+    keyChild: (node: TNode) => TNode | undefined;
 
     /** Discriminating validator kind. */
     kind: (node: TNode) => ValidatorKind;
@@ -69,10 +76,13 @@ interface SchemaNodeReader<TNode> {
  * so nested objects/arrays/unions/records are fully expanded (never collapsed to
  * one level).
  *
- * `date`/`timestamp` are epoch-millisecond numbers in Lunora (not ISO strings),
- * so they schema as integers; `bigint` schemas as an int64 (JSON has no bigint
- * type, so `format: int64` is the conventional OpenAPI carrier); `bytes` is an
- * `ArrayBuffer`, surfaced as base64 per JSON Schema 2020-12 content encoding.
+ * Each node names the JSON CARRIER, not the decoded JS type — the transport
+ * decodes before the parser sees a value, so describing the JS type would
+ * advertise shapes no JSON body can hold. `date`/`timestamp` are
+ * epoch-millisecond numbers in Lunora (not ISO strings), so they schema as
+ * integers; `bigint` rides as an int64 decimal string, the same carrier the
+ * wire codec and `v.literal(5n)` use; `bytes` is an `ArrayBuffer`, surfaced as
+ * base64 per JSON Schema 2020-12 content encoding.
  *
  * A `.check()`/`.meta()` JSON Schema fragment (when the reader exposes one) is
  * shallow-merged onto the node — constraint keys win on conflict. A `.nullable()`
@@ -92,7 +102,14 @@ const jsonSchemaFromNode = <TNode>(node: TNode, reader: SchemaNodeReader<TNode>)
                 return { items: inner === undefined ? {} : jsonSchemaFromNode(inner, reader), type: "array" };
             }
             case "bigint": {
-                return { format: "int64", type: "integer" };
+                // A DECIMAL STRING, not a JSON number. The parser accepts only a
+                // real `bigint`, so `type: "integer"` advertised the one JSON
+                // form it refuses — and truncated past 2^53 besides. Everywhere
+                // else a bigint already rides as its decimal string (the wire
+                // codec's tagged payload, `v.literal(5n)`'s `const`), so this is
+                // the same treatment `bytes` gets: name the JSON carrier, not
+                // the decoded JS type.
+                return { format: "int64", type: "string" };
             }
             case "boolean": {
                 return { type: "boolean" };
@@ -136,8 +153,17 @@ const jsonSchemaFromNode = <TNode>(node: TNode, reader: SchemaNodeReader<TNode>)
             }
             case "record": {
                 const value = reader.valueChild(node);
+                // The key validator is enforced at runtime (`v.record(v.string().pattern(…), …)`
+                // rejects a non-matching key), so it belongs in the schema as
+                // `propertyNames` — reading only the value child left the spec
+                // unable to express a constraint the server requires.
+                const key = reader.keyChild(node);
 
-                return { additionalProperties: value === undefined ? {} : jsonSchemaFromNode(value, reader), type: "object" };
+                return {
+                    additionalProperties: value === undefined ? {} : jsonSchemaFromNode(value, reader),
+                    ...(key === undefined ? {} : { propertyNames: jsonSchemaFromNode(key, reader) }),
+                    type: "object",
+                };
             }
             case "storage": {
                 return { description: "storage object key", type: "string", "x-lunora-storage": true };
@@ -168,9 +194,37 @@ const jsonSchemaFromNode = <TNode>(node: TNode, reader: SchemaNodeReader<TNode>)
 };
 
 /**
- * Build `{ type: "object", properties, required, additionalProperties: false }`
- * from a node shape. A `v.optional(...)` property is the only thing that drops
- * out of `required`; every other property is required.
+ * True when the parser accepts this node's field ABSENT — the only honest test
+ * for whether a key belongs in `required`.
+ *
+ * `kind === "optional"` used to be the whole test, which put two kinds in
+ * `required` that parse `{}` happily: `v.any()` (its parser returns `undefined`
+ * unchanged) and a `v.union(...)` with an optional or `any` member (the union
+ * tries members, one of which accepts `undefined`). A spec that requires a field
+ * the server does not cannot be satisfied by a generated client.
+ * @returns `true` when an absent value parses.
+ */
+const acceptsAbsent = <TNode>(node: TNode, reader: SchemaNodeReader<TNode>): boolean => {
+    const kind = reader.kind(node);
+
+    if (kind === "any" || kind === "optional") {
+        return true;
+    }
+
+    return kind === "union" && reader.members(node).some((member) => acceptsAbsent(member, reader));
+};
+
+/**
+ * Build `{ type: "object", properties, required }` from a node shape.
+ *
+ * Deliberately NOT `additionalProperties: false`: `v.object` STRIPS an
+ * undeclared key rather than refusing it (only `.output()`'s
+ * `rejectUnknownKeys` mode refuses one, and it is not what this schema
+ * describes), so closing the object had a spec-validating client reject bodies
+ * the server accepts. Absent means allowed, which is what the parser does.
+ *
+ * `required` lists every key whose field cannot be absent — see
+ * {@link acceptsAbsent}.
  */
 const objectSchemaFromNodes = <TNode>(shape: Record<string, TNode>, reader: SchemaNodeReader<TNode>): JsonSchema => {
     const properties: Record<string, JsonSchema> = {};
@@ -179,12 +233,12 @@ const objectSchemaFromNodes = <TNode>(shape: Record<string, TNode>, reader: Sche
     for (const [key, child] of Object.entries(shape)) {
         properties[key] = jsonSchemaFromNode(child, reader);
 
-        if (reader.kind(child) !== "optional") {
+        if (!acceptsAbsent(child, reader)) {
             required.push(key);
         }
     }
 
-    return { additionalProperties: false, properties, required, type: "object" };
+    return { properties, required, type: "object" };
 };
 
 export type { JsonSchema, SchemaNodeReader };

--- a/packages/values/src/json-schema-core.ts
+++ b/packages/values/src/json-schema-core.ts
@@ -102,13 +102,24 @@ const jsonSchemaFromNode = <TNode>(node: TNode, reader: SchemaNodeReader<TNode>)
                 return { items: inner === undefined ? {} : jsonSchemaFromNode(inner, reader), type: "array" };
             }
             case "bigint": {
-                // A DECIMAL STRING, not a JSON number. The parser accepts only a
-                // real `bigint`, so `type: "integer"` advertised the one JSON
-                // form it refuses — and truncated past 2^53 besides. Everywhere
-                // else a bigint already rides as its decimal string (the wire
-                // codec's tagged payload, `v.literal(5n)`'s `const`), so this is
-                // the same treatment `bytes` gets: name the JSON carrier, not
-                // the decoded JS type.
+                // A DECIMAL STRING, not a JSON number. `type: "integer"`
+                // advertised the one JSON form the parser definitely refuses,
+                // and truncated past 2^53 besides.
+                //
+                // Read this the way `bytes` and `date` above and below are
+                // read: it names the PAYLOAD's form, not a body that validates
+                // end to end. The actual RPC carrier is the wire codec's tagged
+                // array — `["$lunora.wire$", "bigint", "5"]`, decoded by
+                // `decodeWire` before the parser sees it — so a bare `"5"` no
+                // more satisfies `v.bigint()` than a bare `5` did. `bytes`
+                // (`contentEncoding: "base64"`) and `date` (`type: "integer"`)
+                // describe their decoded payloads the same way; a schema that
+                // described the tagged array instead would have to change all
+                // three, and nothing consumes a tuple schema here today.
+                //
+                // What this buys is the decimal string being the spelling a
+                // bigint actually travels as, everywhere it is written down —
+                // the tagged payload's third slot, `v.literal(5n)`'s `const`.
                 return { format: "int64", type: "string" };
             }
             case "boolean": {

--- a/packages/values/src/to-json-schema.ts
+++ b/packages/values/src/to-json-schema.ts
@@ -28,11 +28,12 @@ const validatorReader: SchemaNodeReader<Validator> = {
     constraints: (validator) => metaOf(validator).constraints as JsonSchema | undefined,
     inner: (validator) => metaOf(validator).inner as Validator | undefined,
     isNullable: (validator) => (metaOf(validator).column as ColumnMeta | undefined)?.notNull === false,
+    keyChild: (validator) => metaOf(validator).keyValidator as Validator | undefined,
     kind: (validator) => validator.kind,
     literalSchema: (validator) => {
         const { value } = metaOf(validator);
 
-        return typeof value === "bigint" ? { const: value.toString(), type: "string" } : { const: value };
+        return typeof value === "bigint" ? { const: value.toString(), format: "int64", type: "string" } : { const: value };
     },
     members: (validator) => metaOf(validator).members as ReadonlyArray<Validator>,
     shape: (validator) => metaOf(validator).shape as Record<string, Validator>,

--- a/shared/sql-readonly.ts
+++ b/shared/sql-readonly.ts
@@ -53,6 +53,13 @@ interface SqlRejection {
 /**
  * A statement is only allowed when it *leads* with a read verb. `EXPLAIN` /
  * `EXPLAIN QUERY PLAN` prefixes are permitted (they describe, never mutate).
+ *
+ * A bare `VALUES (1), (2)` — a read-only row constructor in SQLite — is refused
+ * by this list rather than overlooked by it. The rule the diagnostic states is
+ * exactly the rule enforced ("only SELECT / WITH / EXPLAIN"), and an operator
+ * who wants those rows types `SELECT 1 UNION ALL SELECT 2`. Widening the lead
+ * set buys nothing and adds a verb the CTE scan below would then have to reason
+ * about.
  */
 const READONLY_LEAD = /^(?:explain\s+(?:query\s+plan\s+)?)?(?:select|with)\b/iu;
 
@@ -63,8 +70,18 @@ const READONLY_LEAD = /^(?:explain\s+(?:query\s+plan\s+)?)?(?:select|with)\b/iu;
  * alone aren't enough. A benign query that merely mentions one of these words in
  * a string literal is rejected too — an acceptable trade for an admin tool that
  * must never corrupt the doc-store's FTS / aggregate / rank shadow tables.
+ *
+ * `replace` is the one word on this list that is ALSO a core read-only scalar
+ * (`replace(x, 'a', 'b')`), so it gets its own arm: a bare `\breplace\b` refused
+ * an ordinary `SELECT replace(...)` with a message naming a rule the operator
+ * had not broken. The negative lookahead is the whole discrimination — the write
+ * form is `REPLACE INTO`, never `REPLACE (`. It is deliberately the lookahead
+ * and not a `replace\s+into` match, so an inline block comment wedged between
+ * the two words — whitespace to SQLite's tokenizer, but not to `\s` — still
+ * fails the scan. The residual false refusal (a comment between `replace` and
+ * its own paren) errs toward refusing, and nobody writes it.
  */
-const FORBIDDEN_KEYWORD = /\b(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|replace|truncate|update|vacuum)\b/iu;
+const FORBIDDEN_KEYWORD = /\b(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|truncate|update|vacuum)\b|\breplace\b(?!\s*\()/iu;
 
 /** The statement's first word, used to point the "not read-only" diagnostic somewhere useful. */
 const LEADING_WORD = /^\w+/u;

--- a/tests/e2e/fixtures/lunora.ts
+++ b/tests/e2e/fixtures/lunora.ts
@@ -6,8 +6,11 @@ import { test as base, request as requestApi } from "@playwright/test";
  *
  * These centralise the bits of plumbing that every test needs:
  *   - `resetServer`  — call the `/test/reset` route exposed by the playground
- *     worker (gated by `LUNORA_E2E === "true"`). Clears DO state so tests are
- *     order-independent.
+ *     worker (gated by `LUNORA_E2E === "true"`). Clears the shared **D1** state
+ *     (users, channels, every `.global()` table). It does NOT clear Durable
+ *     Object state — shard-local rows such as `messages` survive it, and stay
+ *     out of each other's way only because every spec mints a fresh channel. A
+ *     spec that needs a clean shard has to mint one, not rely on this.
  *   - `signedInPage` — a Page whose BrowserContext already holds the
  *     better-auth `session_token` cookie. Most chat tests skip the signup
  *     form and use this.

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -12,11 +12,13 @@ import { defineConfig, devices, firefox } from "@playwright/test";
  * Stability tactics:
  *   - `workers: 1` / `fullyParallel: false` — every spec talks to ONE shared
  *     backend (one Vite worker, one D1, shared DO namespaces) and each test
- *     starts with `/test/reset` wiping that shared state. Parallel workers
+ *     starts with `/test/reset` truncating that shared D1. Parallel workers
  *     would race each other's resets and channel lists; this is the stability
  *     boundary, not a workaround.
- *   - Each test calls `await resetServer()` (see fixtures) to clear DO state
- *     before exercising new behaviour, so tests stay order-independent.
+ *   - Each test calls `await resetServer()` (see fixtures). That clears D1 and
+ *     ONLY D1 — Durable Object state is not reset. Order-independence for
+ *     shard-local rows comes from each spec minting its own channel, which is
+ *     the guarantee to preserve when adding one.
  *   - We rely on Playwright auto-wait selectors; explicit `waitForTimeout`
  *     calls are forbidden by convention and only appear where wall-clock time
  *     is itself under test (scheduler delay, signed-URL expiry).


### PR DESCRIPTION
Round-28 foundation wave. The through-line is checks that passed by not looking.

## The error catalog failed open, and its gate could not see why

`isInternalCode` is `getCatalogEntry(code)?.internal === true`, so an **unregistered code is treated as client-safe**. The registration gate that should have caught that matched only the literal `new LunoraError(`, making every `LunoraError` subclass mint invisible to it — including all six `@lunora/payment` codes, one of which carries "webhook secret not configured".

The scanner now sees indirect mints (subclass, `raise(`, `super(`, object literals), and the six codes are catalogued. `CONFIG_INVALID` is `internal`; `PROVIDER_ERROR` deliberately is not — its three mint sites are fixed capability text or echo back the caller's own id.

The scanner also got a self-check, for a reason worth stating: a repo-wide scan only goes red while a violation happens to exist, so once the catalog is complete a narrowing of the pattern back to the literal name lands **green**, and every future subclass mint is client-safe again.

Two follow-ups from review:

- `CONFIG_INVALID: { internal: true }` was over-redacting. `check()`'s argument-shape guard minted the same code for "check() requires a featureId or priceId" — the caller's own mistake — so marking the code internal turned actionable guidance into a generic 500. Those two sites now mint `VALIDATION_ERROR` (already in the payment taxonomy at 400, already catalogued as caller-safe). The `entitlements`-not-configured sites stay internal; they do name server configuration.
- The webhook-rejection entry claimed "the messages are fixed and name no internal state". Five of six mints are fixed strings; `providers/stripe.ts` forwards the Stripe SDK's verification message. The verdict is still right — those texts describe the poster's request — but the justification was not.

## `sql-readonly` refused a valid read

`SELECT REPLACE(name, 'a', 'b')` was rejected because `replace` was on the write-verb list. Now a lookahead — `\breplace\b(?!\s*\()` — which distinguishes the scalar function from `REPLACE INTO`. It is a lookahead rather than `replace\s+into` because a block comment between the two words is whitespace to SQLite's tokenizer but not to `\s`; the residual false refusal is named in the comment. Confirmed unwalkable: `REPLACE/**/INTO` still matches, and a statement mixing both still matches on the write.

## `toJsonSchema` disagreed with the runtime parser

Four counts, each fixed with a paired assertion proving the old expectation was lying — `expect(v.bigint().safeParse(5).ok).toBe(false)` sitting beside the schema assertion. `acceptsAbsent` replaces `kind !== "optional"` with a recursive "does the parser accept this absent" predicate, deleting a whole class of spec-vs-parser disagreement.

One honest limit, corrected after review: `v.bigint()`'s schema names the payload's form, not a body that validates end to end. Every RPC arg path runs `decodeWire` first, so a bigint's actual carrier is the tagged array `["$lunora.wire$","bigint","5"]` and a bare `"5"` fails the parser exactly as a bare `5` did. The emitted shape is unchanged and consistent with how `bytes` and `date` are modelled; only the comment claiming parser agreement is gone.

## Smaller

- The playground's `inbound:onEmail` is now `internalMutation`. The real mail path is unaffected — it POSTs with `x-lunora-system: 1` and dispatches by string path, so there is no typed reference and no client reference.
- A fake e2e DO-reset was deleted rather than implemented: it asserted nothing and existed to look like coverage.
- The docs deny-table gained a self-check, for the same reason the catalog scanner did. Fixing it also fixed a false positive it had: it rejected the **correct** non-destructuring form `const m = useMutation(fn)` then `await m.mutate(args)`. The two forms differ in whether the bound name is later called, which spans two lines, so the scan is now per-fence with a backreference. A CI gate that blocks valid docs is worse than the misuse it catches.

## Verification

Full repo gates: `build:packages`, `lint:types`, `test` (175 tasks), `lint:prettier`, `lint:eslint`, `api:check` (54 snapshots), `lint:package-json` — all green. Package suites: errors 669, values 187, payment 252.

Every doc-gate change was probed against all four real snippet forms; the deny-table's patterns were broken in both directions to confirm the self-check reports a narrowed pattern and an over-matching one.

## Reviewed before opening

A `/thermos` branch audit and code-quality pass ran against this branch first; their findings are fixed here. Three of the wave's original claims were rejected during the fix pass rather than implemented — `.nullable()` already declares the predicate param as `T|null` (verified with a TS18047 probe), and `ctx.db.from(...)` appears nowhere in the codebase.

Known residual, left deliberately: the catalog scanner's patterns are broader than their stated intent (`new TypeError("SOME_CONST")`, any `raise(`). That is the fail-safe direction — it over-collects and an allowlist handles the rest — but it will churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ
