### PR TITLE
test(dispatch,queue,workflow,agent,do): pin both halves of the ctx.run wire bracket

### DIFF
--- a/packages/agent/__tests__/resolve-run-args-wire.test.ts
+++ b/packages/agent/__tests__/resolve-run-args-wire.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The agent loop's dispatcher is `@lunora/dispatch`'s runner (built here by
+ * `resolveAgentRun`, and identically by `createAgentContext` and the voice DO's
+ * `resolveRun`), POSTing to `/_lunora/scheduler/dispatch`. The shard's dispatch
+ * loop decodes the body's `args` exactly once
+ * (`decodeWire(payload.args ?? {})`), so this end has to encode: without it a
+ * `bigint` throws in `JSON.stringify` before the request leaves, and a `Date`
+ * reaches the handler as an ISO string.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import resolveAgentRun from "../src/resolve-run";
+import type { AgentFunctionReference, AgentRunFunction } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: AgentFunctionReference = { __lunoraRef: "agents:agentAppendMessage" };
+
+/** Never reached — the owner branch always builds a fresh dispatcher. */
+const contextRun: AgentRunFunction = async () => undefined;
+
+/** Dispatch `args` through the owner-scoped agent runner and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+        body = init.body as string;
+
+        return new Response(null, { status: 200 });
+    });
+
+    await resolveAgentRun(contextRun, "user-a", ENV)(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("agent dispatch args wire", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(args["amountCents"]).toBeTypeOf("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});

--- a/packages/dispatch/__tests__/dispatch-args-wire.test.ts
+++ b/packages/dispatch/__tests__/dispatch-args-wire.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The dispatch runner's args wire. `createDispatchRunner` POSTs to
+ * `/_lunora/scheduler/dispatch`, the runtime forwards `args` verbatim to the
+ * shard's `/rpc`, and the shard's dispatch loop is the one and only decoder
+ * (`decodeWire(payload.args ?? {})`, `@lunora/do`'s `shard-do`). These pin the
+ * producer half of that bracket: a `bigint` or `Date` argument has to reach the
+ * handler as a `bigint` or `Date`, a pure-JSON argument has to be byte-identical
+ * on the wire, and a caller that already put its args in wire form has to be
+ * left alone — `decodeWire` is not idempotent, so a double encode reaches the
+ * handler as a tagged array, and for a `Date` it does so silently.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
+import { createDispatchRunner } from "../src/create-dispatch-runner";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** Run one dispatch and hand back the POSTed body the way the endpoint parses it. */
+const dispatchBody = async (args: Record<string, unknown>, runnerOptions: { argsAlreadyEncoded?: boolean } = {}): Promise<{ args?: unknown }> => {
+    let body = "";
+
+    const run = createDispatchRunner({
+        env: ENV,
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+        label: "@lunora/queue",
+        ...runnerOptions,
+    });
+
+    await run(REF, args as never);
+
+    return JSON.parse(body) as { args?: unknown };
+};
+
+/** What the shard's single `decodeWire` hands the handler for a dispatch of `args`. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const body = await dispatchBody(args);
+
+    return decodeWire(body.args ?? {}) as Record<string, unknown>;
+};
+
+describe("dispatch runner args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // The type, not merely the absence of a throw: an un-encoded `Date`
+        // arrives as an ISO string, which fails nothing until the handler does
+        // date arithmetic on it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("delivers bytes to the handler as bytes", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ blob: new Uint8Array([1, 2, 3]) });
+
+        expect(args["blob"]).toBeInstanceOf(Uint8Array);
+        expect([...(args["blob"] as Uint8Array)]).toStrictEqual([1, 2, 3]);
+    });
+
+    it("leaves pure-JSON args byte-identical on the wire and at the handler", async () => {
+        expect.assertions(2);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+        const body = await dispatchBody(plain);
+
+        // Identity on the wire: nothing was tagged, so an existing caller's
+        // request body is byte for byte what it always was.
+        expect(body.args).toStrictEqual(plain);
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+
+    it("forwards already-encoded args verbatim so the shard's single decode still lands", async () => {
+        expect.assertions(2);
+
+        // `@lunora/scheduler`'s queue workpool encodes at `enqueue` because the
+        // queue is its own serialising hop, then hands the wire form straight
+        // here. Encoding it a second time would leave the shard's single decode
+        // a tagged array — and for a `Date`, a `{}`.
+        const encoded = encodeWire({ amountCents: 7n, dueAt: new Date("2026-06-01T12:00:00.000Z") }) as Record<string, unknown>;
+        const body = await dispatchBody(encoded, { argsAlreadyEncoded: true });
+
+        expect(body.args).toStrictEqual(encoded);
+
+        const args = decodeWire(body.args ?? {}) as Record<string, unknown>;
+
+        expect(args).toStrictEqual({ amountCents: 7n, dueAt: new Date("2026-06-01T12:00:00.000Z") });
+    });
+});

--- a/packages/dispatch/__tests__/dispatch-result-wire.test.ts
+++ b/packages/dispatch/__tests__/dispatch-result-wire.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The dispatch runner's RESULT wire — the mirror of `dispatch-args-wire.test.ts`.
+ *
+ * The shard is the single encoder on this half: `shard-do`'s dispatch loop calls
+ * `buildDispatchResponse(mutatorClass, encodeWire(result))`, which wraps the
+ * encoded value as `{ result }` (plus `commitCursor` for a plain mutation, or
+ * `lastMutationId` for a `"next"` custom-mutator push). `handleSchedulerDispatch`
+ * and `dispatchToShard` (`@lunora/runtime`) forward that response verbatim, so the
+ * runner is the single decoder — it owns both directions of the wire.
+ *
+ * These pin what a `ctx.run` CALLER receives: the function's own return value, not
+ * the transport envelope, and with `bigint`/`Date`/bytes restored. The `Date` case
+ * is the one that fails silently — an un-decoded `Date` is a tagged array, and a
+ * doubly-decoded one is `{}` — so assert the TYPE, never merely the absence of a
+ * throw.
+ *
+ * The envelope literals below are the same ones `packages/do`'s
+ * `shard-do.dispatch-result-wire.test.ts` asserts a real shard emits, and both
+ * sides run the payload through the same `shared/wire-codec` — that is the join.
+ */
+import { describe, expect, it } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import { createDispatchRunner } from "../src/create-dispatch-runner";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** What `await ctx.run(fn)` resolves to when the shard answers with `body`. */
+const runResult = async (body: string): Promise<unknown> => {
+    const run = createDispatchRunner({
+        env: ENV,
+        fetchImpl: async () => new Response(body, { headers: { "content-type": "application/json" }, status: 200 }),
+        label: "@lunora/queue",
+    });
+
+    return run(REF, {});
+};
+
+/** The exact body a shard sends for a function returning `value` — `encodeWire`, wrapped in the envelope. */
+const shardBody = (value: unknown, envelope: Record<string, unknown> = {}): string => JSON.stringify({ ...envelope, result: encodeWire(value) });
+
+describe("dispatch runner result wire", () => {
+    it("resolves a bigint return value as a bigint", async () => {
+        expect.assertions(2);
+
+        const result = await runResult(shardBody({ amountCents: 4_294_967_296n }));
+
+        expect(typeof (result as { amountCents?: unknown }).amountCents).toBe("bigint");
+        expect(result).toStrictEqual({ amountCents: 4_294_967_296n });
+    });
+
+    it("resolves a Date return value as a Date", async () => {
+        expect.assertions(2);
+
+        // The TYPE, not the absence of a throw: an un-decoded `Date` comes back
+        // as a tagged array and a doubly-decoded one as `{}` — neither throws.
+        const result = await runResult(shardBody({ dueAt: new Date("2026-06-01T12:00:00.000Z") }));
+
+        expect((result as { dueAt?: unknown }).dueAt).toBeInstanceOf(Date);
+        expect((result as { dueAt: Date }).dueAt.toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("resolves bytes as bytes", async () => {
+        expect.assertions(2);
+
+        const result = await runResult(shardBody({ blob: new Uint8Array([1, 2, 3]) }));
+
+        expect((result as { blob?: unknown }).blob).toBeInstanceOf(Uint8Array);
+        expect([...(result as { blob: Uint8Array }).blob]).toStrictEqual([1, 2, 3]);
+    });
+
+    it("resolves a plain-JSON return value unchanged", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+
+        await expect(runResult(shardBody(plain))).resolves.toStrictEqual(plain);
+    });
+
+    it("resolves an array return value as the array itself, not the envelope", async () => {
+        expect.assertions(2);
+
+        // `@lunora/agent`'s loop casts this straight to `AgentMessageRow[]` and
+        // then iterates it — the envelope is an object, so the cast was a lie.
+        const rows = [
+            { role: "user", seq: 1 },
+            { role: "assistant", seq: 2 },
+        ];
+        const result = await runResult(shardBody(rows));
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toStrictEqual(rows);
+    });
+
+    it("unwraps a plain mutation's `commitCursor` envelope", async () => {
+        expect.assertions(1);
+
+        await expect(runResult(shardBody({ ok: true }, { commitCursor: 12 }))).resolves.toStrictEqual({ ok: true });
+    });
+
+    it("unwraps a custom-mutator push's `lastMutationId` envelope", async () => {
+        expect.assertions(1);
+
+        await expect(runResult(shardBody({ runs: 1 }, { lastMutationId: 3 }))).resolves.toStrictEqual({ runs: 1 });
+    });
+
+    it("resolves undefined for a void function", async () => {
+        expect.assertions(1);
+
+        // `encodeWire` tags a top-level `undefined` rather than letting
+        // `JSON.stringify` drop the key, so the shard really does send
+        // `{ result: ["$lunora.wire$","undefined"] }` — pinned on the shard side
+        // by `packages/do`'s `shard-do.dispatch-result-wire.test.ts`.
+        await expect(runResult(shardBody(undefined))).resolves.toBeUndefined();
+    });
+
+    it("refuses a 200 that is not a { result } envelope", async () => {
+        expect.assertions(1);
+
+        // Not the same as a void return. Every arm of `buildDispatchResponse`
+        // spells `result` literally, so a 200 without the key is a body the
+        // shard cannot emit — something else answered. Reading it as
+        // `undefined` would hand a handler a silent wrong answer, so it is
+        // refused rather than guessed at.
+        await expect(runResult(JSON.stringify({ commitCursor: 7 }))).rejects.toThrow(/not a \{ result \} envelope/u);
+    });
+
+    it("resolves undefined for an empty body", async () => {
+        expect.assertions(1);
+
+        await expect(runResult("")).resolves.toBeUndefined();
+    });
+});

--- a/packages/do/__tests__/shard-do.dispatch-result-wire.test.ts
+++ b/packages/do/__tests__/shard-do.dispatch-result-wire.test.ts
@@ -1,0 +1,186 @@
+import { runShardMigrations } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import messagesSchema from "./_helpers/messages-schema";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The shard half of the dispatch RESULT wire — the encoder side of the bracket
+ * `@lunora/dispatch`'s `dispatch-result-wire.test.ts` closes.
+ *
+ * Two things are pinned here, and both are contracts the runner now depends on.
+ *
+ * First, the result is wire-ENCODED exactly once, by `encodeWire`. The runner is
+ * the single decoder, and `decodeWire` is not idempotent — a second encode/decode
+ * pass flattens a `Date` to `{}` while a `bigint` survives, so a drift here is
+ * silent for exactly the type nothing would catch.
+ *
+ * Second, it travels inside an ENVELOPE — `{ result }`, `{ commitCursor, result }`
+ * for a mutation on a CDC-enabled shard, or `{ lastMutationId, result }` for a
+ * `"next"` custom-mutator push (also pinned by
+ * `shard-do.client-watermark.test.ts`, which asserts the envelope on a pure-JSON
+ * result). The runner unwraps `result` and drops the rest; changing the key would
+ * make every `ctx.run` resolve `undefined`.
+ *
+ * The replay case matters for the same reason: `persistIdempotentResult` stores
+ * the ENCODED form, so `respondFromIdempotencyCache` must NOT encode again.
+ */
+
+/** A shard whose handler returns whatever `value` is set to — the value under test. */
+class ReturningShard extends ShardDO {
+    public value: unknown = undefined;
+
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve(this.value);
+    }
+}
+
+/** Like {@link ReturningShard}, but `messages:sendMutator` is a `"next"` custom mutator (the watermarked push path). */
+class ReturningMutatorShard extends ReturningShard {
+    public override handleRpc(): Promise<unknown> {
+        return this.runInTransaction(() => {
+            this.commitMutationBookkeeping(this.value);
+
+            return this.value;
+        });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
+    protected override isCustomMutator(functionPath: string): boolean {
+        return functionPath === "messages:sendMutator";
+    }
+}
+
+const makeState = (database: ReturnType<typeof createSqliteExec>): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets() {
+            return [];
+        },
+        storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+    };
+};
+
+const rpc = (functionPath: string, headers: Record<string, string> = {}): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: { "content-type": "application/json", ...headers },
+        method: "POST",
+    });
+
+/** Dispatch one call on a fresh shard and hand back the parsed response envelope. */
+const dispatchEnvelope = async (value: unknown): Promise<Record<string, unknown>> => {
+    const database = createSqliteExec();
+
+    try {
+        runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+        const shard = new ReturningShard(makeState(database), {});
+        shard.value = value;
+
+        const response = await shard.fetch(rpc("messages:list"));
+
+        return await response.json();
+    } finally {
+        database.close();
+    }
+};
+
+describe("shardDO dispatch result wire", () => {
+    it("encodes a bigint result exactly once, inside a `{ result }` envelope", async () => {
+        expect.assertions(2);
+
+        const value = { amountCents: 4_294_967_296n };
+        const envelope = await dispatchEnvelope(value);
+
+        expect(envelope).toStrictEqual({ result: encodeWire(value) });
+        // Spelled out, so a codec change cannot silently redefine what the
+        // runner's single decode is fed.
+        expect(envelope["result"]).toStrictEqual({ amountCents: ["$lunora.wire$", "bigint", "4294967296"] });
+    });
+
+    it("encodes a Date result exactly once", async () => {
+        expect.assertions(2);
+
+        const value = { dueAt: new Date("2026-06-01T12:00:00.000Z") };
+        const envelope = await dispatchEnvelope(value);
+
+        expect(envelope).toStrictEqual({ result: encodeWire(value) });
+        expect(envelope["result"]).toStrictEqual({ dueAt: ["$lunora.wire$", "date", Date.parse("2026-06-01T12:00:00.000Z")] });
+    });
+
+    it("leaves a pure-JSON result structurally identical inside the envelope", async () => {
+        expect.assertions(1);
+
+        const value = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null }, note: "hi" };
+
+        await expect(dispatchEnvelope(value)).resolves.toStrictEqual({ result: value });
+    });
+
+    it("tags a void handler's `undefined` rather than dropping the `result` key", async () => {
+        expect.assertions(1);
+
+        // `encodeWire` maps a top-level `undefined` to the tagged form, so the
+        // key survives `JSON.stringify` — the runner's decode turns it back into
+        // a real `undefined`.
+        await expect(dispatchEnvelope(undefined)).resolves.toStrictEqual({ result: ["$lunora.wire$", "undefined"] });
+    });
+
+    it("encodes a custom-mutator push's result once, inside a `{ lastMutationId, result }` envelope", async () => {
+        expect.assertions(1);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new ReturningMutatorShard(makeState(database), {});
+            shard.value = { balance: 9_007_199_254_740_993n };
+
+            const response = await shard.fetch(rpc("messages:sendMutator", { "x-lunora-client-id": "c1", "x-lunora-client-seq": "1" }));
+
+            await expect(response.json()).resolves.toStrictEqual({ lastMutationId: 1, result: encodeWire(shard.value) });
+        } finally {
+            database.close();
+        }
+    });
+
+    it("returns the identical encoded envelope when a dedup replay hits the idempotency cache", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new ReturningShard(makeState(database), {});
+            shard.value = { balance: 9_007_199_254_740_993n };
+
+            // `x-lunora-mutation-id` with no client seq is exactly what the
+            // dispatch runner sends (`RunFunctionOptions.dedupId`), so this is
+            // the replay a re-fired `ctx.run` actually takes — NOT the
+            // client-watermark ack, which answers `result: null` and is
+            // unreachable without an `x-lunora-client-seq`.
+            // `commitCursor` rides along because the mutation-id header puts
+            // this on the mutation path of a CDC-enabled shard — the third
+            // envelope variant, and the one a re-fired `ctx.run` actually sees.
+            const replay = { "x-lunora-mutation-id": "m1" };
+            const expected = { commitCursor: 0, result: encodeWire(shard.value) };
+            const fresh = await shard.fetch(rpc("payments:charge", replay));
+
+            await expect(fresh.json()).resolves.toStrictEqual(expected);
+
+            // The cache stores the ENCODED form, so the cached branch must not
+            // encode again — a second pass would leave the runner's single
+            // decode a still-tagged value, and a `Date` a `{}`.
+            const cached = await shard.fetch(rpc("payments:charge", replay));
+
+            await expect(cached.json()).resolves.toStrictEqual(expected);
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/packages/queue/__tests__/run-context-args-wire.test.ts
+++ b/packages/queue/__tests__/run-context-args-wire.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `ctx.run` inside a `defineQueue` push handler is `@lunora/dispatch`'s runner,
+ * POSTing to `/_lunora/scheduler/dispatch`. The shard's dispatch loop decodes
+ * the body's `args` exactly once (`decodeWire(payload.args ?? {})`), so this
+ * end has to encode: without it a `bigint` throws in `JSON.stringify` before the
+ * request leaves, and a `Date` reaches the handler as an ISO string.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import { createQueueRunContext } from "../src/run-context";
+import type { FunctionReference } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+/** Dispatch `args` through a real queue `ctx.run` and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    const ctx = createQueueRunContext({
+        env: ENV,
+        exportName: "charges",
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+    });
+
+    await ctx.run(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("queue ctx.run args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-plugin/types", "node"]
     },

--- a/packages/workflow/__tests__/run-context-args-wire.test.ts
+++ b/packages/workflow/__tests__/run-context-args-wire.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `ctx.run` inside a workflow body is `@lunora/dispatch`'s runner, POSTing to
+ * `/_lunora/scheduler/dispatch`. The shard's dispatch loop decodes the body's
+ * `args` exactly once (`decodeWire(payload.args ?? {})`), so this end has to
+ * encode: without it a `bigint` throws in `JSON.stringify` before the request
+ * leaves, and a `Date` reaches the handler as an ISO string.
+ */
+import { describe, expect, it } from "vitest";
+
+import { decodeWire } from "../../../shared/wire-codec";
+import { createWorkflowRunContext } from "../src/run-context";
+import type { FunctionReference, WorkflowEventLike, WorkflowStepLike } from "../src/types";
+
+const ENV = { LUNORA_ADMIN_TOKEN: "admin-token", LUNORA_ORIGIN_URL: "https://app.example" };
+const REF: FunctionReference = { __lunoraRef: "jobs:charge" };
+
+const EVENT: WorkflowEventLike = {
+    instanceId: "inst-1",
+    payload: {},
+    timestamp: new Date(0),
+    workflowName: "orderPipeline",
+};
+
+/** Dispatch `args` through a real workflow `ctx.run` and hand back what the shard's single decode gives the handler. */
+const handlerArgs = async (args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    let body = "";
+
+    const ctx = createWorkflowRunContext({
+        env: ENV,
+        event: EVENT,
+        exportName: "orderPipeline",
+        fetchImpl: async (_url: unknown, init?: RequestInit) => {
+            body = init?.body as string;
+
+            return new Response(null, { status: 200 });
+        },
+        step: {} as unknown as WorkflowStepLike,
+    });
+
+    await ctx.run(REF, args);
+
+    return decodeWire((JSON.parse(body) as { args?: unknown }).args ?? {}) as Record<string, unknown>;
+};
+
+describe("workflow ctx.run args wire", () => {
+    it("delivers a bigint argument to the handler as a bigint", async () => {
+        expect.assertions(2);
+
+        const args = await handlerArgs({ amountCents: 4_294_967_296n });
+
+        expect(typeof args["amountCents"]).toBe("bigint");
+        expect(args["amountCents"]).toBe(4_294_967_296n);
+    });
+
+    it("delivers a Date argument to the handler as a Date", async () => {
+        expect.assertions(2);
+
+        // Assert the TYPE: an un-encoded `Date` arrives as an ISO string and
+        // nothing throws, so only the type catches it.
+        const args = await handlerArgs({ dueAt: new Date("2026-06-01T12:00:00.000Z") });
+
+        expect(args["dueAt"]).toBeInstanceOf(Date);
+        expect((args["dueAt"] as Date).toISOString()).toBe("2026-06-01T12:00:00.000Z");
+    });
+
+    it("leaves pure-JSON args untouched at the handler", async () => {
+        expect.assertions(1);
+
+        const plain = { count: 3, flag: true, nested: { items: [1, 2, "three"], missing: null } };
+
+        await expect(handlerArgs(plain)).resolves.toStrictEqual(plain);
+    });
+});


### PR DESCRIPTION
Supersedes #640 and #641, which I am closing.

Their source fixes are **already on `alpha`** — `create-dispatch-runner.ts`
encodes args, unwraps the shard's `{ result }` envelope and decodes it, and the
`argsAlreadyEncoded` opt-out landed with #643. What never landed is the six
test files written alongside them. So the behaviour is live and nothing fails
if it regresses.

That gap is not hypothetical: the double encode that broke `alpha` (#643) got
in precisely because no test spanned the producer and consumer halves together.

## Producer half

- a `bigint`, `Date` and bytes argument each reach the handler intact
- pure-JSON args stay byte-identical on the wire (the codec is the identity there)
- args a caller **already** encoded are forwarded verbatim, so the shard's
  single `decodeWire` still lands

## Consumer half

- the `{ result }` envelope is unwrapped and decoded exactly once — including
  the `{ commitCursor, result }` and `{ lastMutationId, result }` variants
- a void function's `["$lunora.wire$","undefined"]` resolves to `undefined`
- a 200 that is **not** a `{ result }` envelope is refused

That last one is the one assertion I changed while porting. #641 asserted a
200 of `{"commitCursor":7}` should read as `undefined`. It should not: all
three arms of `buildDispatchResponse` spell `result` literally, so a 200
without the key is a body the shard cannot emit — something else answered.
Reading it as `undefined` hands a handler a silent wrong answer, so `alpha`'s
stricter behaviour is correct and the test now pins that instead.

## Why the dispatch-local pin matters

`argsAlreadyEncoded` previously had behavioural coverage only from
`@lunora/scheduler`'s suite, which reaches the runner through
`packages/dispatch/dist` — a **built artifact**, in a repo whose `CLAUDE.md`
documents stale `dist/` as a recurring trap. Someone refactoring
`create-dispatch-runner.ts` in isolation would get a green
`--filter @lunora/dispatch test` while restoring the bug. Verified: removing
the flag honouring from the runner now fails
`dispatch-args-wire.test.ts > forwards already-encoded args verbatim`.

## Also

`@lunora/queue` drops `outDir`/`rootDir` from its tsconfig, as every package
importing `shared/` must — a set `rootDir` raises TS6059 on the codec import.

## Verification

`build`, `test`, `lint:types`, `lint:eslint`, `lint:prettier`, `api:check`,
`lint:package-json`, `check-generated-files` all green. (`dist:check` flags
only `packages/studio` and `packages/react`, for having been built
`--development` locally — CI builds prod, and neither package is in this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for the queue package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->