### PR TITLE
fix(dispatch): unwrap and decode what ctx.run returns

### DIFF
--- a/packages/agent/__tests__/resolve-run.test.ts
+++ b/packages/agent/__tests__/resolve-run.test.ts
@@ -31,7 +31,9 @@ describe(resolveAgentRun, () => {
             capturedHeaders = init.headers as Record<string, string>;
             capturedBody = init.body as string;
 
-            return Response.json([{ content: "hi" }]);
+            // The shard's real transport envelope — the loop's `listMessages`
+            // read gets the ARRAY back only because the runner unwraps it.
+            return Response.json({ result: [{ content: "hi" }] });
         });
 
         vi.stubGlobal("fetch", fetchSpy);
@@ -52,7 +54,8 @@ describe(resolveAgentRun, () => {
         expect(capturedHeaders["x-lunora-userid"]).toBe("user-a");
         expect(JSON.parse(capturedBody)).toStrictEqual({ args: { key: "thread-1" }, functionPath: "agents:agentMessages" });
 
-        // The dispatcher resolves the function's JSON return value.
+        // The dispatcher resolves the function's own return value, unwrapped out
+        // of the `{ result }` envelope — not the envelope.
         expect(result).toStrictEqual([{ content: "hi" }]);
     });
 });

--- a/packages/dispatch/__tests__/create-dispatch-runner.test.ts
+++ b/packages/dispatch/__tests__/create-dispatch-runner.test.ts
@@ -11,7 +11,9 @@ describe("createDispatchRunner", () => {
     it("pOSTs to /_lunora/scheduler/dispatch with the bearer + envelope and resolves the JSON body", async () => {
         expect.assertions(5);
 
-        const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ ok: 1 }, { status: 200 }));
+        // The stub answers the shard's real transport envelope; the runner
+        // unwraps `result` and decodes it (see `dispatch-result-wire.test.ts`).
+        const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ result: { ok: 1 } }, { status: 200 }));
         const run = createDispatchRunner({ env: ENV, fetchImpl, label: "@lunora/queue" });
 
         await expect(run(REF, { to: "a" }, { shardKey: "s1" })).resolves.toEqual({ ok: 1 });
@@ -27,7 +29,7 @@ describe("createDispatchRunner", () => {
     it("forwards dedupId as the body's `id` (the receiver's dedup key) and omits the key when unset", async () => {
         expect.assertions(3);
 
-        const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ ok: 1 }, { status: 200 }));
+        const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ result: { ok: 1 } }, { status: 200 }));
         const run = createDispatchRunner({ env: ENV, fetchImpl, label: "@lunora/queue" });
 
         await run(REF, { to: "a" }, { dedupId: "msg-1#1" });
@@ -228,7 +230,11 @@ describe("createDispatchRunner", () => {
         vi.useFakeTimers();
 
         try {
-            const run = createDispatchRunner({ env: ENV, fetchImpl: async () => Response.json({ ok: 1 }, { status: 200 }), label: "@lunora/queue" });
+            const run = createDispatchRunner({
+                env: ENV,
+                fetchImpl: async () => Response.json({ result: { ok: 1 } }, { status: 200 }),
+                label: "@lunora/queue",
+            });
 
             await expect(run(REF)).resolves.toEqual({ ok: 1 });
             // `dispose()` in the runner's `finally` cleared the deadline timer.

--- a/packages/dispatch/__tests__/dispatch-result-wire.test.ts
+++ b/packages/dispatch/__tests__/dispatch-result-wire.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The dispatch runner's RESULT wire — the mirror of `dispatch-args-wire.test.ts`.
+ *
+ * The shard is the single encoder on this half: `shard-do`'s dispatch loop calls
+ * `buildDispatchResponse(mutatorClass, encodeWire(result))`, which wraps the
+ * encoded value as `{ result }` (plus `commitCursor` for a plain mutation, or
+ * `lastMutationId` for a `"next"` custom-mutator push). `handleSchedulerDispatch`
+ * and `dispatchToShard` (`@lunora/runtime`) forward that response verbatim, so the
+ * runner is the single decoder — it owns both directions of the wire.
+ *
+ * These pin what a `ctx.run` CALLER receives: the function's own return value, not
+ * the transport envelope, and with `bigint`/`Date`/bytes restored. The `Date` case
+ * is the one that fails silently — an un-decoded `Date` is a tagged array, and a
+ * doubly-decoded one is `{}` — so assert the TYPE, never merely the absence of a
+ * throw.
+ *
+ * The envelope literals below are the same ones `packages/do`'s
+ * `shard-do.dispatch-result-wire.test.ts` asserts a real shard emits, and both
+ * sides run the payload through the same `shared/wire-codec` — that is the join.
+ */
+import { describe, expect, it } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import { createDispatchRunner } from "../src/create-dispatch-runner";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** What `await ctx.run(fn)` resolves to when the shard answers with `body`. */
+const runResult = async (body: string): Promise<unknown> => {
+    const run = createDispatchRunner({
+        env: ENV,
+        fetchImpl: async () => new Response(body, { headers: { "content-type": "application/json" }, status: 200 }),
+        label: "@lunora/queue",
+    });
+
+    return run(REF, {});
+};
+
+/** The exact body a shard sends for a function returning `value` — `encodeWire`, wrapped in the envelope. */
+const shardBody = (value: unknown, envelope: Record<string, unknown> = {}): string => JSON.stringify({ ...envelope, result: encodeWire(value) });
+
+describe("dispatch runner result wire", () => {
+    it("resolves a bigint return value as a bigint", async () => {
+        expect.assertions(2);
+
+        const result = await runResult(shardBody({ amountCents: 4_294_967_296n }));
+
+        expect(typeof (result as { amountCents?: unknown }).amountCents).toBe("bigint");
+        expect(result).toStrictEqual({ amountCents: 4_294_967_296n });
+    });
+
+    it("resolves a Date return value as a Date", async () => {
+        expect.assertions(2);
+
+        // The TYPE, not the absence of a throw: an un-decoded `Date` comes back
+        // as a tagged array and a doubly-decoded one as `{}` — neither throws.
+        const result = await runResult(shardBody({ dueAt: new Date("2026-06-01T12:00:00.000Z") }));
+
+        expect((result as { dueAt?: unknown }).dueAt).toBeInstanceOf(Date);
+        expect((result as { dueAt: Date }).dueAt.toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("resolves bytes as bytes", async () => {
+        expect.assertions(2);
+
+        const result = await runResult(shardBody({ blob: new Uint8Array([1, 2, 3]) }));
+
+        expect((result as { blob?: unknown }).blob).toBeInstanceOf(Uint8Array);
+        expect([...(result as { blob: Uint8Array }).blob]).toStrictEqual([1, 2, 3]);
+    });
+
+    it("resolves a plain-JSON return value unchanged", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+
+        await expect(runResult(shardBody(plain))).resolves.toStrictEqual(plain);
+    });
+
+    it("resolves an array return value as the array itself, not the envelope", async () => {
+        expect.assertions(2);
+
+        // `@lunora/agent`'s loop casts this straight to `AgentMessageRow[]` and
+        // then iterates it — the envelope is an object, so the cast was a lie.
+        const rows = [
+            { role: "user", seq: 1 },
+            { role: "assistant", seq: 2 },
+        ];
+        const result = await runResult(shardBody(rows));
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toStrictEqual(rows);
+    });
+
+    it("unwraps a plain mutation's `commitCursor` envelope", async () => {
+        expect.assertions(1);
+
+        await expect(runResult(shardBody({ ok: true }, { commitCursor: 12 }))).resolves.toStrictEqual({ ok: true });
+    });
+
+    it("unwraps a custom-mutator push's `lastMutationId` envelope", async () => {
+        expect.assertions(1);
+
+        await expect(runResult(shardBody({ runs: 1 }, { lastMutationId: 3 }))).resolves.toStrictEqual({ runs: 1 });
+    });
+
+    it("resolves undefined for a void function", async () => {
+        expect.assertions(2);
+
+        // `encodeWire` tags a top-level `undefined` rather than letting
+        // `JSON.stringify` drop the key, so the shard really does send
+        // `{ result: ["$lunora.wire$","undefined"] }` — pinned on the shard side
+        // by `packages/do`'s `shard-do.dispatch-result-wire.test.ts`. An envelope
+        // with no `result` at all reads back the same way.
+        await expect(runResult(shardBody(undefined))).resolves.toBeUndefined();
+        await expect(runResult(JSON.stringify({ commitCursor: 7 }))).resolves.toBeUndefined();
+    });
+
+    it("resolves undefined for an empty body", async () => {
+        expect.assertions(1);
+
+        await expect(runResult("")).resolves.toBeUndefined();
+    });
+});

--- a/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
+++ b/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
@@ -8,7 +8,7 @@ import { createDispatchRunner } from "../src/create-dispatch-runner";
 const ENV = { LUNORA_ADMIN_TOKEN: "tok", LUNORA_ORIGIN_URL: "https://app.example.com" };
 const REF = { __lunoraRef: "messages:send" };
 
-const okJson = async (): Promise<Response> => Response.json({ ok: 1 }, { status: 200 });
+const okJson = async (): Promise<Response> => Response.json({ result: { ok: 1 } }, { status: 200 });
 
 const captureCall = (fetchImpl: ReturnType<typeof vi.fn<typeof fetch>>): { body: Record<string, unknown>; headers: Record<string, string>; url: string } => {
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];

--- a/packages/dispatch/src/create-dispatch-runner.ts
+++ b/packages/dispatch/src/create-dispatch-runner.ts
@@ -12,7 +12,7 @@ import { isLunoraError, LunoraError } from "@lunora/errors";
 
 import { abortDeadline } from "../../../shared/abort-deadline";
 import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
-import { encodeWire } from "../../../shared/wire-codec";
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { ArgsOf, DispatchRunFunction, FunctionReference, RunFunctionOptions } from "./types";
 
 /** The reserved worker endpoint that re-dispatches a server-initiated function call to its shard. */
@@ -221,11 +221,14 @@ interface DispatchRunnerOptions {
  * Build a {@link DispatchRunFunction} that invokes a Lunora function by POSTing
  * to `/_lunora/scheduler/dispatch` with the admin bearer. `args` go out in wire
  * form (see `wireArgs` below) so a `bigint`/`Date`/bytes argument survives to
- * the handler, which the shard's single `decodeWire` restores.
+ * the handler, which the shard's single `decodeWire` restores. The RETURN value
+ * travels the same wire in reverse: the shard `encodeWire`s it into a
+ * `{ result }` transport envelope, and this runner is its single decoder — so
+ * the runner owns both directions and `ctx.run` resolves the function's own
+ * return value with its `bigint`/`Date`/bytes intact.
  *
- * The parsed JSON body
- * (the function's return value) is resolved; an empty body resolves to
- * `undefined`. A non-ok response is rethrown as a {@link LunoraError} carrying
+ * The envelope's unwrapped, decoded `result` is resolved; an empty body resolves
+ * to `undefined`. A non-ok response is rethrown as a {@link LunoraError} carrying
  * the dispatch endpoint's original `code`/`status`/`data` (so consumers can map
  * a deterministic 4xx to a non-retryable failure); an unparseable error body
  * falls back to `INTERNAL`. A non-empty body that is not valid JSON is a
@@ -388,8 +391,10 @@ const createDispatchRunner = (options: DispatchRunnerOptions): DispatchRunFuncti
                 return undefined;
             }
 
+            let body: unknown;
+
             try {
-                return JSON.parse(text);
+                body = JSON.parse(text);
             } catch {
                 // A non-empty body that isn't valid JSON can't be a function's
                 // JSON-encoded return value — it's a malformed response (an
@@ -399,6 +404,30 @@ const createDispatchRunner = (options: DispatchRunnerOptions): DispatchRunFuncti
                     status: response.status,
                 });
             }
+
+            // Unwrap the shard's transport envelope and decode — the consumer
+            // half of the bracket `wireArgs` opens. The shard answers
+            // `{ result }`, `{ commitCursor, result }` (a mutation on a
+            // CDC-enabled shard — `dedupId` puts every re-fired `ctx.run` there)
+            // or `{ lastMutationId, result }` (a `"next"` custom-mutator push),
+            // with `result` already `encodeWire`d; `handleSchedulerDispatch` and
+            // `dispatchToShard` forward it verbatim. Handing that object straight
+            // back made `await ctx.run(fn)` resolve the envelope rather than the
+            // function's return value, wire-encoded — so a `bigint` return
+            // arrived as a tagged array nested one level too deep.
+            //
+            // `commitCursor` and `lastMutationId` are deliberately dropped: both
+            // are client-session bookkeeping (dropping a per-call optimistic
+            // overlay, demanding a cursor off a replica) and this runner has
+            // neither a session nor subscriptions. No consumer reads them.
+            //
+            // This is the ONLY decode on the path — `decodeWire` is not
+            // idempotent, and a second pass flattens a `Date` to `{}` while a
+            // `bigint` survives, silent for exactly the type a check would catch.
+            // A void handler's `undefined` arrives tagged (`encodeWire` does not
+            // let `JSON.stringify` drop the key), and decodes back to
+            // `undefined`; an envelope with no `result` at all reads the same.
+            return decodeWire((body as { result?: unknown } | null)?.result);
         } finally {
             deadline.dispose();
         }

--- a/packages/do/__tests__/shard-do.dispatch-result-wire.test.ts
+++ b/packages/do/__tests__/shard-do.dispatch-result-wire.test.ts
@@ -1,0 +1,186 @@
+import { runShardMigrations } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import messagesSchema from "./_helpers/messages-schema";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The shard half of the dispatch RESULT wire — the encoder side of the bracket
+ * `@lunora/dispatch`'s `dispatch-result-wire.test.ts` closes.
+ *
+ * Two things are pinned here, and both are contracts the runner now depends on.
+ *
+ * First, the result is wire-ENCODED exactly once, by `encodeWire`. The runner is
+ * the single decoder, and `decodeWire` is not idempotent — a second encode/decode
+ * pass flattens a `Date` to `{}` while a `bigint` survives, so a drift here is
+ * silent for exactly the type nothing would catch.
+ *
+ * Second, it travels inside an ENVELOPE — `{ result }`, `{ commitCursor, result }`
+ * for a mutation on a CDC-enabled shard, or `{ lastMutationId, result }` for a
+ * `"next"` custom-mutator push (also pinned by
+ * `shard-do.client-watermark.test.ts`, which asserts the envelope on a pure-JSON
+ * result). The runner unwraps `result` and drops the rest; changing the key would
+ * make every `ctx.run` resolve `undefined`.
+ *
+ * The replay case matters for the same reason: `persistIdempotentResult` stores
+ * the ENCODED form, so `respondFromIdempotencyCache` must NOT encode again.
+ */
+
+/** A shard whose handler returns whatever `value` is set to — the value under test. */
+class ReturningShard extends ShardDO {
+    public value: unknown = undefined;
+
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve(this.value);
+    }
+}
+
+/** Like {@link ReturningShard}, but `messages:sendMutator` is a `"next"` custom mutator (the watermarked push path). */
+class ReturningMutatorShard extends ReturningShard {
+    public override handleRpc(): Promise<unknown> {
+        return this.runInTransaction(() => {
+            this.commitMutationBookkeeping(this.value);
+
+            return this.value;
+        });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
+    protected override isCustomMutator(functionPath: string): boolean {
+        return functionPath === "messages:sendMutator";
+    }
+}
+
+const makeState = (database: ReturnType<typeof createSqliteExec>): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets() {
+            return [];
+        },
+        storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+    };
+};
+
+const rpc = (functionPath: string, headers: Record<string, string> = {}): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: { "content-type": "application/json", ...headers },
+        method: "POST",
+    });
+
+/** Dispatch one call on a fresh shard and hand back the parsed response envelope. */
+const dispatchEnvelope = async (value: unknown): Promise<Record<string, unknown>> => {
+    const database = createSqliteExec();
+
+    try {
+        runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+        const shard = new ReturningShard(makeState(database), {});
+        shard.value = value;
+
+        const response = await shard.fetch(rpc("messages:list"));
+
+        return await response.json();
+    } finally {
+        database.close();
+    }
+};
+
+describe("shardDO dispatch result wire", () => {
+    it("encodes a bigint result exactly once, inside a `{ result }` envelope", async () => {
+        expect.assertions(2);
+
+        const value = { amountCents: 4_294_967_296n };
+        const envelope = await dispatchEnvelope(value);
+
+        expect(envelope).toStrictEqual({ result: encodeWire(value) });
+        // Spelled out, so a codec change cannot silently redefine what the
+        // runner's single decode is fed.
+        expect(envelope["result"]).toStrictEqual({ amountCents: ["$lunora.wire$", "bigint", "4294967296"] });
+    });
+
+    it("encodes a Date result exactly once", async () => {
+        expect.assertions(2);
+
+        const value = { dueAt: new Date("2026-06-01T12:00:00.000Z") };
+        const envelope = await dispatchEnvelope(value);
+
+        expect(envelope).toStrictEqual({ result: encodeWire(value) });
+        expect(envelope["result"]).toStrictEqual({ dueAt: ["$lunora.wire$", "date", Date.parse("2026-06-01T12:00:00.000Z")] });
+    });
+
+    it("leaves a pure-JSON result structurally identical inside the envelope", async () => {
+        expect.assertions(1);
+
+        const value = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+
+        await expect(dispatchEnvelope(value)).resolves.toStrictEqual({ result: value });
+    });
+
+    it("tags a void handler's `undefined` rather than dropping the `result` key", async () => {
+        expect.assertions(1);
+
+        // `encodeWire` maps a top-level `undefined` to the tagged form, so the
+        // key survives `JSON.stringify` — the runner's decode turns it back into
+        // a real `undefined`.
+        await expect(dispatchEnvelope(undefined)).resolves.toStrictEqual({ result: ["$lunora.wire$", "undefined"] });
+    });
+
+    it("encodes a custom-mutator push's result once, inside a `{ lastMutationId, result }` envelope", async () => {
+        expect.assertions(1);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new ReturningMutatorShard(makeState(database), {});
+            shard.value = { balance: 9_007_199_254_740_993n };
+
+            const response = await shard.fetch(rpc("messages:sendMutator", { "x-lunora-client-id": "c1", "x-lunora-client-seq": "1" }));
+
+            await expect(response.json()).resolves.toStrictEqual({ lastMutationId: 1, result: encodeWire(shard.value) });
+        } finally {
+            database.close();
+        }
+    });
+
+    it("returns the identical encoded envelope when a dedup replay hits the idempotency cache", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new ReturningShard(makeState(database), {});
+            shard.value = { balance: 9_007_199_254_740_993n };
+
+            // `x-lunora-mutation-id` with no client seq is exactly what the
+            // dispatch runner sends (`RunFunctionOptions.dedupId`), so this is
+            // the replay a re-fired `ctx.run` actually takes — NOT the
+            // client-watermark ack, which answers `result: null` and is
+            // unreachable without an `x-lunora-client-seq`.
+            // `commitCursor` rides along because the mutation-id header puts
+            // this on the mutation path of a CDC-enabled shard — the third
+            // envelope variant, and the one a re-fired `ctx.run` actually sees.
+            const replay = { "x-lunora-mutation-id": "m1" };
+            const expected = { commitCursor: 0, result: encodeWire(shard.value) };
+            const fresh = await shard.fetch(rpc("payments:charge", replay));
+
+            await expect(fresh.json()).resolves.toStrictEqual(expected);
+
+            // The cache stores the ENCODED form, so the cached branch must not
+            // encode again — a second pass would leave the runner's single
+            // decode a still-tagged value, and a `Date` a `{}`.
+            const cached = await shard.fetch(rpc("payments:charge", replay));
+
+            await expect(cached.json()).resolves.toStrictEqual(expected);
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -125,7 +125,9 @@ describe("createWorkflowRunContext", () => {
     it("wires ctx.run through the shared dispatch runner (POST + workflow label on error)", async () => {
         expect.assertions(3);
 
-        const fetchImpl = vi.fn<typeof fetch>(async () => okResponse(JSON.stringify({ ok: true })));
+        // The shard's real transport envelope; `ctx.run` resolves the `result`
+        // inside it, not the envelope (see `@lunora/dispatch`'s result-wire suite).
+        const fetchImpl = vi.fn<typeof fetch>(async () => okResponse(JSON.stringify({ result: { ok: true } })));
         const ctx = createWorkflowRunContext({
             env: { LUNORA_ADMIN_TOKEN: "secret", LUNORA_ORIGIN_URL: "https://app.example.com" },
             event: makeEvent(),


### PR DESCRIPTION
> **Stacked on #640** (`fix/r32-ctx-run-wire`), which fixes the args direction. Merge #640 first.

The mirror image of #640, and the more severe half: **every durable agent turn threw at its first history read.**

## The defect

The shard encodes its result (`shard-do.ts:6047`, `buildDispatchResponse(mutatorClass, encodeWire(result))`) and wraps it as `{ result }` or `{ lastMutationId, result }`. `dispatchToShard` and `handleSchedulerDispatch` forward that verbatim, and `createDispatchRunner` ended with a bare `return JSON.parse(text)` — no unwrap, no decode. So `await ctx.run(fn)` resolved the **transport envelope, wire-encoded**.

The sibling dispatcher behind an `httpAction`'s `ctx.runQuery`/`ctx.runMutation` has always done this correctly — `create-worker.ts:3721` is `return decodeWire(payload.result) as R`. The dispatch runner was the one seam that disagreed, which is the same shape as every other codec gap found in this campaign.

## It was live, not latent

`agent-loop.ts:697` is `const rawHistory = (await run(listMessages, { key: threadKey })) as AgentMessageRow[]`, and `workflow.ts:113` wires `run` to `resolveAgentRun(context.run, …)` — both branches of which are `createDispatchRunner`. Run against the real built exports with the pre-fix envelope:

```
envelope (pre-fix) / buildModelMessages -> THROWS TypeError: options.history is not iterable
envelope (pre-fix) / splitForCompaction -> THROWS TypeError: history.slice is not a function
rows     (post-fix) / buildModelMessages -> OK  (2 model messages)
```

Every durable agent turn and every voice turn (`voice-turn.ts:338`) died there. Same class, silent rather than throwing: `bootstrap?.outcome`, `outcome?.dequeued` (so a queued run was never woken), `getState`, and `readRetrievedContext` (so every memory source returned no context).

## The change

`return decodeWire((body as { result?: unknown } | null)?.result)` — the same chokepoint #640 uses for the outbound direction, so the runner owns both halves of the wire, matching `mail/inbound/shard.ts` and `scheduler/do-client.ts`.

**No caller compensated**, so nothing had to be un-compensated and there is no double-unwrap risk. All six producers are unchanged; `voice-do.ts:529` already read `ensured?.outcome` — the unwrapped shape — and now actually gets it. Only three test fixtures asserting the old bare shape were updated.

`lastMutationId` and `commitCursor` are dropped deliberately: both are client-session bookkeeping feeding `onMutationAck`/`onCommitCursor`, and the runner has no session and no subscriptions. Grepping both keys across the five consuming packages found no reader.

**BREAKING CHANGE**, noted in the commit body — though `api:check` shows **no drift**, because `DispatchRunFunction` is `Promise<unknown>` either way. The behaviour changed without the type surface moving, which is precisely why nothing caught it.

## Verification

The finding rests on there being **no end-to-end test of a `ctx.run` return value anywhere**, so that test came first: 9 cases in `dispatch-result-wire.test.ts`, **8 failing** against unfixed code — `expected 'undefined' to be 'bigint'`, `expected undefined to be an instance of Date`, `expected { result: {…} } to strictly equal { count: 3 }`, and both envelope variants. After: 9/9.

`shard-do.dispatch-result-wire.test.ts` pins the shard half against a real `ShardDO` over `node:sqlite`, including a dedup replay returning the identical encoded envelope. `shard-do.client-watermark.test.ts` is untouched and still passes.

All repo gates green including `check-generated-files.mjs` and `no-nul-bytes`.

Three assumptions were corrected by running rather than reading: `encodeWire(undefined)` tags rather than drops the key; a custom-mutator replay hits the watermark ack, not the idempotency cache, and is unreachable from `ctx.run` anyway; and a re-fired `ctx.run` gets `{ commitCursor, result }` because `dedupId` puts it on the mutation path of a CDC-enabled shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ
