### PR TITLE
security(runtime): let a declared proxy header restore per-IP limiting

### DIFF
--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -2257,6 +2257,7 @@ interface WorkerOptions {
     storageSignedUrl?: StorageSignedUrlFunction;
     storageUpload?: StorageUploadFunction;
     syncGlobals?: GlobalCdcSyncFunction;
+    trustedClientIpHeader?: string;
     trustInboundTraceContext?: TrustInboundTraceContext;
     vectorIntrospector?: VectorIntrospector;
     voiceAgents?: Record<string, ShardNamespaceLike>;
@@ -2395,6 +2396,7 @@ const createQueryCoordinator: (options: QueryCoordinatorOptions) => QueryCoordin
 const createRestRateLimit: (limiter: RateLimiterLike, options: {
     key?: (request: Request, functionPath: string) => string | undefined;
     name: string;
+    trustedClientIpHeader?: string;
 }) => RestRateLimit;
 ```
 

--- a/apps/docs/src/content/docs/concepts/rest-api.mdx
+++ b/apps/docs/src/content/docs/concepts/rest-api.mdx
@@ -135,9 +135,16 @@ export default createWorker({
 ```
 
 It runs **before** dispatch, so a limited request costs you nothing downstream. By
-default it keys on the caller's IP (`CF-Connecting-IP`); pass `key` to key on
-something else, such as an API key header, or the `functionPath` to limit per
-endpoint:
+default it keys on the caller's IP from `CF-Connecting-IP`, but only while running
+on Cloudflare, where the edge stamps that header over anything the client sent.
+On any other target nothing overwrites it, so it is a header the caller typed and
+trusting it would hand an attacker a fresh bucket per request — those deployments
+resolve no IP and pool into one shared `no-trusted-ip` bucket instead. An origin
+fronted by a proxy that does stamp a client address declares it with
+`trustedClientIpHeader` to get per-IP buckets back; see
+[`@lunora/runtime`](/docs/packages/runtime) for what that assertion commits you
+to. Otherwise pass `key` to key on something you control, such as an API key
+header, or the `functionPath` to limit per endpoint:
 
 ```ts
 createRestRateLimit(limiter, {

--- a/packages/runtime/__tests__/client-ip-trust.test.ts
+++ b/packages/runtime/__tests__/client-ip-trust.test.ts
@@ -143,6 +143,95 @@ describe("client IP trust", () => {
         });
     });
 
+    describe("a declared trustedClientIpHeader", () => {
+        it("keys the REST limiter per caller off Cloudflare", async () => {
+            expect.assertions(2);
+
+            const { namespace } = recordingShard();
+            const limiter = {
+                limit: vi.fn<() => Promise<{ ok: boolean; retryAfter: number }>>(async () => {
+                    return { ok: true, retryAfter: 0 };
+                }),
+            };
+            const worker = createWorker({
+                functions,
+                restRateLimit: createRestRateLimit(limiter, { name: "rest", trustedClientIpHeader: "cf-connecting-ip" }),
+                shardDO: namespace,
+            });
+
+            // The behind-Cloudflare origin the fail-closed default pools into one
+            // bucket: with the header declared, two callers get two buckets again.
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rest/messages/list", { headers: { "cf-connecting-ip": "203.0.113.4" } }),
+                {},
+                fakeContext,
+            );
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rest/messages/list", { headers: { "cf-connecting-ip": "203.0.113.5" } }),
+                {},
+                fakeContext,
+            );
+
+            expect(limiter.limit).toHaveBeenNthCalledWith(1, "rest", { key: "203.0.113.4" });
+            expect(limiter.limit).toHaveBeenNthCalledWith(2, "rest", { key: "203.0.113.5" });
+        });
+
+        it("forwards ctx.ip off Cloudflare", async () => {
+            expect.assertions(1);
+
+            const shard = recordingShard();
+            const worker = createWorker({ functions, shardDO: shard.namespace, trustedClientIpHeader: "cf-connecting-ip" });
+
+            await worker.fetch(rpc(), {}, fakeContext);
+
+            expect(shard.calls[0]?.headers.get("x-lunora-client-ip")).toBe("203.0.113.7");
+        });
+
+        it("resolves nothing from a declared header carrying a forwarded chain", async () => {
+            expect.assertions(1);
+
+            const shard = recordingShard();
+            const worker = createWorker({ functions, shardDO: shard.namespace, trustedClientIpHeader: "x-forwarded-for" });
+
+            // A chain's leftmost entry is whatever the client typed, so an
+            // appending proxy cannot be read as one trusted address. The
+            // declaration is for headers infrastructure REPLACES, and a comma is
+            // the cheap signal that this header is not one of them.
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rpc", {
+                    body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                    headers: { "x-forwarded-for": "198.51.100.9, 203.0.113.7" },
+                    method: "POST",
+                }),
+                {},
+                fakeContext,
+            );
+
+            expect(shard.calls[0]?.headers.get("x-lunora-client-ip")).toBeNull();
+        });
+
+        it("is ignored on Cloudflare, where cf-connecting-ip still wins", async () => {
+            expect.assertions(1);
+
+            vi.stubGlobal("navigator", CLOUDFLARE_NAVIGATOR);
+
+            const shard = recordingShard();
+            const worker = createWorker({ functions, shardDO: shard.namespace, trustedClientIpHeader: "x-client-ip" });
+
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rpc", {
+                    body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                    headers: { "cf-connecting-ip": "203.0.113.7", "x-client-ip": "198.51.100.9" },
+                    method: "POST",
+                }),
+                {},
+                fakeContext,
+            );
+
+            expect(shard.calls[0]?.headers.get("x-lunora-client-ip")).toBe("203.0.113.7");
+        });
+    });
+
     describe("x-lunora-client-ip forwarded to the shard (ctx.ip)", () => {
         it("forwards cf-connecting-ip on Cloudflare", async () => {
             expect.assertions(1);

--- a/packages/runtime/docs/index.mdx
+++ b/packages/runtime/docs/index.mdx
@@ -430,24 +430,50 @@ Cloudflare, pass `key` and identify callers by something they cannot forge:
 createRestRateLimit(limiter, { key: (request) => request.headers.get("x-api-key") ?? undefined, name: "rest" });
 ```
 
-This applies to a non-Cloudflare origin sitting **behind** Cloudflare too, and
-that case is worth calling out because it is the one where the default gets
-strictly worse rather than staying neutral. On a bare host with no proxy the
-header was never set, so pooling changes nothing. But an origin fronted by
-Cloudflare — the edge stamps `CF-Connecting-IP`, the origin accepts only
-Cloudflare traffic, so the header genuinely is trustworthy — still resolves no
+### Origins behind a proxy: `trustedClientIpHeader`
+
+A non-Cloudflare origin sitting **behind** Cloudflare is the one case where that
+default gets strictly worse rather than staying neutral. On a bare host with no
+proxy the header was never set, so pooling changes nothing. But on a fronted
+origin — the edge stamps `CF-Connecting-IP`, the origin accepts only Cloudflare
+traffic, so the header genuinely is trustworthy — the runtime still resolves no
 IP, because the code runs on the origin and nothing in the request tells it apart
 from a directly-exposed host. Every caller lands in the single `no-trusted-ip`
-bucket, which one client can exhaust for everyone. Those deployments are the ones
-that must pass `key`; they are also the ones that can, because only the
-deployment knows it is fronted:
+bucket, which one client can exhaust for everyone.
+
+Only the deployment knows it is fronted, so the deployment says so. Declare the
+header and per-IP limiting comes back:
 
 ```ts
-createRestRateLimit(limiter, { key: (request) => request.headers.get("cf-connecting-ip") ?? undefined, name: "rest" });
+createWorker({
+    shardDO: env.SHARD,
+    functions: LUNORA_FUNCTIONS,
+    // Governs `ctx.ip`.
+    trustedClientIpHeader: "cf-connecting-ip",
+    // Governs the REST limiter's default key. Set both, or the two disagree
+    // about who a request came from.
+    restRateLimit: createRestRateLimit(limiter, { name: "rest", trustedClientIpHeader: "cf-connecting-ip" }),
+});
 ```
 
-Only do that where the origin cannot be reached except through the edge —
-otherwise it is the client-writable header this default exists to refuse.
+Declaring it asserts that the named header is set by infrastructure **you
+control**, on every request, replacing whatever the caller sent — so no caller
+can choose its value. A proxy that only forwards or appends a client-supplied
+header is not such a thing, and neither is an origin that can be reached around
+it: if any route bypasses the proxy, a caller arrives with the header they typed,
+rotates it for a fresh bucket per request, and forges the `ctx.ip` your procedures
+key on. Lock the origin to the proxy before setting this. Left unset, the
+fail-closed default above applies; on Cloudflare the option is ignored and
+`CF-Connecting-IP` is used regardless.
+
+A value containing a comma is refused rather than read, because that is an
+appended chain (`x-forwarded-for: <client>, <hop>`) whose leftmost entry is
+client-written. Declare a header your proxy replaces, or key on something else
+with `key`.
+
+This mirrors `@lunora/auth`'s `advanced.ipAddress.trustedProxies` opt-in, which
+solves the same problem for the sign-in limiter. Both are per-deployment
+assertions and neither implies the other, so a fronted origin sets both.
 
 Security guidance: keep the surface small, prefer `.output()` on exposed
 procedures so the response shape is contractual, and rely on the procedure's own

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -1433,6 +1433,52 @@ interface WorkerOptions {
     syncGlobals?: GlobalCdcSyncFunction;
 
     /**
+     * The header carrying the caller's IP, for an origin that is fronted by a
+     * proxy. **Default: unset**, and unset is the safe answer — leave it alone
+     * unless the paragraph below describes your deployment exactly.
+     *
+     * On Cloudflare the runtime already reads `CF-Connecting-IP`, which the edge
+     * stamps over anything the client sent, and this option is ignored. Anywhere
+     * else (`target: "node"`, a container, a bare process) nothing overwrites
+     * that header, so the runtime resolves no IP at all: `ctx.ip` is `undefined`
+     * and the REST limiter's default key pools every caller into one
+     * `no-trusted-ip` bucket. That is correct for a directly-exposed host, and
+     * wrong for an origin sitting BEHIND a proxy that does stamp a client address
+     * — there a real per-IP limit collapses into one bucket a single client can
+     * exhaust for everybody. Naming the header restores per-IP limiting:
+     *
+     * ```ts
+     * trustedClientIpHeader: "cf-connecting-ip"   // origin behind Cloudflare
+     * ```
+     *
+     * ## What you are asserting
+     *
+     * That the named header is set by infrastructure **you control**, on every
+     * request, replacing whatever the caller sent — and therefore that no caller
+     * can choose its value. A proxy that only _forwards_ or _appends_ to a
+     * client-supplied header is not such a thing, and neither is one the origin
+     * can be reached around: if any route bypasses the proxy (a `*.workers.dev`
+     * route left enabled, a load-balancer health port, the origin's own IP
+     * reachable from the internet), a caller reaches this worker with the header
+     * they typed.
+     *
+     * If that assertion is untrue, this is worse than leaving it unset: an
+     * attacker rotates the header for a fresh rate-limit bucket per request — so
+     * the limit stops applying to exactly the traffic it exists to stop, while
+     * still reading as enforced — and forges the `ctx.ip` every procedure keys
+     * on and every audit row records. Lock the origin to the proxy first.
+     *
+     * A value containing a comma is refused rather than read, because that is an
+     * appended forwarding chain (`x-forwarded-for: <client>, <hop>`) whose
+     * leftmost entry is client-written. Declare a header your proxy replaces.
+     *
+     * This governs `ctx.ip` only. `createRestRateLimit` takes the same option for
+     * the REST limiter's default key; set both, or the two disagree about who a
+     * request came from.
+     */
+    trustedClientIpHeader?: string;
+
+    /**
      * Who may hand this worker a trace to join. Controls whether an inbound W3C
      * `traceparent` is continued — adopting its trace id, parenting this
      * dispatch's span under the upstream span, and carrying its `tracestate` to
@@ -1908,6 +1954,11 @@ const resolveForwardContext = async (
     request: Request,
     env: unknown,
     resolveIdentity: WorkerOptions["resolveIdentity"],
+    // Deliberately required rather than optional-with-a-default: every call site
+    // is inside `createWorker` with `options` in scope, and an omitted argument
+    // here would silently drop a deployment's declared header on one route while
+    // the others honoured it.
+    trustedClientIpHeader: WorkerOptions["trustedClientIpHeader"],
     // Defaults to the in-flight context recorded by `handle`. Passed explicitly
     // only by callers that did not reach here through the `fetch` funnel.
     context: ExecutionContextLike | undefined = executionContextByRequest.get(request),
@@ -1956,11 +2007,11 @@ const resolveForwardContext = async (
     // value. On any other host nothing overwrites it, so it is a header the
     // caller typed — forwarding it there would let an attacker choose the `ctx.ip`
     // every procedure rate-limits on. `x-forwarded-for` is client-spoofable in
-    // both cases and deliberately NOT used. Off the edge the header is simply not
-    // forwarded and `ctx.ip` reads `undefined`, which it is already documented to
-    // do. See `./trusted-client-ip.ts` for the behind-Cloudflare origin this
-    // deliberately pools, and what those deployments should do instead.
-    const clientIp = trustedClientIp(request.headers);
+    // both cases and deliberately NOT read by default. Off the edge the header is
+    // simply not forwarded and `ctx.ip` reads `undefined`, which it is already
+    // documented to do — unless a fronted origin declared its own trustworthy
+    // header via `trustedClientIpHeader`. See `./trusted-client-ip.ts`.
+    const clientIp = trustedClientIp(request.headers, trustedClientIpHeader);
 
     if (clientIp) {
         headers["x-lunora-client-ip"] = clientIp;
@@ -2712,7 +2763,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     // the orchestrated calls. No static token configured → nothing to mint, and
     // the operation fails closed downstream exactly as before.
     const resolveAdminForwardContext = async (request: Request, env: unknown): Promise<ForwardContext> => {
-        const context = await resolveForwardContext(request, env, options.resolveIdentity);
+        const context = await resolveForwardContext(request, env, options.resolveIdentity, options.trustedClientIpHeader);
 
         if (accessAdminGrants.has(request) && context.headers["authorization"] === undefined) {
             const token = effectiveAdminToken();
@@ -3708,7 +3759,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     const buildHttpActionContext = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<HttpActionContext> => {
-        const { claims, headers, userId } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { claims, headers, userId } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         const sinkContext = buildSinkContext(env, request, (promise) => context.waitUntil?.(promise));
 
@@ -3881,7 +3932,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // forwarded to the DO so the socket carries a verified userId (the basis
         // for trusted `onConnect`/`onDisconnect` lifecycle hooks). Mirrors the
         // RPC path's `resolveForwardContext` → `authorize*` ordering.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         await assertShardAuthorized(identity, shardKey);
 
@@ -3987,7 +4038,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // Resolve the caller's identity once and forward it to the voice DO so the
         // session's `agents:*` thread writes are attributed to the caller (RLS /
         // ownership). Same shape/authorization ordering as the RPC/WS paths.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         // Deliberately NOT `assertShardAuthorized`, and the difference is the
         // `else`: that helper default-denies only a NON-default shard, because its
@@ -4362,7 +4413,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         // Forward selected headers from the inbound request so the DO can
         // honour auth, sessions, and D1 read-your-writes consistency.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         await authorizeRpcEnvelope(envelope, identity);
 
@@ -4486,7 +4537,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // Use `publicResolveIdentity` (the contract-wrapped resolver) so this public
         // data path enforces `defineIdentity(...)` exactly like `handleRpc` — the raw
         // resolver would let contract-violating claims through to the shard verbatim.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         // Validate + group by target shard (throws on a malformed/reserved/oversized batch).
         const groups = groupBatchCallsByShard(calls, defaultShard);
@@ -4761,7 +4812,13 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // byte-identical to `handleRpc`'s. The context is passed explicitly
             // because this path has no `fetch` funnel to have recorded it, and an
             // SSR host may well hand us a rebuilt `Request` object.
-            const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, callOptions.context);
+            const { headers: forwardedHeaders, identity } = await resolveForwardContext(
+                request,
+                env,
+                publicResolveIdentity,
+                options.trustedClientIpHeader,
+                callOptions.context,
+            );
 
             // Run the IDENTICAL per-shard authorization gate. A `shardKey` of
             // `undefined` resolves to `defaultShard` for both the gate and the
@@ -4999,7 +5056,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         assertArgsObject(args, "REST");
 
         const envelope: RpcEnvelope = { args, functionPath, ...(shardKey === undefined ? {} : { shardKey }) };
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, options.trustedClientIpHeader);
 
         await authorizeRpcEnvelope(envelope, identity);
 

--- a/packages/runtime/src/rest-routes.ts
+++ b/packages/runtime/src/rest-routes.ts
@@ -269,6 +269,13 @@ const UNRESOLVED_IP_BUCKET = "no-trusted-ip";
  * to stop; those deployments pool into {@link UNRESOLVED_IP_BUCKET} instead, and
  * should pass `key` to identify callers by something they cannot forge.
  *
+ * An origin fronted by a proxy that stamps a client address can instead declare
+ * that header as `trustedClientIpHeader` and get per-IP buckets back, at the cost
+ * of asserting the header is unwritable by callers — the same assertion, and the
+ * same consequence for getting it wrong, as `WorkerOptions.trustedClientIpHeader`
+ * (which governs `ctx.ip`). Declare it in both places or the two disagree about
+ * who a request came from.
+ *
  * A rate rejection becomes a `429` with a `Retry-After` header (seconds, ceil of
  * the limiter's ms). A deny-list hit becomes a `403` and no `Retry-After` —
  * matching both `@lunora/ratelimit` entry points, and the only honest answer for
@@ -279,9 +286,13 @@ const UNRESOLVED_IP_BUCKET = "no-trusted-ip";
  * the worker entry and pass it here.
  */
 const createRestRateLimit =
-    (limiter: RateLimiterLike, options: { key?: (request: Request, functionPath: string) => string | undefined; name: string }): RestRateLimit =>
+    (
+        limiter: RateLimiterLike,
+        options: { key?: (request: Request, functionPath: string) => string | undefined; name: string; trustedClientIpHeader?: string },
+    ): RestRateLimit =>
     async (request, functionPath) => {
-        const key = (options.key ? options.key(request, functionPath) : trustedClientIp(request.headers)) ?? UNRESOLVED_IP_BUCKET;
+        const key =
+            (options.key ? options.key(request, functionPath) : trustedClientIp(request.headers, options.trustedClientIpHeader)) ?? UNRESOLVED_IP_BUCKET;
         const status = await limiter.limit(options.name, { key });
 
         if (status.ok) {

--- a/packages/runtime/src/trusted-client-ip.ts
+++ b/packages/runtime/src/trusted-client-ip.ts
@@ -3,40 +3,57 @@ import { onCloudflareEdge } from "../../../shared/on-cloudflare-edge";
 /**
  * The caller's IP for a request, or `undefined` when nothing trustworthy says.
  *
- * `cf-connecting-ip` is the only client-address header worth reading, and only
- * where {@link onCloudflareEdge} holds. Off the edge this deliberately resolves
- * NOTHING rather than falling back to `x-forwarded-for` or the raw header: both
- * are client-written there, and an attacker-chosen address is worse than a
- * missing one — it silently defeats every rate limit keyed on it while reading
- * as if the limit were enforced. Callers already handle the absent case (the
- * REST limiter falls into its shared `no-trusted-ip` bucket; `ctx.ip` is
- * documented optional).
+ * `cf-connecting-ip` is the only client-address header believed without being
+ * asked for, and only where {@link onCloudflareEdge} holds — there the edge
+ * stamps it over whatever the client sent. Off the edge nothing overwrites it,
+ * so by default this resolves NOTHING rather than falling back to
+ * `x-forwarded-for` or the raw header: both are client-written there, and an
+ * attacker-chosen address is worse than a missing one — it silently defeats
+ * every rate limit keyed on it while reading as if the limit were enforced.
+ * Callers already handle the absent case (the REST limiter falls into its shared
+ * `no-trusted-ip` bucket; `ctx.ip` is documented optional).
  *
- * This is `@lunora/runtime` policy, not a repo-wide one, and lives here for that
- * reason: it picks the header and it picks "resolve nothing" over a fallback.
- * `@lunora/auth` answers the same question differently — it accepts declared
- * `trustedProxies` and will then read an `x-forwarded-for` chain — and neither
- * package should inherit the other's choice by importing a shared helper that
- * made it. Only the "am I on Cloudflare?" predicate underneath is shared, so the
- * two cannot disagree about the runtime while disagreeing about the policy.
+ * `trustedClientIpHeader` is the operator's opt-out of that default, for the one
+ * deployment where the default is wrong rather than merely conservative: an
+ * origin sitting BEHIND a proxy that does stamp a client address. See the
+ * `WorkerOptions.trustedClientIpHeader` docblock for what declaring it asserts.
+ * It is the runtime's spelling of `@lunora/auth`'s `trustedProxies` opt-in — the
+ * same "off the edge, believe a header only once an operator has declared it"
+ * shape — but a header NAME rather than a list of proxy addresses, because the
+ * runtime never sees a peer address to match such a list against: `fetch` hands
+ * it a `Request` and nothing else, on workerd and on `@lunora/platform-node`
+ * alike. Declaring the header is the only assertion this layer can actually act
+ * on. Names are compared case-insensitively, as `Headers.get` already is.
  *
- * ## Deployments this makes worse, on purpose
+ * On the edge the declaration is ignored and `cf-connecting-ip` still wins:
+ * there the runtime knows the trustworthy answer without being told, and letting
+ * a config value override it could only make it worse.
  *
- * A `@lunora/platform-node` origin sitting BEHIND Cloudflare is the honest cost.
- * There the edge really does stamp `cf-connecting-ip`, and if the origin accepts
- * only Cloudflare traffic the header really is trustworthy — but this code runs
- * on the origin, where `navigator.userAgent` says Node, and nothing in a request
- * distinguishes that deployment from one exposed directly. So it resolves
- * nothing, and every caller pools into `no-trusted-ip`: one shared bucket any
- * single client can exhaust. That is a DIFFERENT failure mode, not a smaller
- * one — it trades "an attacker escapes their own limit" for "an attacker locks
- * out every honest caller".
+ * A value containing a comma is refused. That is the shape of an appended
+ * forwarding chain (`x-forwarded-for: <client>, <hop>`), whose leftmost entry is
+ * whatever the client typed — reading one as a single address would hand back
+ * exactly the attacker-chosen string this module exists to refuse, and the
+ * runtime has no chain walker to do better (`@lunora/auth` does, which is why
+ * its opt-in takes proxy addresses and can accept a chain). So the declaration
+ * only means anything for a header the fronting infrastructure REPLACES.
  *
- * Those deployments should pass an explicit `key` to `createRestRateLimit` (see
- * `packages/runtime/docs/index.mdx`), which is the one place that knows the
- * origin is fronted. There is no trusted-proxy switch here: the runtime has
- * nowhere to declare one, and a config knob that turns this gate back off is a
- * design decision, not a default.
+ * The rest of the policy stays `@lunora/runtime`'s own rather than shared:
+ * `@lunora/auth` answers the same question differently, and neither package
+ * should inherit the other's choice by importing a helper that made it. Only the
+ * "am I on Cloudflare?" predicate underneath is shared, so the two cannot
+ * disagree about the runtime while disagreeing about the policy.
  */
 // eslint-disable-next-line import/prefer-default-export -- named export: import sites stay uniform (`import { trustedClientIp }`), per the repo's no-default-mixing convention
-export const trustedClientIp = (headers: Headers): string | undefined => (onCloudflareEdge() ? (headers.get("cf-connecting-ip") ?? undefined) : undefined);
+export const trustedClientIp = (headers: Headers, trustedClientIpHeader: string | undefined): string | undefined => {
+    if (onCloudflareEdge()) {
+        return headers.get("cf-connecting-ip") ?? undefined;
+    }
+
+    if (trustedClientIpHeader === undefined) {
+        return undefined;
+    }
+
+    const value = headers.get(trustedClientIpHeader)?.trim();
+
+    return value === undefined || value === "" || value.includes(",") ? undefined : value;
+};


### PR DESCRIPTION
> **Stacked on #630** (`fix/r30-client-ip-trust`) — based on that branch, not `alpha`, so this diff is only the opt-in. Merge #630 first.

## Why

#630 stops the runtime trusting `cf-connecting-ip` off the edge, which is correct — off Cloudflare it is a client-typed header, and trusting it removes the limit entirely. Its consequence, raised in review and left documented there: off the edge the REST limiter's default key collapses to one shared bucket and `ctx.ip` is `undefined`.

For a bare Node host that is no change; the header was already absent. For a `@lunora/platform-node` process **behind** Cloudflare — where the edge does stamp it and the origin only accepts CF traffic — it trades "an attacker escapes their own limit" for "an attacker can lock out every honest caller". A different failure mode, not a smaller one.

#630's answer is "pass an explicit `key`". That covers the REST limiter and has **no equivalent for `ctx.ip`**, which has no callback — so such a deployment could not recover `ctx.ip` at all. That gap is what earns this option beyond a knob.

## The shape

`trustedClientIpHeader?: string`, on `WorkerOptions` (governing `ctx.ip`) and on `createRestRateLimit` (governing the limiter's key). On the edge, `cf-connecting-ip` still wins regardless. Off the edge with nothing declared, the fail-closed default from #630 is unchanged — the opt-in is the only thing that alters it.

It mirrors `@lunora/auth`, which already gates on `onCloudflareEdge()` and re-admits a header only once an operator declares `trustedProxies`. **It takes a header name rather than auth's proxy-address list, and that is forced rather than stylistic**: `fetch` hands the runtime a `Request` and nothing else. Grepping `remoteAddress|remoteAddr|socket.remote|peerAddress` across `runtime`, `platform` and `platform-node` returns **zero** hits — there is no peer address to match an address list against. better-auth can accept `trustedProxies` because it walks an XFF chain past declared hops; this layer has no chain walker.

That is also why a comma-bearing value is refused: that is the appended-chain shape whose leftmost entry is client-written, and reading it as one address would hand back exactly the attacker-chosen string this module exists to refuse.

## Verification

Four cases added, run against the unfixed tree first. Two failed for the right reason — the limiter keying both callers into `"no-trusted-ip"`, and `expected null to be '203.0.113.7'` for `ctx.ip`. **The other two pass vacuously against unfixed code** and are flagged as such in the report rather than counted as regressions: with no opt-in support the answer is already "resolve nothing" and "cf-connecting-ip wins". They are guards against the fix over-reaching, which matters here — a fix that trusted the header everywhere would re-open the original hole.

All seven repo gates green; `api:check` drifted exactly by the two new fields and the snapshot is committed.

## One rough edge, kept rather than papered over

`createRestRateLimit` builds its closure before `createWorker` is called, so the worker cannot inject its own value without changing the `RestRateLimit` contract. Both docblocks and the docs example say to set both, or the two disagree about who a request came from. Unifying them means restructuring that seam, which is worth a reviewer's opinion rather than a silent decision.

Also fixed here: `concepts/rest-api.mdx` still said the default "keys on the caller's IP (`CF-Connecting-IP`)" unconditionally — already wrong as of #630, which missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ
