### PR TITLE
ci(coderabbit): review PRs stacked on a claude/* branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,6 +38,10 @@
             - "fix/r8-compute"
             # Any later audit-chain branch (regex, per CodeRabbit's base_branches).
             - "fix/r[0-9]+-.*"
+            # Long-lived feature branches that carry their own stacks — a PR based
+            # on one is reviewable work, not an integration merge. #637 was
+            # skipped in full for want of this line.
+            - "claude/.*"
 
     "profile": "chill"
 


### PR DESCRIPTION
One line, plus the comment explaining it.

`reviews.auto_review.base_branches` is matched against a PR's **base** branch. A base that matches
no entry gets no review at all — and nothing appears on the PR to say it was skipped, so it reads
exactly like a review that found nothing to say.

The list already handles the audit chain properly: the `fix/r7-*`/`fix/r8-*` bases by name, and
everything since via the `fix/r[0-9]+-.*` regex. #635 and #636 are covered by that regex and were
reviewed normally.

What has never been covered is a PR based on a `claude/*` branch. Those carry stacks too —
`claude/cloud-platform-dx-ojvkmu` is the base of the cloud control-plane work — and **#637 (43
files, +812/−319) was skipped in full** for want of this entry.

## Why a regex rather than the branch name

The named entries above it are a per-stack maintenance cost: each new stack base has to be
remembered and added, and forgetting is invisible until someone notices a PR was never reviewed.
`claude/.*` matches the convention rather than the instance, the same way `fix/r[0-9]+-.*` already
does for the audit chain.

## Verification

`prettier --check` clean; the file parses and the list is unchanged apart from the one addition
(17 → 18 entries, `fix/r[0-9]+-.*` and every named base intact).

Worth flagging: `.coderabbit.yaml` on the `cloud-platform-refresh` branch is **stale** — it predates
the audit-chain additions and still lists only `main` and `alpha`. I nearly shipped this change
there, which would have deleted roughly fifteen entries including the audit-chain regex the moment
#85 merged. That commit is reverted; this PR targets `alpha`, where the file is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wsNs3UM2vixzT7nmoyfsV
