### PR TITLE
fix(shard-engine,container): bracket two control channels with the wire codec

### DIFF
--- a/packages/container/__tests__/bridge.test.ts
+++ b/packages/container/__tests__/bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { encodeWire } from "../../../shared/wire-codec";
 import type { FetchLike } from "../src/bridge";
 import { ContainerBridgeError, createContainerBridge } from "../src/bridge";
 
@@ -43,6 +44,27 @@ describe(createContainerBridge, () => {
         expect(calls[0]!.url).toBe("https://app.example.com/_lunora/rpc");
         expect(JSON.parse(calls[0]!.body)).toStrictEqual({ args: { limit: 5 }, functionPath: "messages:list" });
         expect(calls[0]!.headers.authorization).toBe("Bearer svc-token");
+    });
+
+    it("brackets both directions with the wire codec", async () => {
+        expect.assertions(2);
+
+        // This bridge speaks the same `/_lunora/rpc` protocol as `LunoraClient`,
+        // so it owes the same codec: the shard runs `decodeWire` over inbound
+        // `args` and answers `encodeWire(result)`. Un-bracketed, a `bigint` arg
+        // throws inside `JSON.stringify`, a `Date` arg arrives as an ISO string,
+        // and a `v.bigint()` column comes back as a raw tag array instead of a
+        // value.
+        const { calls, fetch } = stubFetch({ result: encodeWire({ at: new Date("2024-01-01T00:00:00.000Z"), views: 9_007_199_254_740_993n }) });
+        const lunora = createContainerBridge({ baseUrl: "https://app.example.com/", fetch });
+
+        const result = await lunora.query("posts:get", { blob: new Uint8Array([1, 2, 3]).buffer, since: 7n });
+
+        expect(result).toStrictEqual({ at: new Date("2024-01-01T00:00:00.000Z"), views: 9_007_199_254_740_993n });
+        expect(JSON.parse(calls[0]!.body)).toStrictEqual({
+            args: encodeWire({ blob: new Uint8Array([1, 2, 3]).buffer, since: 7n }),
+            functionPath: "posts:get",
+        });
     });
 
     it("omits the Authorization header when no token is given", async () => {

--- a/packages/container/src/bridge.ts
+++ b/packages/container/src/bridge.ts
@@ -16,6 +16,8 @@
 
 import { LunoraError } from "@lunora/errors";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
+
 /** The RPC path the Lunora Worker exposes. */
 const RPC_PATH = "/_lunora/rpc";
 
@@ -175,7 +177,16 @@ const createContainerBridge = (options: ContainerBridgeOptions): ContainerBridge
         }
 
         const response = await fetchImpl(joinUrl(options.baseUrl, RPC_PATH), {
-            body: JSON.stringify({ args, functionPath, shardKey }),
+            // `encodeWire`/`decodeWire` bracket this hop for the same reason
+            // `createShardClient` and `LunoraClient` bracket theirs: this is the
+            // SAME `/_lunora/rpc` protocol, and the shard runs `decodeWire` over
+            // inbound `args` and answers `encodeWire(result)`. Un-bracketed, a
+            // `bigint` argument threw outright here (`JSON.stringify` refuses
+            // one), a `Date`/`Uint8Array` argument reached the handler as an ISO
+            // string / `{}`, and a `v.bigint()` or `v.bytes()` column came back
+            // to the container as a raw `["$lunora.wire$", …]` tag rather than a
+            // value. Identity for pure JSON, so an ordinary call is unchanged.
+            body: JSON.stringify({ args: encodeWire(args), functionPath, shardKey }),
             headers,
             method: "POST",
         });
@@ -211,7 +222,8 @@ const createContainerBridge = (options: ContainerBridgeOptions): ContainerBridge
             throw statusError(functionPath, response);
         }
 
-        return (body as { result: Result }).result;
+        // The inbound half of the bracket above.
+        return decodeWire((body as { result: unknown }).result) as Result;
     };
 
     const run = async <Reference extends BridgeFunctionReference>(

--- a/packages/shard-engine/__tests__/replica.test.ts
+++ b/packages/shard-engine/__tests__/replica.test.ts
@@ -182,6 +182,42 @@ describe("read replicas", () => {
         expect(replica?.appliedSeq()).toBe(2);
     });
 
+    it("carries wire-typed leaves across the control channel intact", async () => {
+        expect.assertions(4);
+
+        // `decodeDocJson` hands the owner REAL `bigint` / `ArrayBuffer` / `Date`
+        // values, so both directions of this channel have to run the codec: an
+        // unencoded `bigint` throws inside `Response.json`, which the follower
+        // reads as "owner unreachable" and retries forever, and unencoded bytes
+        // flatten to `{}` for the follower to write into its copy of the shard.
+        owner.snapshot = [{ doc: { _id: "a", blob: new Uint8Array([1, 2, 3]).buffer, views: 7n }, table: "posts" }];
+
+        const replica = createReplicaLink(host);
+
+        // The snapshot crosses on the bootstrap frame…
+        await replica?.ensureFresh();
+
+        expect(imported[0]?.doc).toStrictEqual({ _id: "a", blob: new Uint8Array([1, 2, 3]).buffer, views: 7n });
+
+        // …and a later write crosses on a pull frame. `9007199254740993` is past
+        // `Number.MAX_SAFE_INTEGER`, so a codec that round-tripped it through a
+        // JSON number would come back off by one rather than merely mistyped.
+        owner.changes = [
+            {
+                doc: { _id: "b", at: new Date("2024-01-01T00:00:00.000Z"), views: 9_007_199_254_740_993n },
+                id: "b",
+                op: "insert",
+                seq: 1,
+                table: "posts",
+                ts: 1,
+            },
+        ];
+
+        await expect(replica?.ensureFresh(1)).resolves.toBe("fresh");
+        expect(applied[0]?.doc).toStrictEqual({ _id: "b", at: new Date("2024-01-01T00:00:00.000Z"), views: 9_007_199_254_740_993n });
+        expect(replica?.appliedSeq()).toBe(1);
+    });
+
     it("serves inside the staleness window without touching the owner", async () => {
         expect.assertions(2);
 

--- a/packages/shard-engine/src/replica.ts
+++ b/packages/shard-engine/src/replica.ts
@@ -293,11 +293,14 @@ const replicaControlRefusal = (host: ReplicaOwnerHost): Response | undefined => 
     return undefined;
 };
 
-/**
+/*
  * Serve the owner half of the `/_lunora/replica` control channel: authenticate
  * the frame, then answer a pull or a bootstrap. Stateless — an owner keeps no
  * per-replica bookkeeping, because a replica's position lives with the replica
  * and the changelog it reads is the one the shard already keeps.
+ *
+ * A section band for what follows, not a docblock: `replicaResponse` sits at the
+ * top of the section and documents itself.
  */
 
 /**

--- a/packages/shard-engine/src/replica.ts
+++ b/packages/shard-engine/src/replica.ts
@@ -42,6 +42,7 @@
 
 import type { RegionHint } from "../../../shared/region-hint";
 import { parseMinSeq, parseReplicaName } from "../../../shared/replica-name";
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { ExportRow } from "./admin-export-import";
 import type { SqlExec } from "./ctx-db";
 import type { CdcChange } from "./ctx-db-cdc";
@@ -298,13 +299,34 @@ const replicaControlRefusal = (host: ReplicaOwnerHost): Response | undefined => 
  * per-replica bookkeeping, because a replica's position lives with the replica
  * and the changelog it reads is the one the shard already keeps.
  */
+
+/**
+ * The outbound bracket for every control-channel body, matched by the
+ * {@link decodeWire} in {@link ShardReplica.pull} / {@link ShardReplica.bootstrap}.
+ *
+ * The documents in these frames came back out of `decodeDocJson`, so a
+ * `v.bigint()` column is a REAL `bigint` here and `v.bytes()` a REAL
+ * `ArrayBuffer`. Uncoded, the first throws `TypeError: Do not know how to
+ * serialize a BigInt` inside `Response.json` — which is precisely the failure
+ * {@link servePull}'s docblock describes: a thrown response reaches the follower
+ * as a bare non-2xx, its pull path reads that as "owner unreachable", and it
+ * retries the identical doomed round trip for the life of the DO without ever
+ * latching `divergent`. The second flattens to `{}`, which the follower then
+ * writes into its copy of the shard.
+ *
+ * The same bracket `shard-do.ts`'s `adminResponse` puts around the admin plane,
+ * and identical in effect: both codecs are the identity on a pure-JSON body, so
+ * the frames carrying no document keep their bytes.
+ */
+const replicaResponse = (body: ReplicaBootstrapResult | ReplicaPullResult): Response => Response.json(encodeWire(body));
+
 /** Serve a `replica_bootstrap`: the whole shard, or a `truncated` refusal when it is too large for one response. */
 const serveBootstrap = async (host: ReplicaOwnerHost, epoch: string): Promise<Response> => {
     // Refuse BEFORE building the snapshot: the cap is the owner's memory budget,
     // and a shard past it would exhaust that budget producing rows nobody is
     // allowed to receive.
     if (host.rowCount() > maxBootstrapRows(host.env())) {
-        return Response.json({ cursor: 0, epoch, rows: [], truncated: true } satisfies ReplicaBootstrapResult);
+        return replicaResponse({ cursor: 0, epoch, rows: [], truncated: true });
     }
 
     // Read the cursor BEFORE the snapshot: a write that lands mid-export may or
@@ -314,7 +336,7 @@ const serveBootstrap = async (host: ReplicaOwnerHost, epoch: string): Promise<Re
     const cursor = host.ownerCursor() ?? 0;
     const rows = await host.exportRows();
 
-    return Response.json({ cursor, epoch, rows } satisfies ReplicaBootstrapResult);
+    return replicaResponse({ cursor, epoch, rows });
 };
 
 /**
@@ -334,12 +356,12 @@ const servePull = (host: ReplicaOwnerHost, epoch: string, sinceSeq: number): Res
     const floor = host.ownerFloor();
 
     if (cursorBelowRetainedFloor(floor, sinceSeq)) {
-        return Response.json({ changes: [], cursor: host.ownerCursor() ?? sinceSeq, epoch, floor } satisfies ReplicaPullResult);
+        return replicaResponse({ changes: [], cursor: host.ownerCursor() ?? sinceSeq, epoch, floor });
     }
 
     const { changes, cursor } = host.readChanges(sinceSeq, PULL_PAGE_SIZE);
 
-    return Response.json({ changes, cursor, epoch, ...(floor === undefined ? {} : { floor }) } satisfies ReplicaPullResult);
+    return replicaResponse({ changes, cursor, epoch, ...(floor === undefined ? {} : { floor }) });
 };
 
 const handleReplicaControl = async (host: ReplicaOwnerHost, request: Request): Promise<Response> => {
@@ -591,7 +613,7 @@ class ShardReplica {
             return undefined;
         }
 
-        const result = (await response.json()) as ReplicaBootstrapResult;
+        const result = decodeWire(await response.json()) as ReplicaBootstrapResult;
 
         if (result.truncated === true) {
             // Too big to copy in one reply. Reads go to the owner rather than to
@@ -632,7 +654,7 @@ class ShardReplica {
     private async pull(sinceSeq: number): Promise<ReplicaPullResult | undefined> {
         const response = await this.request({ sinceSeq, type: "replica_pull" });
 
-        return response === undefined ? undefined : ((await response.json()) as ReplicaPullResult);
+        return response === undefined ? undefined : (decodeWire(await response.json()) as ReplicaPullResult);
     }
 
     /**


### PR DESCRIPTION
Two hops carried decoded documents onto the wire with no codec on either end, while the peer at the other end assumed the codec had run. This is the third instance of that class found in this campaign — after `httpAction`'s `ctx.run*` and `createDispatchRunner` — so the sweep below matters as much as the fix.

## The replica control channel

`packages/shard-engine/src/replica.ts` used the wire codec in **neither direction** — `grep -cE "encodeWire|decodeWire"` returned 0 — while the documents it serialises come straight out of `decodeDocJson`, which is literally `decodeWire(JSON.parse(raw))`. So a `v.bigint()` column is a real `bigint` by the time `Response.json` sees it.

Measured, on the exact shape of the pull response:

```
bigint  -> THROWS TypeError: Do not know how to serialize a BigInt
bytes   -> {"changes":[{"doc":{"_id":"r1","blob":{}},…     ← ArrayBuffer becomes {}
date    -> {"changes":[{"doc":{"_id":"r1","at":"2024-01-01T00:00:00.000Z"},…
```

The bigint case is the severe one, and not because of the throw. The thrown response reaches the follower as a bare non-2xx; `catchUp` reads that as "the owner is unreachable" and returns `"unavailable"` **without latching `divergent`**, so every subsequent read re-issues the identical doomed round trip forever. That is precisely the failure `servePull`'s own docblock says it moved the floor check earlier to avoid. Bootstrap has the same shape, so the replica never holds a single row either. For bytes and Date there is no throw at all — the follower applies `{}` or an ISO string and diverges silently.

Now bracketed by a single `replicaResponse` helper used by all four control-channel responses, with `decodeWire` in `ShardReplica.pull`/`bootstrap` — mirroring `adminResponse` in `shard-do.ts`.

## The container bridge, found by the sweep

`packages/container/src/bridge.ts` posts to `/_lunora/rpc` and ran the codec in neither direction, while the DO decodes inbound args and encodes results. A `bigint` arg threw; a `v.bigint()` result reached the container as a raw tag. Also bracketed.

## The sweep

Every path putting a document-shaped payload on the wire was checked against `origin/alpha`. Twelve are correctly bracketed. The zero-codec ones are safe for stated reasons: `query-coordinator`, the `shard-do` batch path, `nuxt`, `rest-routes` and the CLI backup handler are **pass-throughs** that never decode, so tags ride intact to a peer that does — the CLI's is pinned by two tests that `decodeWire` the NDJSON they assert. `replica/event-log-do*` carries contractually-arbitrary JSON; `auth/do-wiring` carries only scalars; the rest carry no document-shaped payload.

The admin-RPC asymmetry that a project memory still described as open is **already closed** — `shard-do.ts:338` encodes, fixed by #365.

## Deliberately not fixed here

`ctx.scheduler.runAfter/runAt` args are unbracketed at their producers while the shard decodes them. Encoding at the producer alone would push tagged params into every scheduled workflow, because `startWorkflowInstance` hands the same `args` to `create({ params })` with no decode — trading one bug for another. That needs the decode at the workflow-side read plus its own tests, and is handled separately.

## Verification

Regression tests written first and confirmed to fail against the unfixed code: the replica case reports `expected undefined to strictly equal { _id: 'a', blob: …, views: 7n }` (nothing imported, because the bigint threw inside `Response.json`), and an earlier iteration reached the `ensureFresh` assertion and showed `expected 'unavailable' to be 'fresh'` — the forever-retry latch, verbatim. The container case reports `TypeError: Do not know how to serialize a BigInt`. The test uses `9_007_199_254_740_993` specifically so a JSON-number round trip returns a *wrong* value rather than merely a mistyped one.

All seven repo gates green on this branch: build, lint:types, test, prettier, eslint, api:check (54 snapshots), lint:package-json. Package suites: shard-engine 1434, do 695, container 173.

## Reviewed before opening

Both `/thermos` passes ran against this branch first. They confirmed `encodeWire` on the whole body cannot break a structurally-read field (`cursor`, `epoch`, `floor`, `truncated` are all codec-identity), that the container error envelope is read before the decode so no error path changed, and that the scheduler deferral above is the right call. One finding — a section header the new helper displaced — is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `bigint`, dates, binary data, and validated byte values when passing data through remote calls.
  * Preserved large-number and binary document values during replica synchronization.
  * Kept existing behavior unchanged for standard JSON-compatible data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->