### PR TITLE
fix(dispatch): encode ctx.run args once, at the runner

### DIFF
--- a/packages/agent/__tests__/resolve-run-args-wire.test.ts
+++ b/packages/agent/__tests__/resolve-run-args-wire.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The agent loop's dispatcher is `@lunora/dispatch`'s runner (built here by
+ * `resolveAgentRun`, and identically by `createAgentContext` and the voice DO's
+ * `resolveRun`), POSTing to `/_lunora/scheduler/dispatch`. The shard's dispatch
+ * loop decodes the body's `args` exactly once
+ * (`decodeWire(payload.args ?? {})`), so this end has to encode: without it a
+ * `bigint` throws in `JSON.stringify` before the request leaves, and a `Date`
+ * reaches the handler as an ISO string.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import resolveAgentRun from "../src/resolve-run";
+import type { AgentFunctionReference, AgentRunFunction } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: AgentFunctionReference = { __lunoraRef: "agents:agentAppendMessage" };
+
+/** Never reached — the owner branch always builds a fresh dispatcher. */
+const contextRun: AgentRunFunction = async () => undefined;
+
+/** Dispatch `args` through the owner-scoped agent runner and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+        body = init.body as string;
+
+        return new Response(null, { status: 200 });
+    });
+
+    await resolveAgentRun(contextRun, "user-a", ENV)(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("agent dispatch args wire", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(args["amountCents"]).toBeTypeOf("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});

--- a/packages/dispatch/__tests__/dispatch-args-wire.test.ts
+++ b/packages/dispatch/__tests__/dispatch-args-wire.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The dispatch runner's args wire. `createDispatchRunner` POSTs to
+ * `/_lunora/scheduler/dispatch`, the runtime forwards `args` verbatim to the
+ * shard's `/rpc`, and the shard's dispatch loop is the one and only decoder
+ * (`decodeWire(payload.args ?? {})`, `@lunora/do`'s `shard-do`). These pin the
+ * producer half of that bracket: a `bigint` or `Date` argument has to reach the
+ * handler as a `bigint` or `Date`, a pure-JSON argument has to be byte-identical
+ * on the wire, and a caller that already put its args in wire form has to be
+ * left alone — `decodeWire` is not idempotent, so a double encode reaches the
+ * handler as a tagged array, and for a `Date` it does so silently.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
+import { createDispatchRunner } from "../src/create-dispatch-runner";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** Run one dispatch and hand back the POSTed body the way the endpoint parses it. */
+const dispatchBody = async (args: Record<string, unknown>, runnerOptions: { argsAlreadyEncoded?: boolean } = {}): Promise<{ args?: unknown }> => {
+    let body = "";
+
+    const run = createDispatchRunner({
+        env: ENV,
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+        label: "@lunora/queue",
+        ...runnerOptions,
+    });
+
+    await run(REF, args as never);
+
+    return JSON.parse(body) as { args?: unknown };
+};
+
+/** What the shard's single `decodeWire` hands the handler for a dispatch of `args`. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const body = await dispatchBody(args);
+
+    return decodeWire(body.args ?? {}) as Record<string, unknown>;
+};
+
+describe("dispatch runner args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // The type, not merely the absence of a throw: an un-encoded `Date`
+        // arrives as an ISO string, which fails nothing until the handler does
+        // date arithmetic on it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("delivers bytes to the handler as bytes", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ blob: new Uint8Array([1, 2, 3]) });
+
+        expect(args["blob"]).toBeInstanceOf(Uint8Array);
+        expect([...(args["blob"] as Uint8Array)]).toStrictEqual([1, 2, 3]);
+    });
+
+    it("leaves pure-JSON args byte-identical on the wire and at the handler", async () => {
+        expect.assertions(2);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+        const body = await dispatchBody(plain);
+
+        // Identity on the wire: nothing was tagged, so an existing caller's
+        // request body is byte for byte what it always was.
+        expect(body.args).toStrictEqual(plain);
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+
+    it("forwards already-encoded args verbatim so the shard's single decode still lands", async () => {
+        expect.assertions(2);
+
+        // `@lunora/scheduler`'s queue workpool encodes at `enqueue` because the
+        // queue is its own serialising hop, then hands the wire form straight
+        // here. Encoding it a second time would leave the shard's single decode
+        // a tagged array — and for a `Date`, a `{}`.
+        const encoded = encodeWire({ amountCents: 7n, dueAt: new Date("2026-06-01T12:00:00.000Z") }) as Record<string, unknown>;
+        const body = await dispatchBody(encoded, { argsAlreadyEncoded: true });
+
+        expect(body.args).toStrictEqual(encoded);
+
+        const args = decodeWire(body.args ?? {}) as Record<string, unknown>;
+
+        expect(args).toStrictEqual({ amountCents: 7n, dueAt: new Date("2026-06-01T12:00:00.000Z") });
+    });
+});

--- a/packages/dispatch/src/create-dispatch-runner.ts
+++ b/packages/dispatch/src/create-dispatch-runner.ts
@@ -12,6 +12,7 @@ import { isLunoraError, LunoraError } from "@lunora/errors";
 
 import { abortDeadline } from "../../../shared/abort-deadline";
 import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
+import { encodeWire } from "../../../shared/wire-codec";
 import type { ArgsOf, DispatchRunFunction, FunctionReference, RunFunctionOptions } from "./types";
 
 /** The reserved worker endpoint that re-dispatches a server-initiated function call to its shard. */
@@ -182,6 +183,22 @@ const toDispatchTimeoutError = (label: string, functionPath: string, timeoutMs: 
     new LunoraError("INTERNAL", `${label}: function dispatch to "${functionPath}" timed out after ${String(timeoutMs)}ms`, { status: 503 });
 
 interface DispatchRunnerOptions {
+    /**
+     * Set by a caller that carried `args` over a serialising hop of its own and
+     * therefore already put them in wire form — today only
+     * `@lunora/scheduler`'s `httpDispatcher`, which takes a job off a Queue that
+     * `createQueueWorkpool.enqueue` had to encode before `JSON.stringify` could
+     * write the message at all.
+     *
+     * The default (`false`) is what every direct producer wants: `ctx.run` in a
+     * workflow body / queue handler, and the agent loop's / voice session's
+     * dispatchers all hand real values straight here. Setting it when the args
+     * are NOT already encoded, or leaving it unset when they are, both land the
+     * same way — the shard's single `decodeWire` sees a mismatched number of
+     * encodes — and the `Date` case is silent, so state it from the hop that
+     * knows.
+     */
+    argsAlreadyEncoded?: boolean;
     /** Worker `env` — read `LUNORA_ORIGIN_URL` + `LUNORA_ADMIN_TOKEN` at call time. */
     env: Record<string, unknown>;
     /** Injectable fetch (tests); defaults to the global. */
@@ -202,7 +219,11 @@ interface DispatchRunnerOptions {
 
 /**
  * Build a {@link DispatchRunFunction} that invokes a Lunora function by POSTing
- * to `/_lunora/scheduler/dispatch` with the admin bearer. The parsed JSON body
+ * to `/_lunora/scheduler/dispatch` with the admin bearer. `args` go out in wire
+ * form (see `wireArgs` below) so a `bigint`/`Date`/bytes argument survives to
+ * the handler, which the shard's single `decodeWire` restores.
+ *
+ * The parsed JSON body
  * (the function's return value) is resolved; an empty body resolves to
  * `undefined`. A non-ok response is rethrown as a {@link LunoraError} carrying
  * the dispatch endpoint's original `code`/`status`/`data` (so consumers can map
@@ -216,6 +237,37 @@ interface DispatchRunnerOptions {
  */
 const createDispatchRunner = (options: DispatchRunnerOptions): DispatchRunFunction => {
     const { label } = options;
+
+    /**
+     * Put `args` in wire form for the POST body — the producer half of the
+     * bracket the shard closes with its single `decodeWire(payload.args ?? {})`.
+     *
+     * Without it a `bigint` argument throws inside the `JSON.stringify` below
+     * before the request is ever sent, and a `Date` (or bytes) reaches the
+     * handler as an ISO string (or a numeric-keyed object) — which fails nothing
+     * until the handler does date arithmetic on it. `encodeWire` is the identity
+     * on pure JSON, so an existing caller's request body is byte for byte what
+     * it always was.
+     *
+     * `undefined` args normalise to `{}` here rather than being encoded: a
+     * top-level `undefined` would otherwise encode to the tagged form, and the
+     * endpoint already reads an absent `args` as `{}`.
+     *
+     * The runner's `argsAlreadyEncoded` option skips it for the one producer
+     * whose args arrive in wire form off a queue. Nothing between here
+     * and the shard encodes or decodes — `handleSchedulerDispatch` and
+     * `dispatchToShard` in `@lunora/runtime` forward `args` verbatim — which is
+     * load-bearing, because `decodeWire` is not idempotent: a second pass
+     * flattens a `Date` to `{}`.
+     */
+    const wireArgs = (args: unknown): unknown => {
+        if (args === undefined) {
+            return {};
+        }
+
+        return options.argsAlreadyEncoded === true ? args : encodeWire(args);
+    };
+
     const globalFetch = (globalThis as { fetch?: typeof fetch }).fetch;
     // Bind the global `fetch` to `globalThis` so calling it through a captured
     // reference cannot trip "Illegal invocation" in receiver-strict runtimes.
@@ -303,7 +355,7 @@ const createDispatchRunner = (options: DispatchRunnerOptions): DispatchRunFuncti
                     // path, so a per-MESSAGE id reused across a handler's several
                     // calls would make the second call return the first's cached
                     // result. `JSON.stringify` omits the key when unset.
-                    body: JSON.stringify({ args: args ?? {}, functionPath: function_.__lunoraRef, id: runOptions.dedupId, shardKey: runOptions.shardKey }),
+                    body: JSON.stringify({ args: wireArgs(args), functionPath: function_.__lunoraRef, id: runOptions.dedupId, shardKey: runOptions.shardKey }),
                     headers,
                     method: "POST",
                     signal: deadline.signal,

--- a/packages/queue/__tests__/run-context-args-wire.test.ts
+++ b/packages/queue/__tests__/run-context-args-wire.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `ctx.run` inside a `defineQueue` push handler is `@lunora/dispatch`'s runner,
+ * POSTing to `/_lunora/scheduler/dispatch`. The shard's dispatch loop decodes
+ * the body's `args` exactly once (`decodeWire(payload.args ?? {})`), so this
+ * end has to encode: without it a `bigint` throws in `JSON.stringify` before the
+ * request leaves, and a `Date` reaches the handler as an ISO string.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import { createQueueRunContext } from "../src/run-context";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** Dispatch `args` through a real queue `ctx.run` and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    const ctx = createQueueRunContext({
+        env: ENV,
+        exportName: "charges",
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+    });
+
+    await ctx.run(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("queue ctx.run args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -1,8 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
+        // Intentionally no `outDir`/`rootDir` (mirroring `@lunora/workflow`):
+        // `lint:types` is `tsc --noEmit` and the real build is packem (driven by
+        // package.json exports), so neither is load-bearing here. A set `rootDir`
+        // raises TS6059 for the inlined `../../../shared/wire-codec` import (a
+        // file outside this package, bundled in at build time).
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-plugin/types", "node"]
     },

--- a/packages/scheduler/__tests__/queue-workpool-args-wire.test.ts
+++ b/packages/scheduler/__tests__/queue-workpool-args-wire.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The queue workpool's args wire: `enqueue`/`enqueueBatch` put a `QueueJob` on
+ * the queue, `httpDispatcher` POSTs it to `/_lunora/scheduler/dispatch`, and the
+ * shard's dispatch loop is the one and only decoder
+ * (`decodeWire(payload.args ?? {})`, `@lunora/do`'s `shard-do`). These pin the
+ * producer half of that bracket: a `bigint` or `Date` argument has to reach the
+ * handler as a `bigint` or `Date`, and a pure-JSON argument has to be unchanged
+ * byte for byte.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import { createQueueWorkpool, httpDispatcher } from "../src/queue-workpool";
+import type { FunctionReference, QueueJob, QueueLike, QueueSendRequestLike } from "../src/types";
+
+const fnRef = (ref: string): FunctionReference<"mutation"> => {
+    return { __lunoraRef: ref };
+};
+
+/**
+ * How a queue binding serialises a message body. `json` is what
+ * `@lunora/platform-node`'s queue host defaults to (`sendOptions?.contentType ?? "json"`)
+ * and `v8` is Cloudflare's own default, so a job's args must survive both: JSON
+ * refuses a `bigint` outright and flattens a `Date`, while structured clone
+ * carries values the next hop's `JSON.stringify` then refuses instead.
+ */
+const TRANSPORTS: Record<string, (body: QueueJob) => QueueJob> = {
+    json: (body) => {
+        // Deliberately the store-and-forward round trip through a string that
+        // `@lunora/platform-node`'s `encodeBody`/`decodeBody` perform, NOT a deep
+        // clone: refusing a `bigint` and flattening a `Date` is the behaviour
+        // under test.
+        const stored = JSON.stringify(body);
+
+        return JSON.parse(stored) as QueueJob;
+    },
+    v8: (body) => structuredClone(body),
+};
+
+/** Collects what the queue binding was handed, serialised the way the transport would. */
+const recordingQueue = (transport: (body: QueueJob) => QueueJob): QueueLike<QueueJob> & { delivered: QueueJob[] } => {
+    const delivered: QueueJob[] = [];
+
+    return {
+        delivered,
+        send: async (body: QueueJob) => {
+            delivered.push(transport(body));
+        },
+        sendBatch: async (messages: Iterable<QueueSendRequestLike<QueueJob>>) => {
+            for (const message of messages) {
+                delivered.push(transport(message.body));
+            }
+        },
+    };
+};
+
+/**
+ * Run one delivered job through `httpDispatcher` and return what the shard's
+ * dispatch loop would hand the handler. `createQueueConsumer` is deliberately
+ * not in the way: it passes `message.body` to the dispatcher verbatim (pinned by
+ * `queue-workpool.test.ts`), and calling the dispatcher directly lets a producer
+ * failure surface as itself rather than as a swallowed `retry()`.
+ */
+const dispatchToHandlerArgs = async (job: QueueJob): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    const dispatch = httpDispatcher({
+        adminToken: "admintok",
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+        originUrl: "https://app.example",
+    });
+
+    await dispatch(job, "msg-1");
+
+    const payload = JSON.parse(body) as { args?: unknown };
+
+    return decodeWire(payload.args ?? {}) as Record<string, unknown>;
+};
+
+describe.each(Object.entries(TRANSPORTS))("queue workpool args wire over a %s queue", (_name, transport) => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const queue = recordingQueue(transport);
+
+        await createQueueWorkpool({ queue }).enqueue(fnRef("jobs:charge"), { amountCents: 4_294_967_296n });
+
+        const args = await dispatchToHandlerArgs(queue.delivered[0] as QueueJob);
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        const queue = recordingQueue(transport);
+
+        await createQueueWorkpool({ queue }).enqueue(fnRef("jobs:remind"), { dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        const args = await dispatchToHandlerArgs(queue.delivered[0] as QueueJob);
+
+        // The type, not merely the absence of a throw: an un-encoded `Date`
+        // arrives as an ISO string, which fails nothing until the handler does
+        // date arithmetic on it.
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("delivers an enqueueBatch job's bigint argument to the handler as a bigint", async () => {
+        expect.assertions(1);
+
+        const queue = recordingQueue(transport);
+
+        await createQueueWorkpool({ queue }).enqueueBatch([{ args: { amountCents: 7n }, ref: fnRef("jobs:charge") }]);
+
+        const args = await dispatchToHandlerArgs(queue.delivered[0] as QueueJob);
+
+        expect(args["amountCents"]).toBe(7n);
+    });
+
+    it("leaves pure-JSON args untouched on the wire and at the handler", async () => {
+        expect.assertions(2);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+        const queue = recordingQueue(transport);
+
+        await createQueueWorkpool({ queue }).enqueue(fnRef("jobs:report"), plain);
+
+        // Identity on the queue itself: nothing was tagged, so an existing
+        // caller's message body is byte for byte what it always was.
+        expect(queue.delivered[0]?.args).toStrictEqual(plain);
+
+        const args = await dispatchToHandlerArgs(queue.delivered[0] as QueueJob);
+
+        expect(args).toStrictEqual(plain);
+    });
+});

--- a/packages/scheduler/__tests__/queue-workpool-args-wire.test.ts
+++ b/packages/scheduler/__tests__/queue-workpool-args-wire.test.ts
@@ -55,13 +55,14 @@ const recordingQueue = (transport: (body: QueueJob) => QueueJob): QueueLike<Queu
 };
 
 /**
- * Run one delivered job through `httpDispatcher` and return what the shard's
- * dispatch loop would hand the handler. `createQueueConsumer` is deliberately
- * not in the way: it passes `message.body` to the dispatcher verbatim (pinned by
+ * Run one delivered job through `httpDispatcher` and return the `args` it POSTed
+ * to `/_lunora/scheduler/dispatch`, still in wire form — the shard's single
+ * `decodeWire` has not run yet. `createQueueConsumer` is deliberately not in the
+ * way: it passes `message.body` to the dispatcher verbatim (pinned by
  * `queue-workpool.test.ts`), and calling the dispatcher directly lets a producer
  * failure surface as itself rather than as a swallowed `retry()`.
  */
-const dispatchToHandlerArgs = async (job: QueueJob): Promise<Record<string, unknown>> => {
+const dispatchedWireArgs = async (job: QueueJob): Promise<unknown> => {
     let body = "";
 
     const dispatch = httpDispatcher({
@@ -76,10 +77,11 @@ const dispatchToHandlerArgs = async (job: QueueJob): Promise<Record<string, unkn
 
     await dispatch(job, "msg-1");
 
-    const payload = JSON.parse(body) as { args?: unknown };
-
-    return decodeWire(payload.args ?? {}) as Record<string, unknown>;
+    return (JSON.parse(body) as { args?: unknown }).args ?? {};
 };
+
+/** What the shard's dispatch loop would hand the handler for one delivered job. */
+const dispatchToHandlerArgs = async (job: QueueJob): Promise<Record<string, unknown>> => decodeWire(await dispatchedWireArgs(job)) as Record<string, unknown>;
 
 describe.each(Object.entries(TRANSPORTS))("queue workpool args wire over a %s queue", (_name, transport) => {
     it("delivers a bigint argument to the handler as a bigint", async () => {
@@ -138,5 +140,26 @@ describe.each(Object.entries(TRANSPORTS))("queue workpool args wire over a %s qu
         const args = await dispatchToHandlerArgs(queue.delivered[0] as QueueJob);
 
         expect(args).toStrictEqual(plain);
+    });
+
+    it("hands the queued args to the dispatch endpoint unchanged, so the shard decodes exactly once", async () => {
+        expect.assertions(1);
+
+        // The no-double-encode pin. `createDispatchRunner` encodes `args` for
+        // every OTHER producer (`ctx.run` in a workflow body / queue handler,
+        // the agent loop's and voice session's dispatchers), and this path is
+        // the one that must opt out (`argsAlreadyEncoded`) because `enqueue`
+        // already encoded before the queue's own `JSON.stringify`. Asserting the
+        // POST body's `args` are byte-identical to the queued job's is what
+        // fails if that opt-out is ever dropped — the handler-facing assertions
+        // above catch the `bigint`, but a double-encoded `Date` decodes to `{}`
+        // and only a shape check names the cause.
+        const queue = recordingQueue(transport);
+
+        await createQueueWorkpool({ queue }).enqueue(fnRef("jobs:remind"), { amountCents: 7n, dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        const job = queue.delivered[0] as QueueJob;
+
+        await expect(dispatchedWireArgs(job)).resolves.toStrictEqual(job.args);
     });
 });

--- a/packages/scheduler/src/queue-workpool.ts
+++ b/packages/scheduler/src/queue-workpool.ts
@@ -182,12 +182,16 @@ const createQueueConsumer =
  * intermediary's page rather than a function's return value and therefore no
  * evidence the job ran. An empty 2xx is a normal success (a `void` function).
  *
- * `job.args` is forwarded VERBATIM: {@link encodeJobArgs} already put it in wire
- * form at the producer, and the shard's dispatch loop is the single decoder.
- * Encoding again here would leave the handler a tagged array.
+ * `job.args` is forwarded VERBATIM — `argsAlreadyEncoded`, the runner's opt-out
+ * of its own `encodeWire`: {@link encodeJobArgs} already put it in wire form at
+ * the producer (it had to, or the queue's own `JSON.stringify` would have
+ * refused the message), and the shard's dispatch loop is the single decoder.
+ * Encoding again here would leave the handler a tagged array — and a `Date` a
+ * `{}`, silently.
  */
 const httpDispatcher = (options: HttpDispatcherOptions): QueueDispatch => {
     const run = createDispatchRunner({
+        argsAlreadyEncoded: true,
         env: { LUNORA_ADMIN_TOKEN: options.adminToken, LUNORA_ORIGIN_URL: options.originUrl },
         fetchImpl: options.fetchImpl,
         label: "@lunora/scheduler",

--- a/packages/scheduler/src/queue-workpool.ts
+++ b/packages/scheduler/src/queue-workpool.ts
@@ -22,6 +22,7 @@
 import { createDispatchRunner } from "@lunora/dispatch";
 import { LunoraError } from "@lunora/errors";
 
+import { encodeWire } from "../../../shared/wire-codec";
 import type {
     ArgsOf,
     FunctionReference,
@@ -61,6 +62,34 @@ const MAX_QUEUE_BATCH = 100;
 const DEFAULT_JOB_TIMEOUT_MS = 300_000;
 
 /**
+ * The single owner of what this package's producers put in a {@link QueueJob}'s
+ * `args` — `enqueue` and `enqueueBatch` both go through here, so the two cannot
+ * drift on what a job looks like on the queue.
+ *
+ * A job's args can hold a `bigint`, a `Date` or bytes, and the queue is a
+ * serialising hop: `@lunora/platform-node`'s queue host defaults to
+ * `contentType: "json"`, where a `bigint` throws inside `JSON.stringify` before
+ * the message is ever recorded and a `Date` silently arrives as an ISO string.
+ * A structured-clone (`"v8"`) queue carries both one hop further, only for the
+ * dispatcher's own `JSON.stringify` to refuse them identically. Encoding here
+ * makes the message body pure JSON on every host, which is also what keeps a
+ * dead-lettered job readable.
+ *
+ * The counterpart decode is the shard's, and it is the ONLY one on this path:
+ * `@lunora/do`'s dispatch loop runs `decodeWire(payload.args ?? {})` before the
+ * handler. `httpDispatcher` and `/_lunora/scheduler/dispatch` pass `args`
+ * through untouched, so nothing between here and there may encode or decode
+ * again — `decodeWire` is not idempotent, and a second pass flattens a `Date`
+ * to `{}`.
+ *
+ * `encodeWire` is the identity on pure JSON, so an existing caller's message
+ * body is unchanged. Absent args stay absent rather than becoming `{}`: a
+ * top-level `undefined` would otherwise encode to the tagged form.
+ */
+const encodeJobArgs = (args: Record<string, unknown> | undefined): Record<string, unknown> | undefined =>
+    args === undefined ? undefined : (encodeWire(args) as Record<string, unknown>);
+
+/**
  * Build a Queues producer that enqueues Lunora function dispatches. Concurrency
  * and retry policy live on the consumer's `wrangler.jsonc` config, not here.
  */
@@ -72,12 +101,15 @@ const createQueueWorkpool = (options: QueueWorkpoolOptions): QueueWorkpool => {
     }
 
     const enqueue = async <F extends FunctionReference>(function_: F, args: ArgsOf<F>, enqueueOptions: QueueEnqueueOptions = {}): Promise<void> => {
-        // The wire payload is a plain JSON bag; `ArgsOf<F>` is the reference's own
-        // args object, which TS cannot prove is a `Record<string, unknown>` even
-        // though every generated args type is one. Cast at the serialisation
-        // boundary rather than loosening the parameter, which is what makes the
-        // call site arg-checked at all.
-        const job: QueueJob = { args: args as Record<string, unknown>, functionPath: function_.__lunoraRef, shardKey: enqueueOptions.shardKey };
+        // `ArgsOf<F>` is the reference's own args object, which TS cannot prove is
+        // a `Record<string, unknown>` even though every generated args type is
+        // one. Cast at the serialisation boundary rather than loosening the
+        // parameter, which is what makes the call site arg-checked at all.
+        const job: QueueJob = {
+            args: encodeJobArgs(args as Record<string, unknown>),
+            functionPath: function_.__lunoraRef,
+            shardKey: enqueueOptions.shardKey,
+        };
         const sendOptions = enqueueOptions.delaySeconds === undefined ? undefined : { delaySeconds: enqueueOptions.delaySeconds };
 
         await options.queue.send(job, sendOptions);
@@ -95,7 +127,7 @@ const createQueueWorkpool = (options: QueueWorkpoolOptions): QueueWorkpool => {
         }
 
         const messages = jobs.map((job) => {
-            return { body: { args: job.args, functionPath: job.ref.__lunoraRef, shardKey: job.shardKey } satisfies QueueJob };
+            return { body: { args: encodeJobArgs(job.args), functionPath: job.ref.__lunoraRef, shardKey: job.shardKey } satisfies QueueJob };
         });
 
         await options.queue.sendBatch(messages, sendOptions);
@@ -149,6 +181,10 @@ const createQueueConsumer =
  * message — including a 2xx carrying a non-empty non-JSON body, which is an
  * intermediary's page rather than a function's return value and therefore no
  * evidence the job ran. An empty 2xx is a normal success (a `void` function).
+ *
+ * `job.args` is forwarded VERBATIM: {@link encodeJobArgs} already put it in wire
+ * form at the producer, and the shard's dispatch loop is the single decoder.
+ * Encoding again here would leave the handler a tagged array.
  */
 const httpDispatcher = (options: HttpDispatcherOptions): QueueDispatch => {
     const run = createDispatchRunner({

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -390,6 +390,13 @@ export interface MessageBatchLike<Body = unknown> {
 
 /** The wire payload Lunora puts on the queue: a function dispatch. */
 export interface QueueJob {
+    /**
+     * The call's arguments in WIRE form (`shared/wire-codec`), so a `bigint`,
+     * `Date` or bytes survives the queue's own JSON serialisation. The producers
+     * encode; the shard's dispatch loop is the single decoder. A custom
+     * {@link QueueDispatch} must forward this untouched — decoding it here and
+     * letting the shard decode again flattens a `Date` to `{}`.
+     */
     args?: Record<string, unknown>;
     functionPath: string;
     /** Routing hint forwarded to the Worker so the call lands on the right shard. */

--- a/packages/workflow/__tests__/run-context-args-wire.test.ts
+++ b/packages/workflow/__tests__/run-context-args-wire.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `ctx.run` inside a workflow body is `@lunora/dispatch`'s runner, POSTing to
+ * `/_lunora/scheduler/dispatch`. The shard's dispatch loop decodes the body's
+ * `args` exactly once (`decodeWire(payload.args ?? {})`), so this end has to
+ * encode: without it a `bigint` throws in `JSON.stringify` before the request
+ * leaves, and a `Date` reaches the handler as an ISO string.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import { createWorkflowRunContext } from "../src/run-context";
+import type { FunctionReference, WorkflowEventLike, WorkflowStepLike } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+const EVENT: WorkflowEventLike = {
+    instanceId: "inst-1",
+    payload: {},
+    timestamp: new Date(0),
+    workflowName: "orderPipeline",
+};
+
+/** Dispatch `args` through a real workflow `ctx.run` and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    const ctx = createWorkflowRunContext({
+        env: ENV,
+        event: EVENT,
+        exportName: "orderPipeline",
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+        step: {} as unknown as WorkflowStepLike,
+    });
+
+    await ctx.run(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("workflow ctx.run args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});


### PR DESCRIPTION
> **Stacked on #634** (`fix/r32-workpool-wire`) — based on that branch, not `alpha`. Merge #634 first.

`createDispatchRunner` posted `args` with no `encodeWire` against a shard that decodes unconditionally, so `ctx.run(fn, { n: 1n })` threw and a `Date` arrived as an ISO string.

## Six producers, not three

Every non-test caller of the runner:

| Site | Encoded before? |
|---|---|
| `scheduler/queue-workpool.ts` (`httpDispatcher`) | **yes** — #634 brackets it at `enqueue` |
| `queue/run-context.ts` — `ctx.run` in a push handler | no |
| `workflow/run-context.ts` — `ctx.run` in a workflow body | no |
| `agent/resolve-run.ts` | no |
| `agent/voice-do.ts` | no |
| `agent/create-agent-context.ts` | no |

Exactly one decode on the path: `shard-do.ts:5925` inside `runHandler`. The other `decodeWire` calls there are the WebSocket envelope routes and `decodeAdminArgs`.

## Why this encodes in the shared runner rather than per-package wrappers

The plan was five per-package `run` wrappers, to avoid double-encoding the one producer #634 already brackets. The runner turned out to be the better seam, for two reasons:

**The unsafe seam is structurally unreachable.** `handleSchedulerDispatch` takes the `create({ params })` branch only when the body carries a top-level string `workflow` field, and the runner's body literal is `{ args, functionPath, id, shardKey }` — there is no `workflow` key in it, ever. That is a property of the body shape, so it holds for all six producers at once instead of needing a per-package argument. (#634 established this for the queue path specifically; it generalises.)

**The failure modes are asymmetric.** With wrappers, a seventh producer that forgets one silently corrupts `Date`s — `decodeWire` is not idempotent, and a missed encode is indistinguishable from success until someone inspects a value. With one encode plus an `argsAlreadyEncoded` opt-out, the only way to get it wrong is to add a producer with its own serialising hop *and* forget to declare it — and the single existing such site is pinned by a test that fails eight ways if the flag is dropped.

## Verification

Regression tests in `dispatch`, `queue`, `workflow` and `agent`, each written and run against unfixed code first — `TypeError: Do not know how to serialize a BigInt` at `create-dispatch-runner.ts:306`, and `expected '2026-06-01T12:00:00.000Z' to be an instance of Date`. Each asserts the decoded **type**, not merely the absence of a throw, plus a plain-JSON identity case.

The no-double-encode property is pinned on #634's own suite: the POSTed `args` must be byte-identical to what `enqueue` put on the queue. Proven to fire by deleting the opt-out — 8 failures, including `expected [ '$lunora.wire$', 'bigint', '7' ] to be 7n`.

All repo gates green including `check-generated-files.mjs`, `no-nul-bytes`, and `test:coverage` for the five touched packages. Verified the fix reaches the bundle rather than only the source.

`packages/queue/tsconfig.json` drops `outDir`/`rootDir` — the documented convention for importing `shared/*`, mirroring `@lunora/workflow`, which carries the same comment. Six lint findings in my own files were fixed in source, none suppressed.

## Found while doing this, deliberately not fixed

**`ctx.run`'s return value has the mirror-image gap.** The shard encodes its result (`shard-do.ts:6047`) and wraps it as `{ result }`; the runner ends with a bare `return JSON.parse(text)` — no unwrap, no decode. So `await ctx.run(fn)` resolves the *envelope*, wire-encoded: a mutation returning a `bigint` hands the caller `{ result: ["$lunora.wire$","bigint","…"] }`, and `agent-loop.ts` casts that straight to `AgentMessageRow[]`.

There is no end-to-end test of a `ctx.run` return value anywhere, which is why it has stayed invisible. Fixing it changes `ctx.run`'s public return shape, so it belongs in its own change rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dispatch arguments now reliably preserve supported values such as large integers, dates, and binary data when delivered to handlers.
  - Missing arguments are normalized to an empty object, improving consistency for dispatched jobs.
  - Arguments that are already prepared for delivery are no longer encoded twice, preventing potential processing errors.

- **Documentation**
  - Updated dispatch and scheduler documentation to clarify argument forwarding and supported delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->