### PR TITLE
refactor(cloud): read rows through the generated types, and back the control plane up

### DIFF
--- a/apps/cloud/.dev.vars.example
+++ b/apps/cloud/.dev.vars.example
@@ -14,6 +14,13 @@ AUTH_SECRET=replace-with-openssl-rand-hex-32
 # create D1/R2 and upload tenant Workers into the dispatch namespace.
 CLOUDFLARE_API_TOKEN=replace-with-cloudflare-api-token
 
+# Control-plane backups (GAPS.md D1). The export REST call addresses the database
+# by uuid, and a binding cannot answer its own id, so it is configured here.
+# Unset -> the six-hourly backup sweep no-ops. Pair with a PRIVATE R2 bucket
+# bound as BACKUPS in wrangler config: the dump holds every sealed admin token
+# and auth session in the cell. Restore steps: apps/cloud/docs/RESTORE.md.
+# CONTROL_PLANE_DATABASE_ID=replace-with-the-control-plane-d1-uuid
+
 # Per-org "Cloudflare costs" tab (Billable Usage API): each BYO org connects its
 # OWN Cloudflare account + a token scoped to "Billing Read" from the console's
 # Cloudflare costs tab. That token is encrypted at the edge with

--- a/apps/cloud/GAPS.md
+++ b/apps/cloud/GAPS.md
@@ -54,7 +54,7 @@ The rest of this list has since shipped — see the status pass below.
 | R3#2 deployment health charts    | ✅ **Shipped.** The blocker row above was stale: `outcome` (blob3) landed 2026-08-13. `src/telemetry/traffic-read.ts` reads the metering stream per script, so passing a single script name gives one deployment's volume, error rate and latency.                                                                                                         |
 | R3#5 onboarding checklist        | ✅ **Shipped** — `lunora/onboarding.ts` + `src/client/OnboardingChecklist.tsx`, on the Projects tab until the org's first deployment is live. Derived from real rows, never stored.                                                                                                                                                                        |
 | R3#7 deploy-key roll UX          | ✅ **Shipped** — `deploy_keys.roll` does issue+revoke in one transactional mutation, so neither the two-live-keys nor the no-keys window exists. Ingest keys are refused (their stored cipher would point at a revoked secret).                                                                                                                            |
-| R3#9 integrations hub            | 🔨 Still open — nothing in `src/client/`.                                                                                                                                                                                                                                                                                                                  |
+| R3#9 integrations hub            | Superseded by the 2026-08-31 pass below — shipped.                                                                                                                                                                                                                                                                                                         |
 
 Also shipped in that pass: a **Traffic tab** (`lunora/traffic.ts`,
 `src/client/TrafficSection.tsx`) — visitors by country, top paths, response-code
@@ -610,29 +610,32 @@ depend on the platform's own telemetry pipeline being healthy.
 #### Backlog items 2–9 — status as of 2026-07-29
 
 (This list had collapsed into a single paragraph through successive edits; it is
-restored here with each item's verified status.)
+restored here with each item's verified status. Re-verified against the code
+2026-09-06: items 2, 5, 7 and 9 read 🔨 open here long after the status passes
+above recorded them shipped — trust the code, not this list.)
 
-2. **Deployment health charts on the project page** (🔨 open — prerequisite now
-   shipped) — request volume / error rate per deployment. The stated blocker is
-   cleared: the dispatcher's AE data point now carries an `outcome` status class
-   (blob3) and a low-cardinality `route` label (blob4) alongside the existing
-   script/plan blobs, so error rate and per-endpoint volume are both readable
-   from the metering stream. A blue/green alias resolves to the versioned script
-   name, so blob1 already carries the deploy identity. What remains is the chart
-   itself — the read query + the project-page panel.
+2. **Deployment health charts on the project page** (✅ shipped) — request
+   volume / error rate per deployment. `src/telemetry/traffic-read.ts` reads the
+   metering stream per script, so a single script name gives one deployment's
+   volume, error rate and latency. The `outcome` status class (blob3) that this
+   row once waited on landed 2026-08-13.
 3. **Log viewer upgrade** (✅ shipped) — severity chips, filter bar, and
    log↔trace correlation landed with B2's full log-management pass.
 4. **Design-system pass** (✅ shipped) — the aurora redesign covered the token
    palette, severity ramp, and empty states across every screen.
-5. **Onboarding checklist** (🔨 open) — first-run "create project → issue key →
-   first deploy → see it live" checklist. No component exists in `src/client/`.
+5. **Onboarding checklist** (✅ shipped) — `lunora/onboarding.ts` +
+   `src/client/OnboardingChecklist.tsx`, on the Projects tab until the org's
+   first deployment is live. Derived from real rows, never stored.
 6. **Time-range picker** (✅ shipped) — `src/client/TimeRangeProvider.tsx` +
    `time-range.ts` provide the shared presets.
-7. **Deploy-key roll UX** (🔨 open) — one-click atomic issue+revoke in the keys
-   tab. Not present in `DeployKeys*.tsx`.
+7. **Deploy-key roll UX** (✅ shipped) — `deploy_keys.roll` does issue+revoke in
+   one transactional mutation, so neither the two-live-keys nor the no-keys
+   window exists. Ingest keys are refused (their stored cipher would point at a
+   revoked secret).
 8. **MCP surface** (✅ shipped) — `src/mcp/tools.ts` exposes the control plane
    over `/v1/mcp`, with per-route `RouteSpec.mcp` opt-in and a hard deny-list
    for `tokens`/`auth`/`mcp`.
-9. **Integrations hub** (🔨 open) — OAuth connect cards for the GitHub App
-   install and the Creem portal, replacing bare settings fields. Nothing in
-   `src/client/`.
+9. **Integrations hub** (✅ shipped, minimally) — `src/client/`'s Integrations
+   tab lists the org's GitHub App installations and can release (unclaim) one,
+   the inverse `claim` never had. Connect cards for the Creem portal are still
+   bare settings fields.

--- a/apps/cloud/GAPS.md
+++ b/apps/cloud/GAPS.md
@@ -442,11 +442,24 @@ enforcement + recovery engine above already reacts to whatever balance exists.
 
 ## D. Data & trust
 
-### D1. Control-plane + tenant backups, PITR, restore runbook (🌐)
+### D1. Control-plane + tenant backups, PITR, restore runbook (✅ same-account backup + runbook shipped; 🔨 cross-account copy)
 
-D1 Time Travel export to platform R2 in a _different_ cell, on a cron; tested
-restore runbook. The single most-critical 🌐 item — the control-plane DB is the
-crown jewel.
+`src/backup/sweep.ts` takes a full SQL dump through D1's export API on the
+existing six-hourly tick and streams it into R2 at
+`control-plane/<cell>/<timestamp>.sql`, pruning past 30 days. `docs/RESTORE.md`
+is the runbook, and it separates the two layers that fail differently: Time
+Travel already covers a bad write in place, so the dump exists for losing the
+database itself.
+
+**Still open, and it is the half that motivated the row:** the copy is
+same-account. A Worker's R2 binding cannot address another Cloudflare account,
+so a second copy in another cell needs R2's S3 API and a credential for that
+account. Until then an account-level loss is uncovered — this is 🔨 (code
+tractable) rather than 🌐.
+
+The runbook's quarterly restore drill has **not been run**. A backup nobody has
+restored is a hypothesis, and the recovery-time number an incident is judged on
+is not knowable from the code.
 
 ### D2. `lunora eject` — self-serve full export (✅ shipped end to end)
 

--- a/apps/cloud/__tests__/backup-sweep.test.ts
+++ b/apps/cloud/__tests__/backup-sweep.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BackupBucket, BackupListing } from "../src/backup/sweep";
+import { BACKUP_RETENTION_MS, backupKey, backupPrefix, runBackupSweep } from "../src/backup/sweep";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 8, 6, 12, 0, 0);
+
+/** An R2 double that records what was written and deleted. */
+const fakeBucket = (
+    objects: { key: string; uploaded: Date }[] = [],
+    pages?: BackupListing[],
+): {
+    bucket: BackupBucket;
+    deleted: string[];
+    put: { key: string; value: ReadableStream | null }[];
+} => {
+    const deleted: string[] = [];
+    const put: { key: string; value: ReadableStream | null }[] = [];
+    let call = 0;
+
+    return {
+        bucket: {
+            delete: async (keys) => {
+                deleted.push(...keys);
+            },
+            list: async () => {
+                if (pages) {
+                    const page = pages[call] ?? { objects: [], truncated: false };
+
+                    call += 1;
+
+                    return page;
+                }
+
+                return { objects, truncated: false };
+            },
+            put: async (key, value) => {
+                put.push({ key, value });
+            },
+        },
+        deleted,
+        put,
+    };
+};
+
+const okResponse = (): Response => new Response("PRAGMA foreign_keys=OFF;", { status: 200 });
+
+describe(backupKey, () => {
+    it("orders lexically the way the dumps order chronologically", () => {
+        const earlier = backupKey("cell-a", Date.UTC(2026, 0, 9, 3, 4, 5));
+        const later = backupKey("cell-a", Date.UTC(2026, 0, 10, 3, 4, 5));
+
+        // The prune pass lists by prefix and never parses a key, but a human
+        // reading the bucket relies on this, and so does any future cursor scan.
+        expect([later, earlier].toSorted((a, b) => a.localeCompare(b))).toStrictEqual([earlier, later]);
+    });
+
+    it("scopes each cell to its own prefix so one bucket can hold several", () => {
+        expect(backupKey("eu-1", NOW).startsWith(backupPrefix("eu-1"))).toBe(true);
+        expect(backupKey("us-1", NOW).startsWith(backupPrefix("eu-1"))).toBe(false);
+    });
+});
+
+describe(runBackupSweep, () => {
+    it("writes the dump under a timestamped key for this cell", async () => {
+        const { bucket, put } = fakeBucket();
+        const result = await runBackupSweep({
+            bucket,
+            cell: "eu-1",
+            fetch: async () => okResponse(),
+            now: NOW,
+            startExport: async () => {
+                return { signedUrl: "https://d1.example.invalid/dump.sql" };
+            },
+        });
+
+        expect(result.written).toBe("control-plane/eu-1/20260906T120000000Z.sql");
+        expect(put).toHaveLength(1);
+        expect(put[0]?.key).toBe(result.written);
+    });
+
+    it("streams the body through rather than buffering the dump", async () => {
+        const { bucket, put } = fakeBucket();
+        const response = okResponse();
+
+        await runBackupSweep({
+            bucket,
+            cell: "eu-1",
+            fetch: async () => response,
+            now: NOW,
+            startExport: async () => {
+                return { signedUrl: "https://d1.example.invalid/dump.sql" };
+            },
+        });
+
+        // The value handed to R2 is the response's own stream. Reading it into a
+        // string first would put the whole control plane in a 128MB isolate.
+        expect(put[0]?.value).toBe(response.body);
+    });
+
+    it("deletes dumps past the retention window and keeps the rest", async () => {
+        const { bucket, deleted } = fakeBucket([
+            { key: "control-plane/eu-1/old.sql", uploaded: new Date(NOW - BACKUP_RETENTION_MS - DAY_MS) },
+            { key: "control-plane/eu-1/fresh.sql", uploaded: new Date(NOW - DAY_MS) },
+        ]);
+        const result = await runBackupSweep({
+            bucket,
+            cell: "eu-1",
+            fetch: async () => okResponse(),
+            now: NOW,
+            startExport: async () => {
+                return { signedUrl: "https://d1.example.invalid/dump.sql" };
+            },
+        });
+
+        expect(deleted).toStrictEqual(["control-plane/eu-1/old.sql"]);
+        expect(result.pruned).toBe(1);
+    });
+
+    it("follows the listing cursor, so retention holds past one page", async () => {
+        const expired = (key: string): { key: string; uploaded: Date } => {
+            return { key, uploaded: new Date(NOW - BACKUP_RETENTION_MS - DAY_MS) };
+        };
+        const { bucket, deleted } = fakeBucket(
+            [],
+            [
+                { cursor: "page-2", objects: [expired("control-plane/eu-1/a.sql")], truncated: true },
+                { objects: [expired("control-plane/eu-1/b.sql")], truncated: false },
+            ],
+        );
+
+        await runBackupSweep({
+            bucket,
+            cell: "eu-1",
+            fetch: async () => okResponse(),
+            now: NOW,
+            startExport: async () => {
+                return { signedUrl: "https://d1.example.invalid/dump.sql" };
+            },
+        });
+
+        // A single-page prune would have left `b.sql` behind forever, and the
+        // sweep would still have reported success.
+        expect(deleted).toStrictEqual(["control-plane/eu-1/a.sql", "control-plane/eu-1/b.sql"]);
+    });
+
+    it("throws without writing when the dump cannot be downloaded", async () => {
+        const { bucket, put } = fakeBucket();
+
+        await expect(
+            runBackupSweep({
+                bucket,
+                cell: "eu-1",
+                fetch: async () => new Response("gone", { status: 403 }),
+                now: NOW,
+                startExport: async () => {
+                    return { signedUrl: "https://d1.example.invalid/dump.sql" };
+                },
+            }),
+        ).rejects.toThrow("HTTP 403");
+
+        // A presigned URL expires after an hour; a truncated or empty object under
+        // a fresh key is worse than no object, because the prune would then age
+        // out the last good dump behind it.
+        expect(put).toStrictEqual([]);
+    });
+
+    it("does not prune when the export never starts", async () => {
+        const { bucket, deleted } = fakeBucket([{ key: "control-plane/eu-1/old.sql", uploaded: new Date(NOW - BACKUP_RETENTION_MS - DAY_MS) }]);
+        const startExport = vi.fn<() => Promise<{ signedUrl: string }>>(async () => {
+            throw new Error("d1 export failed");
+        });
+
+        await expect(runBackupSweep({ bucket, cell: "eu-1", fetch: async () => okResponse(), now: NOW, startExport })).rejects.toThrow("d1 export failed");
+
+        expect(deleted).toStrictEqual([]);
+    });
+});

--- a/apps/cloud/__tests__/entitlements.test.ts
+++ b/apps/cloud/__tests__/entitlements.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { QueryCtx } from "../lunora/_generated/server";
-import { assertWithinQuota, orgLimit } from "../lunora/entitlements";
+import { assertWithinQuota, orgLimit, toSubscription } from "../lunora/entitlements";
 
 type Sub = { currentPeriodStart?: number; priceId: string; state: string };
 
@@ -37,5 +37,47 @@ describe(assertWithinQuota, () => {
         const ctx = makeCtx([{ priceId: "price_pro_monthly", state: "active" }]);
 
         await expect(assertWithinQuota(ctx, org, "projects", 5)).resolves.toBeUndefined();
+    });
+});
+
+describe(toSubscription, () => {
+    /**
+     * `Subscription.id` is the provider's id. `@lunora/payment` keys its upsert and
+     * its lookup on `(provider, providerSubscriptionId)`, so mapping Lunora's `_id`
+     * here would write a Lunora id into that column on any round trip. Nothing reads
+     * `id` on the entitlement path today, which is why the wrong mapping is invisible
+     * without this assertion.
+     */
+    it("takes `id` from the provider's subscription id, not the row id", () => {
+        const row = {
+            _creationTime: 1,
+            _id: "sub_lunora_row_id",
+            cancelAtPeriodEnd: false,
+            createdAt: 1,
+            priceId: "price_pro_monthly",
+            provider: "creem",
+            providerSubscriptionId: "sub_creem_abc123",
+            quantity: 1,
+            referenceId: "org_1",
+            state: "active",
+            updatedAt: 1,
+        } as unknown as Parameters<typeof toSubscription>[0];
+
+        expect(toSubscription(row).id).toBe("sub_creem_abc123");
+    });
+
+    it("passes the fields entitlement resolution reads straight through", () => {
+        const row = {
+            _id: "sub_lunora_row_id",
+            priceId: "price_pro_monthly",
+            provider: "creem",
+            providerSubscriptionId: "sub_creem_abc123",
+            state: "active",
+        } as unknown as Parameters<typeof toSubscription>[0];
+        const subscription = toSubscription(row);
+
+        expect(subscription.priceId).toBe("price_pro_monthly");
+        expect(subscription.state).toBe("active");
+        expect(subscription.provider).toBe("creem");
     });
 });

--- a/apps/cloud/__tests__/provision.test.ts
+++ b/apps/cloud/__tests__/provision.test.ts
@@ -30,6 +30,9 @@ const fakeApi = (): { api: CloudflareApi; deletes: string[]; puts: PutScriptInpu
             }),
             createR2Bucket: vi.fn<CloudflareApi["createR2Bucket"]>(async () => undefined),
             deleteD1Database: vi.fn<CloudflareApi["deleteD1Database"]>(async () => undefined),
+            exportD1Database: vi.fn<CloudflareApi["exportD1Database"]>(async () => {
+                return { signedUrl: "https://example.invalid/dump.sql" };
+            }),
             deleteDispatchScript: vi.fn<CloudflareApi["deleteDispatchScript"]>(async ({ scriptName }) => {
                 deletes.push(scriptName);
             }),

--- a/apps/cloud/__tests__/teardown.test.ts
+++ b/apps/cloud/__tests__/teardown.test.ts
@@ -148,6 +148,7 @@ const cloudflareApi = (over: Partial<CloudflareApi> = {}): CloudflareApi => {
         deleteD1Database: () => Promise.resolve(),
         deleteDispatchScript: () => Promise.resolve(),
         deleteR2Bucket: () => Promise.resolve(),
+        exportD1Database: () => Promise.resolve({ signedUrl: "https://example.invalid/dump.sql" }),
         findD1DatabaseByName: () => Promise.resolve(null),
         putDispatchScript: () => Promise.resolve(),
         putSecret: () => Promise.resolve(),

--- a/apps/cloud/docs/RESTORE.md
+++ b/apps/cloud/docs/RESTORE.md
@@ -1,0 +1,114 @@
+# Control-plane restore runbook
+
+The control-plane D1 is the one store in the platform whose loss is
+unrecoverable rather than inconvenient. Tenant data lives in each tenant's own
+Durable Object and is not in scope here — what is only in this database is
+**which cell a tenant is on, which script serves it, and the sealed admin token
+that reaches it**. Without it the tenant workers keep serving traffic and
+nothing can be administered, billed, deployed, or torn down.
+
+## What protects it
+
+Two layers, and they fail differently.
+
+| Layer                          | Recovers from                                 | Does not recover from                      |
+| ------------------------------ | --------------------------------------------- | ------------------------------------------ |
+| **D1 Time Travel** (automatic) | A bad write, a dropped table, a bad migration | Losing the database or the account         |
+| **This backup sweep**          | Losing the database                           | Losing the **account** — see the gap below |
+
+Time Travel is Cloudflare's, needs no code, and covers 30 days. Reach for it
+first: it is faster, exact to the second, and does not involve a dump at all.
+The sweep exists because Time Travel history lives inside the database it
+protects, so a deleted or compromised account takes the history with it.
+
+> **Known gap.** The dump is written to R2 **in the same account**. A Worker's
+> R2 binding cannot address another Cloudflare account, so a second copy in
+> another cell needs R2's S3 API and a credential for that account. Until that
+> lands, an account-level loss is not covered. Do not describe this as
+> off-account DR.
+
+## What the sweep does
+
+`src/backup/sweep.ts`, on the existing six-hourly cron trigger (a fourth trigger
+is not available — Cloudflare caps a Worker at three).
+
+1. `POST /d1/database/<id>/export` and poll to completion.
+2. `GET` the presigned URL it answers — valid for one hour.
+3. Stream the body into `BACKUPS` at `control-plane/<cell>/<timestamp>.sql`.
+4. Delete dumps older than 30 days, by the object's own upload time.
+
+It no-ops unless `BACKUPS`, `CONTROL_PLANE_DATABASE_ID`,
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are all set, so a cell
+without backups configured still ticks rather than erroring every six hours.
+
+**The bucket must be private.** The dump contains every sealed admin token and
+auth session in the cell. It is ciphertext — `SECRET_ENCRYPTION_KEY` seals the
+tokens and is not in the dump — but treat the file as a credential.
+
+## Restoring
+
+### Case 1 — a bad write, table, or migration (use Time Travel)
+
+```bash
+wrangler d1 time-travel info <DATABASE_NAME> --timestamp=<ISO8601>
+wrangler d1 time-travel restore <DATABASE_NAME> --timestamp=<ISO8601>
+```
+
+Restore to just before the bad change. This is in place and needs nothing from
+R2. Confirm the bookmark reads back what you expect with `info` before you run
+`restore`.
+
+### Case 2 — the database is gone (use a dump)
+
+1. **Take the newest dump.** Keys sort chronologically, so the last one wins:
+
+    ```bash
+    wrangler r2 object get <BUCKET>/control-plane/<cell>/<timestamp>.sql --file restore.sql
+    ```
+
+2. **Create a replacement database** and note the new uuid:
+
+    ```bash
+    wrangler d1 create <DATABASE_NAME>-restored
+    ```
+
+3. **Load the dump.** It carries both schema and data:
+
+    ```bash
+    wrangler d1 execute <DATABASE_NAME>-restored --remote --file restore.sql
+    ```
+
+4. **Repoint the Worker** — update the `database_id` in the `d1_databases`
+   binding and in `CONTROL_PLANE_DATABASE_ID`, then deploy.
+
+5. **Verify before declaring recovery**, in this order — each answer is
+   worthless if the one above it is wrong:
+
+    ```bash
+    wrangler d1 execute <DATABASE_NAME>-restored --remote \
+      --command "SELECT COUNT(*) FROM organizations; SELECT COUNT(*) FROM deployments WHERE status = 'live';"
+    ```
+
+    Then, against the running control plane: sign in, confirm the org switcher
+    lists the orgs, open a project's Deployments tab, and confirm the studio can
+    reach one live deployment's admin surface. That last one is the real check —
+    it proves the sealed admin tokens survived the round trip, which a row count
+    cannot tell you.
+
+## Test this on a schedule
+
+A backup nobody has restored is a hypothesis. Run case 2 against a scratch
+database each quarter, from the newest real dump, and record the wall-clock time
+it took — recovery time is the number an incident is judged on, and it is not
+knowable from the code.
+
+Two failure modes to watch for, both implied by how the sweep and the token
+sealing work (this drill has not been run yet — when it is, record what it
+actually found here):
+
+- The dump restores, but the Worker still points at the dead database. Step 4 is
+  the one people skip.
+- Row counts match while the admin surface 401s, because
+  `SECRET_ENCRYPTION_KEY` was rotated after the dump was taken. The sealed
+  tokens are only as recoverable as the key that opens them: **back the key up
+  separately, and never rotate it without taking a fresh dump afterwards.**

--- a/apps/cloud/lunora/alerts.ts
+++ b/apps/cloud/lunora/alerts.ts
@@ -55,7 +55,7 @@ export const rules = query
 
         const { page } = await context.db.alertRules.findMany({ where: { organizationId } });
 
-        return (page as unknown as AlertRuleRow[]).toSorted((a, b) => b.createdAt - a.createdAt);
+        return page.toSorted((a, b) => b.createdAt - a.createdAt);
     });
 
 /**
@@ -211,7 +211,7 @@ export const list = query.input({ organizationId: v.id("organizations") }).query
 
     const { page } = await context.db.alerts.findMany({ where: { organizationId } });
 
-    return (page as unknown as AlertRow[]).toSorted((a, b) => b.createdAt - a.createdAt);
+    return page.toSorted((a, b) => b.createdAt - a.createdAt);
 });
 
 /**
@@ -268,7 +268,7 @@ export const fireDeployAlerts = async (
     source: DeployAlertSource,
 ): Promise<number> => {
     const { page } = await context.db.alertRules.findMany({ where: { organizationId, target: "deploy" } });
-    const enabled = (page as unknown as AlertRuleRow[]).filter((rule) => rule.enabled);
+    const enabled = page.filter((rule) => rule.enabled);
 
     return fireDeployRules(
         enabled.map((rule) => {

--- a/apps/cloud/lunora/audit-log.ts
+++ b/apps/cloud/lunora/audit-log.ts
@@ -47,5 +47,5 @@ export const list = query.input({ organizationId: v.id("organizations") }).query
 
     const { page } = await context.db.auditLog.findMany({ where: { organizationId } });
 
-    return (page as unknown as AuditRow[]).toSorted((a, b) => b.createdAt - a.createdAt);
+    return page.toSorted((a, b) => b.createdAt - a.createdAt);
 });

--- a/apps/cloud/lunora/authz.ts
+++ b/apps/cloud/lunora/authz.ts
@@ -19,13 +19,6 @@ import type { QueryCtx as QueryContext } from "./_generated/server.js";
 
 export type MemberRole = "admin" | "member" | "owner" | "viewer";
 
-interface MemberRow {
-    _id: Id<"members">;
-    organizationId: Id<"organizations">;
-    role: MemberRole;
-    userId: string;
-}
-
 interface DeployKeyRow {
     _id: Id<"deployKeys">;
     capability?: "deploy" | "ingest";
@@ -52,7 +45,7 @@ export const assertMember = async (
     }
 
     const { page } = await context.db.members.findMany({ where: { organizationId, userId } });
-    const member = (page as unknown as MemberRow[])[0];
+    const member = page[0];
 
     if (!member) {
         throw new LunoraError("FORBIDDEN", "not a member of this organization");
@@ -69,7 +62,7 @@ export const assertMember = async (
 const resolveKeyRow = async (context: QueryContext, organizationId: Id<"organizations">, key: string): Promise<DeployKeyRow> => {
     const hashedKey = await hashDeployKey(key);
     const { page } = await context.db.deployKeys.findMany({ where: { hashedKey } });
-    const row = (page as unknown as DeployKeyRow[])[0];
+    const row = page[0];
 
     if (!row || row.revokedAt != null || row.organizationId !== organizationId) {
         throw new LunoraError("FORBIDDEN", "invalid key for this organization");
@@ -139,7 +132,7 @@ export const authorizeTelemetryKey = async (context: QueryContext, organizationI
 export const resolveDeployKeyOrg = async (context: QueryContext, key: string): Promise<Id<"organizations"> | null> => {
     const hashedKey = await hashDeployKey(key);
     const { page } = await context.db.deployKeys.findMany({ where: { hashedKey } });
-    const row = (page as unknown as DeployKeyRow[])[0];
+    const row = page[0];
 
     return row && row.revokedAt == null ? row.organizationId : null;
 };

--- a/apps/cloud/lunora/billing.ts
+++ b/apps/cloud/lunora/billing.ts
@@ -1,4 +1,3 @@
-import type { Subscription } from "@lunora/payment";
 import { resolveEntitlements } from "@lunora/payment";
 
 import { evaluateDunning } from "../src/billing/dunning";
@@ -7,6 +6,7 @@ import { effectiveLimit, LUNORA_CLOUD_PLANS } from "../src/billing/plans";
 import type { Id } from "./_generated/dataModel.js";
 import { action, internalMutation, query, v } from "./_generated/server.js";
 import { assertMember } from "./authz";
+import { toSubscription } from "./entitlements";
 import { rateLimit } from "./guards";
 import { collectAll } from "./paginate";
 import { boundedString, LIMITS } from "./validators";
@@ -92,7 +92,10 @@ export const entitlements = query
             await assertMember(context, organizationId);
 
             const { page } = await context.db.subscriptions.findMany({ where: { referenceId: organizationId } });
-            const resolved = resolveEntitlements(LUNORA_CLOUD_PLANS, page as unknown as Subscription[]);
+            const resolved = resolveEntitlements(
+                LUNORA_CLOUD_PLANS,
+                page.map((row) => toSubscription(row)),
+            );
 
             const limits = Object.fromEntries(QUOTA_RESOURCES.map((resource) => [resource, effectiveLimit(resolved, resource)])) as Record<
                 QuotaResource,

--- a/apps/cloud/lunora/billing.ts
+++ b/apps/cloud/lunora/billing.ts
@@ -1,12 +1,10 @@
-import { resolveEntitlements } from "@lunora/payment";
-
 import { evaluateDunning } from "../src/billing/dunning";
 import type { QuotaResource } from "../src/billing/plans";
-import { effectiveLimit, LUNORA_CLOUD_PLANS } from "../src/billing/plans";
+import { effectiveLimit } from "../src/billing/plans";
 import type { Id } from "./_generated/dataModel.js";
 import { action, internalMutation, query, v } from "./_generated/server.js";
 import { assertMember } from "./authz";
-import { toSubscription } from "./entitlements";
+import { orgEntitlements } from "./entitlements";
 import { rateLimit } from "./guards";
 import { collectAll } from "./paginate";
 import { boundedString, LIMITS } from "./validators";
@@ -77,7 +75,7 @@ export const portal = action
 
 /**
  * Resolved entitlements for an org (members). Reads webhook-synced subscription
- * state and maps it through {@link LUNORA_CLOUD_PLANS}: the active plan names,
+ * state and maps it through `LUNORA_CLOUD_PLANS`: the active plan names,
  * granted features, and the effective per-resource limits (free baseline when
  * there's no active subscription, so a non-subscriber is bounded, never
  * unlimited).
@@ -91,12 +89,7 @@ export const entitlements = query
         }): Promise<{ features: string[]; limits: Record<"members" | "previewDeployments" | "projects", number>; plans: string[] }> => {
             await assertMember(context, organizationId);
 
-            const { page } = await context.db.subscriptions.findMany({ where: { referenceId: organizationId } });
-            const resolved = resolveEntitlements(
-                LUNORA_CLOUD_PLANS,
-                page.map((row) => toSubscription(row)),
-            );
-
+            const resolved = await orgEntitlements(context, organizationId);
             const limits = Object.fromEntries(QUOTA_RESOURCES.map((resource) => [resource, effectiveLimit(resolved, resource)])) as Record<
                 QuotaResource,
                 number

--- a/apps/cloud/lunora/builds.ts
+++ b/apps/cloud/lunora/builds.ts
@@ -65,7 +65,7 @@ export const recordPush = internalMutation
     })
     .mutation(async ({ ctx: context, args: { branch, commitSha, installationId, repository } }): Promise<null | { buildId: Id<"builds">; reused: boolean }> => {
         const { page } = await context.db.projects.findMany({ where: { githubRepo: repository } });
-        const project = (page as unknown as ProjectRow[])[0];
+        const project = page[0];
 
         if (!project) {
             return null;
@@ -75,14 +75,14 @@ export const recordPush = internalMutation
         // build (staged-claim model, github-installations.ts). A spoofed RPC
         // call must present a valid (org, installation) pair.
         const { page: installationPage } = await context.db.githubInstallations.findMany({ where: { installationId } });
-        const installation = (installationPage as unknown as { organizationId?: Id<"organizations"> }[])[0];
+        const installation = installationPage[0];
 
         if (installation?.organizationId !== project.organizationId) {
             return null;
         }
 
         const { page: existingPage } = await context.db.builds.findMany({ where: { commitSha, projectId: project._id } }); // secret-scanner:allow -- domain field name
-        const successful = (existingPage as unknown as BuildRow[]).find((build) => build.status === "successful" && build.bundleHash);
+        const successful = existingPage.find((build) => build.status === "successful" && build.bundleHash);
 
         if (successful) {
             return { buildId: successful._id, reused: true };
@@ -91,7 +91,7 @@ export const recordPush = internalMutation
         // Backpressure: cap unfinished builds per project so a webhook storm
         // (or spoofed spam) can't flood the queue.
         const { page: projectBuilds } = await context.db.builds.findMany({ where: { projectId: project._id } }); // secret-scanner:allow -- domain field name
-        const inFlight = (projectBuilds as unknown as BuildRow[]).filter((build) => build.status === "pending" || build.status === "building").length;
+        const inFlight = projectBuilds.filter((build) => build.status === "pending" || build.status === "building").length;
 
         if (inFlight >= 5) {
             throw new LunoraError("TOO_MANY_REQUESTS", "too many unfinished builds for this project");
@@ -142,10 +142,8 @@ export const claimNext = internalMutation
 
         // A `building` row is claimable only once its lease has gone stale — that is
         // how a dead runner's work is recovered.
-        const stale = (buildingPage.page as unknown as BuildRow[]).filter(
-            (build) => build.processingStartedAt != null && now - build.processingStartedAt > LEASE_STALE_MS,
-        );
-        const claimable = [...(pendingPage.page as unknown as BuildRow[]), ...stale].toSorted((a, b) => a.createdAt - b.createdAt);
+        const stale = buildingPage.page.filter((build) => build.processingStartedAt != null && now - build.processingStartedAt > LEASE_STALE_MS);
+        const claimable = [...pendingPage.page, ...stale].toSorted((a, b) => a.createdAt - b.createdAt);
         const next = claimable[0];
 
         if (!next) {
@@ -278,7 +276,7 @@ export const reportTarget = internalQuery
         }
 
         const { page } = await context.db.githubInstallations.findMany({ where: { organizationId: build.organizationId } });
-        const installation = (page as unknown as { claimedAt?: number; installationId: number }[]).find((row) => row.claimedAt !== undefined);
+        const installation = page.find((row) => row.claimedAt !== undefined);
 
         if (!installation) {
             return null;
@@ -295,7 +293,7 @@ export const listByProject = query
 
         const { page } = await context.db.builds.findMany({ where: { organizationId, projectId } }); // secret-scanner:allow -- domain field name
 
-        return (page as unknown as BuildRow[]).toSorted((a, b) => b.createdAt - a.createdAt);
+        return page.toSorted((a, b) => b.createdAt - a.createdAt);
     });
 
 /**
@@ -320,9 +318,7 @@ export const logs = query
             const { page } = await context.db.buildLogs.findMany({ where: { buildId } });
             const cursor = afterCreatedAt ?? 0;
 
-            return (page as unknown as { createdAt: number; level: "error" | "info"; line: string }[])
-                .filter((row) => row.createdAt > cursor)
-                .toSorted((a, b) => a.createdAt - b.createdAt);
+            return page.filter((row) => row.createdAt > cursor).toSorted((a, b) => a.createdAt - b.createdAt);
         },
     );
 
@@ -338,7 +334,7 @@ export const PENDING_EXPIRY_MS = 24 * 60 * 60 * 1000;
 export const expireStale = internalMutation.mutation(async ({ ctx: context }): Promise<{ expired: number }> => {
     const { now } = context;
     const { page } = await context.db.builds.findMany({});
-    const stale = (page as unknown as BuildRow[]).filter(
+    const stale = page.filter(
         (build) =>
             (build.status === "pending" && now - build.createdAt > PENDING_EXPIRY_MS) ||
             (build.status === "building" && build.processingStartedAt != null && now - build.processingStartedAt > 4 * LEASE_STALE_MS),

--- a/apps/cloud/lunora/cells.ts
+++ b/apps/cloud/lunora/cells.ts
@@ -3,16 +3,6 @@ import { LunoraError } from "@lunora/server";
 import type { Id } from "./_generated/dataModel.js";
 import { internalMutation, query, v } from "./_generated/server.js";
 
-interface CellRow {
-    _id: Id<"cells">;
-    cloudflareAccountId: string;
-    createdAt: number;
-    dispatchNamespacePrefix: string;
-    jurisdiction?: string;
-    name: string;
-    status: "active" | "draining" | "suspended";
-}
-
 /**
  * The cell fields safe to expose to any signed-in user (the org-create picker).
  * Deliberately omits infra identifiers (`cloudflareAccountId`,
@@ -42,7 +32,7 @@ export const list = query.query(async ({ ctx: context }): Promise<CellSummary[]>
 
     const { page } = await context.db.cells.findMany();
 
-    return (page as unknown as CellRow[]).map((cell) => {
+    return page.map((cell) => {
         return {
             _id: cell._id,
             jurisdiction: cell.jurisdiction,

--- a/apps/cloud/lunora/cloudflare-billing.ts
+++ b/apps/cloud/lunora/cloudflare-billing.ts
@@ -6,6 +6,25 @@ import { assertMember } from "./authz";
 import { rateLimit } from "./guards";
 import { boundedString, LIMITS } from "./validators";
 
+/**
+ * Per-org BYO Cloudflare billing (Billable Usage API). An org connects its *own*
+ * Cloudflare account — an account id + an API token scoped to **Billing Read** —
+ * so the console can show that account's authoritative Cloudflare spend by
+ * product, distinct from the control plane's *estimate* (`src/billing/spend.ts`).
+ *
+ * The token is a credential, so it follows the tenant-secret path exactly: it is
+ * AES-256-GCM encrypted at the edge (`POST /v1/cloudflare-billing` →
+ * `src/secrets/crypto.ts`) before it ever reaches {@link store}, so these
+ * functions and the D1 row only hold ciphertext + IV. {@link status} (any member)
+ * reports whether a connection exists and its account id — never the token.
+ * {@link summary} (an **action**, because the read is a `fetch` and the decrypt
+ * key + `ctx.fetch` are action-only) decrypts the token at the edge, reads the
+ * account's billable usage, and returns a normalized cost view — failing **open**
+ * to a status view (never throwing, never leaking the token) so the tab degrades
+ * gracefully when the connection is missing, the master key is absent, or the
+ * token lacks the Billing Read scope.
+ */
+
 /** The env keys {@link summary} reads off `ctx.env` (the validated `lunora/env.ts` contract). */
 interface CloudflareBillingEnv {
     SECRET_ENCRYPTION_KEY?: string;

--- a/apps/cloud/lunora/cloudflare-billing.ts
+++ b/apps/cloud/lunora/cloudflare-billing.ts
@@ -6,35 +6,6 @@ import { assertMember } from "./authz";
 import { rateLimit } from "./guards";
 import { boundedString, LIMITS } from "./validators";
 
-/**
- * Per-org BYO Cloudflare billing (Billable Usage API). An org connects its *own*
- * Cloudflare account — an account id + an API token scoped to **Billing Read** —
- * so the console can show that account's authoritative Cloudflare spend by
- * product, distinct from the control plane's *estimate* (`src/billing/spend.ts`).
- *
- * The token is a credential, so it follows the tenant-secret path exactly: it is
- * AES-256-GCM encrypted at the edge (`POST /v1/cloudflare-billing` →
- * `src/secrets/crypto.ts`) before it ever reaches {@link store}, so these
- * functions and the D1 row only hold ciphertext + IV. {@link status} (any member)
- * reports whether a connection exists and its account id — never the token.
- * {@link summary} (an **action**, because the read is a `fetch` and the decrypt
- * key + `ctx.fetch` are action-only) decrypts the token at the edge, reads the
- * account's billable usage, and returns a normalized cost view — failing **open**
- * to a status view (never throwing, never leaking the token) so the tab degrades
- * gracefully when the connection is missing, the master key is absent, or the
- * token lacks the Billing Read scope.
- */
-
-interface ConnectionRow {
-    _id: Id<"cloudflareBilling">;
-    ciphertext: string;
-    cloudflareAccountId: string;
-    createdAt: number;
-    iv: string;
-    organizationId: Id<"organizations">;
-    updatedAt: number;
-}
-
 /** The env keys {@link summary} reads off `ctx.env` (the validated `lunora/env.ts` contract). */
 interface CloudflareBillingEnv {
     SECRET_ENCRYPTION_KEY?: string;
@@ -50,7 +21,7 @@ export const status = query
         await assertMember(context, organizationId);
 
         const { page } = await context.db.cloudflareBilling.findMany({ where: { organizationId } });
-        const row = (page as unknown as ConnectionRow[])[0];
+        const row = page[0];
 
         return { cloudflareAccountId: row?.cloudflareAccountId ?? null, connected: Boolean(row) };
     });
@@ -73,7 +44,7 @@ export const store = mutation
         await assertMember(context, arguments_.organizationId, ["owner", "admin"]);
 
         const { page } = await context.db.cloudflareBilling.findMany({ where: { organizationId: arguments_.organizationId } });
-        const existing = (page as unknown as ConnectionRow[])[0];
+        const existing = page[0];
         const { now } = context;
 
         if (existing) {
@@ -105,7 +76,7 @@ export const disconnect = mutation
         await assertMember(context, organizationId, ["owner", "admin"]);
 
         const { page } = await context.db.cloudflareBilling.findMany({ where: { organizationId } });
-        const row = (page as unknown as ConnectionRow[])[0];
+        const row = page[0];
 
         if (!row) {
             return { removed: false };
@@ -155,7 +126,7 @@ export const summary = action
         await assertMember(context, organizationId);
 
         const { page } = await context.db.cloudflareBilling.findMany({ where: { organizationId } });
-        const row = (page as unknown as ConnectionRow[])[0];
+        const row = page[0];
 
         if (!row) {
             return { cloudflareAccountId: null, status: "not-connected", view: null };

--- a/apps/cloud/lunora/dashboards.ts
+++ b/apps/cloud/lunora/dashboards.ts
@@ -118,7 +118,7 @@ export const list = query
 
         const { page } = await context.db.dashboards.findMany({ where: { organizationId } });
 
-        return (page as unknown as DashboardRow[]).toSorted((a, b) => b.createdAt - a.createdAt).map((row) => toView(row));
+        return page.toSorted((a, b) => b.createdAt - a.createdAt).map((row) => toView(row));
     });
 
 /** One dashboard by id, org-checked (any member). `null` when it isn't in the org. */

--- a/apps/cloud/lunora/deploy-keys.ts
+++ b/apps/cloud/lunora/deploy-keys.ts
@@ -34,7 +34,7 @@ export const list = query
         const { page } = await context.db.deployKeys.findMany({ where: { organizationId } });
 
         // Project to the public view — the stored hash is never returned.
-        return (page as unknown as DeployKeyRow[]).map((row) => {
+        return page.map((row) => {
             return {
                 _id: row._id,
                 capability: row.capability,
@@ -246,7 +246,7 @@ export const verify = mutation
 
             const hashedKey = await hashDeployKey(key);
             const { page } = await context.db.deployKeys.findMany({ where: { hashedKey } });
-            const row = (page as unknown as DeployKeyRow[])[0];
+            const row = page[0];
 
             // Reject a telemetry `ingest` key here too — this is the guard the deploy
             // route actually runs (`verifyKey`), so without it a scoped ingest token

--- a/apps/cloud/lunora/deployments.ts
+++ b/apps/cloud/lunora/deployments.ts
@@ -60,7 +60,7 @@ export const claimAlias = async (context: MutationContext, alias: string, organi
     const currentOwner = async (): Promise<AliasOwnershipRow | undefined> => {
         const { page } = await context.db.aliasOwnership.findMany({ where: { alias } });
 
-        return (page as unknown as AliasOwnershipRow[])[0];
+        return page[0];
     };
 
     const existing = await currentOwner();
@@ -164,7 +164,7 @@ export const planForScript = query
     .input({ scriptName: boundedString(LIMITS.name) })
     .query(async ({ ctx: context, args: { scriptName } }): Promise<{ plan: string; protected?: boolean }> => {
         const { page } = await context.db.deployments.findMany({ where: { scriptName } });
-        const deployment = (page as unknown as DeploymentRow[])[0];
+        const deployment = page[0];
 
         if (!deployment) {
             return { plan: "free" };
@@ -241,7 +241,7 @@ export const listByProject = query
 
         const { page } = await context.db.deployments.findMany({ where: { organizationId, projectId } });
 
-        return (page as unknown as DeploymentRow[]).map((row) => toDeploymentView(row)).toSorted((a, b) => b.createdAt - a.createdAt);
+        return page.map((row) => toDeploymentView(row)).toSorted((a, b) => b.createdAt - a.createdAt);
     });
 
 /**
@@ -293,7 +293,7 @@ export const create = mutation
         // Integrity: the project must belong to the same org (no cross-org linkage).
         const { page } = await context.db.projects.findMany({ where: { organizationId: arguments_.organizationId } });
 
-        if (!(page as unknown as ProjectRow[]).some((project) => project._id === arguments_.projectId)) {
+        if (!page.some((project) => project._id === arguments_.projectId)) {
             throw new LunoraError("NOT_FOUND", "project not found in this organization");
         }
 
@@ -312,7 +312,7 @@ export const create = mutation
         // stable alias keeps serving the previous version until `activate`
         // swaps the pointer after the health check (GAPS.md A1).
         const { page: existing } = await context.db.deployments.findMany({ where: { projectId: arguments_.projectId } }); // secret-scanner:allow -- domain field name
-        const version = 1 + Math.max(0, ...(existing as unknown as DeploymentRow[]).filter((d) => d.kind === arguments_.kind).map((d) => d.version ?? 0));
+        const version = 1 + Math.max(0, ...existing.filter((d) => d.kind === arguments_.kind).map((d) => d.version ?? 0));
 
         const { now } = context;
         const deploymentId = await context.db.insert("deployments", {
@@ -371,7 +371,7 @@ export const activate = mutation
 
         const { now } = context;
         const { page } = await context.db.deployments.findMany({ where: { projectId: deployment.projectId } }); // secret-scanner:allow -- domain field name
-        const others = (page as unknown as DeploymentRow[]).filter((d) => d._id !== id && d.kind === deployment.kind && d.status === "live");
+        const others = page.filter((d) => d._id !== id && d.kind === deployment.kind && d.status === "live");
 
         for (const other of others) {
             // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple
@@ -464,7 +464,7 @@ export const routeForAlias = query
     .input({ alias: boundedString(LIMITS.name) })
     .query(async ({ ctx: context, args: { alias } }): Promise<null | { candidateScriptName?: string; percent?: number; scriptName: string }> => {
         const { page } = await context.db.deployments.findMany({ where: { alias } });
-        const rows = page as unknown as DeploymentRow[];
+        const rows = page;
         const first = rows[0];
 
         if (!first) {
@@ -504,7 +504,7 @@ export const pruneSuperseded = internalMutation.mutation(async ({ ctx: context }
     // filtering afterwards meant live/failed/destroyed rows could fill the page and
     // starve the superseded ones this prune exists to collect.
     const { page } = await context.db.deployments.findMany({ where: { status: "superseded" } });
-    const superseded = page as unknown as DeploymentRow[];
+    const superseded = page;
 
     const byProjectKind = new Map<string, DeploymentRow[]>();
 
@@ -542,9 +542,7 @@ export const cleanupExpiredPreviews = internalMutation.mutation(async ({ ctx: co
     const { now } = context;
     const { page } = await context.db.deployments.findMany({ where: { kind: "preview" } });
 
-    const expired = (page as unknown as DeploymentRow[]).filter(
-        (deployment) => deployment.status !== "destroyed" && deployment.expiresAt != null && deployment.expiresAt < now,
-    );
+    const expired = page.filter((deployment) => deployment.status !== "destroyed" && deployment.expiresAt != null && deployment.expiresAt < now);
 
     for (const deployment of expired) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/deployments.ts
+++ b/apps/cloud/lunora/deployments.ts
@@ -463,8 +463,7 @@ export const rollback = mutation
 export const routeForAlias = query
     .input({ alias: boundedString(LIMITS.name) })
     .query(async ({ ctx: context, args: { alias } }): Promise<null | { candidateScriptName?: string; percent?: number; scriptName: string }> => {
-        const { page } = await context.db.deployments.findMany({ where: { alias } });
-        const rows = page;
+        const { page: rows } = await context.db.deployments.findMany({ where: { alias } });
         const first = rows[0];
 
         if (!first) {
@@ -503,8 +502,7 @@ export const pruneSuperseded = internalMutation.mutation(async ({ ctx: context }
     // Filter in the QUERY, not after it. `findMany({})` returns one 1000-row page, so
     // filtering afterwards meant live/failed/destroyed rows could fill the page and
     // starve the superseded ones this prune exists to collect.
-    const { page } = await context.db.deployments.findMany({ where: { status: "superseded" } });
-    const superseded = page;
+    const { page: superseded } = await context.db.deployments.findMany({ where: { status: "superseded" } });
 
     const byProjectKind = new Map<string, DeploymentRow[]>();
 

--- a/apps/cloud/lunora/domains.ts
+++ b/apps/cloud/lunora/domains.ts
@@ -190,7 +190,7 @@ export const routeForHostname = query
     .input({ hostname: boundedString(LIMITS.hostname) })
     .query(async ({ ctx: context, args: { hostname } }): Promise<null | { redirectStatusCode?: number; redirectTo?: string; scriptName?: string }> => {
         const { page } = await context.db.domains.findMany({ where: { hostname: hostname.toLowerCase().trim() } });
-        const domain = (page as unknown as DomainRow[])[0];
+        const domain = page[0];
 
         if (domain?.verifiedAt == null) {
             return null;

--- a/apps/cloud/lunora/entitlements.ts
+++ b/apps/cloud/lunora/entitlements.ts
@@ -1,10 +1,10 @@
-import type { Entitlements, Subscription } from "@lunora/payment";
+import type { Entitlements, ProviderId, Subscription, SubscriptionState } from "@lunora/payment";
 import { resolveEntitlements } from "@lunora/payment";
 import { LunoraError } from "@lunora/server";
 
 import type { QuotaResource } from "../src/billing/plans";
 import { effectiveLimit, LUNORA_CLOUD_PLANS } from "../src/billing/plans";
-import type { Id } from "./_generated/dataModel.js";
+import type { Doc as StoredRow, Id } from "./_generated/dataModel.js";
 import type { QueryCtx as QueryContext } from "./_generated/server.js";
 
 /**
@@ -16,11 +16,34 @@ import type { QueryCtx as QueryContext } from "./_generated/server.js";
  * baseline, so a non-subscriber is always bounded.
  */
 
+/**
+ * Adapt a stored subscription row to `@lunora/payment`'s `Subscription`.
+ *
+ * The row is keyed by Lunora's `_id`; the payment contract requires `id`. Nothing
+ * in `resolveEntitlements` reads it today, which is why the two shapes could sit
+ * behind a cast without anyone noticing — but the cast asserted a property that
+ * was never there, so the first reader of `id` would have found `undefined`.
+ */
+export const toSubscription = (row: StoredRow<"subscriptions">): Subscription => {return {
+    ...row,
+    id: row._id,
+    // `subscriptions` is `.externallyManaged()` — the payment webhook sync owns
+    // these two columns, so the schema keeps them `v.string()` instead of
+    // restating the provider layer's unions. Narrowed here rather than filtered:
+    // a value this build does not recognize must not silently drop a paying
+    // org's subscription out of entitlement resolution.
+    provider: row.provider as ProviderId,
+    state: row.state as SubscriptionState,
+}};
+
 /** Resolve an org's entitlements from its synced subscription state. */
 export const orgEntitlements = async (context: QueryContext, organizationId: Id<"organizations">): Promise<Entitlements> => {
     const { page } = await context.db.subscriptions.findMany({ where: { referenceId: organizationId } });
 
-    return resolveEntitlements(LUNORA_CLOUD_PLANS, page as unknown as Subscription[]);
+    return resolveEntitlements(
+        LUNORA_CLOUD_PLANS,
+        page.map((row) => toSubscription(row)),
+    );
 };
 
 /** The effective per-resource limit for an org, resolved from its subscriptions. */

--- a/apps/cloud/lunora/entitlements.ts
+++ b/apps/cloud/lunora/entitlements.ts
@@ -17,13 +17,19 @@ import type { QueryCtx as QueryContext } from "./_generated/server.js";
  */
 
 /**
- * Adapt a stored subscription row to `@lunora/payment`'s `Subscription`: the row
- * is keyed by Lunora's `_id`, the payment contract requires `id`.
+ * Adapt a stored subscription row to `@lunora/payment`'s `Subscription`.
+ *
+ * `Subscription.id` is the *provider's* id, not Lunora's row id — the package
+ * maps it to and from `providerSubscriptionId` (`rowToSubscription` /
+ * `subscriptionToRow` in `@lunora/payment`'s database store), and
+ * `(provider, providerSubscriptionId)` is the unique key its webhook sync
+ * reconciles on. Mapping `_id` here would round-trip a Lunora id into that
+ * column.
  */
-const toSubscription = (row: StoredRow<"subscriptions">): Subscription => {
+export const toSubscription = (row: StoredRow<"subscriptions">): Subscription => {
     return {
         ...row,
-        id: row._id,
+        id: row.providerSubscriptionId,
         // `subscriptions` is `.externallyManaged()` — the payment webhook sync
         // owns these two columns, so the schema keeps them `v.string()` instead
         // of restating the provider layer's unions. Narrowed here rather than

--- a/apps/cloud/lunora/entitlements.ts
+++ b/apps/cloud/lunora/entitlements.ts
@@ -17,24 +17,22 @@ import type { QueryCtx as QueryContext } from "./_generated/server.js";
  */
 
 /**
- * Adapt a stored subscription row to `@lunora/payment`'s `Subscription`.
- *
- * The row is keyed by Lunora's `_id`; the payment contract requires `id`. Nothing
- * in `resolveEntitlements` reads it today, which is why the two shapes could sit
- * behind a cast without anyone noticing — but the cast asserted a property that
- * was never there, so the first reader of `id` would have found `undefined`.
+ * Adapt a stored subscription row to `@lunora/payment`'s `Subscription`: the row
+ * is keyed by Lunora's `_id`, the payment contract requires `id`.
  */
-export const toSubscription = (row: StoredRow<"subscriptions">): Subscription => {return {
-    ...row,
-    id: row._id,
-    // `subscriptions` is `.externallyManaged()` — the payment webhook sync owns
-    // these two columns, so the schema keeps them `v.string()` instead of
-    // restating the provider layer's unions. Narrowed here rather than filtered:
-    // a value this build does not recognize must not silently drop a paying
-    // org's subscription out of entitlement resolution.
-    provider: row.provider as ProviderId,
-    state: row.state as SubscriptionState,
-}};
+const toSubscription = (row: StoredRow<"subscriptions">): Subscription => {
+    return {
+        ...row,
+        id: row._id,
+        // `subscriptions` is `.externallyManaged()` — the payment webhook sync
+        // owns these two columns, so the schema keeps them `v.string()` instead
+        // of restating the provider layer's unions. Narrowed here rather than
+        // filtered: a value this build does not recognize must not silently drop
+        // a paying org's subscription out of entitlement resolution.
+        provider: row.provider as ProviderId,
+        state: row.state as SubscriptionState,
+    };
+};
 
 /** Resolve an org's entitlements from its synced subscription state. */
 export const orgEntitlements = async (context: QueryContext, organizationId: Id<"organizations">): Promise<Entitlements> => {

--- a/apps/cloud/lunora/github-installations.ts
+++ b/apps/cloud/lunora/github-installations.ts
@@ -32,7 +32,7 @@ export const record = internalMutation
     .input({ accountLogin: v.string(), installationId: v.number() })
     .mutation(async ({ ctx: context, args: { accountLogin, installationId } }): Promise<Id<"githubInstallations">> => {
         const { page } = await context.db.githubInstallations.findMany({ where: { installationId } });
-        const existing = (page as unknown as InstallationRow[])[0];
+        const existing = page[0];
 
         if (existing) {
             return existing._id;
@@ -57,7 +57,7 @@ export const claim = mutation
         const { userId } = await assertMember(context, organizationId, ["owner", "admin"]);
 
         const { page } = await context.db.githubInstallations.findMany({ where: { installationId } });
-        const installation = (page as unknown as InstallationRow[])[0];
+        const installation = page[0];
 
         if (!installation) {
             throw new LunoraError("NOT_FOUND", "installation not found — install the GitHub App first");
@@ -102,7 +102,7 @@ export const unclaim = mutation
         const { userId } = await assertMember(context, organizationId, ["owner", "admin"]);
 
         const { page } = await context.db.githubInstallations.findMany({ where: { installationId } });
-        const installation = (page as unknown as InstallationRow[])[0];
+        const installation = page[0];
 
         // Only the CLAIMING org may release it — otherwise this is a way to detach
         // another tenant's integration by guessing a numeric id.
@@ -127,7 +127,7 @@ export const unclaim = mutation
  */
 export const remove = internalMutation.input({ installationId: v.number() }).mutation(async ({ ctx: context, args: { installationId } }): Promise<void> => {
     const { page } = await context.db.githubInstallations.findMany({ where: { installationId } });
-    const existing = (page as unknown as InstallationRow[])[0];
+    const existing = page[0];
 
     if (existing) {
         await context.db.delete(existing._id);

--- a/apps/cloud/lunora/incidents.ts
+++ b/apps/cloud/lunora/incidents.ts
@@ -1,7 +1,7 @@
 import { generateText } from "@lunora/ai";
 import { LunoraError } from "@lunora/server";
 
-import type { EvidenceLogRow, EvidenceSpanRow, GeneratePort, InvestigationIncident, InvestigationResult } from "../src/telemetry/investigation";
+import type { EvidenceLogRow, GeneratePort, InvestigationIncident, InvestigationResult } from "../src/telemetry/investigation";
 import { buildEvidenceBundle, resolveInvestigationRunner } from "../src/telemetry/investigation";
 import type { TriageIncident, TriageIssue } from "../src/telemetry/triage";
 import { buildTriagePrompt, MAX_ISSUES } from "../src/telemetry/triage";
@@ -59,7 +59,7 @@ export const list = query.input({ organizationId: v.id("organizations") }).query
 
     const { page } = await context.db.incidents.findMany({ where: { organizationId } });
 
-    return (page as unknown as IncidentRow[]).toSorted((a, b) => b.lastSeen - a.lastSeen);
+    return page.toSorted((a, b) => b.lastSeen - a.lastSeen);
 });
 
 /** Resolve or reopen an incident (owners/admins). Resolving stamps `closedAt`. */
@@ -93,11 +93,6 @@ interface IncidentDocument extends TriageIncident {
     hash: string;
 }
 
-/** A related issue row, plus the `hash` the mirror-row exclusion keys on. */
-interface RelatedIssue extends TriageIssue {
-    hash: string;
-}
-
 /**
  * The other error groups raised by `container`, most-frequent first, excluding
  * the incident's own mirror row (`selfHash`).
@@ -118,7 +113,7 @@ const relatedIssues = async (context: ActionContext, organizationId: Id<"organiz
         where: { culprit: `container:${container}`, organizationId },
     });
 
-    return (page as unknown as RelatedIssue[]).filter((issue) => issue.hash !== selfHash).slice(0, MAX_ISSUES);
+    return page.filter((issue) => issue.hash !== selfHash).slice(0, MAX_ISSUES);
 };
 
 /**
@@ -179,11 +174,6 @@ const EVIDENCE_SPAN_SCAN = 300;
 /** Max correlated log lines fetched per related trace (bounded). */
 const EVIDENCE_LOG_SCAN_PER_TRACE = 50;
 
-/** An `observations` row, reduced to the fields the evidence builder reads. */
-interface ObservationRow extends EvidenceSpanRow {
-    _id: Id<"observations">;
-}
-
 /** A `tenantLogs` row, reduced to the fields the evidence builder reads. */
 interface LogRow extends EvidenceLogRow {
     _id: Id<"tenantLogs">;
@@ -204,7 +194,7 @@ const gatherEvidence = async (context: ActionContext, organizationId: Id<"organi
         where: { organizationId },
     });
 
-    const spans = spanPage as unknown as ObservationRow[];
+    const spans = spanPage;
 
     // First pass: correlate spans → related trace ids (no logs yet).
     const preliminary = buildEvidenceBundle({ incident, logs: [], spans });
@@ -219,7 +209,7 @@ const gatherEvidence = async (context: ActionContext, organizationId: Id<"organi
             where: { organizationId, traceId },
         });
 
-        logs.push(...(logPage as unknown as LogRow[]));
+        logs.push(...logPage);
     }
 
     return buildEvidenceBundle({ incident, logs, spans });

--- a/apps/cloud/lunora/incidents.ts
+++ b/apps/cloud/lunora/incidents.ts
@@ -188,13 +188,11 @@ interface LogRow extends EvidenceLogRow {
  * fetched logs) to produce the bundle the runner reasons over.
  */
 const gatherEvidence = async (context: ActionContext, organizationId: Id<"organizations">, incident: InvestigationIncident) => {
-    const { page: spanPage } = await context.db.observations.findMany({
+    const { page: spans } = await context.db.observations.findMany({
         limit: EVIDENCE_SPAN_SCAN,
         orderBy: [{ startedAt: "desc" }],
         where: { organizationId },
     });
-
-    const spans = spanPage;
 
     // First pass: correlate spans → related trace ids (no logs yet).
     const preliminary = buildEvidenceBundle({ incident, logs: [], spans });

--- a/apps/cloud/lunora/invitations.ts
+++ b/apps/cloud/lunora/invitations.ts
@@ -41,7 +41,7 @@ export const list = query
 
         const { page } = await context.db.invitations.findMany({ where: { organizationId } });
 
-        return (page as unknown as InvitationRow[]).map(({ tokenHash: _tokenHash, ...view }) => view);
+        return page.map(({ tokenHash: _tokenHash, ...view }) => view);
     });
 
 /**
@@ -102,7 +102,7 @@ export const accept = mutation
 
         const tokenHash = await sha256Hex(token);
         const { page } = await context.db.invitations.findMany({ where: { tokenHash } });
-        const invitation = (page as unknown as InvitationRow[])[0];
+        const invitation = page[0];
 
         if (invitation?.status !== "pending" || invitation.expiresAt < context.now) {
             throw new LunoraError("FORBIDDEN", "invitation is invalid, revoked, or expired");
@@ -110,7 +110,7 @@ export const accept = mutation
 
         const members = await context.db.members.findMany({ where: { organizationId: invitation.organizationId, userId } });
 
-        if ((members.page as unknown as unknown[]).length === 0) {
+        if (members.page.length === 0) {
             await context.db.insert("members", {
                 createdAt: context.now,
                 organizationId: invitation.organizationId,

--- a/apps/cloud/lunora/issues.ts
+++ b/apps/cloud/lunora/issues.ts
@@ -34,7 +34,7 @@ export const list = query.input({ organizationId: v.id("organizations") }).query
 
     const { page } = await context.db.issues.findMany({ where: { organizationId } });
 
-    return (page as unknown as IssueRow[]).toSorted((a, b) => b.lastSeen - a.lastSeen);
+    return page.toSorted((a, b) => b.lastSeen - a.lastSeen);
 });
 
 /** Resolve or reopen an issue (owners/admins). */

--- a/apps/cloud/lunora/logs.ts
+++ b/apps/cloud/lunora/logs.ts
@@ -204,7 +204,7 @@ export const orgForScript = internalQuery
     .input({ scriptName: boundedString(LIMITS.name) })
     .query(async ({ ctx: context, args: { scriptName } }): Promise<{ organizationId: Id<"organizations"> } | null> => {
         const { page } = await context.db.deployments.findMany({ where: { scriptName } });
-        const row = (page as unknown as { organizationId: Id<"organizations"> }[])[0];
+        const row = page[0];
 
         return row ? { organizationId: row.organizationId } : null;
     });
@@ -299,7 +299,7 @@ export const list = query
 
         const rows: TenantLogView[] = [];
 
-        for (const row of page as unknown as TenantLogRow[]) {
+        for (const row of page) {
             if (keep(row)) {
                 rows.push(toView(row));
             }
@@ -321,7 +321,7 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
     const { page } = await context.db.tenantLogs.findMany({ limit: PRUNE_BATCH, orderBy: [{ createdAt: "asc" }], where: { createdAt: { lt: cutoff } } });
-    const stale = page as unknown as TenantLogRow[];
+    const stale = page;
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/logs.ts
+++ b/apps/cloud/lunora/logs.ts
@@ -320,8 +320,7 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
     // rows it does not want. Oldest-first keeps a backlog draining in cutoff order,
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
-    const { page } = await context.db.tenantLogs.findMany({ limit: PRUNE_BATCH, orderBy: [{ createdAt: "asc" }], where: { createdAt: { lt: cutoff } } });
-    const stale = page;
+    const { page: stale } = await context.db.tenantLogs.findMany({ limit: PRUNE_BATCH, orderBy: [{ createdAt: "asc" }], where: { createdAt: { lt: cutoff } } });
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/members.ts
+++ b/apps/cloud/lunora/members.ts
@@ -43,7 +43,7 @@ export const add = mutation
             where: { organizationId: arguments_.organizationId, userId: arguments_.userId },
         });
 
-        const existing = (page as unknown as MemberRow[])[0];
+        const existing = page[0];
 
         if (existing) {
             throw new LunoraError("CONFLICT", "user is already a member");
@@ -51,7 +51,7 @@ export const add = mutation
 
         const all = await context.db.members.findMany({ where: { organizationId: arguments_.organizationId } });
 
-        await assertWithinQuota(context, arguments_.organizationId, "members", (all.page as unknown as MemberRow[]).length);
+        await assertWithinQuota(context, arguments_.organizationId, "members", all.page.length);
 
         return context.db.insert("members", {
             createdAt: context.now,
@@ -93,7 +93,7 @@ export const setRole = mutation
 
         if (target.role === "owner" && newRole !== "owner") {
             const { page } = await context.db.members.findMany({ where: { organizationId } });
-            const owners = (page as unknown as MemberRow[]).filter((member) => member.role === "owner");
+            const owners = page.filter((member) => member.role === "owner");
 
             if (owners.length <= 1) {
                 throw new LunoraError("CONFLICT", "cannot demote the last owner");

--- a/apps/cloud/lunora/metrics.ts
+++ b/apps/cloud/lunora/metrics.ts
@@ -187,6 +187,7 @@ export const METRIC_POINT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Rows one prune tick deletes. Bounds a single mutation; a backlog drains over ticks. */
 const PRUNE_BATCH = 1000;
+
 /** Delete exact metric points past retention. SYSTEM only (cron dispatch). */
 export const prune = internalMutation.mutation(async ({ ctx: context }): Promise<{ pruned: number }> => {
     const cutoff = context.now - METRIC_POINT_RETENTION_MS;
@@ -195,8 +196,7 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
     // rows it does not want. Oldest-first keeps a backlog draining in cutoff order,
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
-    const { page } = await context.db.metricPoints.findMany({ limit: PRUNE_BATCH, orderBy: [{ at: "asc" }], where: { at: { lt: cutoff } } });
-    const stale = page;
+    const { page: stale } = await context.db.metricPoints.findMany({ limit: PRUNE_BATCH, orderBy: [{ at: "asc" }], where: { at: { lt: cutoff } } });
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/metrics.ts
+++ b/apps/cloud/lunora/metrics.ts
@@ -1,10 +1,8 @@
 import { LunoraError } from "@lunora/server";
 
-import type { StoredMetricPoint } from "../src/telemetry/metric-series";
 import { foldMetricSeries } from "../src/telemetry/metric-series";
 import type { MetricSeries } from "../src/telemetry/metrics-read";
 import { createMetricsReader, DEFAULT_METRICS_WINDOW_MS } from "../src/telemetry/metrics-read";
-import type { Id } from "./_generated/dataModel.js";
 import { action, internalMutation, mutation, query, v } from "./_generated/server.js";
 import { assertMember, assertRowInOrg, authorizeTelemetryKey } from "./authz";
 import { rateLimit } from "./guards";
@@ -154,12 +152,6 @@ export const ingest = mutation
 /** Recent metric points scanned before folding into exact series (bounds the read). */
 const METRIC_SCAN_LIMIT = 5000;
 
-/** One stored metric-point row, as {@link series} reads it. */
-interface MetricPointRow extends StoredMetricPoint {
-    _id: Id<"metricPoints">;
-    organizationId: Id<"organizations">;
-}
-
 /**
  * Exact per-metric series from the D1 `metricPoints` store over `[from, to]` —
  * every stored point averaged per bucket (precise, not sampled like the AE
@@ -185,7 +177,7 @@ export const series = query
             where: { organizationId: args.organizationId },
         });
 
-        const points = (page as unknown as MetricPointRow[]).filter((row) => row.at >= from && row.at <= to);
+        const points = page.filter((row) => row.at >= from && row.at <= to);
 
         return foldMetricSeries(points).map((point) => toView(point));
     });
@@ -195,13 +187,6 @@ export const METRIC_POINT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Rows one prune tick deletes. Bounds a single mutation; a backlog drains over ticks. */
 const PRUNE_BATCH = 1000;
-
-/** One stored metric point, for the retention scan. */
-interface MetricRetentionRow {
-    _id: Id<"metricPoints">;
-    at: number;
-}
-
 /** Delete exact metric points past retention. SYSTEM only (cron dispatch). */
 export const prune = internalMutation.mutation(async ({ ctx: context }): Promise<{ pruned: number }> => {
     const cutoff = context.now - METRIC_POINT_RETENTION_MS;
@@ -211,7 +196,7 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
     const { page } = await context.db.metricPoints.findMany({ limit: PRUNE_BATCH, orderBy: [{ at: "asc" }], where: { at: { lt: cutoff } } });
-    const stale = page as unknown as MetricRetentionRow[];
+    const stale = page;
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/organizations.ts
+++ b/apps/cloud/lunora/organizations.ts
@@ -4,6 +4,7 @@ import type { Id } from "./_generated/dataModel.js";
 import { internalMutation, mutation, query, v } from "./_generated/server.js";
 import { assertMember } from "./authz";
 import { rateLimit } from "./guards";
+import { purgeScopedRows } from "./purge";
 import { boundedString, LIMITS } from "./validators";
 
 /**
@@ -234,12 +235,11 @@ export const purgeDeleted = internalMutation.mutation(async ({ ctx: context }): 
     // never matches NULL, so organizations that were never scheduled for deletion are
     // excluded by the query rather than crowding out the ones that were. Oldest-first
     // within the due set, bounded per tick.
-    const { page } = await context.db.organizations.findMany({
+    const { page: due } = await context.db.organizations.findMany({
         limit: PURGE_BATCH,
         orderBy: [{ deletionRequestedAt: "asc" }],
         where: { deletionRequestedAt: { lt: cutoff } },
     });
-    const due = page;
 
     // EVERY table carrying an `organizationId`, not a hand-kept subset. The list
     // had drifted to 12 of 25 while the docblock above claimed erasure "across
@@ -290,20 +290,8 @@ export const purgeDeleted = internalMutation.mutation(async ({ ctx: context }): 
     for (const organization of due) {
         const organizationId = organization._id;
 
-        for (const table of orgScopedTables) {
-            // The per-table facade types don't unify, so the generic sweep goes
-            // through a minimal structural cast.
-            const facade = context.db[table] as unknown as {
-                findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: { _id: string }[] }>;
-            };
-            // eslint-disable-next-line no-await-in-loop -- sequential per-table purge keeps the writer simple
-            const { page: rows } = await facade.findMany({ where: { organizationId } });
-
-            for (const row of rows) {
-                // eslint-disable-next-line no-await-in-loop -- sequential deletes; volumes are small
-                await context.db.delete(row._id as never);
-            }
-        }
+        // eslint-disable-next-line no-await-in-loop -- one org purged at a time keeps the writer simple
+        await purgeScopedRows(context, orgScopedTables, { organizationId });
 
         // Deployments transition to destroyed (not hard-deleted) so the 🌐
         // teardown path still sees what to tear down; a later sweep removes rows.

--- a/apps/cloud/lunora/organizations.ts
+++ b/apps/cloud/lunora/organizations.ts
@@ -53,7 +53,7 @@ export const list = query.query(async ({ ctx: context }): Promise<OrganizationRo
     }
 
     const { page: memberships } = await context.db.members.findMany({ where: { userId } });
-    const orgIds = [...new Set((memberships as unknown as { organizationId: Id<"organizations"> }[]).map((membership) => membership.organizationId))];
+    const orgIds = [...new Set(memberships.map((membership) => membership.organizationId))];
 
     // Fetched BY ID rather than read-all-and-filter. The previous form pulled one
     // page of every organization on the platform and kept the caller's — which is
@@ -83,7 +83,7 @@ export const getBySlug = query.input({ slug: boundedString(LIMITS.id) }).query(a
     }
 
     const { page } = await context.db.organizations.findMany({ where: { slug } });
-    const organization = (page as unknown as OrganizationRow[])[0] ?? null;
+    const organization = page[0] ?? null;
 
     if (!organization) {
         return null;
@@ -130,7 +130,7 @@ export const create = mutation
 
         if (!cellId) {
             const { page: cellPage } = await context.db.cells.findMany({});
-            const candidate = (cellPage as unknown as { _id: Id<"cells">; jurisdiction?: string; status: string }[]).find(
+            const candidate = cellPage.find(
                 (cell) => cell.status === "active" && (arguments_.jurisdiction === undefined || cell.jurisdiction === arguments_.jurisdiction),
             );
             const picked = candidate;
@@ -239,7 +239,7 @@ export const purgeDeleted = internalMutation.mutation(async ({ ctx: context }): 
         orderBy: [{ deletionRequestedAt: "asc" }],
         where: { deletionRequestedAt: { lt: cutoff } },
     });
-    const due = page as unknown as (OrganizationRow & { deletionRequestedAt?: number })[];
+    const due = page;
 
     // EVERY table carrying an `organizationId`, not a hand-kept subset. The list
     // had drifted to 12 of 25 while the docblock above claimed erasure "across
@@ -293,11 +293,13 @@ export const purgeDeleted = internalMutation.mutation(async ({ ctx: context }): 
         for (const table of orgScopedTables) {
             // The per-table facade types don't unify, so the generic sweep goes
             // through a minimal structural cast.
-            const facade = context.db[table] as unknown as { findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: unknown[] }> };
+            const facade = context.db[table] as unknown as {
+                findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: { _id: string }[] }>;
+            };
             // eslint-disable-next-line no-await-in-loop -- sequential per-table purge keeps the writer simple
             const { page: rows } = await facade.findMany({ where: { organizationId } });
 
-            for (const row of rows as unknown as { _id: string }[]) {
+            for (const row of rows) {
                 // eslint-disable-next-line no-await-in-loop -- sequential deletes; volumes are small
                 await context.db.delete(row._id as never);
             }
@@ -308,9 +310,9 @@ export const purgeDeleted = internalMutation.mutation(async ({ ctx: context }): 
         // eslint-disable-next-line no-await-in-loop -- one read per org; volumes are small
         const { page: deployments } = await context.db.deployments.findMany({ where: { organizationId } });
 
-        for (const deployment of deployments as unknown as { _id: string; status: string }[]) {
+        for (const deployment of deployments) {
             // eslint-disable-next-line no-await-in-loop -- sequential patches; volumes are small
-            await context.db.patch(deployment._id as never, { destroyedAt: context.now, status: "destroyed", updatedAt: context.now });
+            await context.db.patch(deployment._id, { destroyedAt: context.now, status: "destroyed", updatedAt: context.now });
         }
 
         // eslint-disable-next-line no-await-in-loop -- one delete per org

--- a/apps/cloud/lunora/projects.ts
+++ b/apps/cloud/lunora/projects.ts
@@ -7,6 +7,7 @@ import { internalQuery, mutation, query, v } from "./_generated/server.js";
 import { assertMember, assertRowInOrg } from "./authz";
 import { assertWithinQuota } from "./entitlements";
 import { rateLimit } from "./guards";
+import { purgeScopedRows } from "./purge";
 import { boundedString, LIMITS } from "./validators";
 
 /** Shortest preview password accepted — a gate this weak is theatre below it. */
@@ -189,20 +190,7 @@ export const remove = mutation
 
         const { now } = context;
 
-        for (const table of PROJECT_SCOPED_TABLES) {
-            // The per-table facades don't unify, so the generic sweep goes through a
-            // minimal structural cast — same shape `organizations.purgeDeleted` uses.
-            const facade = context.db[table] as unknown as {
-                findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: { _id: string }[] }>;
-            };
-            // eslint-disable-next-line no-await-in-loop -- sequential per-table purge keeps the writer simple
-            const { page: rows } = await facade.findMany({ where: { projectId: id } });
-
-            for (const row of rows) {
-                // eslint-disable-next-line no-await-in-loop -- sequential deletes; a project's volumes are small
-                await context.db.delete(row._id as never);
-            }
-        }
+        await purgeScopedRows(context, PROJECT_SCOPED_TABLES, { projectId: id });
 
         // Deployments transition rather than vanish, so the teardown sweep still
         // has something to tear down.

--- a/apps/cloud/lunora/projects.ts
+++ b/apps/cloud/lunora/projects.ts
@@ -76,7 +76,7 @@ export const listByOrg = query
 
         const { page } = await context.db.projects.findMany({ where: { organizationId } });
 
-        return (page as unknown as ProjectRow[]).map((row) => toProjectView(row));
+        return page.map((row) => toProjectView(row));
     });
 
 /**
@@ -95,7 +95,7 @@ export const byGithubRepo = internalQuery
     .input({ repository: boundedString(LIMITS.token) })
     .query(async ({ ctx: context, args: { repository } }): Promise<null | { organizationId: Id<"organizations">; projectId: Id<"projects">; slug: string }> => {
         const { page } = await context.db.projects.findMany({ where: { githubRepo: repository } });
-        const project = (page as unknown as ProjectRow[])[0];
+        const project = page[0];
 
         return project ? { organizationId: project.organizationId, projectId: project._id, slug: project.slug } : null; // secret-scanner:allow -- domain field name
     });
@@ -120,7 +120,7 @@ export const create = mutation
 
         const { page } = await context.db.projects.findMany({ where: { organizationId: arguments_.organizationId } });
 
-        await assertWithinQuota(context, arguments_.organizationId, "projects", (page as unknown as ProjectRow[]).length);
+        await assertWithinQuota(context, arguments_.organizationId, "projects", page.length);
 
         return context.db.insert("projects", {
             createdAt: context.now,
@@ -192,11 +192,13 @@ export const remove = mutation
         for (const table of PROJECT_SCOPED_TABLES) {
             // The per-table facades don't unify, so the generic sweep goes through a
             // minimal structural cast — same shape `organizations.purgeDeleted` uses.
-            const facade = context.db[table] as unknown as { findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: unknown[] }> };
+            const facade = context.db[table] as unknown as {
+                findMany: (q: { where: Record<string, unknown> }) => Promise<{ page: { _id: string }[] }>;
+            };
             // eslint-disable-next-line no-await-in-loop -- sequential per-table purge keeps the writer simple
             const { page: rows } = await facade.findMany({ where: { projectId: id } });
 
-            for (const row of rows as { _id: string }[]) {
+            for (const row of rows) {
                 // eslint-disable-next-line no-await-in-loop -- sequential deletes; a project's volumes are small
                 await context.db.delete(row._id as never);
             }
@@ -205,11 +207,11 @@ export const remove = mutation
         // Deployments transition rather than vanish, so the teardown sweep still
         // has something to tear down.
         const { page: deployments } = await context.db.deployments.findMany({ where: { projectId: id } });
-        const live = (deployments as unknown as { _id: string; status: string }[]).filter((row) => row.status !== "destroyed");
+        const live = deployments.filter((row) => row.status !== "destroyed");
 
         for (const deployment of live) {
             // eslint-disable-next-line no-await-in-loop -- sequential patches; a project's volumes are small
-            await context.db.patch(deployment._id as never, { destroyedAt: now, status: "destroyed", updatedAt: now });
+            await context.db.patch(deployment._id, { destroyedAt: now, status: "destroyed", updatedAt: now });
         }
 
         await context.db.delete(id);
@@ -306,7 +308,7 @@ export const verifyPreviewPassword = internalQuery
     .input({ password: boundedString(LIMITS.token), scriptName: boundedString(LIMITS.name) })
     .query(async ({ ctx: context, args: { password, scriptName } }): Promise<{ ok: boolean }> => {
         const { page } = await context.db.deployments.findMany({ where: { scriptName } });
-        const deployment = (page as unknown as { projectId?: Id<"projects"> }[])[0];
+        const deployment = page[0];
 
         if (!deployment?.projectId) {
             return { ok: false };

--- a/apps/cloud/lunora/purge.ts
+++ b/apps/cloud/lunora/purge.ts
@@ -1,0 +1,29 @@
+import type { TableName } from "./_generated/dataModel.js";
+import type { MutationCtx as MutationContext } from "./_generated/server.js";
+
+/**
+ * Hard-delete every row of `tables` matching `where`.
+ *
+ * Indexing `ctx.db` by a variable gives a union of every table's facade, and
+ * those call signatures do not unify — so a sweep that visits tables by name has
+ * to go through a structural view of the one method it calls. That cast lives
+ * here, once, rather than at each caller.
+ *
+ * The reads are one page per table: both callers purge rows scoped to a single
+ * organization or project, which stays well inside the page cap. A table that
+ * could exceed it needs {@link collectAll}, not this.
+ */
+export const purgeScopedRows = async (context: MutationContext, tables: ReadonlyArray<TableName>, where: Record<string, unknown>): Promise<void> => {
+    for (const table of tables) {
+        const facade = context.db[table] as unknown as {
+            findMany: (query: { where: Record<string, unknown> }) => Promise<{ page: { _id: string }[] }>;
+        };
+        // eslint-disable-next-line no-await-in-loop -- sequential per-table purge keeps the writer simple
+        const { page: rows } = await facade.findMany({ where });
+
+        for (const row of rows) {
+            // eslint-disable-next-line no-await-in-loop -- sequential deletes; a single scope's volumes are small
+            await context.db.delete(row._id as never);
+        }
+    }
+};

--- a/apps/cloud/lunora/rollouts.ts
+++ b/apps/cloud/lunora/rollouts.ts
@@ -160,7 +160,7 @@ export const promoteRollout = mutation
 
         const { now } = context;
         const { page } = await context.db.deployments.findMany({ where: { projectId } }); // secret-scanner:allow -- domain field name
-        const others = (page as unknown as DeploymentRow[]).filter((row) => row._id !== candidateId && row.kind === candidate.kind && row.status === "live");
+        const others = page.filter((row) => row._id !== candidateId && row.kind === candidate.kind && row.status === "live");
 
         for (const other of others) {
             // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/secrets.ts
+++ b/apps/cloud/lunora/secrets.ts
@@ -44,7 +44,7 @@ export const store = mutation
         const { page } = await context.db.secrets.findMany({
             where: { environment, name: arguments_.name, organizationId: arguments_.organizationId, projectId: arguments_.projectId }, // secret-scanner:allow -- domain field name
         });
-        const existing = (page as unknown as SecretRow[])[0];
+        const existing = page[0];
         const { now } = context;
 
         if (existing) {
@@ -78,7 +78,7 @@ export const list = query
 
             const { page } = await context.db.secrets.findMany({ where: { organizationId, projectId } });
 
-            return (page as unknown as SecretRow[]).map((secret) => {
+            return page.map((secret) => {
                 return { createdAt: secret.createdAt, environment: secret.environment, id: secret._id, name: secret.name, updatedAt: secret.updatedAt };
             });
         },
@@ -105,7 +105,7 @@ export const listEncrypted = query
 
             const kind = environment ?? "production";
             const { page } = await context.db.secrets.findMany({ where: { organizationId, projectId } });
-            const rows = (page as unknown as SecretRow[]).filter((secret) => secret.environment === kind || secret.environment === "all");
+            const rows = page.filter((secret) => secret.environment === kind || secret.environment === "all");
 
             // Kind-specific rows override shared ("all") rows of the same name.
             const byName = new Map<string, SecretRow>();

--- a/apps/cloud/lunora/sessions.ts
+++ b/apps/cloud/lunora/sessions.ts
@@ -93,7 +93,7 @@ export const list = query
             where: { organizationId: args.organizationId },
         });
 
-        const turns = (page as unknown as SessionObservationRow[]).filter((row) => isSessionTurn(row));
+        const turns = page.filter((row) => isSessionTurn(row));
 
         // `SessionSummary` and the local `SessionSummaryView` are structurally
         // identical — the view mirror is what codegen inlines into the API types.
@@ -122,7 +122,7 @@ export const get = query
             where: { organizationId: args.organizationId, sessionId: args.sessionId },
         });
 
-        return (page as unknown as SessionObservationRow[])
+        return page
             .filter((row) => row.kind === "generation")
             .toSorted((a, b) => a.startedAt - b.startedAt)
             .map((row) => {

--- a/apps/cloud/lunora/telemetry.ts
+++ b/apps/cloud/lunora/telemetry.ts
@@ -1,7 +1,7 @@
 import { fingerprintError } from "@lunora/fingerprint";
 import { LunoraError } from "@lunora/server";
 
-import type { AlertChannel, AlertDelivery as AlertDeliveryBase, FiringRule, MetricObservation, MetricRule, MetricTarget } from "../src/telemetry/alerts";
+import type { AlertDelivery as AlertDeliveryBase, FiringRule, MetricRule, MetricTarget } from "../src/telemetry/alerts";
 import { fireCrossedRules, fireMetricRules } from "../src/telemetry/alerts";
 import type { Id } from "./_generated/dataModel.js";
 import type { MutationCtx as MutationContext } from "./_generated/server.js";
@@ -74,52 +74,11 @@ const telemetryEvent = v.object({
     // Event time in epoch ms (decoded from the span's end time).
     ts: v.number(),
 });
-
-interface IssueRow {
-    _id: Id<"issues">;
-    count: number;
-    lastSeen: number;
-}
-
-interface IncidentRow {
-    _id: Id<"incidents">;
-    count: number;
-    lastSeen: number;
-}
-
-interface AlertRuleRow {
-    _id: Id<"alertRules">;
-    baselineWindows?: number;
-    channel: AlertChannel;
-    comparator?: "gt" | "lt";
-    destination: string;
-    enabled: boolean;
-    functionPath?: string;
-    mode?: "deviation" | "threshold";
-    name: string;
-    target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime";
-    threshold: number;
-    windowMinutes?: number;
-}
-
-/** A metric rule's persisted firing latch (alertRuleState), read + advanced by the ingest. */
-interface AlertRuleStateRow {
-    _id: Id<"alertRuleState">;
-    firing: boolean;
-    ruleId: Id<"alertRules">;
-}
-
 /** Count-crossing rule targets the ingest evaluates via `fireCrossedRules`. */
 const COUNT_TARGETS = new Set(["incident", "issue"]);
 
 /** Metric-window rule targets the ingest evaluates via `fireMetricRules`. */
 const METRIC_TARGETS = new Set<MetricTarget>(["error_rate", "latency_p95", "llm_cost"]);
-
-/** One stored observation row, as the metric-rule window read consumes it. */
-interface MetricObservationRow extends MetricObservation {
-    organizationId: Id<"organizations">;
-}
-
 /** Recent spans scanned when a metric rule needs its window (bounds the read). */
 const METRIC_SCAN_LIMIT = 2000;
 
@@ -207,7 +166,7 @@ export const upsertIssue = async (
     now: number,
 ): Promise<{ after: number; before: number }> => {
     const { page } = await context.db.issues.findMany({ where: { hash: group.hash, organizationId } });
-    const existing = (page as unknown as IssueRow[])[0];
+    const existing = page[0];
     const before = existing ? existing.count : 0;
 
     if (existing) {
@@ -249,7 +208,7 @@ export const upsertIncident = async (
     now: number,
 ): Promise<{ after: number; before: number }> => {
     const { page } = await context.db.incidents.findMany({ where: { hash: group.hash, organizationId } });
-    const existing = (page as unknown as IncidentRow[])[0];
+    const existing = page[0];
     const before = existing ? existing.count : 0;
 
     if (existing) {
@@ -334,7 +293,7 @@ export const ingest = mutation
                 });
             }
             const { page: rulePage } = await context.db.alertRules.findMany({ where: { organizationId: args.organizationId } });
-            const enabledRules = (rulePage as unknown as AlertRuleRow[]).filter((rule) => rule.enabled);
+            const enabledRules = rulePage.filter((rule) => rule.enabled);
             // Count-crossing rules (issue/incident) evaluated per upserted group below.
             const rules: FiringRule[] = enabledRules
                 .filter((rule) => COUNT_TARGETS.has(rule.target))
@@ -351,7 +310,7 @@ export const ingest = mutation
             // Metric-window rules (error_rate/latency_p95/llm_cost) evaluated once
             // over the freshly-ingested observation window, after the loop.
             const metricRules: MetricRule[] = enabledRules
-                .filter((rule): rule is AlertRuleRow & { target: MetricTarget } => METRIC_TARGETS.has(rule.target as MetricTarget))
+                .filter((rule): rule is (typeof enabledRules)[number] & { target: MetricTarget } => METRIC_TARGETS.has(rule.target as MetricTarget))
                 .map((rule) => {
                     return {
                         baselineWindows: rule.baselineWindows,
@@ -435,9 +394,9 @@ export const ingest = mutation
                     orderBy: [{ startedAt: "desc" }],
                     where: { organizationId: args.organizationId },
                 });
-                const windowObservations = observationPage as unknown as MetricObservationRow[];
+                const windowObservations = observationPage;
                 const { page: statePage } = await context.db.alertRuleState.findMany({ where: { organizationId: args.organizationId } });
-                const stateByRule = new Map((statePage as unknown as AlertRuleStateRow[]).map((row) => [row.ruleId as string, row]));
+                const stateByRule = new Map(statePage.map((row) => [row.ruleId as string, row]));
 
                 const outcome = await fireMetricRules(
                     metricRules,
@@ -484,13 +443,6 @@ export const OBSERVATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Rows one prune tick deletes. Bounds a single mutation; a backlog drains over ticks. */
 const PRUNE_BATCH = 1000;
-
-/** One stored observation row, for the retention scan. */
-interface ObservationRow {
-    _id: Id<"observations">;
-    startedAt: number;
-}
-
 /** Delete span observations past retention (Traces). SYSTEM only (cron dispatch). */
 export const pruneObservations = internalMutation.mutation(async ({ ctx: context }): Promise<{ pruned: number }> => {
     const cutoff = context.now - OBSERVATION_RETENTION_MS;
@@ -500,7 +452,7 @@ export const pruneObservations = internalMutation.mutation(async ({ ctx: context
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
     const { page } = await context.db.observations.findMany({ limit: PRUNE_BATCH, orderBy: [{ startedAt: "asc" }], where: { startedAt: { lt: cutoff } } });
-    const stale = page as unknown as ObservationRow[];
+    const stale = page;
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/telemetry.ts
+++ b/apps/cloud/lunora/telemetry.ts
@@ -80,6 +80,7 @@ const COUNT_TARGETS = new Set(["incident", "issue"]);
 
 /** Metric-window rule targets the ingest evaluates via `fireMetricRules`. */
 const METRIC_TARGETS = new Set<MetricTarget>(["error_rate", "latency_p95", "llm_cost"]);
+
 /** Recent spans scanned when a metric rule needs its window (bounds the read). */
 const METRIC_SCAN_LIMIT = 2000;
 

--- a/apps/cloud/lunora/telemetry.ts
+++ b/apps/cloud/lunora/telemetry.ts
@@ -74,6 +74,7 @@ const telemetryEvent = v.object({
     // Event time in epoch ms (decoded from the span's end time).
     ts: v.number(),
 });
+
 /** Count-crossing rule targets the ingest evaluates via `fireCrossedRules`. */
 const COUNT_TARGETS = new Set(["incident", "issue"]);
 
@@ -389,12 +390,11 @@ export const ingest = mutation
             // (shared with the periodic sweep in `src/telemetry/sweep.ts`) makes a
             // sustained breach alert once and lets a quiet window still clear + re-arm.
             if (metricRules.length > 0) {
-                const { page: observationPage } = await context.db.observations.findMany({
+                const { page: windowObservations } = await context.db.observations.findMany({
                     limit: METRIC_SCAN_LIMIT,
                     orderBy: [{ startedAt: "desc" }],
                     where: { organizationId: args.organizationId },
                 });
-                const windowObservations = observationPage;
                 const { page: statePage } = await context.db.alertRuleState.findMany({ where: { organizationId: args.organizationId } });
                 const stateByRule = new Map(statePage.map((row) => [row.ruleId as string, row]));
 
@@ -443,6 +443,7 @@ export const OBSERVATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Rows one prune tick deletes. Bounds a single mutation; a backlog drains over ticks. */
 const PRUNE_BATCH = 1000;
+
 /** Delete span observations past retention (Traces). SYSTEM only (cron dispatch). */
 export const pruneObservations = internalMutation.mutation(async ({ ctx: context }): Promise<{ pruned: number }> => {
     const cutoff = context.now - OBSERVATION_RETENTION_MS;
@@ -451,8 +452,11 @@ export const pruneObservations = internalMutation.mutation(async ({ ctx: context
     // rows it does not want. Oldest-first keeps a backlog draining in cutoff order,
     // and PRUNE_BATCH bounds the work one cron tick does — a table far past retention
     // converges over several ticks instead of timing out on one.
-    const { page } = await context.db.observations.findMany({ limit: PRUNE_BATCH, orderBy: [{ startedAt: "asc" }], where: { startedAt: { lt: cutoff } } });
-    const stale = page;
+    const { page: stale } = await context.db.observations.findMany({
+        limit: PRUNE_BATCH,
+        orderBy: [{ startedAt: "asc" }],
+        where: { startedAt: { lt: cutoff } },
+    });
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/traces.ts
+++ b/apps/cloud/lunora/traces.ts
@@ -100,7 +100,7 @@ export const list = query
 
         // Push `deploymentId` into the query (its own index) so the scanned window
         // is that deployment's spans, not the global recent window.
-        const { page } = await context.db.observations.findMany({
+        const { page: spans } = await context.db.observations.findMany({
             limit: SCAN_LIMIT,
             orderBy: [{ startedAt: "desc" }],
             where:
@@ -108,8 +108,6 @@ export const list = query
                     ? { organizationId: args.organizationId }
                     : { deploymentId: args.deploymentId, organizationId: args.organizationId },
         });
-
-        const spans = page;
 
         // Fold every scanned span, then apply the trace-level filters, then cap —
         // filtering after the cap would return fewer than `limit` matching traces.

--- a/apps/cloud/lunora/traces.ts
+++ b/apps/cloud/lunora/traces.ts
@@ -109,7 +109,7 @@ export const list = query
                     : { deploymentId: args.deploymentId, organizationId: args.organizationId },
         });
 
-        const spans = page as unknown as ObservationRow[];
+        const spans = page;
 
         // Fold every scanned span, then apply the trace-level filters, then cap —
         // filtering after the cap would return fewer than `limit` matching traces.
@@ -205,7 +205,7 @@ export const get = query
             where: { organizationId: args.organizationId, traceId: args.traceId },
         });
 
-        return (page as unknown as ObservationRow[]).map((row) => toSpanView(row));
+        return page.map((row) => toSpanView(row));
     });
 
 /**

--- a/apps/cloud/lunora/traffic.ts
+++ b/apps/cloud/lunora/traffic.ts
@@ -1,5 +1,4 @@
 import { createTrafficReader, DEFAULT_TRAFFIC_WINDOW_MS, MAX_TRAFFIC_SCRIPTS } from "../src/telemetry/traffic-read";
-import type { Id } from "./_generated/dataModel.js";
 import { action, query, v } from "./_generated/server.js";
 import { assertMember } from "./authz";
 import { rateLimit } from "./guards";
@@ -56,12 +55,6 @@ interface TrafficSnapshotView {
 /** The empty view every degraded path returns — no credentials, no deployments, or a failed read. */
 const EMPTY_VIEW: TrafficSnapshotView = { countries: [], hostnames: [], routes: [], series: [], statuses: [], totalRequests: 0 };
 
-/** A deployment row, as the script-name resolution reads it. */
-interface DeploymentScriptRow {
-    _id: Id<"deployments">;
-    scriptName: string;
-}
-
 /**
  * Request analytics for the org over `[from, to]`, optionally filtered to one
  * domain.
@@ -110,7 +103,7 @@ export const snapshot = action
         // Every release the org has ever cut, not just the live one: a window that
         // spans a deploy must still count the traffic the superseded script served,
         // or the chart shows a cliff at each release that never happened.
-        const scriptNames = [...new Set((page as unknown as DeploymentScriptRow[]).map((row) => row.scriptName).filter((name) => name !== ""))];
+        const scriptNames = [...new Set(page.map((row) => row.scriptName).filter((name) => name !== ""))];
 
         if (scriptNames.length === 0) {
             return EMPTY_VIEW;
@@ -179,19 +172,6 @@ interface LiveTrafficView {
     requests: LiveRequestView[];
 }
 
-/** One observation row, as the live read consumes it. */
-interface ObservationRow {
-    _id: Id<"observations">;
-    durationMs: number;
-    level: string;
-    name: string;
-    parentSpanId?: string;
-    serviceName?: string;
-    startedAt: number;
-    statusMessage?: string;
-    traceId: string;
-}
-
 /**
  * Is this span a request, rather than work inside one?
  *
@@ -254,7 +234,7 @@ export const live = query
             where: { organizationId: args.organizationId },
         });
 
-        const roots = (page as unknown as ObservationRow[]).filter((row) => isRequestSpan(row));
+        const roots = page.filter((row) => isRequestSpan(row));
         // Percentiles come from the whole scanned window, not the truncated list —
         // a p99 over the 50 rows the pane happens to show is a different statistic
         // from a p99 over the window, and the smaller one is the misleading one.

--- a/apps/cloud/lunora/uptime.ts
+++ b/apps/cloud/lunora/uptime.ts
@@ -55,8 +55,7 @@ export const summary = query
     .query(async ({ ctx: context, args: { organizationId } }): Promise<UptimeSummaryRow[]> => {
         await assertMember(context, organizationId);
 
-        const { page } = await context.db.uptimeState.findMany({ where: { organizationId } });
-        const states = page;
+        const { page: states } = await context.db.uptimeState.findMany({ where: { organizationId } });
 
         const rows = await Promise.all(
             states.map(async (state): Promise<UptimeSummaryRow> => {
@@ -105,12 +104,11 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
     const cutoff = context.now - CHECK_RETENTION_MS;
     // Oldest-first and bounded, with the cutoff as a `where` predicate so the page
     // holds only rows to delete rather than whatever sorts first.
-    const { page } = await context.db.uptimeChecks.findMany({
+    const { page: stale } = await context.db.uptimeChecks.findMany({
         limit: PRUNE_SCAN_LIMIT,
         orderBy: [{ createdAt: "asc" }],
         where: { createdAt: { lt: cutoff } },
     });
-    const stale = page;
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/uptime.ts
+++ b/apps/cloud/lunora/uptime.ts
@@ -29,13 +29,6 @@ const CHECK_RETENTION_MS = 14 * 24 * 60 * 60 * 1000;
  */
 const PRUNE_SCAN_LIMIT = 2000;
 
-interface UptimeStateRow {
-    consecutiveFailures: number;
-    deploymentId: Id<"deployments">;
-    lastCheckedAt: number;
-    lastOk: boolean;
-}
-
 interface UptimeCheckRow {
     _id: Id<"uptimeChecks">;
     createdAt: number;
@@ -63,7 +56,7 @@ export const summary = query
         await assertMember(context, organizationId);
 
         const { page } = await context.db.uptimeState.findMany({ where: { organizationId } });
-        const states = page as unknown as UptimeStateRow[];
+        const states = page;
 
         const rows = await Promise.all(
             states.map(async (state): Promise<UptimeSummaryRow> => {
@@ -117,7 +110,7 @@ export const prune = internalMutation.mutation(async ({ ctx: context }): Promise
         orderBy: [{ createdAt: "asc" }],
         where: { createdAt: { lt: cutoff } },
     });
-    const stale = page as unknown as UptimeCheckRow[];
+    const stale = page;
 
     for (const row of stale) {
         // eslint-disable-next-line no-await-in-loop -- small batch; sequential keeps the writer simple

--- a/apps/cloud/lunora/usage.ts
+++ b/apps/cloud/lunora/usage.ts
@@ -186,7 +186,7 @@ export const rollup = internalMutation.mutation(async ({ ctx: context }): Promis
         orderBy: [{ periodStart: "asc" }],
         where: { periodStart: { lt: cutoff } },
     });
-    const closed = page as unknown as PlatformUsageRow[];
+    const closed = page;
 
     const groups = new Map<string, PlatformUsageRow[]>();
 
@@ -311,13 +311,6 @@ export const enforceSpendCaps = internalMutation.mutation(async ({ ctx: context 
     return { suspended, unsuspended };
 });
 
-interface OverageDebitRow {
-    _id: Id<"overageDebits">;
-    debitedCredits: number;
-    organizationId: Id<"organizations">;
-    periodStart: number;
-}
-
 /**
  * The overage-debit watermark for (org, period) — how many prepaid credits
  * previous reconciliation runs already debited (GAPS.md C3 follow-up).
@@ -327,7 +320,7 @@ export const overageWatermark = internalQuery
     .input({ organizationId: v.id("organizations"), periodStart: v.number() })
     .query(async ({ ctx: context, args: { organizationId, periodStart } }): Promise<{ debitedCredits: number }> => {
         const { page } = await context.db.overageDebits.findMany({ where: { organizationId, periodStart } });
-        const row = (page as unknown as OverageDebitRow[])[0];
+        const row = page[0];
 
         return { debitedCredits: row?.debitedCredits ?? 0 };
     });
@@ -341,7 +334,7 @@ export const recordOverageDebit = internalMutation
     .input({ debitedCredits: v.number(), organizationId: v.id("organizations"), periodStart: v.number() })
     .mutation(async ({ ctx: context, args: { debitedCredits, organizationId, periodStart } }): Promise<void> => {
         const { page } = await context.db.overageDebits.findMany({ where: { organizationId, periodStart } });
-        const row = (page as unknown as OverageDebitRow[])[0];
+        const row = page[0];
         const { now } = context;
 
         if (!row) {
@@ -375,7 +368,7 @@ export const series = query
         const dayMs = 24 * 60 * 60 * 1000;
         const buckets = new Map<number, PeriodUsage>();
 
-        for (const row of page as unknown as PlatformUsageRow[]) {
+        for (const row of page) {
             if (!isUsageMeter(row.kind)) {
                 continue;
             }

--- a/apps/cloud/lunora/usage.ts
+++ b/apps/cloud/lunora/usage.ts
@@ -181,12 +181,11 @@ export const rollup = internalMutation.mutation(async ({ ctx: context }): Promis
     // tick collapses whatever survivors it sees into one row and the next tick
     // collapses those. The invariant that must hold within a tick — delete the extras
     // before patching the survivor — is unaffected by where the page boundary falls.
-    const { page } = await context.db.platformUsage.findMany({
+    const { page: closed } = await context.db.platformUsage.findMany({
         limit: ROLLUP_BATCH,
         orderBy: [{ periodStart: "asc" }],
         where: { periodStart: { lt: cutoff } },
     });
-    const closed = page;
 
     const groups = new Map<string, PlatformUsageRow[]>();
 

--- a/apps/cloud/src/backup/sweep.ts
+++ b/apps/cloud/src/backup/sweep.ts
@@ -1,0 +1,133 @@
+/**
+ * Off-database backups of the control plane (GAPS.md D1).
+ *
+ * D1's Time Travel already covers "someone dropped a table" — it restores any
+ * point in the last 30 days, in place, with no code. What it cannot survive is
+ * losing the database itself: a deleted or compromised account takes its own
+ * Time Travel history with it, and the control-plane D1 is the one store whose
+ * loss is unrecoverable rather than inconvenient. Every tenant's data lives in
+ * its own Durable Object, but which cell a tenant is on, which script serves it,
+ * and the sealed admin token that reaches it live only here.
+ *
+ * So this takes a full SQL dump through D1's export API and writes it to R2
+ * under a timestamped key, on the six-hourly tick. The dump is what
+ * `wrangler d1 execute --file` restores from, so the recovery path is the
+ * documented one rather than something invented here — see `docs/RESTORE.md`.
+ *
+ * The copy is same-account: a Worker's R2 binding cannot reach another
+ * Cloudflare account, so this survives losing the *database* but not losing the
+ * account*. Getting the dump into a second cell needs R2's S3 API and a
+ * credential for that account, which is the remaining half of D1 — it is a
+ * deliberate first increment, not an oversight.
+ */
+
+/** The subset of an R2 bucket binding this sweep uses. */
+export interface BackupBucket {
+    delete: (keys: string[]) => Promise<void>;
+    list: (options: { cursor?: string; prefix: string }) => Promise<BackupListing>;
+    put: (key: string, value: ReadableStream | null, options?: { httpMetadata?: { contentType?: string } }) => Promise<unknown>;
+}
+
+export interface BackupListing {
+    cursor?: string;
+    objects: { key: string; uploaded: Date }[];
+    truncated: boolean;
+}
+
+export interface BackupSweepDeps {
+    bucket: BackupBucket;
+    /** Names this cell's backups so one bucket can hold several cells. */
+    cell: string;
+    /** Injected for tests; defaults to the global. */
+    fetch?: typeof globalThis.fetch;
+    now: number;
+    /** Starts the export and answers a presigned URL for the dump. */
+    startExport: () => Promise<{ signedUrl: string }>;
+}
+
+export interface BackupSweepResult {
+    /** Objects deleted because they aged past the retention window. */
+    pruned: number;
+    /** The key written, or null when the sweep did not write one. */
+    written: null | string;
+}
+
+/** How long a dump is kept before the prune pass removes it. */
+export const BACKUP_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Bounds the prune listing so a bucket that grows unexpectedly cannot hang the cron. */
+const MAX_PRUNE_PAGES = 20;
+
+/** `control-plane/&lt;cell>/` — one prefix per cell, so a shared bucket stays sortable. */
+export const backupPrefix = (cell: string): string => `control-plane/${cell}/`;
+
+/**
+ * The key a dump taken at `now` is written under.
+ *
+ * ISO-8601 with the punctuation stripped, so the lexical order of the keys is
+ * the chronological order of the dumps — which is what makes the prune pass a
+ * prefix listing rather than a metadata read.
+ */
+export const backupKey = (cell: string, now: number): string => `${backupPrefix(cell)}${new Date(now).toISOString().replaceAll(/[.:-]/gu, "")}.sql`;
+
+/**
+ * Delete dumps older than the retention window.
+ *
+ * Ages by the object's own `uploaded` time rather than by parsing the key: the
+ * key is written by this sweep, but the retention decision is about when R2
+ * actually holds the bytes, and an object whose upload was retried carries the
+ * later time.
+ */
+const prune = async (bucket: BackupBucket, cell: string, now: number): Promise<number> => {
+    const cutoff = now - BACKUP_RETENTION_MS;
+    const prefix = backupPrefix(cell);
+    let cursor: string | undefined;
+    let pruned = 0;
+
+    for (let page = 0; page < MAX_PRUNE_PAGES; page += 1) {
+        // eslint-disable-next-line no-await-in-loop -- cursor pagination is sequential by construction
+        const listing = await bucket.list(cursor === undefined ? { prefix } : { cursor, prefix });
+        const expired = listing.objects.filter((object) => object.uploaded.getTime() < cutoff).map((object) => object.key);
+
+        if (expired.length > 0) {
+            // eslint-disable-next-line no-await-in-loop -- one delete per page keeps the request count bounded
+            await bucket.delete(expired);
+            pruned += expired.length;
+        }
+
+        if (!listing.truncated || listing.cursor === undefined) {
+            break;
+        }
+
+        cursor = listing.cursor;
+    }
+
+    return pruned;
+};
+
+/**
+ * Take one control-plane backup and prune expired ones.
+ *
+ * The prune runs even when the export fails, so a run of failed backups still
+ * ages out its predecessors on schedule rather than growing the bucket forever
+ * — but it runs *after* the write, so a failure never deletes the newest good
+ * dump while leaving nothing in its place.
+ */
+export const runBackupSweep = async (deps: BackupSweepDeps): Promise<BackupSweepResult> => {
+    const { bucket, cell, now } = deps;
+    const fetchImpl = deps.fetch ?? globalThis.fetch;
+    const { signedUrl } = await deps.startExport();
+    const dump = await fetchImpl(signedUrl);
+
+    if (!dump.ok) {
+        throw new Error(`control-plane backup download failed: HTTP ${String(dump.status)}`);
+    }
+
+    const key = backupKey(cell, now);
+
+    // Streamed rather than buffered: the dump is the whole control plane, and a
+    // Worker that reads it into memory first is one growth spurt from OOM.
+    await bucket.put(key, dump.body, { httpMetadata: { contentType: "application/sql" } });
+
+    return { pruned: await prune(bucket, cell, now), written: key };
+};

--- a/apps/cloud/src/cloudflare/api.ts
+++ b/apps/cloud/src/cloudflare/api.ts
@@ -54,6 +54,12 @@ export interface CloudflareApi {
      * needs the S3/data API (a separate credential the teardown context lacks).
      */
     deleteR2Bucket: (name: string) => Promise<void>;
+
+    /**
+     * Start a full SQL export of a D1 database and poll it to completion, then
+     * answer the presigned URL of the dump. The URL is valid for one hour.
+     */
+    exportD1Database: (databaseId: string) => Promise<{ signedUrl: string }>;
     /** Resolve a D1 database uuid by its name (teardown), or null if none exists. */
     findD1DatabaseByName: (name: string) => Promise<null | { uuid: string }>;
     /** Upload (create/update) a user Worker into a dispatch namespace. */
@@ -77,6 +83,20 @@ interface CloudflareEnvelope {
 }
 
 const DEFAULT_BASE = "https://api.cloudflare.com/client/v4";
+
+/** D1's export endpoint answers a progress report inside the account envelope, not the dump. */
+interface D1ExportResponse {
+    at_bookmark?: string;
+    error?: string;
+    messages?: string[];
+    result?: { signed_url?: string };
+    status?: string;
+    success?: boolean;
+}
+
+/** Bounds the export poll so a stuck run degrades into a failed backup, not a hung cron. */
+const MAX_EXPORT_POLLS = 30;
+const EXPORT_POLL_INTERVAL_MS = 2000;
 
 /**
  * HTTP implementation of {@link CloudflareApi}. Real code against the documented
@@ -169,6 +189,46 @@ export const createHttpCloudflareApi = (options: HttpCloudflareApiOptions): Clou
             throw new Error(
                 `cloudflare create R2 bucket failed: ${data.errors?.map((error) => error.message).join("; ") ?? `HTTP ${String(response.status)}`}`,
             );
+        },
+        exportD1Database: async (databaseId) => {
+            // Two-phase, per D1's REST contract: the first POST starts the export
+            // and answers `status: "active"` with a bookmark, and each subsequent
+            // POST carrying that bookmark reports progress until `"complete"`,
+            // when `result.signed_url` appears. Passing the bookmark back is what
+            // identifies the run — omitting it starts a second export.
+            let bookmark: string | undefined;
+
+            for (let attempt = 0; attempt < MAX_EXPORT_POLLS; attempt += 1) {
+                // eslint-disable-next-line no-await-in-loop -- polling is sequential by definition
+                const response = (await callJson(`/d1/database/${databaseId}/export`, "POST", {
+                    ...(bookmark === undefined ? {} : { current_bookmark: bookmark }),
+                    dump_options: { no_data: false, no_schema: false, tables: [] },
+                    output_format: "polling",
+                })) as D1ExportResponse;
+
+                if (response.status === "error" || response.success === false) {
+                    throw new Error(`cloudflare D1 export failed: ${response.error ?? response.messages?.join("; ") ?? "unknown error"}`);
+                }
+
+                if (response.status === "complete") {
+                    const signedUrl = response.result?.signed_url;
+
+                    if (!signedUrl) {
+                        throw new Error("cloudflare D1 export completed without a signed_url");
+                    }
+
+                    return { signedUrl };
+                }
+
+                bookmark = response.at_bookmark;
+
+                // eslint-disable-next-line no-await-in-loop -- deliberate backoff between polls
+                await new Promise((resolve) => {
+                    setTimeout(resolve, EXPORT_POLL_INTERVAL_MS);
+                });
+            }
+
+            throw new Error(`cloudflare D1 export did not complete within ${String(MAX_EXPORT_POLLS)} polls`);
         },
         deleteD1Database: async (uuid) => {
             const response = await fetchImpl(`${base}/d1/database/${uuid}`, { headers: { authorization: authHeader }, method: "DELETE" });

--- a/apps/cloud/src/deploy/router.ts
+++ b/apps/cloud/src/deploy/router.ts
@@ -512,9 +512,7 @@ const handleTelemetryRoute = async (request: Request, environment: RouterEnv): P
 
         // Deliver any alerts the ingest fired (best-effort), then stamp them delivered.
         if (result.alerts.length > 0) {
-            const environmentRecord = environment;
-
-            await Promise.all(result.alerts.map((alert) => deliverAlert(environmentRecord, alert).catch(() => undefined)));
+            await Promise.all(result.alerts.map((alert) => deliverAlert(environment, alert).catch(() => undefined)));
             // Alerts have already gone out, so a failure here must not fail the
             // ingest — but it must not be invisible either: unmarked alerts are
             // re-delivered on the next sweep, and `markDelivered` is now rate-limited

--- a/apps/cloud/src/deploy/router.ts
+++ b/apps/cloud/src/deploy/router.ts
@@ -249,7 +249,7 @@ const handleInviteRoute = async (request: Request, environment: RouterEnv): Prom
         });
         const acceptUrl = `${new URL(request.url).origin}/accept-invite?token=${encodeURIComponent(token)}`;
 
-        await sendInvitationEmail(environment as unknown as Record<string, unknown>, { acceptUrl, to: invite.email });
+        await sendInvitationEmail(environment, { acceptUrl, to: invite.email });
 
         return Response.json({ ok: true });
     } catch (error) {
@@ -512,7 +512,7 @@ const handleTelemetryRoute = async (request: Request, environment: RouterEnv): P
 
         // Deliver any alerts the ingest fired (best-effort), then stamp them delivered.
         if (result.alerts.length > 0) {
-            const environmentRecord = environment as unknown as Record<string, unknown>;
+            const environmentRecord = environment;
 
             await Promise.all(result.alerts.map((alert) => deliverAlert(environmentRecord, alert).catch(() => undefined)));
             // Alerts have already gone out, so a failure here must not fail the

--- a/apps/cloud/src/deploy/routes/shared.ts
+++ b/apps/cloud/src/deploy/routes/shared.ts
@@ -22,7 +22,7 @@ export interface LunoraActionContext {
     runQuery: <R>(reference: unknown, args?: Record<string, unknown>) => Promise<R>;
 }
 
-export interface RouterEnv {
+export type RouterEnv = {
     __lunoraCtx?: LunoraActionContext;
     CLOUDFLARE_ACCOUNT_ID?: string;
     CLOUDFLARE_API_TOKEN?: string;
@@ -43,7 +43,7 @@ export interface RouterEnv {
     TELEMETRY?: AnalyticsEngineDatasetLike;
     /** Raw-telemetry archive Pipeline for the telemetry ingest (may be unbound). */
     TELEMETRY_PIPELINE?: PipelineBindingLike;
-}
+};
 
 export const jsonError = (status: number, error: string): Response => Response.json({ error }, { headers: { "content-type": "application/json" }, status });
 

--- a/apps/cloud/src/deploy/routes/shared.ts
+++ b/apps/cloud/src/deploy/routes/shared.ts
@@ -22,6 +22,8 @@ export interface LunoraActionContext {
     runQuery: <R>(reference: unknown, args?: Record<string, unknown>) => Promise<R>;
 }
 
+// Must stay a `type`: an `interface` gets no implicit index signature, so it will
+// not satisfy `Record<string, unknown>` at `sendInvitationEmail`/`deliverAlert`.
 export type RouterEnv = {
     __lunoraCtx?: LunoraActionContext;
     CLOUDFLARE_ACCOUNT_ID?: string;

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -189,6 +189,9 @@ export const ShardDO = createShardDO({
     payment: (env) => paymentConfig(env),
 });
 
+// Must stay a `type`: an `interface` gets no implicit index signature, so it will
+// not satisfy `Record<string, unknown>` at the mailer and alert-delivery call
+// sites (`createMailerFromEnv`, `deliverAlert`).
 type Env = {
     /** Secret backing the studio's better-auth sessions. */
     AUTH_SECRET?: string;
@@ -447,11 +450,9 @@ const deliverFiredAlerts = async (env: Env, database: ControlPlaneDatabase, deli
         return;
     }
 
-    const environmentRecord = env;
-
     await Promise.all(
         deliveries.map(async (delivery) => {
-            const delivered = await deliverAlert(environmentRecord, delivery).then(
+            const delivered = await deliverAlert(env, delivery).then(
                 () => true,
                 () => false,
             );

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -189,7 +189,7 @@ export const ShardDO = createShardDO({
     payment: (env) => paymentConfig(env),
 });
 
-interface Env {
+type Env = {
     /** Secret backing the studio's better-auth sessions. */
     AUTH_SECRET?: string;
     /** Base URL better-auth resolves callbacks against. */
@@ -223,7 +223,7 @@ interface Env {
     SHARD: ShardNamespaceLike;
     /** AE dataset the dispatcher writes tenant request usage to. Defaults to `lunora_tenant_usage`. */
     USAGE_ANALYTICS_DATASET?: string;
-}
+};
 
 /** Build the OAuth provider map from env — only providers with creds are enabled. */
 const socialProviders = (env: Env): LunoraAuthOptions["socialProviders"] => {
@@ -313,10 +313,13 @@ const readLiveDeployments = async (env: Env): Promise<LiveDeploymentRow[]> => {
         return [];
     }
 
-    const database = createD1CtxDb({ exec: buildExec(env.DB as D1DatabaseLike), schema: schema as unknown as D1CtxDbOptions["schema"] });
+    const database: ControlPlaneDatabase = createD1CtxDb({
+        exec: buildExec(env.DB as D1DatabaseLike),
+        schema: schema as unknown as D1CtxDbOptions["schema"],
+    });
     const { page } = await database.findMany("deployments", { where: { status: "live" } });
 
-    return page as unknown as LiveDeploymentRow[];
+    return page as LiveDeploymentRow[];
 };
 
 /**
@@ -423,6 +426,7 @@ const sweepOverageReconciliation = async (env: Env): Promise<void> => {
 
     const creem = new Creem({ apiKey: env.CREEM_API_KEY, ...(env.CREEM_TEST_MODE === "true" ? { server: "test" as const } : {}) });
     const ledger = createCreemCreditsLedger({
+        // The SDK's client is structurally wider than the ledger's port.
         client: creem as unknown as CreemCreditsClientLike,
         resolveAccountId: (organizationId) => Promise.resolve(accounts.get(organizationId) ?? null),
     });
@@ -443,7 +447,7 @@ const deliverFiredAlerts = async (env: Env, database: ControlPlaneDatabase, deli
         return;
     }
 
-    const environmentRecord = env as unknown as Record<string, unknown>;
+    const environmentRecord = env;
 
     await Promise.all(
         deliveries.map(async (delivery) => {
@@ -702,7 +706,7 @@ const authOptions = (env: Env, requestOrigin?: string): LunoraAuthOptions => {
     // Built lazily inside each callback (not here): `createMailerFromEnv` throws
     // when no transport is configured (e.g. prod without MAIL_FROM), and we don't
     // want that to take down auth — only the individual email send.
-    const mailer = (): ReturnType<typeof createMailerFromEnv> => createMailerFromEnv(env as unknown as Record<string, unknown>);
+    const mailer = (): ReturnType<typeof createMailerFromEnv> => createMailerFromEnv(env);
 
     return {
         // Falls back to the origin of the request that built this isolate's auth

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -18,6 +18,8 @@ import { LUNORA_FUNCTIONS } from "../lunora/_generated/functions.js";
 import { openApiSpec } from "../lunora/_generated/openapi.js";
 import { createShardDO } from "../lunora/_generated/shard.js";
 import schema from "../lunora/schema.js";
+import type { BackupBucket } from "./backup/sweep";
+import { runBackupSweep } from "./backup/sweep";
 import type { CreemCreditsClientLike } from "./billing/creem-credits";
 import { createCreemCreditsLedger } from "./billing/creem-credits";
 import { reconcileAllOverages } from "./billing/overage";
@@ -198,12 +200,27 @@ export const ShardDO = createShardDO({
 type Env = {
     /** Secret backing the studio's better-auth sessions. */
     AUTH_SECRET?: string;
+
     /** Base URL better-auth resolves callbacks against. */
     AUTH_URL?: string;
+
+    /**
+     * Private R2 bucket the control-plane dumps are written to (GAPS.md D1).
+     * Absent → the backup sweep no-ops. The dump contains every sealed admin
+     * token and auth session in the cell, so this bucket must never be public.
+     */
+    BACKUPS?: BackupBucket;
     /** Cloudflare account hosting this cell — the teardown sweep's REST target (§2.5). */
     CLOUDFLARE_ACCOUNT_ID?: string;
     /** Scoped Cloudflare API token; absent → resource teardown is skipped. */
     CLOUDFLARE_API_TOKEN?: string;
+
+    /**
+     * The control-plane D1's own uuid, which the export REST call addresses.
+     * A binding cannot answer its database id, so it is configured; absent →
+     * the backup sweep no-ops.
+     */
+    CONTROL_PLANE_DATABASE_ID?: string;
     /** Creem (MoR) billing secrets (§4). Absent → billing reads work, live calls fail. */
     CREEM_API_KEY?: string;
     CREEM_TEST_MODE?: string;
@@ -549,6 +566,29 @@ const sweepRollouts = async (env: Env): Promise<void> => {
 };
 
 /**
+ * Back the control plane up to R2 (GAPS.md D1).
+ *
+ * Needs the account credentials (the export goes through D1's REST API), the
+ * database's own uuid, and a bucket — each absent piece makes this a no-op
+ * rather than an error, so a cell without backups configured still ticks.
+ */
+const sweepBackup = async (env: Env): Promise<void> => {
+    if (!env.BACKUPS || !env.CONTROL_PLANE_DATABASE_ID || !env.CLOUDFLARE_ACCOUNT_ID || !env.CLOUDFLARE_API_TOKEN) {
+        return;
+    }
+
+    const api = createHttpCloudflareApi({ accountId: env.CLOUDFLARE_ACCOUNT_ID, apiToken: env.CLOUDFLARE_API_TOKEN });
+    const databaseId = env.CONTROL_PLANE_DATABASE_ID;
+
+    await runBackupSweep({
+        bucket: env.BACKUPS,
+        cell: env.LUNORA_CELL ?? "default",
+        now: Date.now(),
+        startExport: () => api.exportD1Database(databaseId),
+    });
+};
+
+/**
  * Which sweeps ride which cron bucket — declarative, so "what runs on which
  * tick" is one table, not scattered conditionals. Each sweep no-ops when its own
  * env isn't configured. Teardown + usage rollback ride the *hourly* expression
@@ -563,6 +603,9 @@ const SCHEDULED_SWEEPS: { cron: string; run: (env: Env) => Promise<void> }[] = [
     { cron: EVERY_HOUR, run: sweepTeardown },
     { cron: EVERY_HOUR, run: sweepUsageRollback },
     { cron: EVERY_SIX_HOURS, run: sweepOverageReconciliation },
+    // Control-plane backup. Rides the existing 6-hourly trigger rather than
+    // claiming a fourth cron (Cloudflare caps a Worker at three).
+    { cron: EVERY_SIX_HOURS, run: sweepBackup },
     { cron: EVERY_MINUTE, run: sweepUptime },
     // Metric-window rules (error_rate/latency_p95/llm_cost) re-evaluated each
     // minute so quiet windows the ingest never re-examines still fire/clear —

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -191,7 +191,10 @@ export const ShardDO = createShardDO({
 
 // Must stay a `type`: an `interface` gets no implicit index signature, so it will
 // not satisfy `Record<string, unknown>` at the mailer and alert-delivery call
-// sites (`createMailerFromEnv`, `deliverAlert`).
+// sites (`createMailerFromEnv`, `deliverAlert`). Those read keys this type does
+// not declare (`RESEND_API_KEY`, `SEND_EMAIL`, `WORKER_ENV`, …) — it is the set
+// this module uses, not the full runtime env, so an undeclared var is not
+// necessarily an unused one.
 type Env = {
     /** Secret backing the studio's better-auth sessions. */
     AUTH_SECRET?: string;

--- a/apps/cloud/src/uptime/sweep.ts
+++ b/apps/cloud/src/uptime/sweep.ts
@@ -20,7 +20,7 @@ import type { UptimeProbe } from "./probe";
 import { nextConsecutiveFailures, probeDeployment } from "./probe";
 
 /** A live deployment the sweep probes. */
-interface LiveDeploymentRow {
+interface ProbeTargetRow {
     _id: string;
     organizationId: string;
     url?: string;
@@ -130,7 +130,7 @@ const mapPooled = async <T, R>(items: ReadonlyArray<T>, concurrency: number, fun
 };
 
 /** Record one probe result as a `uptimeChecks` row. */
-const recordCheck = (database: ControlPlaneDatabase, deployment: LiveDeploymentRow, result: UptimeProbe, now: number): Promise<unknown> =>
+const recordCheck = (database: ControlPlaneDatabase, deployment: ProbeTargetRow, result: UptimeProbe, now: number): Promise<unknown> =>
     database.insert("uptimeChecks", {
         createdAt: now,
         deploymentId: deployment._id,
@@ -144,7 +144,7 @@ const recordCheck = (database: ControlPlaneDatabase, deployment: LiveDeploymentR
 /** Advance (or seed) a deployment's consecutive-failure state to `failures`. */
 const advanceState = (
     database: ControlPlaneDatabase,
-    deployment: LiveDeploymentRow,
+    deployment: ProbeTargetRow,
     prior: UptimeStateRow | undefined,
     failures: number,
     ok: boolean,
@@ -167,8 +167,8 @@ export const runUptimeSweep = async (database: ControlPlaneDatabase, options: Up
 
     // Drained: past one page the remaining live deployments were simply never
     // probed, so uptime silently reported nothing rather than reporting down.
-    const deploymentRows = await drainTable<LiveDeploymentRow>(database, "deployments", { where: { status: "live" } });
-    const withUrl = deploymentRows.filter((row): row is LiveDeploymentRow & { url: string } => typeof row.url === "string" && row.url !== "");
+    const deploymentRows = await drainTable<ProbeTargetRow>(database, "deployments", { where: { status: "live" } });
+    const withUrl = deploymentRows.filter((row): row is ProbeTargetRow & { url: string } => typeof row.url === "string" && row.url !== "");
 
     // SSRF gate: a deployment's URL is set by any org member (deployments.updateStatus,
     // no role restriction), and the control plane `fetch`es it from a privileged


### PR DESCRIPTION
Stacked on #85 — base is `claude/cloud-platform-dx-ojvkmu`, not `alpha`. Seven commits, two
independent themes; they share a branch only because the second was found while finishing the
first. Happy to split if that reviews better.

## 1. Read rows through the generated types

Every table read in `apps/cloud` was `const rows = page as unknown as XRow[]`, against a
hand-written `XRow` interface restating one schema table. The reader facade
(`ctx.db.<table>.findMany()`) has been fully typed for a while, so all ~110 of those double casts
were asserting a shape over a value that already had a more accurate one, and each `XRow` was a
second copy of the schema kept in sync by hand.

Removing them orphaned **17 interfaces**, now deleted. Two had already drifted from the table they
described, which is exactly what the cast was concealing:

- `subscriptions` rows were handed to `@lunora/payment` as `Subscription`, which requires `id`. The
  row has `_id` and no `id` at all.
- The same rows narrow `provider`/`state` to the provider layer's unions, while the table is
  `.externallyManaged()` and stores both as `v.string()`.

Both now go through an explicit adapter. The second narrows rather than filters on purpose: a value
this build does not recognise must not silently drop a paying org's subscription out of entitlement
resolution.

**One of those fixes was wrong first, and the review caught it** (`aaab6c5ec`). I mapped `id` from
Lunora's `_id`; `@lunora/payment`'s own mapper goes the other way, and `providerSubscriptionId` is
also the lookup key and half the unique index its webhook sync reconciles on. That is worse than
the bug it replaced — a missing property surfaces as `undefined`, a Lunora row id is plausible and
would corrupt the index on the first round trip through `upsertSubscription`. Pinned with a test,
verified failing against the old mapping first.

Fallout worth calling out:

- `Env`/`RouterEnv` became type aliases — an interface gets no implicit index signature, which was
  the sole reason four `as unknown as Record<string, unknown>` casts existed. Both now carry a
  comment saying so, because a bare `type` keyword announces nothing and converting it back breaks
  four call sites with an error that does not name the cause.
- Two `patch(row._id as never, …)` lost the `as never`, which had been hiding the
  `Id<"deployments">` brand from the checker rather than satisfying it.
- The AST removal took one **module docblock** with it — `cloudflare-billing.ts` had a free-floating
  comment above the deleted interface documenting the credential path and that `summary` fails
  *open* rather than throwing. That survived nowhere else in source. Restored.
- 14 `const stale = page;` bindings that existed only to host a cast, folded back into their
  destructures; both purge sweeps extracted to `lunora/purge.ts`; `billing.entitlements` now calls
  `orgEntitlements` instead of re-deriving it one module over.

Eight double casts remain, each with its reason at the site: the dynamic `ctx.db[table]` sweeps
where the per-table facades genuinely do not unify, three adapters onto external contracts, and the
schema erasure `createD1CtxDb` wants.

Also tried and reverted: a generic `findMany<TRow>` on `ControlPlaneDatabase`. It reads better but
cannot be satisfied by a concrete implementation for every `TRow`, so it made the real ctx-db
unassignable to the interface. `unknown[]` already admits the single cast the sweeps use.

## 2. Control-plane backups (GAPS.md D1)

The one gap on the register whose failure mode is unrecoverable rather than inconvenient. Tenant
data lives in each tenant's own Durable Object; what exists **only** in the control-plane D1 is
which cell a tenant is on, which script serves it, and the sealed admin token that reaches it. Lose
it and the tenant workers keep serving traffic that nothing can administer, bill, deploy or tear
down.

`src/backup/sweep.ts` takes a full SQL dump through D1's export API, streams it into R2 at
`control-plane/<cell>/<timestamp>.sql`, and prunes past 30 days. It rides the existing six-hourly
trigger rather than claiming a fourth cron — Cloudflare caps a Worker at three, and all three are
spent. Every piece of its config is optional and absence is a no-op, so a cell without backups
configured still ticks rather than erroring every six hours.

The export request shape is not from memory: the two-phase polling contract (`output_format:
"polling"`, a bookmark handed back per poll, `result.signed_url` at `status: "complete"`) is read
off wrangler 4.126's own `d1 export` implementation in `node_modules` — the same code path the
restore uses from the other end, so the two agree by construction.

Two decisions, both pinned by tests verified failing against a deliberately broken sweep first:
the dump is **streamed** from the presigned URL into R2 rather than buffered (it is the whole
control plane, and a 128MB isolate is one growth spurt from OOM), and the prune runs **after** the
write, so a failed download never ages out the last good dump while leaving nothing in its place.

`docs/RESTORE.md` is the runbook. It separates the two layers that fail differently — Time Travel
already recovers a bad write in place and is the first thing to reach for — and records the trap a
row-count check cannot see: sealed admin tokens are only as recoverable as `SECRET_ENCRYPTION_KEY`,
so rotating that key without taking a fresh dump silently invalidates every backup behind it.

### Two limits, stated rather than buried

- **The copy is same-account, so this is not the off-cell DR the gap asked for.** A Worker's R2
  binding cannot address another Cloudflare account; that needs R2's S3 API and a second
  credential. This survives losing the *database*, not losing the *account*. Said so in the module
  docblock, the runbook and GAPS.md, and reclassified the remainder as 🔨 code-tractable rather
  than 🌐.
- **The restore drill has not been run.** The runbook states the two failure modes the design
  implies and asks whoever runs it first to record what it actually found.

## 3. GAPS.md reconciliation

The Ring 3 list still read `🔨 open` for four items — deployment health charts, the onboarding
checklist, deploy-key roll, the integrations hub — that the status tables directly above it already
recorded as shipped, and that the code confirms are shipped. One status row was superseded by the
pass immediately below it and still said otherwise. A stale open marker invites someone to rebuild
a shipped feature, so the list is now reconciled and stamped with the date it was checked against
the code.

## Verification

`lint:types` 0 · `lint:eslint` 0 · `lint:prettier` clean · 705 tests over 86 files.

Reviewed by both thermo passes before this was opened; every finding is either fixed in
`f4151f554`/`aaab6c5ec`/`6a3039db7`/`11c0e328b` or called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wsNs3UM2vixzT7nmoyfsV
