### PR TITLE
feat(codegen): discover the crons configured on createWorker

### DIFF
--- a/packages/codegen/__tests__/discover/worker-entry-crons.test.ts
+++ b/packages/codegen/__tests__/discover/worker-entry-crons.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { Project } from "ts-morph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import discoverWorkerEntryCrons from "../../src/discover/worker-entry-crons";
+
+let workdir: string;
+let project: Project;
+
+/** Write a project-relative source file — the worker entry lives outside `lunora/`. */
+const writeAt = (relative: string, source: string): string => {
+    const path = join(workdir, relative);
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, source, "utf8");
+
+    return path;
+};
+
+const discover = (): string[] => discoverWorkerEntryCrons(project, join(workdir, "lunora"));
+
+describe("discoverWorkerEntryCrons", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-entry-crons-"));
+        mkdirSync(join(workdir, "lunora"), { recursive: true });
+        project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("reads a string-literal backupCron from the worker entry", () => {
+        expect.assertions(1);
+
+        writeAt("src/server/index.ts", `export default createWorker({ backupCron: "0 3 * * *", backupStore: env.BACKUPS });`);
+
+        expect(discover()).toStrictEqual(["0 3 * * *"]);
+    });
+
+    it("reads the keys of a crons handler map, in source order after backupCron", () => {
+        expect.assertions(1);
+
+        writeAt(
+            "src/server/index.ts",
+            `export default createWorker({
+                backupCron: "0 3 * * *",
+                crons: { "*/15 * * * *": async () => {}, "0 0 1 * *": rollUp },
+            });`,
+        );
+
+        expect(discover()).toStrictEqual(["0 3 * * *", "*/15 * * * *", "0 0 1 * *"]);
+    });
+
+    it("reads a backtick-quoted backupCron", () => {
+        expect.assertions(1);
+
+        // A `crons` KEY has no such form — a bare template literal is not a legal
+        // property name — so backticks only ever reach the `backupCron` read.
+        writeAt("src/index.ts", "export default createWorker({ backupCron: `0 3 * * *` });");
+
+        expect(discover()).toStrictEqual(["0 3 * * *"]);
+    });
+
+    it("reads a shorthand-method crons key", () => {
+        expect.assertions(1);
+
+        writeAt("src/worker.ts", `export default createWorker({ crons: { "0 6 * * 1"() { return sweep(); } } });`);
+
+        expect(discover()).toStrictEqual(["0 6 * * 1"]);
+    });
+
+    // The residue the `package.json` `lunora.crons` ownership record exists for:
+    // `.extend(fn)` is a supported way to configure `backupCron`, so a computed
+    // one is legitimate code no AST scan can resolve. It must read as
+    // hand-written, not be invented as a literal.
+    it.each([
+        ["a computed backupCron", `export default createWorker({ backupCron: env.NIGHTLY_CRON });`],
+        ["a template-substituted backupCron", `export default createWorker({ backupCron: \`0 \${hour} * * *\` });`],
+        ["a computed crons key", `export default createWorker({ crons: { [env.SWEEP_CRON]: sweep } });`],
+        ["an identifier crons key", `export default createWorker({ crons: { nightly: sweep } });`],
+        ["a spread crons map", `export default createWorker({ crons: { ...baseCrons } });`],
+        ["an opaque options object", `export default createWorker(options);`],
+    ])("finds nothing in %s", (_label, source) => {
+        expect.assertions(1);
+
+        writeAt("src/server/index.ts", source);
+
+        expect(discover()).toStrictEqual([]);
+    });
+
+    it("reads the object literal an .extend() callback returns, in both body forms", () => {
+        expect.assertions(1);
+
+        writeAt("src/server/index.ts", `export default app.extend(() => ({ backupCron: "0 4 * * *" })).build();`);
+        writeAt(
+            "src/server/nightly.ts",
+            `export const withSweep = (builder) =>
+                builder.extend((env) => {
+                    return { crons: { "0 5 * * *": sweep } };
+                });`,
+        );
+
+        // File order across the entry roots is not something this pins.
+        expect(discover().toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["0 4 * * *", "0 5 * * *"]);
+    });
+
+    it("finds nothing in an .extend() callback whose body is not a literal", () => {
+        expect.assertions(1);
+
+        writeAt(
+            "src/server/index.ts",
+            `export default app.extend((env) => {
+                const overrides = { backupCron: env.NIGHTLY_CRON };
+
+                return overrides;
+            }).build();`,
+        );
+
+        expect(discover()).toStrictEqual([]);
+    });
+
+    it("scans lunora/ too, so an entry helper kept there is not missed", () => {
+        expect.assertions(1);
+
+        writeAt("lunora/worker-options.ts", `export const options = createWorker({ backupCron: "0 2 * * *" });`);
+
+        expect(discover()).toStrictEqual(["0 2 * * *"]);
+    });
+
+    it("ignores a createWorker call outside the entry roots", () => {
+        expect.assertions(1);
+
+        writeAt("src/components/Preview.ts", `export const fake = createWorker({ backupCron: "0 3 * * *" });`);
+
+        expect(discover()).toStrictEqual([]);
+    });
+
+    it("deduplicates an expression declared twice", () => {
+        expect.assertions(1);
+
+        writeAt("src/server/index.ts", `export default createWorker({ backupCron: "0 3 * * *", crons: { "0 3 * * *": alsoAtThree } });`);
+
+        expect(discover()).toStrictEqual(["0 3 * * *"]);
+    });
+});

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -1225,6 +1225,84 @@ export default schema;
             expect(withIndex.generated.app).toContain("indexes: this.shardExtras.vectors(env as unknown as Record<string, unknown>),");
         });
 
+        it("adds a worker entry's static backupCron and crons keys to the wrangler trigger set", () => {
+            expect.assertions(4);
+
+            mkdirSync(join(workdir, "src", "server"), { recursive: true });
+            writeFileSync(
+                join(workdir, "src", "server", "index.ts"),
+                `import { createWorker } from "@lunora/runtime";
+
+export default createWorker({
+    backupCron: "0 3 * * *",
+    crons: { "*/15 * * * *": async () => {} },
+});
+`,
+                "utf8",
+            );
+            writeFileSync(
+                join(workdir, "lunora", "crons.ts"),
+                `import { cronJobs } from "@lunora/scheduler";
+import { internal } from "./_generated/api.js";
+const crons = cronJobs();
+crons.cron("ping", "0 * * * *", internal.messages.list, {});
+export default crons;
+`,
+                "utf8",
+            );
+
+            const result = runCodegen({ lint: false, projectRoot: workdir });
+
+            // Declared crons lead, in the order `emitWranglerCronTriggers` renders
+            // them; entry-derived expressions append.
+            expect(result.cronTriggers).toStrictEqual(["0 * * * *", "0 3 * * *", "*/15 * * * *"]);
+            // Neither entry expression names a dispatchable job — `createWorker`
+            // runs those itself — so the generated dispatcher map must not grow one.
+            expect(result.generated.crons).toContain('"0 * * * *"');
+            expect(result.generated.crons).not.toContain("0 3 * * *");
+            expect(result.generated.crons).not.toContain("*/15 * * * *");
+        });
+
+        it("leaves a computed backupCron out of the trigger set, for the ownership record to preserve", () => {
+            expect.assertions(1);
+
+            mkdirSync(join(workdir, "src", "server"), { recursive: true });
+            writeFileSync(
+                join(workdir, "src", "server", "index.ts"),
+                `import { createWorker } from "@lunora/runtime";
+
+export default createWorker({ backupCron: process.env.NIGHTLY_CRON });
+`,
+                "utf8",
+            );
+
+            const result = runCodegen({ lint: false, projectRoot: workdir });
+
+            // Out of reach for any AST scan, which is why `package.json`'s
+            // `lunora.crons` ownership record stays: `reconcileWranglerCrons` keeps
+            // an entry that is in neither the generated set nor that record — see
+            // `@lunora/config`'s reconcile-crons tests.
+            expect(result.cronTriggers).toStrictEqual([]);
+        });
+
+        it("reads a backupCron out of an `.extend()` callback's returned literal", () => {
+            expect.assertions(1);
+
+            mkdirSync(join(workdir, "src", "server"), { recursive: true });
+            writeFileSync(
+                join(workdir, "src", "server", "index.ts"),
+                `import app from "../../lunora/_generated/app.js";
+
+export default app.extend(() => ({ backupCron: "0 4 * * *" })).build();
+`,
+                "utf8",
+            );
+
+            const result = runCodegen({ lint: false, projectRoot: workdir });
+
+            expect(result.cronTriggers).toStrictEqual(["0 4 * * *"]);
+        });
+
         it("does not emit a seed client for a project that doesn't depend on @lunora/seed", () => {
             expect.assertions(1);
 

--- a/packages/codegen/src/declaration-surface.ts
+++ b/packages/codegen/src/declaration-surface.ts
@@ -49,6 +49,7 @@ import { discoverPlatformSignals } from "./discover/platform-signals";
 import { discoverQueues } from "./discover/queues";
 import { discoverSandboxUsage } from "./discover/sandbox";
 import discoverStorageRulesMetadata from "./discover/storage-rules";
+import discoverWorkerEntryCrons from "./discover/worker-entry-crons";
 import { discoverWorkflows } from "./discover/workflows";
 import { buildStorageColumns, emitDataModel, emitServer } from "./emit";
 import type { AgentIR, ContainerIR, CronJobIR, EnvIR, IdentityIR, QueueIR, SchemaIR, StorageRulesMetadataIR, WorkflowIR } from "./ir";
@@ -134,6 +135,14 @@ interface DeclarationSurface {
     declaredDependencies: ReadonlySet<string> | undefined;
     /** The same names with the absent case flattened to an empty set. */
     dependencies: ReadonlySet<string>;
+
+    /**
+     * Cron expressions the worker entry pins outside `lunora/crons.ts` —
+     * `createWorker({ backupCron })` and the keys of `createWorker({ crons })`.
+     * Not jobs (`createWorker` dispatches them itself), only schedules that must
+     * reach wrangler's `triggers.crons`.
+     */
+    entryCronTriggers: ReadonlyArray<string>;
     env: EnvIR | undefined;
 
     /**
@@ -218,6 +227,13 @@ const buildDeclarationSurface = (options: DeclarationSurfaceOptions): Declaratio
     // nothing from `_generated/`, which `listLunoraSourceFiles` skips, so moving
     // it earlier cannot change what it finds.
     const crons = discoverCrons(project, lunoraDirectory, workflows, agents);
+
+    // The other two cron surfaces, which are configured on `createWorker` rather
+    // than registered through `cronJobs()` and so are invisible to the discoverer
+    // above. They produce no job — only schedules the wrangler reconciler has to
+    // know it generated. Read beside the crons for that reason alone; nothing in
+    // this phase consumes them.
+    const entryCronTriggers = discoverWorkerEntryCrons(project, lunoraDirectory);
 
     // Intersect what the app uses with what the deploy target supports. For the
     // default Cloudflare target the matrix marks nothing unsupported, so the gate
@@ -306,6 +322,7 @@ const buildDeclarationSurface = (options: DeclarationSurfaceOptions): Declaratio
         dataModelContent: emitDataModel(schema),
         declaredDependencies,
         dependencies,
+        entryCronTriggers,
         env,
         featureUsage,
         hasFlags,

--- a/packages/codegen/src/discover/ast.ts
+++ b/packages/codegen/src/discover/ast.ts
@@ -2,7 +2,7 @@ import type { Stats } from "node:fs";
 import { lstatSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { dirname, extname, join, relative, sep } from "node:path";
 
-import type { CallExpression, Expression, Project, SourceFile } from "ts-morph";
+import type { Block, CallExpression, Expression, ObjectLiteralExpression, Project, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
 import { diagnosticAt } from "../diagnostics";
@@ -515,6 +515,45 @@ const stringPropertyOf = (object: Node, name: string): string | undefined => {
     return initializer && Node.isStringLiteral(initializer) ? initializer.getLiteralText() : undefined;
 };
 
+/** The sole statement of a single-statement `{ return {...}; }` block, when it returns an object literal. */
+const objectLiteralFromReturnBlock = (block: Block): ObjectLiteralExpression | undefined => {
+    const statements = block.getStatements();
+    const [statement] = statements;
+
+    if (statements.length !== 1 || statement === undefined || !Node.isReturnStatement(statement)) {
+        return undefined;
+    }
+
+    const expression = statement.getExpression();
+
+    return expression !== undefined && Node.isObjectLiteralExpression(expression) ? expression : undefined;
+};
+
+/**
+ * The object literal a callback body evaluates to, covering the concise-body
+ * form (`() => ({...})`, where the parens make the object literal the whole
+ * body) and the block-body form (`() => { return {...}; }`). Anything else
+ * (a variable, a multi-statement block, a conditional) is not analyzable.
+ *
+ * Shared by the two readers of the generated `.extend(fn)` escape hatch —
+ * `discover/config-calls` (which keys) and `discover/worker-entry-crons` (which
+ * cron expressions) — because they must agree on which `.extend()` bodies are
+ * statically readable at all.
+ */
+const objectLiteralFromCallbackBody = (body: Node): ObjectLiteralExpression | undefined => {
+    if (Node.isObjectLiteralExpression(body)) {
+        return body;
+    }
+
+    if (Node.isParenthesizedExpression(body)) {
+        const inner = body.getExpression();
+
+        return Node.isObjectLiteralExpression(inner) ? inner : undefined;
+    }
+
+    return Node.isBlock(body) ? objectLiteralFromReturnBlock(body) : undefined;
+};
+
 /** True when `node` is the literal `ctx` identifier — the anchor a `ctx.flags.*` read starts from. */
 const isContextIdentifier = (node: Node): boolean => Node.isIdentifier(node) && node.getText() === "ctx";
 
@@ -548,6 +587,7 @@ export {
     listLunoraSourceFiles,
     listSecurityScanFiles,
     lunoraRelativePath,
+    objectLiteralFromCallbackBody,
     propertyInitializer,
     readTargetOf,
     stringPropertyFor,

--- a/packages/codegen/src/discover/config-calls.ts
+++ b/packages/codegen/src/discover/config-calls.ts
@@ -1,11 +1,11 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import type { ArrowFunction, Block, FunctionExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile } from "ts-morph";
+import type { ArrowFunction, FunctionExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
 import type { ConfigCallIR } from "../ir";
-import { listSecurityScanFiles } from "./ast";
+import { listSecurityScanFiles, objectLiteralFromCallbackBody } from "./ast";
 import { calleeName } from "./callee";
 
 /**
@@ -96,40 +96,6 @@ const keysFromObjectLiteral = (objectLiteral: ObjectLiteralExpression): ConfigCa
  */
 const readConfigArgument = (argument: TsNode | undefined): ConfigCallEvidence =>
     argument && Node.isObjectLiteralExpression(argument) ? keysFromObjectLiteral(argument) : { analyzable: false, presentKeys: [], trueKeys: [] };
-
-/** The sole statement of a single-statement `{ return {...}; }` block, when it returns an object literal. */
-const objectLiteralFromReturnBlock = (block: Block): ObjectLiteralExpression | undefined => {
-    const statements = block.getStatements();
-    const [statement] = statements;
-
-    if (statements.length !== 1 || statement === undefined || !Node.isReturnStatement(statement)) {
-        return undefined;
-    }
-
-    const expression = statement.getExpression();
-
-    return expression !== undefined && Node.isObjectLiteralExpression(expression) ? expression : undefined;
-};
-
-/**
- * The object literal a callback body evaluates to, covering the concise-body
- * form (`() => ({...})`, where the parens make the object literal the whole
- * body) and the block-body form (`() => { return {...}; }`). Anything else
- * (a variable, a multi-statement block, a conditional) is not analyzable.
- */
-const objectLiteralFromCallbackBody = (body: TsNode): ObjectLiteralExpression | undefined => {
-    if (Node.isObjectLiteralExpression(body)) {
-        return body;
-    }
-
-    if (Node.isParenthesizedExpression(body)) {
-        const inner = body.getExpression();
-
-        return Node.isObjectLiteralExpression(inner) ? inner : undefined;
-    }
-
-    return Node.isBlock(body) ? objectLiteralFromReturnBlock(body) : undefined;
-};
 
 /**
  * Read a callback argument (an arrow function or function expression) whose

--- a/packages/codegen/src/discover/worker-entry-crons.ts
+++ b/packages/codegen/src/discover/worker-entry-crons.ts
@@ -1,0 +1,133 @@
+import type { CallExpression, ObjectLiteralExpression, Project } from "ts-morph";
+import { Node, SyntaxKind } from "ts-morph";
+
+import { listSecurityScanFiles, objectLiteralFromCallbackBody, propertyInitializer } from "./ast";
+import { calleeName } from "./callee";
+
+/** The runtime worker factory whose options object pins cron expressions. */
+const WORKER_FACTORY = "createWorker";
+
+/**
+ * The generated `AppBuilder` escape hatch: `.extend((env, derived) =>
+ * Partial<WorkerOptions>)`, whose result is merged straight into the
+ * `createWorker(...)` options at runtime. Matched by method name only — the same
+ * import-agnostic convention `discover/config-calls` uses for the same call.
+ */
+const EXTEND_METHOD = "extend";
+
+/**
+ * A node's literal string value in either quoting the config could use, or
+ * `undefined` for anything the compiler would have to evaluate. A substituted
+ * template (`` `0 ${hour} * * *` ``) is deliberately NOT a
+ * `NoSubstitutionTemplateLiteral`, so it falls out here with the rest of the
+ * computed forms.
+ */
+const literalText = (node: Node | undefined): string | undefined =>
+    node !== undefined && (Node.isStringLiteral(node) || Node.isNoSubstitutionTemplateLiteral(node)) ? node.getLiteralValue() : undefined;
+
+/**
+ * The cron expressions a `WorkerOptions` object literal pins, in source order:
+ * the `backupCron` literal, then every statically-named key of the `crons`
+ * handler map.
+ *
+ * A cron expression contains spaces, so a `crons` key is ALWAYS a quoted name —
+ * an identifier key cannot spell one. That is why only literal keys are read: a
+ * computed key (`[env.CRON]: handler`) or a spread is out of reach, not merely
+ * unusual.
+ */
+const cronsFromWorkerOptions = (options: ObjectLiteralExpression): string[] => {
+    const found: string[] = [];
+    const backupCron = literalText(propertyInitializer(options, "backupCron"));
+
+    if (backupCron !== undefined) {
+        found.push(backupCron);
+    }
+
+    const handlers = propertyInitializer(options, "crons");
+
+    if (handlers === undefined || !Node.isObjectLiteralExpression(handlers)) {
+        return found;
+    }
+
+    for (const property of handlers.getProperties()) {
+        if (!Node.isPropertyAssignment(property) && !Node.isMethodDeclaration(property)) {
+            continue;
+        }
+
+        const key = literalText(property.getNameNode());
+
+        if (key !== undefined) {
+            found.push(key);
+        }
+    }
+
+    return found;
+};
+
+/**
+ * The cron expressions one call contributes: the options literal a
+ * `createWorker({...})` is passed, or the literal an `.extend(fn)` callback
+ * returns. Empty for every other call, and for an argument that is not a
+ * statically readable literal.
+ */
+const cronsFromCall = (call: CallExpression): string[] => {
+    const name = calleeName(call.getExpression());
+    const [argument] = call.getArguments();
+
+    if (argument === undefined) {
+        return [];
+    }
+
+    if (name === WORKER_FACTORY) {
+        return Node.isObjectLiteralExpression(argument) ? cronsFromWorkerOptions(argument) : [];
+    }
+
+    if (name !== EXTEND_METHOD || !(Node.isArrowFunction(argument) || Node.isFunctionExpression(argument))) {
+        return [];
+    }
+
+    const returned = objectLiteralFromCallbackBody(argument.getBody());
+
+    return returned === undefined ? [] : cronsFromWorkerOptions(returned);
+};
+
+/**
+ * The cron expressions the worker entry pins outside `lunora/crons.ts`:
+ * `createWorker({ backupCron })` (the nightly NDJSON backup, compared verbatim
+ * against the firing trigger) and the keys of `createWorker({ crons })`
+ * (handlers dispatched by exact expression). Both need an entry in wrangler's
+ * `triggers.crons` to fire at all, and neither is a `cronJobs()` registration,
+ * so `discover/crons` never saw them — which is why the cron reconciler used to
+ * delete them.
+ *
+ * Scans the worker-entry file set as well as `lunora/` (see
+ * {@link listSecurityScanFiles}) for the same reason the config-call lints do:
+ * `createWorker` is called from the entry by convention and never from under
+ * `lunora/`.
+ *
+ * **Deliberately incomplete, and the reconciler's ownership record is what
+ * covers the rest.** `.extend((env) => ({ backupCron: env.NIGHTLY_CRON }))` is a
+ * documented, supported way to configure this, and no AST scan can resolve it;
+ * the same goes for a spread, a variable, or a computed `crons` key. Discovery
+ * buys the common static case — an expression found here is one the reconciler
+ * knows it OWNS, so it is cleared when the entry stops declaring it, rather than
+ * merely surviving as "not ours". Anything it cannot read falls back to
+ * `package.json`'s `lunora.crons` record, which keeps an unrecognised entry
+ * instead of deleting it. Removing that record on the strength of this scan
+ * would reinstate the deletion bug for every dynamically-configured app.
+ */
+const discoverWorkerEntryCrons = (project: Project, lunoraDirectory: string): string[] => {
+    const found: string[] = [];
+
+    for (const { filePath } of listSecurityScanFiles(lunoraDirectory)) {
+        const sourceFile = project.getSourceFile(filePath) ?? project.addSourceFileAtPath(filePath);
+
+        for (const call of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+            found.push(...cronsFromCall(call));
+        }
+    }
+
+    return [...new Set(found)];
+};
+
+export default discoverWorkerEntryCrons;

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -608,6 +608,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         crons,
         dataModelContent,
         dependencies,
+        entryCronTriggers,
         env,
         featureUsage,
         hasFlags,
@@ -1062,7 +1063,11 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         advisorContext,
         agents,
         containers,
-        cronTriggers: emitWranglerCronTriggers(crons),
+        // Declared jobs plus the schedules `createWorker` is configured with
+        // directly (`backupCron`, `crons` keys). Both need a wrangler trigger to
+        // fire, and both count against Cloudflare's per-worker Cron Trigger cap,
+        // so the reconciler and the CLI's limit warning have to see one list.
+        cronTriggers: [...new Set([...emitWranglerCronTriggers(crons), ...entryCronTriggers])],
         generated: {
             agents: agentsContent,
             api: apiContent,

--- a/packages/config/__tests__/reconcile-crons.test.ts
+++ b/packages/config/__tests__/reconcile-crons.test.ts
@@ -114,12 +114,15 @@ describe("reconcileWranglerCrons", () => {
         expect(readManaged(workdir)).toBeUndefined();
     });
 
-    it("preserves a hand-written trigger the project's crons.ts never declared, and reports it", () => {
+    it("preserves a trigger codegen could not derive — a computed backupCron — and reports it", () => {
         expect.assertions(3);
 
-        // `backupCron` / `createWorker({ crons })` are documented as needing a
-        // hand-written `triggers.crons` entry, and codegen cannot see either — so
-        // an entry Lunora never generated is the user's and must survive.
+        // Codegen reads a LITERAL `createWorker({ backupCron })` out of the worker
+        // entry, so the static case arrives in the generated set. This is the case
+        // it cannot: `.extend((env) => ({ backupCron: env.NIGHTLY_CRON }))` is a
+        // supported way to configure the backup and its value exists only at
+        // runtime. An entry Lunora never generated is the user's and must survive
+        // — this is the interaction that keeps the ownership record necessary.
         writeWrangler(workdir, '{\n    "triggers": { "crons": ["0 3 * * *"] }\n}\n');
         writeManifest(workdir);
 

--- a/packages/config/src/cloudflare/reconcile-crons.ts
+++ b/packages/config/src/cloudflare/reconcile-crons.ts
@@ -184,14 +184,23 @@ const recordManagedCrons = (manifest: Manifest, managed: ReadonlyArray<string>):
  * config `triggers.crons` array, preserving comments and formatting via
  * `jsonc-parser`'s structural edits.
  *
- * **This does not own the whole array.** Two runtime cron surfaces are invisible
- * to codegen and are documented as needing a hand-written `triggers.crons` entry:
- * `createWorker({ backupCron })` (the nightly NDJSON backup) and
- * `createWorker({ crons })` (handlers keyed by expression). Replacing the array
+ * **This does not own the whole array.** Two runtime cron surfaces live on
+ * `createWorker` rather than in `lunora/crons.ts`: `backupCron` (the nightly
+ * NDJSON backup) and `crons` (handlers keyed by expression). Replacing the array
  * wholesale deleted both on the next `lunora deploy` or dev-server schema save,
  * silently — the nightly backup simply stopped. So an entry this reconciler did
  * not generate is the user's, is kept, and is reported in
  * {@link ReconcileResult.preserved}.
+ *
+ * Codegen now scans the worker entry for both, so the STATIC case arrives in
+ * `cronTriggers` like any declared cron — kept because it is generated, and
+ * cleared when the entry stops declaring it. What it cannot resolve is the
+ * dynamic case, and that case is supported: `.extend((env) => ({ backupCron:
+ * env.NIGHTLY_CRON }))` is the documented escape hatch, and its value exists
+ * only at runtime. That residue — plus a computed `crons` key, a spread options
+ * object, and anything a project put in `triggers.crons` for its own reasons —
+ * is what the preserve rule below is for. It is not redundant with discovery; it
+ * is the half discovery provably cannot reach.
  *
  * Ownership is recorded in the project's `package.json` under `lunora.crons`,
  * which is why a REMOVED generated cron still gets cleared (it is in the record

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -122,7 +122,7 @@ let worker: LunoraWorker | null = null;
 const build = (env: BackupEnv): LunoraWorker =>
     (worker ??= createWorker({
         adminToken: env.LUNORA_ADMIN_TOKEN,
-        backupCron: "0 3 * * *", // must match an entry in wrangler `triggers.crons`, verbatim
+        backupCron: "0 3 * * *", // a literal is written into wrangler `triggers.crons` for you
         backupRetain: 14,
         backupStore: env.BACKUPS, // a bound R2 bucket satisfies `BackupStore`
         queryCoordinator, // the export walks every shard through it
@@ -138,7 +138,7 @@ export default {
 Five things are easy to get wrong, and four of them fail silently:
 
 - **`scheduled` must be wired.** `createWorker` returns it, but a worker that only exports `fetch` never runs a backup, and nothing reports that.
-- **`backupCron` is compared verbatim** against the firing expression. `"0 3 * * *"` and `"0  3 * * *"` are different strings, and the mismatch is silent — the trigger fires, no backup runs.
+- **`backupCron` is compared verbatim** against the firing expression. `"0 3 * * *"` and `"0  3 * * *"` are different strings, and the mismatch is silent — the trigger fires, no backup runs. A literal is discovered by codegen and written into `triggers.crons`; a computed one (`env.NIGHTLY_CRON`, or one supplied via `.extend()`) is not, so that entry is yours to add — the reconciler will not remove it.
 - **`backupStore`, `adminToken` and `queryCoordinator` are all required.** The snapshot is assembled by walking every shard's admin export route, so it needs the coordinator to reach them and a token to authorize itself. Missing any one throws `BACKUP_NOT_CONFIGURED` from inside the scheduled handler — the one failure here that is loud.
 - **`backupRetain` does not delete anything.** It is a reporting window: each run logs how many snapshots sit past the newest N and tells you to run `lunora backup prune`, which is the only thing that removes a backup. A bucket therefore grows until you prune it.
 - **The snapshot is built in memory.** It is capped at 24 MiB and refuses past it, writing nothing — narrow it with `backupTables`, or take that snapshot off-platform with `lunora backup create --bucket`.

--- a/packages/runtime/docs/index.mdx
+++ b/packages/runtime/docs/index.mdx
@@ -183,7 +183,7 @@ const build = (env: Env): LunoraWorker =>
         // Built-in backup: on this cron, export every table to NDJSON and write
         // it (plus a manifest sidecar) to the bound R2 bucket.
         backupStore: env.BACKUPS, // any R2 bucket binding
-        backupCron: "0 3 * * *", // must match a wrangler triggers.crons entry
+        backupCron: "0 3 * * *", // a literal here is written into triggers.crons for you
         backupRetain: 14, // the window: `lunora backup prune` keeps the newest 14
         // backupPrefix: "backups/", // key prefix (default)
         // backupTables: ["users"],  // omit to back up every table
@@ -313,11 +313,17 @@ available; the snapshot is still readable with `wrangler r2 object get`.
 ```
 
 The `crons` array must contain the exact `backupCron` string; Wrangler only
-delivers triggers it declares. `lunora deploy` and the dev server rewrite
-`triggers.crons` from your `lunora/crons.ts`, but they only ever remove entries
-they generated — the set they own is recorded in your `package.json` under
-`lunora.crons`, and an entry you hand-wrote for `backupCron` is left alone and
-reported as kept. To restore a scheduled snapshot, download the NDJSON object and
+delivers triggers it declares. `lunora deploy` and the dev server write
+`triggers.crons` for you: codegen reads your `lunora/crons.ts` registrations
+**and** the `backupCron` / `crons` keys your worker entry passes to
+`createWorker`, so a string literal like the one above needs no hand-editing.
+
+A value codegen cannot read statically — `backupCron: env.NIGHTLY_CRON`, or one
+supplied through `.extend((env) => ({ … }))` — still needs its own
+`triggers.crons` entry, and that entry is safe to add: these commands only ever
+remove entries they generated, the set they own being recorded in your
+`package.json` under `lunora.crons`. Anything else is left alone and reported as
+kept. To restore a scheduled snapshot, download the NDJSON object and
 feed it to `lunora backup restore <file>` (optionally with `--to <time>` for
 point-in-time replay).
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -903,6 +903,12 @@ interface WorkerOptions {
      * with this exact expression fires. Must match an entry in the worker's
      * wrangler `triggers.crons` (and the string is compared verbatim). Omit it
      * and no automatic backup runs.
+     *
+     * A **string literal** here is discovered by codegen and written into
+     * `triggers.crons` by `lunora deploy` / the dev server. A value it cannot
+     * read statically — a variable, or one supplied through `.extend((env) => ({
+     * … }))` — needs the trigger entry added by hand; it will not be removed,
+     * because the reconciler only clears entries it recorded as its own.
      */
     backupCron?: string;
 
@@ -958,6 +964,11 @@ interface WorkerOptions {
      * `scheduled()` entry dispatches the handler whose key equals the firing
      * trigger's `cron`. Independent of the built-in backup — a handler keyed on
      * the same expression as {@link WorkerOptions.backupCron} runs alongside it.
+     *
+     * Quoted keys of an object literal here are discovered by codegen and
+     * written into wrangler's `triggers.crons`; a computed key (`[env.SWEEP]:`)
+     * or a spread map needs its trigger entry by hand, on the same terms as
+     * {@link WorkerOptions.backupCron}.
      */
     crons?: Record<string, CronHandler>;
 


### PR DESCRIPTION
> **Stacked on #629** (`fix/r30-schedule-provisioning`) — based on that branch, not `alpha`, so this diff is only the discovery. Merge #629 first.

## Why

#629 stops `lunora deploy` deleting hand-written `triggers.crons` entries, by recording which crons codegen generated in `package.json` → `lunora.crons`. That record exists because two cron surfaces are invisible to codegen: `createWorker({ backupCron })` and `createWorker({ crons })`, both documented as needing a hand-written wrangler entry.

This makes the common case visible. A `backupCron: "0 3 * * *"` literal in the worker entry is now a cron codegen knows it owns — so it is kept for the right reason rather than merely preserved as "not ours", and it is **cleared correctly when removed**, which the ownership record alone cannot do for it.

## The record stays — the proposal to delete it does not hold

The review that suggested this discovery argued it would make the generated set complete and let the ownership record be deleted. It cannot.

`.extend(fn)` is the generated escape hatch: `(env, derived) => Partial<WorkerOptions>`, merged straight into the `createWorker` options. Both `backupCron` and `crons` are members of `WorkerOptions`, and the emitted `AppBuilder` applies every `extendFn` to the built options at runtime. So `.extend((env) => ({ backupCron: env.NIGHTLY_CRON }))` is legitimate and no AST scan can resolve it — discovery is **structurally** incomplete, not incidentally so. The record is the safety net for exactly that residue; removing it would reintroduce #629's deletion bug for dynamically-configured apps, with a smaller blast radius and no signal.

## What it reads, and what it cannot

`packages/codegen/src/discover/worker-entry-crons.ts` scans the existing worker-entry file set — the same `listSecurityScanFiles` five security lints already use — for `createWorker({…})` option literals and for the literal an `.extend(fn)` callback returns.

Reachable: `backupCron` as a string or untagged template literal, on either surface, with a concise body or a single-`return` block; `crons` keys as string literals, including the shorthand-method form. Deduped, then unioned into the `cronTriggers` both the reconciler and the CLI's Cron-Trigger-limit warning consume.

Out of reach, each pinned by a test asserting **nothing** is found: a variable or member expression, a substituted template, a computed or identifier `crons` key, a spread map, an opaque options object, a multi-statement `.extend` body, and a `createWorker` call outside the entry roots.

`objectLiteralFromCallbackBody` moved into `discover/ast.ts` rather than being duplicated — both readers of `.extend(fn)` must agree on which bodies are statically readable.

## Verification

Against unfixed code the two positive tests fail for the right reason (`expected [] to strictly equal [ '0 4 * * *' ]`, and the missing `"0 3 * * *"` in the trigger set); the computed-`backupCron` test passes both before and after, which is correct — it must never be discovered.

The interaction is pinned where it matters: `reconcile-crons.test.ts`'s existing preserve test was retitled from "a hand-written trigger the project's crons.ts never declared" to "a trigger codegen could not derive — a computed backupCron", because its old rationale is now false for half the cases while its assertions still cover the right half.

Fixtures are codegen unit plus a `runCodegen` integration test that writes a real `src/server/index.ts` and runs the whole wiring — rather than putting a `backupCron` into a demo app with no use for one. No example sets these options, so `check-generated-files.mjs` reports no regeneration.

All seven repo gates green.

## Considered and skipped

Folding `entryCronTriggers` into the platform-gate signal — a `backupCron` on a host whose matrix rates `cronTriggers` unsupported is inert, so it is arguably honest, but it changes gate output for apps that pass silently today and no `ctx.*` surface is being added, so the platform-parity rule does not compel it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically includes literal worker backup and scheduled cron configurations in generated deployment triggers.
  * Supports cron schedules configured directly on worker definitions and extensions, with duplicate schedules removed.

* **Documentation**
  * Clarified that dynamically computed or spread cron configurations must be added to deployment triggers manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->