### PR TITLE
fix(client,workflow,testing): stop losing wire-decode failures

### DIFF
--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -3509,6 +3509,57 @@ describe("lunoraClient", () => {
             unsubscribe();
         });
 
+        it("surfaces a decode failure instead of discarding it as a non-JSON frame", () => {
+            expect.assertions(3);
+
+            // The `try` here is documented as covering the JSON PARSE, but it
+            // used to wrap the decode and the consumer callback too — with an
+            // empty body. So a `decodeWire` throw on a malformed tag was
+            // discarded in total silence and the operator's live job list just
+            // stopped updating, with nothing logged and nothing thrown.
+            //
+            // Narrowed to the parse, the failure now reaches
+            // `openManagedSocket`'s last-resort frame-handler catch, which
+            // reports it. The socket deliberately stays up: one bad frame must
+            // not take the listener down.
+            const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+            try {
+                const client = new LunoraClient({
+                    fetch: async () => jsonResponse({ result: null }),
+                    url: "https://app.example",
+                    WebSocket: createMockWebSocket(),
+                    wsToken: "adm1n",
+                });
+
+                const seen: unknown[] = [];
+                const unsubscribe = client.subscribeScheduledJobs((jobs) => seen.push(jobs[0]?.args));
+
+                latestSocket().open();
+                latestSocket().receive({
+                    records: [{ args: ["$lunora.wire$", "bigint", "not-a-number"], enqueuedAt: 1, functionPath: "billing:settle", id: "j1", scheduledFor: 2 }],
+                    type: "jobs",
+                });
+
+                expect(errors).toHaveBeenCalledWith("[lunora] server frame handler threw", expect.any(RangeError));
+                // The consumer is not handed a half-decoded list.
+                expect(seen).toStrictEqual([]);
+
+                // A well-formed frame still lands afterwards — the subscription
+                // survives the bad one rather than going quiet for good.
+                latestSocket().receive({
+                    records: [{ args: encodeWire({ amount: 7n }), enqueuedAt: 1, functionPath: "billing:settle", id: "j2", scheduledFor: 2 }],
+                    type: "jobs",
+                });
+
+                expect(seen).toStrictEqual([{ amount: 7n }]);
+
+                unsubscribe();
+            } finally {
+                errors.mockRestore();
+            }
+        });
+
         it("opens the scheduler admin WS with the token and delivers pushed job lists", () => {
             expect.assertions(4);
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -2827,21 +2827,30 @@ class LunoraClient {
                     // `lastFrameAt` is stamped by `openManagedSocket` itself
                     // (its `message` listener) for every caller — nothing to
                     // do here beyond parsing.
-                    try {
-                        const message = JSON.parse(typeof event.data === "string" ? event.data : "") as { records?: ScheduleRecord[]; type?: string };
+                    let message: { records?: ScheduleRecord[]; type?: string };
 
-                        if (message.type === "jobs" && Array.isArray(message.records)) {
-                            // A payload frame is the proof of a live, ACCEPTED
-                            // socket that `open` alone never was: the upgrade
-                            // succeeds before the admin credential is checked,
-                            // so resetting on `open` made a rejected token
-                            // reconnect at the initial delay forever instead of
-                            // backing off (mirrors the shard socket's fix).
-                            reconnect.reset();
-                            onJobs(message.records.map((record) => decodeRecordArgs(record)));
-                        }
+                    try {
+                        message = JSON.parse(typeof event.data === "string" ? event.data : "") as { records?: ScheduleRecord[]; type?: string };
                     } catch {
-                        /* a non-JSON frame — ignore */
+                        // A non-JSON frame, and the ONLY thing this catch ever
+                        // meant. It used to wrap the decode and the consumer
+                        // callback as well, so a `decodeWire` throw on a
+                        // malformed tag — or anything `onJobs` itself raised —
+                        // was discarded under a comment about JSON, and the
+                        // operator's live job list silently stopped updating
+                        // with no error reported anywhere.
+                        return;
+                    }
+
+                    if (message.type === "jobs" && Array.isArray(message.records)) {
+                        // A payload frame is the proof of a live, ACCEPTED
+                        // socket that `open` alone never was: the upgrade
+                        // succeeds before the admin credential is checked,
+                        // so resetting on `open` made a rejected token
+                        // reconnect at the initial delay forever instead of
+                        // backing off (mirrors the shard socket's fix).
+                        reconnect.reset();
+                        onJobs(message.records.map((record) => decodeRecordArgs(record)));
                     }
                 },
             });

--- a/packages/testing/__tests__/scheduler.test.ts
+++ b/packages/testing/__tests__/scheduler.test.ts
@@ -790,13 +790,19 @@ describe("fake scheduler production parity", () => {
         await expect(t.run(async (ctx) => ctx.scheduler.runAt(1, "log:appendLog", { message: "x" }))).resolves.toMatch(/\S/u);
     });
 
-    it("rejects args the scheduler cannot serialize", async () => {
+    it("accepts the args production accepts, bigint included", async () => {
         expect.assertions(1);
 
         const t = start();
 
-        // Production posts the job as JSON, so a bigint arg throws at schedule time.
-        await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: 1n as unknown as string }))).rejects.toThrow(/BigInt/u);
+        // This used to assert the opposite, on the premise that "production posts
+        // the job as JSON, so a bigint arg throws at schedule time". That stopped
+        // being true when `createScheduler.runAt` / `createWorkpool.enqueue` began
+        // encoding args through the wire codec BEFORE `callDO`'s `JSON.stringify`:
+        // a bigint is carried as a tag and the job schedules. A harness that
+        // refuses a value production takes tells a test the opposite of what ships,
+        // which is the same failure the old assertion was written to prevent.
+        await expect(t.run(async (ctx) => ctx.scheduler.runAfter(0, "log:appendLog", { message: 1n as unknown as string }))).resolves.toMatch(/\S/u);
     });
 
     it("gives a scheduled job the advanced clock as ctx.now", async () => {
@@ -812,5 +818,34 @@ describe("fake scheduler production parity", () => {
         // The job fired an hour into the virtual clock, so it must see that instant —
         // not the harness's construction time.
         await expect(t.query(readLog, {})).resolves.toStrictEqual([expect.objectContaining({ message: `now:${String(1_000_000 + 3_600_000)}` })]);
+    });
+});
+
+describe("fake scheduler — the wire hop production makes", () => {
+    it("round-trips args through the codec rather than handing them over by reference", async () => {
+        expect.assertions(4);
+
+        const t = start();
+        const dueAt = new Date("2026-06-01T12:00:00.000Z");
+
+        // Production's hop is `encodeWire` (in `createScheduler.runAt`) →
+        // `JSON.stringify` (in `callDO`) → the DO's storage → `decodeWire`. The
+        // fake runs the same bracket, so what a handler sees here is what it
+        // sees in production — including the two places that is NOT the
+        // caller's own object. A bare `JSON.stringify(args)` check threw on the
+        // `bigint` that production now carries fine.
+        await t.run(async (ctx) => ctx.scheduler.runAfter(1000, "log:appendLog", { amountCents: 42n, dueAt, message: "x", skipped: undefined }));
+
+        const [job] = await t.run(async (ctx) => ctx.scheduler.list());
+
+        expect(job?.args["amountCents"]).toBe(42n);
+        expect(job?.args["dueAt"]).toStrictEqual(dueAt);
+        // A rebuilt Date, not the caller's instance — a fake that handed `args`
+        // straight through would pass every value assertion above and still
+        // hide that production round-trips them.
+        expect(job?.args["dueAt"]).not.toBe(dueAt);
+        // `encodeWire` drops an `undefined` object field outright, so the
+        // handler never sees the key at all.
+        expect(job?.args).not.toHaveProperty("skipped");
     });
 });

--- a/packages/testing/src/fake-scheduler.ts
+++ b/packages/testing/src/fake-scheduler.ts
@@ -2,6 +2,8 @@ import { LunoraError } from "@lunora/errors";
 import { assertScheduleDelay, MAX_RETRY_ATTEMPTS, RETRY_BASE_DELAY_MS } from "@lunora/scheduler";
 import type { ScheduledJob, Scheduler } from "@lunora/server";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
+
 /** A pending job entry in the fake scheduler queue. */
 interface FakeScheduledJob extends ScheduledJob {
     /** The args the job was scheduled with. */
@@ -162,11 +164,27 @@ const createFakeScheduler = (
     const recordedFailures: ScheduledJobFailure[] = [];
 
     const enqueue = (scheduledFor: number, functionPath: string, args: Record<string, unknown> = {}, requestedId?: string): string => {
-        // Production posts the job to the SchedulerDO as a JSON body
-        // (`@lunora/scheduler`'s `callDO` → `JSON.stringify`), so an arg it cannot
-        // serialize — a `bigint`, a cycle — throws at SCHEDULE time. Do the same
-        // work here rather than accepting the job and failing only in production.
-        JSON.stringify(args);
+        // Stand in for the same round trip production makes, so a test double
+        // neither accepts what production rejects nor rejects what it accepts.
+        //
+        // `createScheduler.runAt` / `createWorkpool.enqueue` now `encodeWire` the
+        // args BEFORE `callDO`'s `JSON.stringify`, so a `bigint` or a `Date`
+        // survives scheduling and comes back a `bigint` or a `Date`. A bare
+        // `JSON.stringify(args)` here therefore threw on exactly the arguments
+        // production handles, failing valid tests; and it let a `Date` through
+        // as a live object the real path would have handed back as a `Date` only
+        // by way of the codec. What still throws is what the codec still cannot
+        // carry — a cycle, a function — which is the check worth keeping.
+        const encoded = encodeWire(args);
+
+        // The job body must still survive the JSON hop production makes
+        // (`callDO` → `JSON.stringify`), so keep the check rather than trusting
+        // the encode: it is what rejects a body the codec produced but JSON
+        // cannot carry. (`encodeWire` above already refuses a cycle itself, at
+        // its nesting bound.) `structuredClone` would accept both and lose it.
+        JSON.stringify(encoded);
+
+        const wireArgs = decodeWire(encoded) as Record<string, unknown>;
 
         // A caller-supplied id is honoured exactly as the SchedulerDO honours
         // `RunOptions.id`: `@lunora/server`'s deferred-schedule facade decides the
@@ -177,7 +195,7 @@ const createFakeScheduler = (
         nextId += 1;
 
         pending.set(id, {
-            args,
+            args: wireArgs,
             enqueuedAt: nowMs,
             functionPath,
             id,

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -185,3 +185,27 @@ describe("createWorkflowRunContext", () => {
         expect(spy).toHaveBeenCalledWith("[workflow:orderPipeline]", "hi", 1);
     });
 });
+
+describe("createWorkflowRunContext — undecodable params", () => {
+    it("fails the instance without retrying instead of raising a bare codec error", () => {
+        expect.assertions(3);
+
+        // The params are already durable, so every retry decodes the identical
+        // bytes to the identical failure. A bare `TypeError`/`RangeError` here
+        // is retryable to the platform, so it burned the whole retry budget
+        // re-deriving that same answer.
+        const event = { ...makeEvent(), payload: ["$lunora.wire$", "bigint", "not-a-number"] as unknown as { orderId: string } };
+
+        let thrown: unknown;
+
+        try {
+            createWorkflowRunContext({ env: {}, event, exportName: "orderPipeline", step: makeStep() });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).name).toBe("NonRetryableError");
+        expect((thrown as Error).message).toMatch(/orderPipeline/u);
+    });
+});

--- a/packages/workflow/src/run-context.ts
+++ b/packages/workflow/src/run-context.ts
@@ -13,6 +13,7 @@ import { LunoraError } from "@lunora/errors";
 import { decodeWire } from "../../../shared/wire-codec";
 import { workflowBindingName } from "./define-workflow";
 import type { NativeNonRetryableErrorConstructor } from "./errors";
+import { raiseNonRetryable } from "./errors";
 import type { WorkflowBindingResolver } from "./fan-out";
 import { createParallel, createSpawn } from "./fan-out";
 import { createRunStep } from "./run-step";
@@ -91,17 +92,38 @@ const createWorkflowRunContext = <Params = Record<string, unknown>>(options: Run
         step: options.step,
     };
 
+    // `decodeWire`, not the raw payload: a scheduled workflow's args travel in
+    // wire form because Workflow `params` are JSON-serialised into durable
+    // storage, and this is the first point that can hand the handler real
+    // `bigint`/`Date`/bytes values. Identity for pure JSON, so a directly
+    // created or spawned instance is unaffected.
+    //
+    // A payload the codec refuses is PERMANENT — the params are already in
+    // durable storage and no retry re-serialises them — but `decodeWire` throws
+    // a bare `TypeError` (malformed tag) or `RangeError` (past its depth bound),
+    // which the platform treats as retryable and re-runs until the budget is
+    // gone. Raise it non-retryably, naming the workflow, so it fails once and
+    // says why.
+    const decodeParams = (): Readonly<Params> => {
+        try {
+            return decodeWire(options.event.payload) as Readonly<Params>;
+        } catch (error) {
+            return raiseNonRetryable(
+                `@lunora/workflow: workflow "${options.exportName}" params could not be decoded — ${error instanceof Error ? error.message : String(error)}`,
+                error,
+                options.nonRetryableErrorClass,
+            );
+        }
+    };
+
+    const params = decodeParams();
+
     return {
         env: options.env,
         event: options.event,
         log,
         parallel: createParallel(fanOutDeps),
-        // `decodeWire`, not the raw payload: a scheduled workflow's args travel in
-        // wire form because Workflow `params` are JSON-serialised into durable
-        // storage, and this is the first point that can hand the handler real
-        // `bigint`/`Date`/bytes values. Identity for pure JSON, so a directly
-        // created or spawned instance is unaffected.
-        params: decodeWire(options.event.payload) as Readonly<Params>,
+        params,
         run,
         runStep: createRunStep({ env: options.env, log, nonRetryableErrorClass: options.nonRetryableErrorClass, run, step: options.step }),
         spawn: createSpawn(fanOutDeps),


### PR DESCRIPTION
Three places where a scheduler payload the wire codec refuses went somewhere
other than the operator or the developer. Each was found while ruling on #631,
whose remaining half turned out to be these.

## 1. The client discarded decode failures in silence

`subscribeScheduledJobs` wrapped its whole message handler in a `try` whose
body was `/* a non-JSON frame — ignore */`. That `try` covered the JSON parse
it documents — and also the record decode and the consumer callback:

```js
try {
    const message = JSON.parse(...);
    if (message.type === "jobs" && ...) {
        reconnect.reset();
        onJobs(message.records.map((record) => decodeRecordArgs(record)));  // can throw
    }
} catch {
    /* a non-JSON frame — ignore */                                        // ...and did
}
```

So a malformed tag threw inside `decodeWire`, was discarded with an **empty
catch body**, and the operator's live job list just stopped updating — nothing
logged, nothing thrown. Narrowed to the parse it is named for. The failure now
reaches `openManagedSocket`'s last-resort frame-handler catch, which reports
it; the socket stays up, because one bad frame must not take the listener down.

The test pins all three: the error is reported, the consumer is not handed a
half-decoded list, and a well-formed frame still lands afterwards. Against the
unfixed client `console.error` is **never called at all**.

## 2. A workflow burned its retry budget on a permanent failure

`params: decodeWire(options.event.payload)` was unguarded. The params are
already in durable storage, so a payload the codec refuses is permanent and
every retry decodes the identical bytes to the identical failure — but
`decodeWire` raises a bare `TypeError`/`RangeError`, which the platform treats
as **retryable**. Now raised non-retryably, naming the workflow. Verified
against the unfixed code: `expected 'RangeError' to be 'NonRetryableError'`.

## 3. The test double rejected what production accepts

`fake-scheduler` asserted `JSON.stringify(args)` on raw args, under:

> Production posts the job to the SchedulerDO as a JSON body … so an arg it
> cannot serialize — a `bigint` … — throws at SCHEDULE time.

That premise died when `createScheduler.runAt` / `createWorkpool.enqueue` began
encoding args through the codec **before** `callDO`'s `JSON.stringify`.
Production carries a `bigint` fine; only the fake rejected it — a harness
telling tests the opposite of what ships. It now runs the same encode/decode
bracket, so a handler sees what production hands it, including a `Date` rebuilt
rather than passed by reference. The `JSON.stringify` check is kept, on the
**encoded** body, since that is the hop that still has to succeed.

One existing test asserted the stale premise directly (`rejects.toThrow(/BigInt/)`)
and is inverted to match what ships.

## On #631

This branch is the live remainder of #631, which I am closing. Its first commit
(wire-bracketing the scheduler producers) is fully on `alpha` already, in a
better form — `encodeArgsOrThrow` rather than a bare `encodeWire(...) as`. Its
`do-client` change is a **competing design**: it moves encode ownership to the
transport, and `alpha` shipped per-producer encoding, so applying it on top
would double-encode. Its `system-reader` hunk landed verbatim.

## Verification

All eight gates green: `build`, `test`, `lint:types`, `lint:eslint`,
`lint:prettier`, `api:check`, `lint:package-json`, `check-generated-files`.
Each of the three fixes was re-run against the unfixed code first and observed
to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Non-JSON scheduled-job WebSocket messages are now safely ignored.
  - Errors while decoding job data or handling scheduled jobs are no longer hidden.
  - Workflow parameter decoding failures now produce clear, non-retryable errors.
  - Scheduled-job test behavior now matches production handling for values such as dates and large integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->