### PR TITLE
fix(scorecards): bump the pin past the permissions bug that killed every run

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -4,7 +4,7 @@
     "schedule":
         - "cron": "37 14 * * 6"
     "push":
-        "branches": ["main"]
+        "branches": ["main", "master", "alpha", "beta"]
 "permissions": {}
 "jobs":
     "scorecards":
@@ -13,7 +13,7 @@
             "id-token": "write"
             "actions": "read"
             "contents": "read"
-        "uses": "anolilab/workflows/.github/workflows/scorecards.yml@045a2d464dad0661a570c8a3c19f4b32bf9efad9" # v15.3.0+
+        "uses": "anolilab/workflows/.github/workflows/scorecards.yml@9663c7c69bc7dac1a294407a44c30f68977303bb" # main
         "with":
-            "branch": "main"
+            "branch": "alpha"
             "publish_results": true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -13,7 +13,7 @@
             "id-token": "write"
             "actions": "read"
             "contents": "read"
-        "uses": "anolilab/workflows/.github/workflows/scorecards.yml@9663c7c69bc7dac1a294407a44c30f68977303bb" # main
+        "uses": "anolilab/workflows/.github/workflows/scorecards.yml@1d2834fe34a15bd35bf49a1b1071a8b71e8d6319" # main
         "with":
             "branch": "alpha"
             "publish_results": true


### PR DESCRIPTION
`.github/workflows/scorecards.yml` has failed at startup on every scheduled run for weeks — no jobs, no logs, and `api.scorecard.dev` has been serving a score frozen at the last successful run (or nothing at all).

The cause is the pinned revision of the reusable workflow (`v15.3.0+`). At that revision the called workflow declares workflow-level `permissions: "read-all"`, while this caller declares `permissions: {}`. A called workflow may not request more permission than its caller granted, so GitHub rejects the whole run before scheduling a job — which is why there is nothing to look at in the Actions tab. Upstream narrowed the callee to `permissions: contents: read`, so bumping the pin is the entire fix.

While in the file, the push trigger now lists every branch semantic-release publishes from — `main`, `master`, `alpha`, `beta` — rather than `main` alone.

It also corrects the `branch` input: this repository develops on `alpha`, but the workflow was passing `main`, so even a working run would have been pointed at the wrong branch.

Scorecard itself only supports `push`/`schedule` on the **default branch**, so anolilab/workflows#500 adds a guard to the reusable workflow that skips runs from a non-default branch. Until that lands and the pin moves again, a push to one of the listed non-default branches would produce a run that cannot publish; the scheduled run, which is what feeds the badge, is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Supply-chain security checks now run for pushes to the `main`, `master`, `alpha`, and `beta` branches.
  - Updated the security workflow to use a pinned configuration and the appropriate branch settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->