### PR TITLE
fix(payment): key the mutating calls the providers let us key

### DIFF
--- a/packages/payment/__tests__/providers/dodopayments.test.ts
+++ b/packages/payment/__tests__/providers/dodopayments.test.ts
@@ -1,5 +1,6 @@
 import { createHmac } from "node:crypto";
 
+import DodoPayments from "dodopayments";
 import { describe, expect, it } from "vitest";
 
 import type { DodoPaymentsClientLike } from "../../src/providers/dodopayments";
@@ -240,6 +241,32 @@ describe("dodopayments adapter", () => {
 
         expect(typeof options?.idempotencyKey).toBe("string");
         expect(options?.idempotencyKey).not.toHaveLength(0);
+    });
+
+    it("pins that the SDK drops that key rather than sending it (the fake above cannot see this)", async () => {
+        expect.assertions(2);
+
+        let sent: Headers | undefined;
+        // The real client, not the structural fake: `buildHeaders` only emits an idempotency header
+        // when `this.idempotencyHeader` is truthy, and that field is declared `protected` and never
+        // assigned anywhere in the package — so the key we pass type-checks and goes nowhere. Flip
+        // this test to assert the header when a future SDK release starts setting it, and update the
+        // `@lunora/payment` idempotency docblock with it.
+        const client = new DodoPayments({
+            bearerToken: "test-key",
+            environment: "test_mode",
+            fetch: async (_input, init) => {
+                sent = new Headers(init?.headers);
+
+                return Response.json({ customer_id: "cus_1", email: "a@b.test" });
+            },
+            maxRetries: 0,
+        });
+
+        await client.customers.create({ email: "a@b.test", name: "user_1" }, { idempotencyKey: "customer:dodopayments:user_1" });
+
+        expect(sent).toBeDefined();
+        expect([...(sent as Headers).keys()].filter((name) => name.includes("idempotency"))).toStrictEqual([]);
     });
 
     it("ingests usage as a Dodo usage-event keyed on the customer id", async () => {

--- a/packages/payment/__tests__/providers/stripe.test.ts
+++ b/packages/payment/__tests__/providers/stripe.test.ts
@@ -634,6 +634,71 @@ describe("stripe adapter", () => {
         expect(subscription.state).toBe("active");
     });
 
+    it("carries a stable idempotency key on resume, distinct from the cancel key", async () => {
+        expect.assertions(2);
+
+        const calls: RecordedCall[] = [];
+        const adapter = createStripeAdapter({ client: makeClient(calls), webhookSecret: "whsec" });
+
+        await adapter.resumeSubscription("sub_1");
+
+        const call = calls.find((entry) => entry.name === "sub.update");
+
+        // Stable for the logical operation, so a Worker retry replays instead of re-issuing. The
+        // operation name must differ from `cancel_subscription` or a resume would replay the cancel.
+        expect((call?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).toBe("resume_subscription:stripe:sub_1");
+        expect((call?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).not.toBe("cancel_subscription:stripe:sub_1");
+    });
+
+    it("lets the caller override the resume idempotency key", async () => {
+        expect.assertions(1);
+
+        const calls: RecordedCall[] = [];
+        const adapter = createStripeAdapter({ client: makeClient(calls), webhookSecret: "whsec" });
+
+        await adapter.resumeSubscription("sub_1", { idempotencyKey: "resume_2" });
+
+        const call = calls.find((entry) => entry.name === "sub.update");
+
+        expect((call?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).toBe("resume_2");
+    });
+
+    it("keys a plan/quantity update on the subscription AND the target plan (proration moves money)", async () => {
+        expect.assertions(2);
+
+        const calls: RecordedCall[] = [];
+        const adapter = createStripeAdapter({ client: makeClient(calls), webhookSecret: "whsec" });
+
+        await adapter.updateSubscription("sub_1", { priceId: "price_new", quantity: 3 });
+
+        const first = calls.find((entry) => entry.name === "sub.update");
+
+        expect((first?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).toBe("update_subscription:stripe:sub_1:price_new:3");
+
+        // A different target is a different logical operation: reusing one key across two parameter
+        // sets makes Stripe reject the second call as a mismatch.
+        const other: RecordedCall[] = [];
+
+        await createStripeAdapter({ client: makeClient(other), webhookSecret: "whsec" }).updateSubscription("sub_1", { quantity: 3 });
+
+        expect((other.find((entry) => entry.name === "sub.update")?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).toBe(
+            "update_subscription:stripe:sub_1::3",
+        );
+    });
+
+    it("lets the caller override the plan-change idempotency key", async () => {
+        expect.assertions(1);
+
+        const calls: RecordedCall[] = [];
+        const adapter = createStripeAdapter({ client: makeClient(calls), webhookSecret: "whsec" });
+
+        await adapter.updateSubscription("sub_1", { idempotencyKey: "plan_2", priceId: "price_new" });
+
+        const call = calls.find((entry) => entry.name === "sub.update");
+
+        expect((call?.args[2] as undefined | { idempotencyKey?: string })?.idempotencyKey).toBe("plan_2");
+    });
+
     it("resumes a subscription by toggling cancel_at_period_end back to false", async () => {
         expect.assertions(3);
 

--- a/packages/payment/docs/index.mdx
+++ b/packages/payment/docs/index.mdx
@@ -18,7 +18,8 @@ deliveries safe by construction, and synced into a durable store that rides the
 request's `ctx.db`. Switching providers is a configuration change: the provider
 is a stateless translator; the store owns all state.
 
-Outbound calls carry idempotency keys (no double-charge), and every mutation is
+Outbound calls carry idempotency keys wherever the provider accepts one (no
+double-charge), and every mutation is
 authorized per-caller. Each adapter takes the provider's SDK client by injection.
 The provider SDKs are **optional peer dependencies**, so you install (and bundle) only
 the providers you actually use.

--- a/packages/payment/src/adapter.ts
+++ b/packages/payment/src/adapter.ts
@@ -91,7 +91,12 @@ export interface PaymentAdapter {
      * absent, `track` still records usage durably and `check` enforces limits locally.
      */
     reportUsage?: (input: ReportUsageInput) => Promise<void>;
-    resumeSubscription: (subscriptionId: string) => Promise<Subscription>;
+
+    /**
+     * Clear a pending cancellation. `options.idempotencyKey` overrides the adapter's own stable key
+     * and is honoured by the Stripe adapter only — no other provider's endpoint accepts one.
+     */
+    resumeSubscription: (subscriptionId: string, options?: { idempotencyKey?: string }) => Promise<Subscription>;
     updateSubscription: (subscriptionId: string, patch: SubscriptionPatch) => Promise<Subscription>;
 }
 

--- a/packages/payment/src/idempotency.ts
+++ b/packages/payment/src/idempotency.ts
@@ -43,10 +43,15 @@
  * `customers.create` type-checks and never leaves the process. Dodo's only working idempotency in
  * this SDK version is body-level (`event_id` on usage ingestion), which we do use.
  *
- * **Two Stripe calls are un-keyed but trivially keyable** — `subscriptions.update` in
- * `resumeSubscription` and in `updateSubscription` (a plan/quantity change, so a money-moving
- * proration) are the only mutating Stripe calls in that adapter with no third `RequestOptions`
- * argument. Adding one is a follow-up, not a change to make blind.
+ * **A key is stable for the logical OPERATION, not fresh per attempt.** A plan change is keyed on
+ * the subscription AND the target plan/quantity, so an identical retry replays while a different
+ * target is a different key — one key across two parameter sets is a provider-side mismatch error.
+ * The cost of that stability is a toggle: re-issuing a target that was applied and then changed
+ * away from, inside the provider's idempotency window (24h on Stripe), replays the first response
+ * instead of acting. Pass an explicit key (`SubscriptionPatch.idempotencyKey`,
+ * `CancelSubscriptionOptions.idempotencyKey`, `resumeSubscription`'s `options`) for that case.
+ * Those overrides are honoured by the Stripe adapter only — per the list above, no other
+ * provider's plan-change endpoint accepts a key at all.
  */
 import type { Money } from "./types";
 

--- a/packages/payment/src/providers/creem.ts
+++ b/packages/payment/src/providers/creem.ts
@@ -377,6 +377,9 @@ export const createCreemAdapter = (options: CreemAdapterOptions): PaymentAdapter
         updateSubscription: async (subscriptionId, patch: SubscriptionPatch) => {
             // A plan change is an `upgrade` to the new product (prorated immediately); a bare
             // metadata/quantity patch has no upgrade semantics, so return the current truth.
+            // Un-deduped on purpose, for want of anywhere to put a key: neither
+            // `UpgradeSubscriptionRequestEntity` nor Creem's `RequestOptions` carries one (checkout's
+            // `requestId` has no counterpart here), so a retry charges the proration twice.
             if (patch.priceId) {
                 return subscriptionFromCreem(
                     await client.subscriptions.upgrade(subscriptionId, { productId: patch.priceId, updateBehavior: "proration-charge-immediately" }),

--- a/packages/payment/src/providers/dodopayments.ts
+++ b/packages/payment/src/providers/dodopayments.ts
@@ -314,8 +314,10 @@ export const createDodoPaymentsAdapter = (options: DodoPaymentsAdapterOptions): 
 
         getOrCreateCustomer: async (ref: CustomerRef): Promise<Customer> => {
             // Dodo's `customers.create` is NOT idempotent by email, so a retried/raced first checkout
-            // for the same reference would mint duplicate customers. Key the create on the reference so
-            // repeats return the same customer (the facade also gates this behind a store lookup).
+            // for the same reference would mint duplicate customers. The store lookup the facade puts in
+            // front of this call is what actually prevents that: the key below is INERT on this SDK,
+            // which drops it rather than sending a header (see the `@lunora/payment` idempotency
+            // docblock). It is passed anyway so the call is covered the day the SDK starts honouring it.
             const customer = asRecord(
                 await client.customers.create(
                     { email: ref.email ?? "", name: ref.metadata?.name ?? ref.referenceId },
@@ -429,6 +431,8 @@ export const createDodoPaymentsAdapter = (options: DodoPaymentsAdapterOptions): 
                     patch.priceId !== undefined && patch.quantity !== undefined ? undefined : await client.subscriptions.retrieve(subscriptionId),
                 );
 
+                // Un-deduped on purpose, for want of anywhere to put a key: `SubscriptionChangePlanParams`
+                // has no idempotency field and this SDK never sends the header one. A retry prorates twice.
                 await client.subscriptions.changePlan(subscriptionId, {
                     product_id: patch.priceId ?? readString(current, "product_id") ?? "",
                     proration_billing_mode: "prorated_immediately",

--- a/packages/payment/src/providers/stripe.ts
+++ b/packages/payment/src/providers/stripe.ts
@@ -506,8 +506,14 @@ export const createStripeAdapter = (options: StripeAdapterOptions): PaymentAdapt
             );
         },
 
-        resumeSubscription: async (subscriptionId) => {
-            const subscription = await client.subscriptions.update(subscriptionId, { cancel_at_period_end: false });
+        resumeSubscription: async (subscriptionId, resumeOptions) => {
+            // Its own operation name: `cancel_subscription`'s key on the same subscription would make a
+            // resume replay the cancel's cached response instead of clearing the pending cancellation.
+            const subscription = await client.subscriptions.update(
+                subscriptionId,
+                { cancel_at_period_end: false },
+                { idempotencyKey: resumeOptions?.idempotencyKey ?? idempotencyKey("resume_subscription", "stripe", subscriptionId) },
+            );
 
             return subscriptionFromStripe(subscription);
         },
@@ -523,7 +529,13 @@ export const createStripeAdapter = (options: StripeAdapterOptions): PaymentAdapt
                 parameters.items = [{ id: current.items.data[0]?.id, price: patch.priceId, quantity: patch.quantity }];
             }
 
-            const subscription = await client.subscriptions.update(subscriptionId, parameters);
+            // A plan change prorates, so an un-keyed retry charges twice. The TARGET is part of the key:
+            // this is the one call whose parameters vary, and reusing one key across two of them makes
+            // Stripe reject the second as a mismatch — while an identical retry must still replay.
+            const subscription = await client.subscriptions.update(subscriptionId, parameters, {
+                idempotencyKey:
+                    patch.idempotencyKey ?? idempotencyKey("update_subscription", "stripe", subscriptionId, patch.priceId ?? "", patch.quantity ?? ""),
+            });
 
             return subscriptionFromStripe(subscription);
         },

--- a/packages/payment/src/types.ts
+++ b/packages/payment/src/types.ts
@@ -359,6 +359,14 @@ export interface CancelSubscriptionOptions {
  * @experimental
  */
 export interface SubscriptionPatch {
+    /**
+     * Override the outbound idempotency key. Honoured by the Stripe adapter only — no other provider's
+     * plan-change endpoint accepts a key at all (see the `idempotency` module docblock). Stripe
+     * otherwise derives one from the subscription and the target plan/quantity, which is stable across
+     * retries of the same intent; pass your own only to re-issue a target that was already applied and
+     * then changed away from, which a stable key would replay rather than prorate again.
+     */
+    readonly idempotencyKey?: string;
     readonly priceId?: string;
     readonly quantity?: number;
 }


### PR DESCRIPTION
Follow-up to #633, which corrected `idempotency.ts`'s claim that a Polar refund was "THE ONE EXCEPTION" to every mutating provider call carrying a stable key. It is not, and that PR deliberately left the fixes here because whether a provider accepts a key is per-provider work.

## Stripe: two un-keyed calls, both fixed

`subscriptions.update` accepts a key as its third argument — one call site already passed one, two did not:

- **resume** now uses `resume_subscription:stripe:<subId>`, deliberately its own operation name. Reusing the cancel key on the same subscription would make a resume replay the cancel's cached response.
- **plan change** now uses `update_subscription:stripe:<subId>:<priceId>:<quantity>`. The target is in the key for the same reason `capturePayment` puts the amount in its own: one key across two parameter sets is a Stripe mismatch error, while an identical retry must still replay. This is the path that moves money immediately through proration.

`SubscriptionPatch.idempotencyKey` and a `resumeSubscription` options argument give callers the same override that cancel and capture already have — because a stable key has a real ceiling: re-issuing a target that was applied and then changed away from, inside Stripe's 24h window, replays instead of acting. Both are documented Stripe-only, and both types are `@experimental`, so no snapshot drift.

## Dodo: it cannot carry a key, and no header was guessed

The SDK builds an idempotency header only when `this.idempotencyHeader` is truthy. That field is `protected`, declared, read at `client.js:457-461` — and **assigned nowhere in the package**. `ClientOptions` exposes no such field either, so a subclass is the only route, and that still needs a header name Dodo honours. Its OpenAPI-derived resources declare idempotency **only as body fields on unrelated endpoints**; `CustomerCreateParams` and `SubscriptionChangePlanParams` carry none, and the API reference documents no request header.

So the key Lunora already passes on `customers.create` type-checks and is silently dropped. Proven against the real client with an injected fetch — 11 headers captured, none of them idempotency, so the assertion is not vacuous.

**No header was invented.** A wrong header name is worse than a documented gap, because it looks like protection. Instead there is a canary test: it drives the real SDK, asserts no idempotency header leaves, passes today by design, and **fails when a future release starts honouring the key** — pointing at the docblock that would then be stale.

## Creem, Polar, Autumn: checked, and also cannot

Creem's `upgrade` takes Speakeasy's `RequestOptions` (`timeoutMs`, `retries`, `retryCodes`, `serverURL`, `fetchOptions` — no idempotency field). Polar's `subscriptions.update` has the identical shape. `autumn-js` contains no idempotency surface at all.

So a prorated plan change is un-deduped on every provider except Stripe. `idempotency.ts` now names all three uncovered classes with the reason each cannot carry a key, and `docs/index.mdx` says "wherever the provider accepts one" rather than implying universal coverage.

## Verification

Four Stripe tests written and run against unfixed code first, each failing `expected undefined to be '…'` — no third argument reached the SDK. After: 28 pass. Package suite 256 pass.

All seven repo gates green, plus `check-generated-files.mjs`.

The over-refund and local-marker guards these keys complement are untouched — for Polar they remain the only protection, which is what `idempotency.ts` says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional idempotency key overrides when resuming or updating subscriptions.
  * Stripe subscription operations now use stable idempotency keys by default to help prevent duplicate actions during retries.
  * Documented that custom idempotency key overrides are honored only by Stripe.

* **Documentation**
  * Clarified idempotency coverage, replay behavior, and provider-specific retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->