### PR TITLE
fix(scheduler,workflow): bracket the scheduler args with the wire codec

### DIFF
--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -2810,6 +2810,25 @@ describe("lunoraClient", () => {
             await expect(client.listScheduledJobs()).resolves.toEqual([]);
         });
 
+        it("listScheduledJobs raises WIRE_DECODE_FAILED on args the codec refuses", async () => {
+            expect.assertions(2);
+
+            // `decodeWire` throws a bare `TypeError` on a malformed tag and a
+            // `RangeError` past its depth bound, and can decode to a non-object.
+            // Both used to escape unmapped — and inside `subscribeScheduledJobs`
+            // they landed in a `catch` labelled "a non-JSON frame", which silently
+            // froze the operator's job list.
+            const malformed = [{ args: ["$lunora.wire$", "bigint", "not-a-number"], enqueuedAt: 1, id: "j1", scheduledFor: 2 }];
+            const client = new LunoraClient({
+                fetch: async () => jsonResponse({ records: malformed }),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            await expect(client.listScheduledJobs()).rejects.toMatchObject({ code: "WIRE_DECODE_FAILED" });
+            await expect(client.listScheduledJobs()).rejects.toThrow(/j1/u);
+        });
+
         it("cancelScheduledJob POSTs the id and normalises the result", async () => {
             expect.assertions(4);
 
@@ -3489,6 +3508,41 @@ describe("lunoraClient", () => {
 
             expect(seen).toHaveLength(1);
 
+            unsubscribe();
+            client.close();
+        });
+
+        it("surfaces a decode failure instead of swallowing it as a non-JSON frame", () => {
+            expect.assertions(2);
+
+            // The `try` around this handler covers the JSON PARSE and nothing
+            // else. It used to wrap the decode and the consumer callback too,
+            // under a comment claiming "a non-JSON frame" — so a `decodeWire`
+            // throw was discarded and the operator's job list silently stopped
+            // updating with no error anywhere.
+            const client = new LunoraClient({
+                fetch: async () => jsonResponse({ result: null }),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+                wsToken: "adm1n",
+            });
+
+            const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+            const seen: string[][] = [];
+            const unsubscribe = client.subscribeScheduledJobs((jobs) => seen.push(jobs.map((job) => job.id)));
+            const socket = latestSocket();
+
+            socket.open();
+            socket.receive({ records: [{ args: ["$lunora.wire$", "bigint", "not-a-number"], enqueuedAt: 1, id: "j1", scheduledFor: 2 }], type: "jobs" });
+
+            // Reaches `openManagedSocket`'s last-resort frame-handler guard —
+            // which reports it — instead of the local `catch` that used to
+            // discard it as a stray frame. The consumer is never called with a
+            // half-decoded list.
+            expect(error).toHaveBeenCalledWith("[lunora] server frame handler threw", expect.objectContaining({ code: "WIRE_DECODE_FAILED" }));
+            expect(seen).toHaveLength(0);
+
+            error.mockRestore();
             unsubscribe();
             client.close();
         });

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -277,6 +277,26 @@ type WSState = "idle" | "connecting" | "open" | "closed";
  */
 type ConnectionStatus = "connected" | "connecting" | "idle" | "offline";
 
+/**
+ * Decode the wire form out of a batch of `ScheduleRecord`s.
+ *
+ * A scheduled job's `args` are a WIRE payload: `@lunora/scheduler` `encodeWire`s
+ * them at the producer so a `bigint`/`Date`/bytes arg survives the JSON hop into
+ * the SchedulerDO, and every consumer decodes — the shard for a function target,
+ * `@lunora/workflow`'s run-context for a workflow one. These read APIs are
+ * consumers too, so without this a caller reading a job's args back would get a
+ * raw `["$lunora.wire$", …]` array where its value belonged. Identity for pure
+ * JSON, so an ordinary job's record is unchanged.
+ *
+ * Only `args` is decoded: every other field on the record is a plain scalar the
+ * DO writes itself (`id`, `scheduledFor`, `functionPath`, …) and never went
+ * through the codec.
+ */
+const decodeScheduleRecords = (records: ScheduleRecord[]): ScheduleRecord[] =>
+    records.map((record) => {
+        return { ...record, args: decodeWire(record.args) as Record<string, unknown> };
+    });
+
 /** One shard's socket + watermark state in a {@link LunoraClient.debug} snapshot. */
 interface ClientDebugShard {
     /**
@@ -2583,7 +2603,7 @@ class LunoraClient {
 
         const body = (await this.adminFetch(SCHEDULED_PATH, "GET")) as { records?: ScheduleRecord[] };
 
-        return body.records ?? [];
+        return decodeScheduleRecords(body.records ?? []);
     }
 
     /**
@@ -2634,13 +2654,18 @@ class LunoraClient {
         // one, so stopping at the first page would hide exactly the backlog the
         // operator opened it for. Returning `records` alone made this silently
         // truncate the moment the route grew its limit.
-        return await collectPages<ScheduleRecord>(
-            async (cursor) =>
-                (await this.adminFetch(cursor === undefined ? SCHEDULED_DEAD_PATH : `${SCHEDULED_DEAD_PATH}?cursor=${encodeURIComponent(cursor)}`, "GET")) as {
-                    cursor?: string;
-                    records?: ScheduleRecord[];
-                    truncated?: boolean;
-                },
+        return decodeScheduleRecords(
+            await collectPages<ScheduleRecord>(
+                async (cursor) =>
+                    (await this.adminFetch(
+                        cursor === undefined ? SCHEDULED_DEAD_PATH : `${SCHEDULED_DEAD_PATH}?cursor=${encodeURIComponent(cursor)}`,
+                        "GET",
+                    )) as {
+                        cursor?: string;
+                        records?: ScheduleRecord[];
+                        truncated?: boolean;
+                    },
+            ),
         );
     }
 
@@ -2817,7 +2842,7 @@ class LunoraClient {
                             // reconnect at the initial delay forever instead of
                             // backing off (mirrors the shard socket's fix).
                             reconnect.reset();
-                            onJobs(message.records);
+                            onJobs(decodeScheduleRecords(message.records));
                         }
                     } catch {
                         /* a non-JSON frame — ignore */

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -291,10 +291,29 @@ type ConnectionStatus = "connected" | "connecting" | "idle" | "offline";
  * Only `args` is decoded: every other field on the record is a plain scalar the
  * DO writes itself (`id`, `scheduledFor`, `functionPath`, …) and never went
  * through the codec.
+ * @throws LunoraError `WIRE_DECODE_FAILED` when a record's `args` are not a
+ * decodable wire payload — `decodeWire` raises a bare `RangeError` past its
+ * depth bound and a `TypeError` on a malformed tag, and decoding can change the
+ * SHAPE as well as the leaves (a top-level tagged scalar decodes to a
+ * primitive). Both are re-shaped here so a caller sees a coded error rather than
+ * an unmapped throw or a record whose `args` are not an object. Mirrors
+ * `decodeAdminArgs` on the shard.
  */
 const decodeScheduleRecords = (records: ScheduleRecord[]): ScheduleRecord[] =>
     records.map((record) => {
-        return { ...record, args: decodeWire(record.args) as Record<string, unknown> };
+        let args: unknown;
+
+        try {
+            args = decodeWire(record.args);
+        } catch {
+            throw new LunoraError("WIRE_DECODE_FAILED", `malformed wire args on scheduled job "${record.id}"`);
+        }
+
+        if (args === null || typeof args !== "object" || Array.isArray(args)) {
+            throw new LunoraError("WIRE_DECODE_FAILED", `malformed wire args on scheduled job "${record.id}"`);
+        }
+
+        return { ...record, args: args as Record<string, unknown> };
     });
 
 /** One shard's socket + watermark state in a {@link LunoraClient.debug} snapshot. */
@@ -2831,21 +2850,32 @@ class LunoraClient {
                     // `lastFrameAt` is stamped by `openManagedSocket` itself
                     // (its `message` listener) for every caller — nothing to
                     // do here beyond parsing.
-                    try {
-                        const message = JSON.parse(typeof event.data === "string" ? event.data : "") as { records?: ScheduleRecord[]; type?: string };
+                    // The `try` covers the PARSE and nothing else. It used to wrap
+                    // the decode and the `onJobs` callback too, under a comment
+                    // that said "a non-JSON frame" — so a `decodeScheduleRecords`
+                    // throw (or the consumer's own) was DISCARDED as if it were a
+                    // stray frame and the operator's job list silently stopped
+                    // updating. Narrowed, those reach `openManagedSocket`'s
+                    // last-resort frame-handler guard, which reports them and
+                    // keeps the socket's listener alive.
+                    let message: { records?: ScheduleRecord[]; type?: string };
 
-                        if (message.type === "jobs" && Array.isArray(message.records)) {
-                            // A payload frame is the proof of a live, ACCEPTED
-                            // socket that `open` alone never was: the upgrade
-                            // succeeds before the admin credential is checked,
-                            // so resetting on `open` made a rejected token
-                            // reconnect at the initial delay forever instead of
-                            // backing off (mirrors the shard socket's fix).
-                            reconnect.reset();
-                            onJobs(decodeScheduleRecords(message.records));
-                        }
+                    try {
+                        message = JSON.parse(typeof event.data === "string" ? event.data : "") as { records?: ScheduleRecord[]; type?: string };
                     } catch {
                         /* a non-JSON frame — ignore */
+                        return;
+                    }
+
+                    if (message.type === "jobs" && Array.isArray(message.records)) {
+                        // A payload frame is the proof of a live, ACCEPTED
+                        // socket that `open` alone never was: the upgrade
+                        // succeeds before the admin credential is checked,
+                        // so resetting on `open` made a rejected token
+                        // reconnect at the initial delay forever instead of
+                        // backing off (mirrors the shard socket's fix).
+                        reconnect.reset();
+                        onJobs(decodeScheduleRecords(message.records));
                     }
                 },
             });

--- a/packages/mail/__tests__/inbound-handler.test.ts
+++ b/packages/mail/__tests__/inbound-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { decodeWire } from "../../../shared/wire-codec";
 import type { ForwardableEmailMessageLike } from "../src/inbound/handler";
 import { createInboundEmailHandler, dispatchToLunoraFunction } from "../src/inbound/handler";
 import type { InboundEmail } from "../src/inbound/parse";
@@ -498,6 +499,43 @@ describe("dispatchToLunoraFunction", () => {
         const envelope = JSON.parse(init.body) as { args: unknown; shardKey: string };
 
         expect(envelope).toStrictEqual({ args: { subject: "Hi" }, functionPath: "inbound:onEmail", shardKey: "tenant-7" });
+    });
+
+    it("wire-encodes the envelope args so a custom resolveArgs can return a bigint/Date", async () => {
+        expect.assertions(3);
+
+        // The shard decodes `args` on BOTH arms this envelope can reach — the
+        // ordinary function dispatch (`decodeWire(payload.args)`) and the reserved
+        // `__lunora_admin__:*` ops (`decodeAdminArgs`) — so the producer has to
+        // encode or the hop is asymmetric. The default `resolveArgs` is
+        // `toJsonSafeEmail`, which is already pure JSON (attachment bytes are
+        // base64'd), so only a caller-supplied override was exposed: a `bigint`
+        // threw in `JSON.stringify` and a `Date` arrived as an ISO string.
+        const receivedAt = new Date("2026-06-01T12:00:00.000Z");
+        const { fetch, shard } = stubShard({
+            json: async () => {
+                return { result: "ok" };
+            },
+            ok: true,
+        });
+
+        const dispatch = dispatchToLunoraFunction({
+            functionPath: "inbound:onEmail",
+            resolveArgs: () => {
+                return { receivedAt, sizeBytes: 9_007_199_254_740_993n };
+            },
+            shard,
+        });
+
+        await dispatch(fixture, { ctx: undefined, env: { LUNORA_ADMIN_TOKEN: "secret" }, message: fakeMessage() });
+
+        const [, init] = fetch.mock.calls[0] as unknown as [string, { body: string }];
+        const envelope = JSON.parse(init.body) as { args: unknown; functionPath: string };
+        const decoded = decodeWire(envelope.args) as { receivedAt: unknown; sizeBytes: unknown };
+
+        expect(envelope.functionPath).toBe("inbound:onEmail");
+        expect(decoded.sizeBytes).toBe(9_007_199_254_740_993n);
+        expect(decoded.receivedAt).toStrictEqual(receivedAt);
     });
 
     it("throws (so the handler rejects) when the admin token is missing", async () => {

--- a/packages/mail/src/inbound/shard.ts
+++ b/packages/mail/src/inbound/shard.ts
@@ -7,6 +7,8 @@
  */
 import { LunoraError } from "@lunora/errors";
 
+import { encodeWire } from "../../../../shared/wire-codec";
+
 /** Default shard the runtime routes admin RPC (captured mail, inbound dispatch) through. */
 const DEFAULT_ROOT_SHARD = "__root__";
 
@@ -84,7 +86,21 @@ const postShardRpc = async (namespace: ShardNamespaceLike, options: PostShardRpc
     const scoped = applyJurisdiction(namespace, options.jurisdiction);
     const stub = scoped.get(scoped.idFromName(options.shardKey));
     const response = await stub.fetch("https://shard.internal/rpc", {
-        body: JSON.stringify(options.envelope),
+        // The envelope is a WIRE payload, and the shard decodes it on BOTH arms
+        // this route reaches: an ordinary function dispatch runs
+        // `decodeWire(payload.args)`, and a reserved `__lunora_admin__:*` op runs
+        // `decodeAdminArgs`. Un-encoded, the hop was asymmetric — a `bigint` threw
+        // in `JSON.stringify` before anything was sent, and a `Date` arrived as an
+        // ISO string. Encoding here rather than at the two callers keeps this
+        // function the single owner of what goes on the wire, as it already is of
+        // the URL, the headers and the response checks.
+        //
+        // Identity for pure JSON, so neither existing caller changes: the capture
+        // sink's `SendPayload` is strings throughout, and the inbound dispatcher's
+        // default `resolveArgs` (`toJsonSafeEmail`) has already base64'd the only
+        // binary it carries. It is a caller-supplied `resolveArgs` override that
+        // was exposed.
+        body: JSON.stringify(encodeWire(options.envelope)),
         headers: {
             authorization: `Bearer ${options.adminToken}`,
             "content-type": "application/json",

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -42,6 +42,34 @@ const createShardSpy = (response = new Response("ok", { status: 200 })): ShardSp
     return spy;
 };
 
+/**
+ * Render an args bag by TYPE, so an assertion crossing the worker's JSON
+ * response still proves a real `Date`/`bigint` came back out of `ctx.scheduler`
+ * — a tagged `["$lunora.wire$", …]` array renders as `array`, and an ISO string
+ * as `string`.
+ */
+const describeValue = (value: unknown): string => {
+    if (typeof value === "bigint") {
+        return `bigint:${value.toString()}`;
+    }
+
+    if (value instanceof Date) {
+        return `date:${value.toISOString()}`;
+    }
+
+    return `${typeof value}:${String(value)}`;
+};
+
+const describeArgs = (args: Record<string, unknown> | undefined): Record<string, string> =>
+    Object.fromEntries(Object.entries(args ?? {}).map(([key, value]) => [key, describeValue(value)]));
+
+/** The wire form of a job's args as the SchedulerDO stores it, after the JSON hop it made to get there. */
+const asStoredArgs = (args: Record<string, unknown>): Record<string, unknown> => {
+    const json = JSON.stringify(encodeWire(args));
+
+    return JSON.parse(json) as Record<string, unknown>;
+};
+
 const fakeContext: ExecutionContextLike = {
     passThroughOnException: () => undefined,
     waitUntil: () => undefined,
@@ -1866,6 +1894,102 @@ describe("createWorker — HTTP actions", () => {
 
         expect(decoded.amountCents).toBe(9_007_199_254_740_993n);
         expect(decoded.dueAt).toStrictEqual(dueAt);
+    });
+
+    it("c.var.lunora.scheduler.list/get decode args back out of the wire form", async () => {
+        expect.assertions(2);
+
+        // The read half of the same facade. The SchedulerDO stores the producer's
+        // envelope verbatim — `args` in wire form — so without a decode at the
+        // transport these handed an operator a tagged `["$lunora.wire$", …]`
+        // array where the value belonged.
+        const dueAt = new Date("2026-06-01T12:00:00.000Z");
+        const stored = {
+            args: asStoredArgs({ amountCents: 42n, dueAt }),
+            functionPath: "billing:settle",
+            id: "job-1",
+            scheduledFor: 2,
+        };
+        const scheduler = createShardSpy();
+
+        scheduler.namespace = {
+            get: () => {
+                return {
+                    fetch: async (request: Request) =>
+                        new URL(request.url).pathname === "/get"
+                            ? Response.json({ record: stored }, { status: 200 })
+                            : Response.json({ records: [stored] }, { status: 200 }),
+                };
+            },
+            idFromName: (name: string) => {
+                return { __name: name };
+            },
+        };
+
+        const worker = createWorker({
+            httpRouter: honoApp((app) =>
+                app.get("/jobs", async (c) => {
+                    const listed = (await c.var.lunora.scheduler?.list()) ?? [];
+                    const one = await c.var.lunora.scheduler?.get("job-1");
+
+                    return Response.json({
+                        getArgs: describeArgs(one?.["args"] as Record<string, unknown> | undefined),
+                        listArgs: describeArgs(listed[0]?.["args"] as Record<string, unknown> | undefined),
+                        listLength: listed.length,
+                    });
+                }),
+            ),
+            schedulerDO: scheduler.namespace,
+            shardDO: shard.namespace,
+        });
+
+        const res = await worker.fetch(new Request("https://app.example/jobs"), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+        // Both readers, in one shape: a real `bigint`/`Date` where the wire form
+        // used to leave a tagged array (`object:$lunora.wire$,date,…`).
+        await expect(res.json()).resolves.toStrictEqual({
+            getArgs: { amountCents: "bigint:42", dueAt: "date:2026-06-01T12:00:00.000Z" },
+            listArgs: { amountCents: "bigint:42", dueAt: "date:2026-06-01T12:00:00.000Z" },
+            listLength: 1,
+        });
+    });
+
+    it("c.var.lunora.scheduler.get unwraps the DO envelope and answers null on a miss", async () => {
+        expect.assertions(2);
+
+        // The DO answers `{ record }` and omits `record` on a miss. Handing the
+        // envelope back made a hit read as `{ record: {...} }` (so
+        // `job.scheduledFor` was `undefined`) and a miss read as a truthy `{}`.
+        const scheduler = createShardSpy();
+
+        scheduler.namespace = {
+            get: () => {
+                return {
+                    fetch: async (request: Request) =>
+                        new URL(request.url).searchParams.get("id") === "job-1"
+                            ? Response.json({ record: { functionPath: "billing:settle", id: "job-1", scheduledFor: 2 } }, { status: 200 })
+                            : Response.json({}, { status: 200 }),
+                };
+            },
+            idFromName: (name: string) => {
+                return { __name: name };
+            },
+        };
+
+        const worker = createWorker({
+            httpRouter: honoApp((app) =>
+                app.get("/jobs/:id", async (c) => Response.json({ job: (await c.var.lunora.scheduler?.get(c.req.param("id"))) ?? null })),
+            ),
+            schedulerDO: scheduler.namespace,
+            shardDO: shard.namespace,
+        });
+
+        const hit = await worker.fetch(new Request("https://app.example/jobs/job-1"), {}, fakeContext);
+        const miss = await worker.fetch(new Request("https://app.example/jobs/nope"), {}, fakeContext);
+
+        await expect(hit.json()).resolves.toStrictEqual({ job: { functionPath: "billing:settle", id: "job-1", scheduledFor: 2 } });
+        await expect(miss.json()).resolves.toStrictEqual({ job: null });
     });
 
     it("c.var.lunora.storage stores an object through the worker's own R2 binding", async () => {

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { decodeIdentityHeader } from "../../../shared/identity-header";
-import { encodeWire } from "../../../shared/wire-codec";
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { ExecutionContextLike, HttpActionContext, HttpRouterLike, Route } from "../src/create-worker";
 import { composeWorker, createLunoraHandler, createWorker } from "../src/create-worker";
 import type { ObservabilityEvent } from "../src/observability";
@@ -1829,6 +1829,43 @@ describe("createWorker — HTTP actions", () => {
         // `env.LUNORA_ORIGIN_URL` at both schedule and fire time, deliberately,
         // so a request cannot steer where the job dispatches back to.
         expect(body["originUrl"]).toBeUndefined();
+    });
+
+    it("c.var.lunora.scheduler wire-encodes args so a bigint/Date arg survives the hop", async () => {
+        expect.assertions(4);
+
+        // This facade is the SECOND producer on the SchedulerDO's `/schedule`
+        // route (`@lunora/scheduler`'s `createScheduler` is the first), and both
+        // its consumers decode: the shard `decodeWire`s a function target's args,
+        // `@lunora/workflow`'s run-context decodes a workflow target's params.
+        // Un-encoded, a `bigint` arg threw inside `JSON.stringify` before the job
+        // was recorded and a `Date` silently arrived as an ISO string.
+        const scheduler = createShardSpy(Response.json({ id: "job-1", scheduledFor: 1 }, { status: 200 }));
+        const dueAt = new Date("2026-06-01T12:00:00.000Z");
+
+        const worker = createWorker({
+            httpRouter: honoApp((app) =>
+                app.post("/hooks/stripe", async (c) => {
+                    const id = await c.var.lunora.scheduler?.runAfter(0, { __lunoraRef: "billing:settle" }, { amountCents: 9_007_199_254_740_993n, dueAt });
+
+                    return new Response(id ?? "no-scheduler", { status: 202 });
+                }),
+            ),
+            schedulerDO: scheduler.namespace,
+            shardDO: shard.namespace,
+        });
+
+        const res = await worker.fetch(new Request("https://app.example/hooks/stripe", { method: "POST" }), {}, fakeContext);
+
+        expect(res.status).toBe(202);
+        expect(scheduler.calls).toHaveLength(1);
+
+        const body = (await scheduler.calls[0]?.request.json()) as { args: unknown };
+        // `decodeWire` is exactly what the shard applies to `payload.args`.
+        const decoded = decodeWire(body.args) as { amountCents: unknown; dueAt: unknown };
+
+        expect(decoded.amountCents).toBe(9_007_199_254_740_993n);
+        expect(decoded.dueAt).toStrictEqual(dueAt);
     });
 
     it("c.var.lunora.storage stores an object through the worker's own R2 binding", async () => {

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -3532,6 +3532,13 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         const instanceName = options.schedulerInstanceName ?? "default";
         const stub = (): ResolvedShard => resolveShard(namespace, instanceName);
 
+        // `call`/`post` are the single owner of what this facade puts on, and takes
+        // off, the SchedulerDO wire — mirroring `@lunora/scheduler`'s `do-client`,
+        // the other client of the same routes. A job's `args` can hold a
+        // `bigint`/`Date`/bytes, none of which survive raw JSON; bracketing the
+        // codec at the transport rather than at `schedule` alone is what keeps
+        // `list`/`get` from handing back the tagged `["$lunora.wire$", …]` form.
+        // Both codecs are the identity on pure JSON.
         const call = async <R>(path: string, init: RequestInit): Promise<R> => {
             const response = await stub().fetch(new Request(`https://scheduler.internal${path}`, init));
 
@@ -3542,11 +3549,11 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                 });
             }
 
-            return await response.json();
+            return decodeWire(await response.json()) as R;
         };
 
         const post = async <R>(path: string, body: unknown): Promise<R> =>
-            await call<R>(path, { body: JSON.stringify(body), headers: { "content-type": "application/json" }, method: "POST" });
+            await call<R>(path, { body: JSON.stringify(encodeWire(body)), headers: { "content-type": "application/json" }, method: "POST" });
 
         // A generated `workflows.<name>` / `agents.<name>` reference carries a
         // `binding` and starts a durable instance per fire; a function reference
@@ -3605,14 +3612,8 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             );
 
         const schedule = async (scheduledFor: number, target: unknown, args: Record<string, unknown> = {}): Promise<string> => {
-            // `encodeWire` for the same reason `@lunora/scheduler`'s own
-            // `createScheduler.runAt` does — this facade is the second producer on
-            // the SAME `/schedule` route, and both its consumers decode. Without it
-            // `post`'s `JSON.stringify` threw on a `bigint` arg before the job was
-            // recorded, and rendered a `Date` as an ISO string the handler read back
-            // as a string. Identity for pure JSON.
             const { id } = await post<{ id: string }>("/schedule", {
-                args: encodeWire(args) as Record<string, unknown>,
+                args,
                 scheduledFor,
                 ...targetFields(target),
             });
@@ -3622,7 +3623,19 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         return {
             cancel: async (id) => await post<{ cancelled: boolean }>("/cancel", { id }),
-            get: async (id) => await call<Record<string, unknown> | null>(`/get?id=${encodeURIComponent(id)}`, { method: "GET" }),
+            // The DO answers `{ record }` and omits `record` on a miss. Handing
+            // that envelope straight back broke the declared
+            // `Record<string, unknown> | null`: a hit read as
+            // `{ record: {...} }`, so `job.scheduledFor` was `undefined`, and a
+            // miss read as a TRUTHY `{}` rather than `null`, so `if (job)` said
+            // a cancelled job was still pending. `@lunora/scheduler`'s `get` —
+            // the other client of this route — has always unwrapped it.
+            get: async (id) => {
+                const body = await call<{ record?: Record<string, unknown> }>(`/get?id=${encodeURIComponent(id)}`, { method: "GET" });
+
+                // eslint-disable-next-line unicorn/no-null -- public contract is `Record<string, unknown> | null`, matching `@lunora/scheduler`'s `get`
+                return body.record ?? null;
+            },
             list: listAll,
             runAfter: async (delayMs, target, args) => {
                 // `@lunora/scheduler`'s `assertScheduleDelay`, restated: this

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -3605,7 +3605,17 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             );
 
         const schedule = async (scheduledFor: number, target: unknown, args: Record<string, unknown> = {}): Promise<string> => {
-            const { id } = await post<{ id: string }>("/schedule", { args, scheduledFor, ...targetFields(target) });
+            // `encodeWire` for the same reason `@lunora/scheduler`'s own
+            // `createScheduler.runAt` does — this facade is the second producer on
+            // the SAME `/schedule` route, and both its consumers decode. Without it
+            // `post`'s `JSON.stringify` threw on a `bigint` arg before the job was
+            // recorded, and rendered a `Date` as an ISO string the handler read back
+            // as a string. Identity for pure JSON.
+            const { id } = await post<{ id: string }>("/schedule", {
+                args: encodeWire(args) as Record<string, unknown>,
+                scheduledFor,
+                ...targetFields(target),
+            });
 
             return id;
         };

--- a/packages/scheduler/__tests__/args-wire.test.ts
+++ b/packages/scheduler/__tests__/args-wire.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import createScheduler from "../src/create-scheduler";
+import createWorkpool from "../src/create-workpool";
+import type { DurableObjectNamespaceLike, DurableObjectStubLike, FunctionReference, WorkflowReference } from "../src/types";
+
+/**
+ * The scheduler's `args` are a WIRE payload, and this pins both halves of that.
+ *
+ * `ctx.scheduler.runAfter/runAt` forwards `args` to the SchedulerDO as JSON, the
+ * DO stores them, and on fire re-serialises them to the runtime — which hands a
+ * function target's args to the shard, whose dispatch loop `decodeWire`s them
+ * (`packages/do/src/shard-do.ts`). Un-encoded, that path was asymmetric in the
+ * two ways the codec exists to prevent: a `bigint` arg threw at the producer's
+ * own `JSON.stringify` before the job was ever recorded, and a `Date` silently
+ * degraded to an ISO string by the time the handler read it.
+ */
+
+const at = new Date("2026-06-01T12:00:00.000Z");
+
+/**
+ * The `args` a producer actually put on the wire, after the JSON hop they must
+ * survive. Deliberately `JSON.stringify` + `JSON.parse` rather than
+ * `structuredClone`: the point is that the payload is JSON-safe, and
+ * `structuredClone` would carry a `Date`/`bigint` through and prove nothing.
+ */
+const overTheWire = (body: Record<string, unknown>): unknown => {
+    const json = JSON.stringify(body.args);
+
+    return JSON.parse(json);
+};
+
+const fakeNamespace = (): { bodies: Record<string, unknown>[]; namespace: DurableObjectNamespaceLike } => {
+    const bodies: Record<string, unknown>[] = [];
+    const stub = {
+        fetch: vi.fn<DurableObjectStubLike["fetch"]>(async (_input: Request | string, init?: RequestInit) => {
+            bodies.push(init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {});
+
+            return Response.json({ id: "job-1", scheduledFor: 1 }, { status: 200 });
+        }),
+    };
+
+    return {
+        bodies,
+        namespace: {
+            get: () => stub,
+            idFromName: (name: string) => {
+                return { toString: () => name };
+            },
+        },
+    };
+};
+
+const fnRef: FunctionReference<"mutation"> = { __lunoraRef: "billing:settle" };
+const workflowRef: WorkflowReference = { binding: "WORKFLOW_PAYOUT", isLunoraWorkflow: true, name: "payout" };
+
+describe("scheduler args wire codec", () => {
+    it("carries a bigint arg to a function target instead of throwing at the producer", async () => {
+        expect.assertions(2);
+
+        const { bodies, namespace } = fakeNamespace();
+        const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
+
+        // Un-encoded this rejects inside `JSON.stringify` ("Do not know how to
+        // serialize a BigInt") — the job never reaches the DO at all.
+        await scheduler.runAfter(1000, fnRef, { amountCents: 9_007_199_254_740_993n });
+
+        expect(bodies).toHaveLength(1);
+        // `decodeWire` is what the shard applies to `payload.args`, so this is
+        // literally the value the handler is called with.
+        expect(decodeWire(overTheWire(bodies[0] as Record<string, unknown>))).toStrictEqual({ amountCents: 9_007_199_254_740_993n });
+    });
+
+    it("carries a Date arg to a function target as a Date, not an ISO string", async () => {
+        expect.assertions(2);
+
+        const { bodies, namespace } = fakeNamespace();
+        const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
+
+        await scheduler.runAt(at, fnRef, { dueAt: at });
+
+        const decoded = decodeWire(overTheWire(bodies[0] as Record<string, unknown>)) as { dueAt: unknown };
+
+        // Fails SILENTLY without the codec: raw `JSON.stringify` renders a Date
+        // as an ISO string, so the handler is handed a string and never throws.
+        expect(decoded.dueAt).toBeInstanceOf(Date);
+        expect(decoded.dueAt).toStrictEqual(at);
+    });
+
+    it("carries bigint and Date args to a workflow target", async () => {
+        expect.assertions(3);
+
+        const { bodies, namespace } = fakeNamespace();
+        const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
+
+        await scheduler.runAfter(1000, workflowRef, { dueAt: at, invoiceId: 42n });
+
+        // The workflow branch sends `workflow` instead of `functionPath`; its args
+        // are decoded by `@lunora/workflow`'s run-context, not by the shard.
+        expect(bodies[0]).toMatchObject({ workflow: "WORKFLOW_PAYOUT" });
+
+        const decoded = decodeWire(overTheWire(bodies[0] as Record<string, unknown>)) as { dueAt: unknown; invoiceId: unknown };
+
+        expect(decoded.invoiceId).toBe(42n);
+        expect(decoded.dueAt).toStrictEqual(at);
+    });
+
+    it("carries a bigint arg through a workpool enqueue", async () => {
+        expect.assertions(1);
+
+        const { bodies, namespace } = fakeNamespace();
+        const pool = createWorkpool({ maxConcurrency: 2, namespace, originUrl: "https://app.test" });
+
+        await pool.enqueue(fnRef, { amountCents: 1n });
+
+        expect(decodeWire(overTheWire(bodies[0] as Record<string, unknown>))).toStrictEqual({ amountCents: 1n });
+    });
+
+    it("leaves plain-JSON args byte-identical, so nothing changes for existing callers", async () => {
+        expect.assertions(2);
+
+        const { bodies, namespace } = fakeNamespace();
+        const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
+        const plain = { attempt: 3, nested: { ok: true, tags: ["a", "b"] }, userId: "u-1" };
+
+        await scheduler.runAfter(1000, fnRef, plain);
+
+        // The codec is identity on a value with no special leaves — same bytes on
+        // the wire as before, and the shard's decode gives the same object back.
+        expect(bodies[0]?.args).toStrictEqual(plain);
+        expect(decodeWire(overTheWire(bodies[0] as Record<string, unknown>))).toStrictEqual(plain);
+    });
+});

--- a/packages/scheduler/__tests__/args-wire.test.ts
+++ b/packages/scheduler/__tests__/args-wire.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { decodeWire } from "../../../shared/wire-codec";
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import createScheduler from "../src/create-scheduler";
 import createWorkpool from "../src/create-workpool";
 import type { DurableObjectNamespaceLike, DurableObjectStubLike, FunctionReference, WorkflowReference } from "../src/types";
@@ -130,5 +130,85 @@ describe("scheduler args wire codec", () => {
         // the wire as before, and the shard's decode gives the same object back.
         expect(bodies[0]?.args).toStrictEqual(plain);
         expect(decodeWire(overTheWire(bodies[0] as Record<string, unknown>))).toStrictEqual(plain);
+    });
+});
+
+/**
+ * A namespace whose DO answers the READ routes with records exactly as they sit
+ * in its storage: `args` in wire form, everything else plain. That is what the
+ * SchedulerDO actually holds — it stores the producer's envelope and never
+ * inspects `args` — so these drive the other end of the hop the tests above
+ * pin, rather than restating the producer's own invariant.
+ */
+const readOnlyNamespace = (record: Record<string, unknown>): DurableObjectNamespaceLike => {
+    const stub = {
+        fetch: vi.fn<DurableObjectStubLike["fetch"]>(async (input: Request | string) => {
+            const path = new URL(typeof input === "string" ? input : input.url).pathname;
+
+            if (path === "/get") {
+                return Response.json({ record }, { status: 200 });
+            }
+
+            return Response.json({ records: [record] }, { status: 200 });
+        }),
+    };
+
+    return {
+        get: () => stub,
+        idFromName: (name: string) => {
+            return { toString: () => name };
+        },
+    };
+};
+
+/** The wire form of a job's args as it sits in the DO's storage, after the JSON hop it made to get there. */
+const asStored = (args: Record<string, unknown>): Record<string, unknown> => {
+    const json = JSON.stringify(encodeWire(args));
+
+    return JSON.parse(json) as Record<string, unknown>;
+};
+
+const storedRecord = {
+    args: asStored({ amountCents: 42n, dueAt: at }),
+    enqueuedAt: 1,
+    functionPath: "billing:settle",
+    id: "job-1",
+    scheduledFor: 2,
+};
+
+describe("scheduler read-back", () => {
+    it.each(["list", "dead"] as const)("%s() hands back decoded args, not the tagged wire form", async (method) => {
+        expect.assertions(4);
+
+        const scheduler = createScheduler({ namespace: readOnlyNamespace(storedRecord), originUrl: "https://app.test" });
+        const [record] = await scheduler[method]();
+
+        expect(record?.args["dueAt"]).toBeInstanceOf(Date);
+        expect(record?.args["dueAt"]).toStrictEqual(at);
+        expect(record?.args["amountCents"]).toBe(42n);
+        // The codec is the identity on the rest of the record, so the plain
+        // fields are unchanged byte for byte.
+        expect(record?.functionPath).toBe("billing:settle");
+    });
+
+    it("get() hands back decoded args, not the tagged wire form", async () => {
+        expect.assertions(4);
+
+        const scheduler = createScheduler({ namespace: readOnlyNamespace(storedRecord), originUrl: "https://app.test" });
+        const record = await scheduler.get("job-1");
+
+        expect(record?.args["dueAt"]).toBeInstanceOf(Date);
+        expect(record?.args["amountCents"]).toBe(42n);
+        expect(record?.id).toBe("job-1");
+        expect(record?.scheduledFor).toBe(2);
+    });
+
+    it("leaves a plain-JSON record untouched on the way back", async () => {
+        expect.assertions(1);
+
+        const plain = { args: { attempt: 3, userId: "u-1" }, enqueuedAt: 1, functionPath: "billing:settle", id: "job-2", scheduledFor: 2 };
+        const scheduler = createScheduler({ namespace: readOnlyNamespace(plain), originUrl: "https://app.test" });
+
+        await expect(scheduler.get("job-2")).resolves.toStrictEqual(plain);
     });
 });

--- a/packages/scheduler/src/create-scheduler.ts
+++ b/packages/scheduler/src/create-scheduler.ts
@@ -1,6 +1,7 @@
 import { LunoraError } from "@lunora/errors";
 
 import { collectPages } from "../../../shared/collect-pages";
+import { encodeWire } from "../../../shared/wire-codec";
 import { assertSchedulerOptions, callDO, getDO } from "./do-client";
 import type { CronTarget, LunoraSchedulerOptions, RunOptions, Scheduler, ScheduleRecord, ScheduleTargetArgs } from "./types";
 import { isWorkflowReference } from "./types";
@@ -40,7 +41,23 @@ const createScheduler = (options: LunoraSchedulerOptions): Scheduler => {
         // instance. `maxConcurrency` only means anything for a pooled job, so it
         // rides along only when `pool` is set (mirroring `createWorkpool`).
         const base = {
-            args,
+            // `args` are a WIRE payload from here on, and both consumers now agree
+            // on that. Un-encoded, `callDO`'s `JSON.stringify` THREW on a `bigint`
+            // arg before the job was ever recorded, and silently rendered a `Date`
+            // as an ISO string that the handler then read back as a string.
+            //
+            // The two targets decode in different places, which is why the encode
+            // belongs here rather than at either one. A function target is routed
+            // through the shard, whose dispatch loop already `decodeWire`s
+            // `payload.args`. A workflow target becomes `create({ params })`, and
+            // Cloudflare JSON-serialises workflow `params` into durable storage —
+            // so the tagged wire form is precisely what CAN make that hop (a real
+            // `bigint` fails instance creation outright), and `@lunora/workflow`
+            // decodes at the read, in `run-context.ts`.
+            //
+            // Identity for pure JSON, so an existing caller's payload is unchanged
+            // byte for byte.
+            args: encodeWire(args) as Record<string, unknown>,
             // Pre-minted id, when the caller decided it before the call could be
             // made (see `RunOptions.id`). Absent for an ordinary schedule, and the
             // DO mints one.

--- a/packages/scheduler/src/create-scheduler.ts
+++ b/packages/scheduler/src/create-scheduler.ts
@@ -1,7 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
 import { collectPages } from "../../../shared/collect-pages";
-import { encodeWire } from "../../../shared/wire-codec";
 import { assertSchedulerOptions, callDO, getDO } from "./do-client";
 import type { CronTarget, LunoraSchedulerOptions, RunOptions, Scheduler, ScheduleRecord, ScheduleTargetArgs } from "./types";
 import { isWorkflowReference } from "./types";
@@ -41,23 +40,14 @@ const createScheduler = (options: LunoraSchedulerOptions): Scheduler => {
         // instance. `maxConcurrency` only means anything for a pooled job, so it
         // rides along only when `pool` is set (mirroring `createWorkpool`).
         const base = {
-            // `args` are a WIRE payload from here on, and both consumers now agree
-            // on that. Un-encoded, `callDO`'s `JSON.stringify` THREW on a `bigint`
-            // arg before the job was ever recorded, and silently rendered a `Date`
-            // as an ISO string that the handler then read back as a string.
-            //
-            // The two targets decode in different places, which is why the encode
-            // belongs here rather than at either one. A function target is routed
-            // through the shard, whose dispatch loop already `decodeWire`s
-            // `payload.args`. A workflow target becomes `create({ params })`, and
-            // Cloudflare JSON-serialises workflow `params` into durable storage —
-            // so the tagged wire form is precisely what CAN make that hop (a real
-            // `bigint` fails instance creation outright), and `@lunora/workflow`
-            // decodes at the read, in `run-context.ts`.
-            //
-            // Identity for pure JSON, so an existing caller's payload is unchanged
-            // byte for byte.
-            args: encodeWire(args) as Record<string, unknown>,
+            // `callDO` puts this whole envelope through `encodeWire`, so a
+            // `bigint`/`Date`/bytes arg survives the JSON hop into the DO. The
+            // two targets decode in different places — a function target through
+            // the shard's dispatch loop, a workflow target in
+            // `@lunora/workflow`'s run-context, since Cloudflare JSON-serialises
+            // workflow `params` into durable storage and the tagged form is
+            // precisely what CAN make that hop.
+            args,
             // Pre-minted id, when the caller decided it before the call could be
             // made (see `RunOptions.id`). Absent for an ordinary schedule, and the
             // DO mints one.

--- a/packages/scheduler/src/create-workpool.ts
+++ b/packages/scheduler/src/create-workpool.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
+import { encodeWire } from "../../../shared/wire-codec";
 import { assertSchedulerOptions, callDO, getDO } from "./do-client";
 import type { ArgsOf, EnqueueOptions, FunctionReference, Workpool, WorkpoolOptions } from "./types";
 import assertScheduleDelay from "./validate-delay";
@@ -53,7 +54,10 @@ const createWorkpool = (options: WorkpoolOptions): Workpool => {
         assertScheduleDelay(delayMs, "workpool.enqueue");
 
         return callDO<{ id: string; scheduledFor: number }>(options, "/schedule", {
-            args,
+            // Same wire contract as `createScheduler.runAt` — a pooled job takes the
+            // identical `/schedule` route to the identical shard-side `decodeWire`,
+            // so an un-encoded `bigint` arg threw here for the same reason.
+            args: encodeWire(args) as Record<string, unknown>,
             functionPath: function_.__lunoraRef,
             instanceName: options.instanceName ?? "default",
             maxConcurrency: options.maxConcurrency,

--- a/packages/scheduler/src/create-workpool.ts
+++ b/packages/scheduler/src/create-workpool.ts
@@ -1,6 +1,5 @@
 import { LunoraError } from "@lunora/errors";
 
-import { encodeWire } from "../../../shared/wire-codec";
 import { assertSchedulerOptions, callDO, getDO } from "./do-client";
 import type { ArgsOf, EnqueueOptions, FunctionReference, Workpool, WorkpoolOptions } from "./types";
 import assertScheduleDelay from "./validate-delay";
@@ -54,10 +53,10 @@ const createWorkpool = (options: WorkpoolOptions): Workpool => {
         assertScheduleDelay(delayMs, "workpool.enqueue");
 
         return callDO<{ id: string; scheduledFor: number }>(options, "/schedule", {
-            // Same wire contract as `createScheduler.runAt` — a pooled job takes the
-            // identical `/schedule` route to the identical shard-side `decodeWire`,
-            // so an un-encoded `bigint` arg threw here for the same reason.
-            args: encodeWire(args) as Record<string, unknown>,
+            // Wire-encoded by `callDO`, same as `createScheduler.runAt` — a pooled
+            // job takes the identical `/schedule` route to the identical
+            // shard-side `decodeWire`.
+            args,
             functionPath: function_.__lunoraRef,
             instanceName: options.instanceName ?? "default",
             maxConcurrency: options.maxConcurrency,

--- a/packages/scheduler/src/do-client.ts
+++ b/packages/scheduler/src/do-client.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import applyJurisdiction from "./jurisdiction";
 import type { DurableObjectNamespaceLike, LunoraSchedulerOptions } from "./types";
 
@@ -67,6 +68,20 @@ const raiseDOFailure = (path: string, status: number, text: string): never => {
     throw new LunoraError("INTERNAL", `@lunora/scheduler: SchedulerDO ${path} failed (${String(status)}): ${text}`);
 };
 
+/**
+ * The single owner of what this package puts on, and takes off, the SchedulerDO
+ * wire — as it already is of the URL, the headers, and the response checks.
+ *
+ * A job's `args` can hold a `bigint`, a `Date` or bytes, none of which survive
+ * raw JSON: the first throws inside `JSON.stringify` before the job is ever
+ * recorded, the second silently arrives as an ISO string. Bracketing the codec
+ * here rather than at each caller is what keeps the two directions in step —
+ * encoding at the producers alone left `list`/`get`/`dead` handing back the
+ * tagged `["$lunora.wire$", …]` form, and every future route would have had to
+ * remember both halves. Both codecs are the identity on pure JSON, so
+ * `functionPath`, `scheduledFor`, `cursor` and friends are unchanged byte for
+ * byte.
+ */
 const requestDO = async <T>(options: LunoraSchedulerOptions, path: string, init: RequestInit): Promise<T> => {
     const stub = schedulerStub(options);
     const response = await stub.fetch(`https://scheduler.internal${path}`, init);
@@ -75,13 +90,13 @@ const requestDO = async <T>(options: LunoraSchedulerOptions, path: string, init:
         raiseDOFailure(path, response.status, await response.text());
     }
 
-    return await response.json();
+    return decodeWire(await response.json()) as T;
 };
 
 /** POST `body` to the SchedulerDO `path`, throwing a shaped `LunoraError` on any non-2xx. */
 const callDO = async <T>(options: LunoraSchedulerOptions, path: string, body: unknown): Promise<T> =>
     requestDO<T>(options, path, {
-        body: JSON.stringify(body),
+        body: JSON.stringify(encodeWire(body)),
         headers: { "content-type": "application/json" },
         method: "POST",
     });

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -139,6 +139,13 @@ export interface RunOptions {
 }
 
 export interface ScheduleRecord {
+    /**
+     * The arguments the job will be dispatched with. Decoded — every read in
+     * this package comes back through `do-client`'s `requestDO`, which
+     * `decodeWire`s the whole SchedulerDO response — so a `bigint`/`Date`/bytes
+     * arg is that value here, not the tagged wire form. Only the DO's own
+     * storage holds the encoded form.
+     */
     args: Record<string, unknown>;
 
     /**

--- a/packages/shard-engine/__tests__/system-reader.test.ts
+++ b/packages/shard-engine/__tests__/system-reader.test.ts
@@ -34,6 +34,24 @@ describe("createSystemReader — _scheduled_functions", () => {
         ]);
     });
 
+    it("passes a Date/bigint arg through untouched rather than decoding it a second time", async () => {
+        expect.assertions(2);
+
+        // The source is `ctx.scheduler` — `@lunora/scheduler`'s `createScheduler`,
+        // which `decodeWire`s every SchedulerDO response at its transport. Running
+        // the codec again here is NOT a no-op on what it hands back: a `Date` has
+        // no own enumerable keys, so a second `decodeWire` flattens it to `{}`.
+        const dueAt = new Date("2026-06-01T12:00:00.000Z");
+        const list = vi.fn<() => Promise<Record<string, unknown>[]>>(async () => [scheduledRecord({ args: { amountCents: 42n, dueAt } })]);
+        const scheduler: SystemReaderSchedulerLike = { get: vi.fn<SystemReaderSchedulerLike["get"]>(), list };
+
+        const reader = createSystemReader({ scheduler });
+        const [doc] = await reader.query("_scheduled_functions").collect();
+
+        expect(doc?.args["dueAt"]).toStrictEqual(dueAt);
+        expect(doc?.args["amountCents"]).toBe(42n);
+    });
+
     it("leaves functionPath absent on a workflow-targeted job instead of inventing an empty path", async () => {
         expect.assertions(1);
 

--- a/packages/shard-engine/src/system-reader.ts
+++ b/packages/shard-engine/src/system-reader.ts
@@ -31,6 +31,8 @@
  */
 import { LunoraError } from "@lunora/errors";
 
+import { decodeWire } from "../../../shared/wire-codec";
+
 /* eslint-disable unicorn/prevent-abbreviations -- `Doc`/`SystemDoc`/`ScheduledFunctionDoc` are the deliberate public API names for `ctx.db.system` (they mirror Convex's `Doc` naming and the spec the consuming `@lunora/server` types re-export); `doc`/`docs` is the domain term for a stored document throughout the DO ORM (see ctx-db.ts). Renaming would break the documented surface. */
 
 /** The system tables `ctx.db.system` can read. */
@@ -172,7 +174,14 @@ interface SystemReaderOptions {
  */
 const toScheduledFunctionDoc = (record: Record<string, unknown>): ScheduledFunctionDoc => {
     const doc: ScheduledFunctionDoc = {
-        args: (record["args"] as Record<string, unknown> | undefined) ?? {},
+        // `decodeWire`, because the record's `args` are in WIRE form: the scheduler
+        // encodes them at the producer so a `bigint`/`Date`/bytes arg survives the
+        // JSON hop to the SchedulerDO, and every other consumer decodes (the shard
+        // for a function target, `@lunora/workflow`'s run-context for a workflow
+        // one). This read is a consumer too — a handler inspecting a pending job's
+        // args to dedupe before enqueueing would otherwise compare against a raw
+        // `["$lunora.wire$", …]` array and never match. Identity for pure JSON.
+        args: (decodeWire(record["args"] ?? {}) as Record<string, unknown> | undefined) ?? {},
         enqueuedAt: typeof record["enqueuedAt"] === "number" ? record["enqueuedAt"] : 0,
         id: typeof record["id"] === "string" ? record["id"] : "",
         scheduledFor: typeof record["scheduledFor"] === "number" ? record["scheduledFor"] : 0,

--- a/packages/shard-engine/src/system-reader.ts
+++ b/packages/shard-engine/src/system-reader.ts
@@ -31,8 +31,6 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { decodeWire } from "../../../shared/wire-codec";
-
 /* eslint-disable unicorn/prevent-abbreviations -- `Doc`/`SystemDoc`/`ScheduledFunctionDoc` are the deliberate public API names for `ctx.db.system` (they mirror Convex's `Doc` naming and the spec the consuming `@lunora/server` types re-export); `doc`/`docs` is the domain term for a stored document throughout the DO ORM (see ctx-db.ts). Renaming would break the documented surface. */
 
 /** The system tables `ctx.db.system` can read. */
@@ -174,14 +172,15 @@ interface SystemReaderOptions {
  */
 const toScheduledFunctionDoc = (record: Record<string, unknown>): ScheduledFunctionDoc => {
     const doc: ScheduledFunctionDoc = {
-        // `decodeWire`, because the record's `args` are in WIRE form: the scheduler
-        // encodes them at the producer so a `bigint`/`Date`/bytes arg survives the
-        // JSON hop to the SchedulerDO, and every other consumer decodes (the shard
-        // for a function target, `@lunora/workflow`'s run-context for a workflow
-        // one). This read is a consumer too — a handler inspecting a pending job's
-        // args to dedupe before enqueueing would otherwise compare against a raw
-        // `["$lunora.wire$", …]` array and never match. Identity for pure JSON.
-        args: (decodeWire(record["args"] ?? {}) as Record<string, unknown> | undefined) ?? {},
+        // NOT decoded here. `args` cross the wire to the SchedulerDO in encoded
+        // form, but the source this reader is handed (`ctx.scheduler`, i.e.
+        // `@lunora/scheduler`'s `createScheduler`) already `decodeWire`s every
+        // response at its transport, so the record arriving here holds real
+        // `Date`/`bigint`/bytes values. A second decode is not a no-op on those:
+        // a `Date` has no own enumerable keys, so it re-decodes to `{}` — the
+        // exact corruption the codec exists to prevent, inflicted by decoding
+        // twice instead of not at all.
+        args: (record["args"] as Record<string, unknown> | undefined) ?? {},
         enqueuedAt: typeof record["enqueuedAt"] === "number" ? record["enqueuedAt"] : 0,
         id: typeof record["id"] === "string" ? record["id"] : "",
         scheduledFor: typeof record["scheduledFor"] === "number" ? record["scheduledFor"] : 0,

--- a/packages/testing/__tests__/scheduler.test.ts
+++ b/packages/testing/__tests__/scheduler.test.ts
@@ -806,6 +806,31 @@ describe("fake scheduler production parity", () => {
         await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: 1n as unknown as string }))).resolves.toMatch(/\S/u);
     });
 
+    it("puts args through the production wire hop, not a by-reference handoff", async () => {
+        expect.assertions(4);
+
+        const t = start();
+        const dueAt = new Date("2026-06-01T12:00:00.000Z");
+
+        // Production's hop is `encodeWire` → `JSON.stringify` → the DO's storage →
+        // `decodeWire`. The fake runs all three, so what the handler sees here is
+        // what it sees in production — including the two places that is NOT the
+        // caller's own object.
+        await t.run(async (ctx) => ctx.scheduler.runAfter(1000, "log:appendLog", { amountCents: 42n, dueAt, message: "x", skipped: undefined }));
+
+        const [job] = await t.run(async (ctx) => ctx.scheduler.list());
+
+        expect(job?.args["amountCents"]).toBe(42n);
+        expect(job?.args["dueAt"]).toStrictEqual(dueAt);
+        // A rebuilt Date, not the caller's instance — a fake that handed `args`
+        // straight through would pass every value assertion and still hide that
+        // production round-trips them.
+        expect(job?.args["dueAt"]).not.toBe(dueAt);
+        // `encodeWire` drops an `undefined` object field exactly as
+        // `JSON.stringify` does, so the handler never sees the key at all.
+        expect(job?.args).not.toHaveProperty("skipped");
+    });
+
     it("gives a scheduled job the advanced clock as ctx.now", async () => {
         expect.assertions(1);
 

--- a/packages/testing/__tests__/scheduler.test.ts
+++ b/packages/testing/__tests__/scheduler.test.ts
@@ -790,13 +790,20 @@ describe("fake scheduler production parity", () => {
         await expect(t.run(async (ctx) => ctx.scheduler.runAt(1, "log:appendLog", { message: "x" }))).resolves.toMatch(/\S/u);
     });
 
-    it("rejects args the scheduler cannot serialize", async () => {
-        expect.assertions(1);
+    it("rejects args the wire codec cannot carry, and accepts the ones it can", async () => {
+        expect.assertions(2);
 
         const t = start();
 
-        // Production posts the job as JSON, so a bigint arg throws at schedule time.
-        await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: 1n as unknown as string }))).rejects.toThrow(/BigInt/u);
+        // Production wire-encodes the args before posting them, so what throws at
+        // schedule time is what `encodeWire` refuses: a non-plain object has no own
+        // enumerable keys, and encoding it to `{}` would be silent data loss.
+        await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: /re/u as unknown as string }))).rejects.toThrow(/wire-codec/u);
+
+        // …and a `bigint` is now carried rather than refused. The fake is a THIRD
+        // `runAt` alongside `createScheduler` and the deferral facade, so a harness
+        // that rejected this would tell a test the opposite of what ships.
+        await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: 1n as unknown as string }))).resolves.toMatch(/\S/u);
     });
 
     it("gives a scheduled job the advanced clock as ctx.now", async () => {

--- a/packages/testing/src/fake-scheduler.ts
+++ b/packages/testing/src/fake-scheduler.ts
@@ -2,7 +2,7 @@ import { LunoraError } from "@lunora/errors";
 import { assertScheduleDelay, MAX_RETRY_ATTEMPTS, RETRY_BASE_DELAY_MS } from "@lunora/scheduler";
 import type { ScheduledJob, Scheduler } from "@lunora/server";
 
-import { encodeWire } from "../../../shared/wire-codec";
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 
 /** A pending job entry in the fake scheduler queue. */
 interface FakeScheduledJob extends ScheduledJob {
@@ -164,18 +164,17 @@ const createFakeScheduler = (
     const recordedFailures: ScheduledJobFailure[] = [];
 
     const enqueue = (scheduledFor: number, functionPath: string, args: Record<string, unknown> = {}, requestedId?: string): string => {
-        // Production wire-encodes the args before posting them to the SchedulerDO
-        // (`@lunora/scheduler`'s `createScheduler.runAt` → `encodeWire` → `callDO`),
-        // so an arg the CODEC cannot carry — a cycle, a `RegExp`, a class instance
-        // — throws at SCHEDULE time. Do the same work here rather than accepting
-        // the job and failing only in production.
-        //
-        // Note what this deliberately no longer rejects: a `bigint` or a `Date`.
-        // Raw `JSON.stringify` threw on the first and silently flattened the second,
-        // and mirroring that here made the fake refuse jobs production now accepts.
-        // The encoded value is discarded — the fake dispatches in-process, so the
-        // handler must see what production's decode hands it, which is `args` itself.
-        encodeWire(args);
+        // The production hop, run for real: `@lunora/scheduler`'s `callDO`
+        // `encodeWire`s the envelope, `JSON.stringify` puts it on the wire, the
+        // SchedulerDO stores and re-serialises it, and the consumer `decodeWire`s
+        // it back. Doing all three here means an arg the codec cannot carry (a
+        // cycle, a `RegExp`, a class instance) throws at SCHEDULE time exactly as
+        // it does in production, and the handler sees precisely what production's
+        // decode hands it — including the two places that is NOT `args` itself: an
+        // `undefined` object field is dropped, and a `Date`/`bigint` comes back as
+        // an equal but distinct value rather than the caller's own instance.
+        const json = JSON.stringify(encodeWire(args));
+        const wireArgs = decodeWire(JSON.parse(json)) as Record<string, unknown>;
 
         // A caller-supplied id is honoured exactly as the SchedulerDO honours
         // `RunOptions.id`: `@lunora/server`'s deferred-schedule facade decides the
@@ -186,7 +185,7 @@ const createFakeScheduler = (
         nextId += 1;
 
         pending.set(id, {
-            args,
+            args: wireArgs,
             enqueuedAt: nowMs,
             functionPath,
             id,

--- a/packages/testing/src/fake-scheduler.ts
+++ b/packages/testing/src/fake-scheduler.ts
@@ -2,6 +2,8 @@ import { LunoraError } from "@lunora/errors";
 import { assertScheduleDelay, MAX_RETRY_ATTEMPTS, RETRY_BASE_DELAY_MS } from "@lunora/scheduler";
 import type { ScheduledJob, Scheduler } from "@lunora/server";
 
+import { encodeWire } from "../../../shared/wire-codec";
+
 /** A pending job entry in the fake scheduler queue. */
 interface FakeScheduledJob extends ScheduledJob {
     /** The args the job was scheduled with. */
@@ -162,11 +164,18 @@ const createFakeScheduler = (
     const recordedFailures: ScheduledJobFailure[] = [];
 
     const enqueue = (scheduledFor: number, functionPath: string, args: Record<string, unknown> = {}, requestedId?: string): string => {
-        // Production posts the job to the SchedulerDO as a JSON body
-        // (`@lunora/scheduler`'s `callDO` → `JSON.stringify`), so an arg it cannot
-        // serialize — a `bigint`, a cycle — throws at SCHEDULE time. Do the same
-        // work here rather than accepting the job and failing only in production.
-        JSON.stringify(args);
+        // Production wire-encodes the args before posting them to the SchedulerDO
+        // (`@lunora/scheduler`'s `createScheduler.runAt` → `encodeWire` → `callDO`),
+        // so an arg the CODEC cannot carry — a cycle, a `RegExp`, a class instance
+        // — throws at SCHEDULE time. Do the same work here rather than accepting
+        // the job and failing only in production.
+        //
+        // Note what this deliberately no longer rejects: a `bigint` or a `Date`.
+        // Raw `JSON.stringify` threw on the first and silently flattened the second,
+        // and mirroring that here made the fake refuse jobs production now accepts.
+        // The encoded value is discarded — the fake dispatches in-process, so the
+        // handler must see what production's decode hands it, which is `args` itself.
+        encodeWire(args);
 
         // A caller-supplied id is honoured exactly as the SchedulerDO honours
         // `RunOptions.id`: `@lunora/server`'s deferred-schedule facade decides the

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -228,3 +228,26 @@ describe("createWorkflowRunContext params wire codec", () => {
         expect(contextFor(plain).params).toStrictEqual(plain);
     });
 });
+
+describe("createWorkflowRunContext — undecodable params", () => {
+    it("fails the instance without retrying instead of raising a bare codec error", () => {
+        expect.assertions(3);
+
+        // The params are already durable, so every retry decodes the identical
+        // bytes to the identical failure. A bare `TypeError`/`RangeError` here
+        // would burn the whole retry budget re-deriving that answer.
+        const event = { ...makeEvent(), payload: ["$lunora.wire$", "bigint", "not-a-number"] as unknown as { orderId: string } };
+
+        let thrown: unknown;
+
+        try {
+            createWorkflowRunContext({ env: {}, event, exportName: "orderPipeline", step: makeStep() });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).name).toBe("NonRetryableError");
+        expect((thrown as Error).message).toMatch(/orderPipeline/u);
+    });
+});

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -1,6 +1,7 @@
 import { v } from "@lunora/values";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { encodeWire } from "../../../shared/wire-codec";
 import { defineWorkflowEvent } from "../src/define-event";
 import { defineStep } from "../src/define-step";
 import { createWorkflowRunContext } from "../src/run-context";
@@ -41,7 +42,9 @@ describe("createWorkflowRunContext", () => {
         const ctx = createWorkflowRunContext({ env: { LUNORA_ORIGIN_URL: "x" }, event, exportName: "orderPipeline", step });
 
         expect(ctx.params).toEqual({ orderId: "o1" });
-        expect(ctx.event).toBe(event);
+        // Not the same object reference: the payload is `decodeWire`d off the wire
+        // form, so the context carries a rebuilt event with the decoded payload.
+        expect(ctx.event).toEqual(event);
         expect(ctx.step).toBe(step);
         expect(ctx.env).toEqual({ LUNORA_ORIGIN_URL: "x" });
         expect(typeof ctx.run).toBe("function");
@@ -157,5 +160,71 @@ describe("createWorkflowRunContext", () => {
         ctx.log.info("hi", 1);
 
         expect(spy).toHaveBeenCalledWith("[workflow:orderPipeline]", "hi", 1);
+    });
+});
+
+/**
+ * A scheduled workflow's params are the scheduler's `args`: `ctx.scheduler
+ * .runAfter(delay, workflows.payout, args)` encodes them (`shared/wire-codec`),
+ * they ride through the SchedulerDO and Cloudflare's own durable serialisation
+ * of `create({ params })`, and arrive here as `event.payload`. Decoding at the
+ * READ is what makes this target symmetric with the function target, which the
+ * shard decodes in its dispatch loop.
+ */
+describe("createWorkflowRunContext params wire codec", () => {
+    /**
+     * What Cloudflare hands back: the params, JSON round-tripped through durable
+     * storage. Deliberately `JSON.stringify` + `JSON.parse` and not
+     * `structuredClone` — modelling that hop is the whole point, and
+     * `structuredClone` would carry a `Date`/`bigint` through it intact.
+     */
+    const throughDurableStorage = (params: unknown): Record<string, unknown> => {
+        const json = JSON.stringify(encodeWire(params));
+
+        return JSON.parse(json) as Record<string, unknown>;
+    };
+
+    const dueAt = new Date("2026-06-01T12:00:00.000Z");
+
+    const contextFor = (payload: Record<string, unknown>): ReturnType<typeof createWorkflowRunContext> =>
+        createWorkflowRunContext({
+            env: {},
+            event: { ...makeEvent(), payload } as unknown as WorkflowEventLike<{ orderId: string }>,
+            exportName: "orderPipeline",
+            step: makeStep(),
+        });
+
+    it("decodes a bigint param into a real bigint", () => {
+        expect.assertions(1);
+
+        const ctx = contextFor(throughDurableStorage({ invoiceCents: 9_007_199_254_740_993n }));
+
+        expect(ctx.params).toStrictEqual({ invoiceCents: 9_007_199_254_740_993n });
+    });
+
+    it("decodes a Date param into a real Date rather than an ISO string", () => {
+        expect.assertions(2);
+
+        const ctx = contextFor(throughDurableStorage({ dueAt }));
+        const params = ctx.params as { dueAt: unknown };
+
+        expect(params.dueAt).toBeInstanceOf(Date);
+        expect(params.dueAt).toStrictEqual(dueAt);
+    });
+
+    it("decodes ctx.event.payload too, so `params` stays a true alias of it", () => {
+        expect.assertions(1);
+
+        const ctx = contextFor(throughDurableStorage({ dueAt }));
+
+        expect(ctx.event.payload).toStrictEqual(ctx.params);
+    });
+
+    it("leaves plain-JSON params untouched, so nothing changes for existing workflows", () => {
+        expect.assertions(1);
+
+        const plain = { attempt: 3, nested: { ok: true, tags: ["a", "b"] }, orderId: "o1" };
+
+        expect(contextFor(plain).params).toStrictEqual(plain);
     });
 });

--- a/packages/workflow/src/run-context.ts
+++ b/packages/workflow/src/run-context.ts
@@ -13,6 +13,7 @@ import { LunoraError } from "@lunora/errors";
 import { decodeWire } from "../../../shared/wire-codec";
 import { workflowBindingName } from "./define-workflow";
 import type { NativeNonRetryableErrorConstructor } from "./errors";
+import { raiseNonRetryable } from "./errors";
 import type { WorkflowBindingResolver } from "./fan-out";
 import { createParallel, createSpawn } from "./fan-out";
 import { createRunStep } from "./run-step";
@@ -45,13 +46,33 @@ const createWorkflowRunContext = <Params = Record<string, unknown>>(options: Run
     // instance creation outright and a real `Date` degrades to an ISO string. So
     // the value cannot be decoded any earlier than here and still be intact.
     //
-    // `decodeWire` is identity for pure JSON, so params from every other create
-    // surface (`ctx.parallel`/`ctx.spawn`, a hand-written `env.WORKFLOW_X.create`)
-    // are untouched. It runs before the context is built so `ctx.params` and
-    // `ctx.event.payload` cannot disagree — `params` is documented as an alias of
-    // the payload, and handing one the decoded value and the other a raw tagged
-    // array would make that a lie.
-    const event: WorkflowEventLike<Params> = { ...options.event, payload: decodeWire(options.event.payload) as Readonly<Params> };
+    // `decodeWire` returns the same VALUES for params from every other create
+    // surface (`ctx.parallel`/`ctx.spawn`, a hand-written `env.WORKFLOW_X.create`),
+    // since it is the identity on pure JSON. It is not a no-op on all of them,
+    // though: the codec enforces its own nesting bound, so a pure-JSON payload
+    // deeper than that is refused here rather than reaching the handler. It runs
+    // before the context is built so `ctx.params` and `ctx.event.payload` cannot
+    // disagree — `params` is documented as an alias of the payload, and handing
+    // one the decoded value and the other a raw tagged array would make that a
+    // lie.
+    //
+    // A refusal is NON-retryable: the params are already durable, so every retry
+    // decodes the identical bytes to the identical failure. A bare `RangeError`/
+    // `TypeError` escaping here would instead burn the instance's whole retry
+    // budget re-deriving the same answer.
+    let payload: unknown;
+
+    try {
+        payload = decodeWire(options.event.payload);
+    } catch (error) {
+        raiseNonRetryable(
+            `@lunora/workflow: workflow "${options.exportName}" params could not be decoded — ${error instanceof Error ? error.message : String(error)}`,
+            error,
+            options.nonRetryableErrorClass,
+        );
+    }
+
+    const event: WorkflowEventLike<Params> = { ...options.event, payload: payload as Readonly<Params> };
 
     // `@lunora/dispatch`'s runner is deliberately loose at the boundary (its
     // `ArgsOf` collapses to `Record<string, unknown>`); this package's

--- a/packages/workflow/src/run-context.ts
+++ b/packages/workflow/src/run-context.ts
@@ -10,6 +10,7 @@
 import { createDispatchLogger, createDispatchRunner } from "@lunora/dispatch";
 import { LunoraError } from "@lunora/errors";
 
+import { decodeWire } from "../../../shared/wire-codec";
 import { workflowBindingName } from "./define-workflow";
 import type { NativeNonRetryableErrorConstructor } from "./errors";
 import type { WorkflowBindingResolver } from "./fan-out";
@@ -31,6 +32,27 @@ interface RunContextOptions<Params> {
 /** Assemble the {@link WorkflowRunContext} passed to a `defineWorkflow` handler. */
 const createWorkflowRunContext = <Params = Record<string, unknown>>(options: RunContextOptions<Params>): WorkflowRunContext<Params> => {
     const log = createDispatchLogger(`[workflow:${options.exportName}]`);
+
+    // Decode the wire codec (`bigint`/`Date`/`bytes`/`Map`/… leaves) out of the
+    // params, mirroring what `@lunora/do`'s dispatch loop does to a function
+    // target's args — a scheduled workflow's params ARE the scheduler's `args`
+    // (`ctx.scheduler.runAfter(delay, workflows.payout, args)`), and
+    // `@lunora/scheduler` encodes them at the producer.
+    //
+    // The decode belongs at this READ rather than at dispatch because Cloudflare
+    // JSON-serialises workflow `params` into durable storage on `create()`. The
+    // tagged wire form is exactly what survives that hop; a real `bigint` fails
+    // instance creation outright and a real `Date` degrades to an ISO string. So
+    // the value cannot be decoded any earlier than here and still be intact.
+    //
+    // `decodeWire` is identity for pure JSON, so params from every other create
+    // surface (`ctx.parallel`/`ctx.spawn`, a hand-written `env.WORKFLOW_X.create`)
+    // are untouched. It runs before the context is built so `ctx.params` and
+    // `ctx.event.payload` cannot disagree — `params` is documented as an alias of
+    // the payload, and handing one the decoded value and the other a raw tagged
+    // array would make that a lie.
+    const event: WorkflowEventLike<Params> = { ...options.event, payload: decodeWire(options.event.payload) as Readonly<Params> };
+
     // `@lunora/dispatch`'s runner is deliberately loose at the boundary (its
     // `ArgsOf` collapses to `Record<string, unknown>`); this package's
     // `WorkflowRunFunction` reads the reference's `__lunoraPhantom` instead, so a
@@ -92,10 +114,10 @@ const createWorkflowRunContext = <Params = Record<string, unknown>>(options: Run
 
     return {
         env: options.env,
-        event: options.event,
+        event,
         log,
         parallel: createParallel(fanOutDeps),
-        params: options.event.payload,
+        params: event.payload,
         run,
         runStep: createRunStep({ env: options.env, log, nonRetryableErrorClass: options.nonRetryableErrorClass, run, step: options.step }),
         spawn: createSpawn(fanOutDeps),


### PR DESCRIPTION
Round-31. `ctx.scheduler.runAfter/runAt` args never went through the wire codec at the producer, while one of two consumers decoded them — so a `bigint` arg threw before the job was ever recorded, and a `Date` silently became a string.

## The asymmetry

Producers sent raw: `create-scheduler.ts`, `create-workpool.ts`, `create-worker.ts`'s `/schedule` post, and `mail/inbound/shard.ts`. Consumers disagreed: a function target routes through the shard, which decodes at `shard-do.ts:5925`; a workflow target goes to `create({ params })` and `packages/workflow` contained **no** `decodeWire` at all.

That asymmetry is why this was left open in round 30 rather than "just encoded at the producer": doing so alone would have fixed the shard path and pushed raw tagged arrays into every scheduled workflow's `params`.

## The fix, and where it ended up

Both sides are now bracketed, and after review the codec moved to the **chokepoints** rather than sitting at call sites: `do-client.ts`'s `callDO` encodes and `requestDO` decodes, so `/schedule`, `/cancel`, `/list`, `/get`, `/dead`, `/dead/retry` and every future route are correct by construction. Same for `buildHttpScheduler`'s `post`/`call`. The codec is identity for plain JSON, so `functionPath`, `scheduledFor`, `cursor` and friends are byte-identical.

That was not cosmetic. The first version encoded at the producer and left `list()`, `get()` and `dead()` un-decoded **twenty-six lines below in the same file** — improving dispatch while regressing read-back, on the documented public `Scheduler` surface. Call sites went from 9 scattered to 8 with 2 chokepoints; undecoded read routes from 5 to 0. This defect class has now been found four times in this campaign, which is the argument for a chokepoint over a convention.

The workflow side decodes where the handler reads `params`, not at dispatch: Cloudflare JSON-serialises `params` into durable storage, so the wire form is exactly what survives that hop, whereas a real `bigint` fails instance creation and a `Date` degrades to a string.

## Three defects found while fixing it

- **`ctx.scheduler.get()` returned the wrong shape** in the runtime facade — the DO's `{ record }` envelope rather than the record, so `job.scheduledFor` was `undefined`, and a truthy `{}` on a miss instead of `null`, so `if (job)` reported a cancelled job as still pending.
- **A run-context decode failure was retryable.** Workflow params are already durable, so every retry decodes identical bytes to the identical failure and burns the whole budget. Now non-retryable.
- **`decodeWire` is not idempotent.** Once the codec moved into `do-client`, the existing `system-reader` decode became a *second* one — and a second decode flattens a `Date` to `{}`, because a `Date` has no own enumerable keys (a `bigint` survives). Verified: `once: { dueAt: 2026-06-01T…, n: 42n }` → `twice: { dueAt: {}, n: 42n }`. That decode is removed, with a comment naming the trap.

## Verification

Every regression test was run against the unfixed code first, and the new ones drive the **consumers** rather than restating `decodeWire(what the producer sent)` — which is precisely why the read-back hole passed every gate the first time round. Eight before/after pairs, including `expected [ '$lunora.wire$', 'date', … ] to be an instance of Date` on `list`/`get`/`dead`.

All seven repo gates green, `api:check` with no drift.

`packages/mail` is bracketed at `postShardRpc`, its single wire owner. One behaviour break noted in its commit body: a caller-supplied `resolveArgs` override returning a class instance previously delivered a lossy `{}` and now throws, because the codec refuses non-plain objects.

## Still open, deliberately

`createDispatchRunner` ships `args` un-encoded to the same decoding shard, so `ctx.run(fn, { n: 1n })` is broken in `@lunora/queue`, `@lunora/workflow` and `@lunora/agent`. Fixing it in the shared runner is **mutually exclusive** with the queue-workpool bracket on a sibling branch — it would double-encode — so it belongs at each package's own `run` wrapper and is filed rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ
