### PR TITLE
ci(codspeed): measure head and base against the same build

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -121,7 +121,8 @@
             # measuring code that is not the branch's code is worse than no benchmark —
             # every false positive costs a manual disproof.
             - "name": "Build packages"
-              "run": 'pnpm exec vis run build --no-cache --query "tag=type:package"'
+              "run": |
+                  pnpm exec vis run build --no-cache --query "tag=type:package"
 
             # PRs run only the affected benches; pushes run all of them to keep the
             # baseline complete. `--no-cache` forces real execution — a vis cache hit

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -100,18 +100,28 @@
               "run": "pnpm install --frozen-lockfile"
 
             # Benchmarks import the workspace packages from their gitignored `dist/`,
-            # so without this they fail to resolve. PRs build only the affected chain,
-            # mirroring the bench selection below; pushes build everything.
+            # so without this they fail to resolve.
+            #
+            # The SAME full, uncached build on every event, deliberately. A PR used to
+            # build only the affected chain while the `alpha` push that produced the
+            # baseline built everything — so head and base were measured against
+            # different `dist/` sets, which is what CodSpeed reports as "Different
+            # runtime environments detected". Two concrete ways that produced false
+            # regressions of 10-70% on benchmarks whose packages the PR never touched:
+            #
+            #   - `packages/do` does not depend on `@lunora/codegen`, so a codegen-only
+            #     PR left `packages/do/dist` unbuilt while its benchmarks still ran.
+            #   - the build cache keys on a package's own inputs and does NOT see
+            #     `shared/*`, which is bundler-inlined. `shard-do.ts` alone imports it
+            #     15 times, so a PR editing `shared/wire-codec.ts` benchmarked a `dist/`
+            #     still carrying the OLD inlined copy.
+            #
+            # `--no-cache` is here for the same reason `test:bench` already carries it:
+            # a cache hit serves a `dist/` built from different source, and a benchmark
+            # measuring code that is not the branch's code is worse than no benchmark —
+            # every false positive costs a manual disproof.
             - "name": "Build packages"
-              "shell": "bash"
-              "env":
-                  "EVENT_NAME": "${{ github.event_name }}"
-              "run": |
-                  if [ "$EVENT_NAME" = "pull_request" ]; then
-                      pnpm run build:affected:packages
-                  else
-                      pnpm run build:packages
-                  fi
+              "run": 'pnpm exec vis run build --no-cache --query "tag=type:package"'
 
             # PRs run only the affected benches; pushes run all of them to keep the
             # baseline complete. `--no-cache` forces real execution — a vis cache hit


### PR DESCRIPTION
Every open PR in this repo is currently red on CodSpeed, and none of the reported regressions is real. The cause is in the benchmark job itself.

## The asymmetry

| | baseline (push to `alpha`) | head (pull request) |
|---|---|---|
| build | `build:packages` — all | `build:affected:packages` — subset |
| benches | `vis run test:bench` — all | `vis affected test:bench` — subset |

Head and base were measured against different `dist/` sets. CodSpeed says so at the top of every affected report: *"Different runtime environments detected — Some benchmarks with significant performance changes were compared across different runtime environments, which may affect the accuracy of the results."*

## Two concrete ways a PR benchmarked code that was not its own

- **`packages/do` does not depend on `@lunora/codegen`.** A codegen-only PR therefore left `packages/do/dist` unbuilt, while the change-filter (`packages/**`, `shared/**`) still admitted the job and `vis affected test:bench` still selected its benchmarks.
- **The build cache does not see `shared/*`.** It keys on a package's own inputs, and `shared/` is bundler-inlined rather than a dependency edge — `shard-do.ts` alone imports it 15 times. A PR editing `shared/wire-codec.ts` benchmarked a `dist/` still carrying the old inlined copy. `--no-cache` was applied to `test:bench` and never to the build above it.

## The evidence these were artifacts

- `normalizeLogFields :: flat 3 primitives` was reported as a regression on **three unrelated branches at once** — telemetry, codegen+scripts, and errors/values — every one from the identical `55.6 µs` base. None of them touches that benchmark or anything it measures.
- The sharpest case changes **zero** files under `packages/do` and is credited with **-72.84%** on `broadcast-delta` and **-52.72%** on `normalize-log-fields`, both `packages/do` benchmarks.
- `broadcast-delta — low fanout` at `114 µs → 42x µs` was attributed to one branch before a rebase and a different branch after, with the same magnitude.
- `v.string()` appeared as a regression on one run and a **+18.32% improvement** on another. Its module closure is two files, which none of these branches touches.

## The change

Build everything, uncached, on every event, so the two sides are comparable. Bench *selection* still narrows on a pull request — only the build is now symmetric.

`--no-cache` is here for the same reason the `test:bench` step one line below already carries it: a cache hit serves a `dist/` built from different source. A benchmark measuring code that is not the branch's code is worse than no benchmark, because each false positive has to be disproved by hand — three of them were this week, and that is the cost this PR removes.

## Trade-off, stated plainly

The benchmark job now pays a full uncached package build whenever it runs. That is a real CI cost increase, bounded by the existing change-filter, and it is the price of the numbers meaning anything. If it proves too slow, the cheaper half-measure is to keep the full build but drop `--no-cache` — that fixes the `packages/do` case above but leaves the `shared/` blind spot, so it would trade some correctness back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized benchmark builds to always build all packages across pull requests and pushes.
  * Benchmark builds now run without cache to ensure consistent comparisons across changes.
  * Updated benchmark build execution to use a consistent command and configuration for all events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->