### PR TITLE
docs: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![CI][ci-badge]][ci]
 [![npm version][npm-version-badge]][npm-version]
 [![PRs Welcome][prs-welcome-badge]][prs-welcome]
+[![OpenSSF Scorecard][scorecard-badge]][scorecard]
 
 </div>
 
@@ -321,6 +322,8 @@ For security reports, see [`SECURITY.md`](./SECURITY.md). For community guidelin
 
 [typescript-badge]: https://img.shields.io/badge/Typescript-294E80.svg?style=for-the-badge&logo=typescript
 [typescript-url]: https://www.typescriptlang.org/
+[scorecard-badge]: https://api.scorecard.dev/projects/github.com/anolilab/lunora/badge?style=for-the-badge
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/anolilab/lunora
 [license-badge]: https://img.shields.io/badge/license-FSL--1.1--Apache--2.0-blue.svg?style=for-the-badge
 [license]: ./LICENSE.md
 [status-badge]: https://img.shields.io/badge/status-alpha-blueviolet.svg?style=for-the-badge


### PR DESCRIPTION
Adds the OpenSSF Scorecard badge to the README. The Scorecard workflow already runs with `publish_results: true`, so the score is public — this just surfaces it.

Note for the record: Lunora cannot take the OpenSSF Best Practices Badge, because that badge requires an OSI/FSF-recognised licence and this project is FSL-1.1-Apache-2.0 (source-available). Scorecard has no such requirement and works on any public repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf