### PR TITLE
security(server): govern .global() writes and scope shape read policies

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,6 +23,10 @@
             # Audit-round fix PRs are stacked on this branch so each group is
             # reviewable on its own; auto review skips any base not listed here.
             - "fix/audit-round-5"
+            # Round-33 core-defect chain: the authorization group lands first,
+            # carrying the fix for the fail-open its own shape-scoping change
+            # introduces, and the rest is based on it.
+            - "fix/r33-server-authz-complete"
             # The audit chain: each group PR is based on the previous one.
             - "fix/r7-auth-agent-mail"
             - "fix/r7-payment"

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -741,6 +741,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `ShapeGuardDeclaration` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `ShapeReadWhereRequest` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1070,6 +1074,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `asBucketStorage` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `assertShapesDeclareReadPolicies` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -5471,6 +5479,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `ShapeGuardDeclaration` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `ShapeReadWhereRequest` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5800,6 +5812,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `asBucketStorage` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `assertShapesDeclareReadPolicies` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -1976,6 +1976,15 @@ interface ShapeDefinition<Args extends ValidatorMap = ValidatorMap, Context = Qu
 }
 ```
 
+### `ShapeGuardDeclaration` (interface)
+
+```ts
+interface ShapeGuardDeclaration {
+    readonly table: string;
+    readonly use?: unknown;
+}
+```
+
 ### `ShapeReadWhereRequest` (interface)
 
 ```ts
@@ -2853,6 +2862,12 @@ const anyApi: AnyApi;
 
 ```ts
 const asBucketStorage: (raw: unknown) => unknown;
+```
+
+### `assertShapesDeclareReadPolicies` (const)
+
+```ts
+const assertShapesDeclareReadPolicies: (shapes: Readonly<Record<string, ShapeGuardDeclaration>>, readPolicyTables: Iterable<string>, rlsRequired: boolean) => void;
 ```
 
 ### `beginDeferredSchedules` (const)

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -1980,8 +1980,9 @@ interface ShapeDefinition<Args extends ValidatorMap = ValidatorMap, Context = Qu
 
 ```ts
 interface ShapeGuardDeclaration {
+    readonly rlsRegistry: RlsReadRegistry;
     readonly table: string;
-    readonly use?: unknown;
+    readonly use?: ReadonlyArray<unknown>;
 }
 ```
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -1778,6 +1778,7 @@ interface RegisteredShape<Args extends ValidatorMap = ValidatorMap, Context = Qu
     readonly compileWhere: (context: unknown, rawArgs: Record<string, unknown>, options?: {
         ownerField?: string;
     }) => WhereInput;
+    readonly rlsRegistry: RlsReadRegistry;
 }
 ```
 
@@ -1970,6 +1971,7 @@ interface ShapeDefinition<Args extends ValidatorMap = ValidatorMap, Context = Qu
     readonly columns?: ReadonlyArray<string>;
     readonly owner?: string | true;
     readonly table: string;
+    readonly use?: ReadonlyArray<Middleware<never, unknown>>;
     readonly where?: (context: Context, args: InferValidatorMap<Args>) => WhereInput | boolean;
 }
 ```
@@ -2880,7 +2882,7 @@ const buildMaskRegistry: (functions: Iterable<unknown>) => MaskRegistry;
 ### `buildRlsReadRegistry` (const)
 
 ```ts
-const buildRlsReadRegistry: (functions: Iterable<unknown>) => RlsReadRegistry;
+const buildRlsReadRegistry: (guards: Iterable<unknown>) => RlsReadRegistry;
 ```
 
 ### `cacheKeyFor` (const)

--- a/apps/docs/src/content/docs/concepts/local-first.mdx
+++ b/apps/docs/src/content/docs/concepts/local-first.mdx
@@ -65,8 +65,8 @@ this:
 
 A **shape** names a table, a predicate, and an optional column projection. The
 client subscribes by shape _name_ + validated `args`; the DO resolves the
-predicate server-side and AND-composes it with the table's RLS read base-where,
-then streams only the matching rows.
+predicate server-side and AND-composes it with the read policies **the shape
+itself declares**, then streams only the matching rows.
 
 ```ts title="lunora/shapes.ts"
 import { defineShape, v } from "lunorash/server";
@@ -79,6 +79,36 @@ export const messagesByChannel = defineShape({
     columns: ["text", "authorId", "channelId"], // optional projection
 });
 ```
+
+### Opting a shape into RLS (`use`)
+
+A shape runs no procedure, so a `.use(rls(...))` chain never fires for it and the
+policies your queries declare do not reach it. A shape names its own guards:
+
+```ts title="lunora/shapes.ts"
+export const messagesByChannel = defineShape({
+    table: "messages",
+    args: { channelId: v.id("channels") },
+    use: [tenantScoped], // the same rls(...) guard the equivalent query lists
+    where: (_ctx, { channelId }) => ({ channelId }),
+});
+```
+
+Their `on: "read"` policies are evaluated under the socket's verified identity
+and AND-merged with `where` before a row replicates. Several guards compose:
+every one of them must admit a row. Only the policies are read — a shape cannot
+run `requireAdmin` or a rate limiter, so never lean on a procedure-level gate to
+protect one.
+
+Omitting `use` is a decision, not a default:
+
+- Under `.rls("required")`, a shape over a non-`.public()` table that names no
+  guard replicates **nothing**.
+- Otherwise codegen stamps a boot check into the generated DO: when the project's
+  `rls()` guards declare an `on: "read"` policy for the shape's table and the
+  shape names none, the worker refuses to start and names the shape and the
+  table. Write `use: []` to say the omission is deliberate — the shape's own
+  `where` is the whole filter.
 
 Shard-local shapes replicate out of the changelog, so the app has to turn it on:
 

--- a/apps/docs/src/content/docs/concepts/rls.mdx
+++ b/apps/docs/src/content/docs/concepts/rls.mdx
@@ -83,13 +83,22 @@ const documentPolicies = definePolicies([
   `insert`, the pre-write row on `update`/`delete`.
 - `ctx`: the full procedure context the middleware closed over.
 
-:::caution[A middleware's roles do not reach live shapes]
-Only the identity claim is read on both paths. `ctx.auth.roles` written by a
-middleware reaches queries, mutations and actions, but a **live shape runs no
-procedure** — so no middleware fires and the role list is empty there. A policy
-that restricts on a role (`!auth.roles.includes("restricted")`) then never takes
-its restricting branch on the shape path, and rows replicate over a subscription
-that the equivalent query withholds.
+:::caution[No policy reaches a live shape unless the shape names it]
+A **live shape runs no procedure**, so no `.use(rls(...))` middleware fires for
+it and none of the policies on this page apply to it by default. A shape declares
+its own guards with
+[`defineShape({ use })`](/docs/concepts/local-first#opting-a-shape-into-rls-use).
+
+1. **A shape that names no guard is filtered by its `where` alone.** Under
+   `.rls("required")` it replicates nothing (fail-closed); otherwise codegen
+   refuses to boot the app when the shape's table is governed on read, naming the
+   shape and the table. `use: []` says the omission is deliberate.
+2. **A middleware's roles do not reach a shape even when it does name the
+   guard.** Only the identity claim is read there: `ctx.auth.roles` written by a
+   middleware reaches queries, mutations and actions, but nothing runs to write it
+   on the shape path, so the role list is empty. A policy that restricts on a role
+   (`!auth.roles.includes("restricted")`) never takes its restricting branch, and
+   rows replicate over a subscription the equivalent query withholds.
 
 Derive roles at the identity, where both paths see them.
 [`createAccessResolver`](/docs/packages/cloudflare-access)'s `roles` option maps

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisorProcedure, AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, ExportRow, ImportShardResult, KeyRange, MaskPoliciesResult, MigrationRunResult, QueryReadScope, RunShardApplyCdcArgs, RunShardExportArgs, RunShardImportArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, TransactionHeadroomTracker, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, TelemetrySink, WhereInput } from "@lunora/do";
 import { applyCdcChanges, buildReprojectionMigration, assertShapeShardable, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, markUnvouchableReads, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "@lunora/do";
-import { asBucketStorage, beginDeferredSchedules, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "@lunora/server";
+import { asBucketStorage, beginDeferredSchedules, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "@lunora/server";
 import { bindOrm, bindTableFacade } from "@lunora/server";
 
 import schema from "../schema.js";
@@ -145,9 +145,6 @@ const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
 
 /** Structural schema snapshot + its content hash, recorded in the shard's `__lunora_schema_history` ledger on cold start so the studio can show a schema-version timeline and diff any two versions. */
 const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: "b4a95534fd46f14a", json: "{\n  \"migrationIds\": [],\n  \"tables\": {\n    \"boards\": {\n      \"fields\": {\n        \"name\": {\n          \"kind\": \"string\",\n          \"nullable\": false,\n          \"optional\": false,\n          \"unique\": false\n        },\n        \"ownerId\": {\n          \"kind\": \"string\",\n          \"nullable\": false,\n          \"optional\": false,\n          \"unique\": false\n        }\n      },\n      \"indexes\": {\n        \"by_owner\": {\n          \"fields\": [\n            \"ownerId\"\n          ],\n          \"unique\": false\n        }\n      },\n      \"relations\": {},\n      \"shardMode\": \"global\"\n    },\n    \"notes\": {\n      \"fields\": {\n        \"boardId\": {\n          \"kind\": \"string\",\n          \"nullable\": false,\n          \"optional\": false,\n          \"unique\": false\n        },\n        \"body\": {\n          \"kind\": \"string\",\n          \"nullable\": false,\n          \"optional\": false,\n          \"unique\": false\n        },\n        \"ownerId\": {\n          \"kind\": \"string\",\n          \"nullable\": false,\n          \"optional\": false,\n          \"unique\": false\n        }\n      },\n      \"indexes\": {\n        \"by_board\": {\n          \"fields\": [\n            \"boardId\"\n          ],\n          \"unique\": false\n        }\n      },\n      \"relations\": {},\n      \"shardMode\": \"shardBy:boardId\"\n    }\n  },\n  \"version\": 1\n}\n" };
-
-/** Per-table RLS read policies (hoisted from `.use(rls(...))` chains) the shape resolver AND-merges into each `defineShape` predicate so partial replication honours read policies. */
-const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCTIONS));
 
 export interface ShardDOConfig {
     /** Opt into change-data-capture: records a post-image to `__cdc_log` on every write (backs streaming export + replay-PITR). */
@@ -570,20 +567,26 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 ownerField: (schema as unknown as { tables: Record<string, { ownerField?: string }> }).tables[shape.table]?.ownerField,
             }) as unknown as WhereInput;
 
-            // AND-compose with the table's RLS read base-where. A shape runs no
-            // procedure, so the `.use(rls(...))` middleware never fires; without
-            // this merge its reads would bypass every read policy on the table
-            // (rows the caller can't see would replicate). `composeShapeReadWhere`
-            // evaluates the table's read policies under this same trusted ctx
+            // AND-compose with the read policies this SHAPE declares
+            // (`defineShape({ use: [guard] })`, pre-indexed into
+            // `shape.rlsRegistry`). A shape runs no procedure, so the
+            // `.use(rls(...))` middleware never fires; without this merge its
+            // reads would bypass the read policies it opted into.
+            // `composeShapeReadWhere` evaluates them under this same trusted ctx
             // and fails closed under a `.rls("required")` schema for a
-            // non-`.public()`, policy-less table.
+            // non-`.public()` table the shape declared no read policy for.
+            //
+            // The registry is the shape's OWN — never one folded from every
+            // registered function. A project-wide union let one admin-only
+            // procedure's allow-all read policy unrestrict every shape on the
+            // table; see the SCOPE note in `shape-read-base.ts`.
             //
             // It is NOT identical to the request-time path, and must not be
             // described as such: roles come from the identity's `roles` claim
             // only, because no middleware runs here to contribute
             // `ctx.auth.roles`. Derive roles at the identity if a policy gates
             // on them — see `shape-read-base.ts`.
-            const effectiveWhere = composeShapeReadWhere(LUNORA_RLS_READ_REGISTRY, {
+            const effectiveWhere = composeShapeReadWhere(shape.rlsRegistry, {
                 ctx,
                 identity: identity?.identity ?? null,
                 rlsRequired: (schema as unknown as { rlsMode?: string }).rlsMode === "required",

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -535,7 +535,7 @@ export const sendMessage = defineMutator({
             };
 
             it("registers shapes into LUNORA_SHAPES and overrides resolveShape on the DO", () => {
-                expect.assertions(9);
+                expect.assertions(10);
 
                 writeShapes();
 
@@ -559,6 +559,38 @@ export const sendMessage = defineMutator({
                 // read policies unions them, and a single allow-all policy inside an
                 // admin-only procedure then unrestricted every shape on that table.
                 expect(result.generated.shard).not.toContain("buildRlsReadRegistry");
+                // No read policy anywhere in the project ⇒ nothing for a shape to
+                // replicate around, so the boot-time guard is not stamped either.
+                expect(result.generated.shard).not.toContain("assertShapesDeclareReadPolicies");
+            });
+
+            it("stamps the boot-time guard when a shape's table is governed on read but the shape names no use()", () => {
+                expect.assertions(2);
+
+                writeShapes();
+                // A query tenant-scopes `messages` on read. The shape above declares no
+                // `use`, so its registry is empty and it would replicate the channel
+                // filter alone — every tenant's rows, silently. Codegen hands the runtime
+                // the governed tables; `@lunora/server` holds the verdict, because only
+                // the registry knows whether `use` was written.
+                writeFileSync(
+                    join(workdir, "lunora", "guarded.ts"),
+                    `import { query, rls } from "@lunora/server";
+export const listMessages = query
+    .use(rls([{ on: "read", table: "messages", when: ({ auth }) => ({ tenantId: auth.userId }) }]))
+    .query(async () => []);
+`,
+                    "utf8",
+                );
+
+                const result = runCodegen({ lint: false, projectRoot: workdir });
+
+                /* eslint-disable no-secrets/no-secrets -- dense generated-code assertions, not credentials */
+                expect(result.generated.shard).toContain("assertShapesDeclareReadPolicies, beginDeferredSchedules");
+                expect(result.generated.shard).toContain(
+                    'assertShapesDeclareReadPolicies(LUNORA_SHAPES, ["messages"], (schema as unknown as { rlsMode?: string }).rlsMode === "required");',
+                );
+                /* eslint-enable no-secrets/no-secrets */
             });
 
             it("registers mutators into the dispatch table + LUNORA_MUTATOR_PATHS and overrides isCustomMutator", () => {

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -535,7 +535,7 @@ export const sendMessage = defineMutator({
             };
 
             it("registers shapes into LUNORA_SHAPES and overrides resolveShape on the DO", () => {
-                expect.assertions(10);
+                expect.assertions(9);
 
                 writeShapes();
 
@@ -551,14 +551,14 @@ export const sendMessage = defineMutator({
                 // The cross-shard-join guard is imported + called against the compiled predicate.
                 expect(result.generated.shard).toContain("assertShapeShardable");
                 expect(result.generated.shard).toContain("assertShapeShardable(effectiveWhere, schema as unknown as SchemaLike, shape.table)");
-                // The shape predicate is AND-merged with the table's RLS read base-where:
-                // a module-scope registry is built from the function table, the helper is
-                // imported, and the resolver composes it before the shardability guard.
-                // eslint-disable-next-line no-secrets/no-secrets -- asserting on generated TS, not a credential
-                expect(result.generated.shard).toContain("const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCTIONS));");
-                expect(result.generated.shard).toContain("buildRlsReadRegistry, composeShapeReadWhere");
-                // eslint-disable-next-line no-secrets/no-secrets -- asserting on generated TS, not a credential
-                expect(result.generated.shard).toContain("composeShapeReadWhere(LUNORA_RLS_READ_REGISTRY,");
+                // The shape predicate is AND-merged with the read policies the SHAPE
+                // declares (`defineShape({ use })`, pre-indexed by `defineShape` into
+                // `shape.rlsRegistry`), before the shardability guard.
+                expect(result.generated.shard).toContain("composeShapeReadWhere(shape.rlsRegistry,");
+                // NOT a project-wide registry. Folding in every registered function's
+                // read policies unions them, and a single allow-all policy inside an
+                // admin-only procedure then unrestricted every shape on that table.
+                expect(result.generated.shard).not.toContain("buildRlsReadRegistry");
             });
 
             it("registers mutators into the dispatch table + LUNORA_MUTATOR_PATHS and overrides isCustomMutator", () => {

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -4620,6 +4620,26 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
         }
 `
         : "";
+    // Boot-time fail-closed check for the OTHER direction of shape RLS scoping: a
+    // shape whose table the project governs on read but that names no `use` has an
+    // empty registry, so it replicates on its own `where` alone — unfiltered, with
+    // no error. Only the runtime registry knows whether `use` was written (the
+    // shape IR does not lift it), so the tables come from codegen and the verdict
+    // from `@lunora/server`. Emitted only when both halves exist, so a project
+    // without shapes or without read policies keeps a byte-identical `shard.ts`.
+    const shapeReadPolicyTables = hasShapes
+        ? [...new Set(rlsData.policies.filter((policy) => policy.on === "read" && policy.table !== "").map((policy) => policy.table))].toSorted((a, b) =>
+              a.localeCompare(b),
+          )
+        : [];
+    const shapeReadPolicyAssertion =
+        shapeReadPolicyTables.length > 0
+            ? `
+/** Refuses to boot a shape that would replicate around the read policies its table is governed by (\`defineShape({ use })\` is how a shape opts in; \`use: []\` acknowledges an ungoverned one). */
+assertShapesDeclareReadPolicies(LUNORA_SHAPES, ${JSON.stringify(shapeReadPolicyTables)}, (schema as unknown as { rlsMode?: string }).rlsMode === "required");
+`
+            : "";
+
     const customMutatorOverride = hasMutators
         ? `
         protected override isCustomMutator(functionPath: string): boolean {
@@ -4634,6 +4654,9 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
     // pulled in only when the project has shapes so a shape-free `shard.ts`
     // stays byte-identical.
     const shapeGuardImport = hasShapes ? "assertShapeShardable, " : "";
+    // Imported only when the boot-time check is actually stamped: an unused import in
+    // generated output fails the strict `noUnusedLocals` config it compiles under.
+    const shapeReadPolicyImport = shapeReadPolicyAssertion === "" ? "" : "assertShapesDeclareReadPolicies, ";
 
     const importLines = [
         `import type { ${doTypeImports.join(", ")} } from "${base.do}";`,
@@ -4650,7 +4673,7 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
         // read-registry builder + `composeShapeReadWhere` so `resolveShape` can
         // AND-merge a shape's predicate with the table's read base-where.
         hasShapes
-            ? `import { asBucketStorage, beginDeferredSchedules, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`
+            ? `import { asBucketStorage, ${shapeReadPolicyImport}beginDeferredSchedules, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`
             : `import { asBucketStorage, beginDeferredSchedules, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`,
     ];
 
@@ -5387,7 +5410,7 @@ const LUNORA_ADVISOR_PROCEDURES: AdvisorProcedure[] = ${JSON.stringify(advisorPr
 
 /** Read-only RLS metadata (policies + roles discovered from \`.use(rls(...))\` chains) served via \`__lunora_admin__:rlsPolicies\` for the studio's RLS inspector. */
 const LUNORA_RLS_METADATA: RlsPoliciesResult = ${JSON.stringify(rlsData, undefined, 4)};
-
+${shapeReadPolicyAssertion}
 /** Read-only masking metadata (table + column + strategy discovered from \`.use(mask(...))\` chains) served via \`__lunora_admin__:maskPolicies\` for the studio's data-browser mask preview. */
 const LUNORA_MASK_METADATA: MaskPoliciesResult = ${JSON.stringify(maskData, undefined, 4)};
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -4576,20 +4576,26 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
                 ownerField: (schema as unknown as { tables: Record<string, { ownerField?: string }> }).tables[shape.table]?.ownerField,
             }) as unknown as WhereInput;
 
-            // AND-compose with the table's RLS read base-where. A shape runs no
-            // procedure, so the \`.use(rls(...))\` middleware never fires; without
-            // this merge its reads would bypass every read policy on the table
-            // (rows the caller can't see would replicate). \`composeShapeReadWhere\`
-            // evaluates the table's read policies under this same trusted ctx
+            // AND-compose with the read policies this SHAPE declares
+            // (\`defineShape({ use: [guard] })\`, pre-indexed into
+            // \`shape.rlsRegistry\`). A shape runs no procedure, so the
+            // \`.use(rls(...))\` middleware never fires; without this merge its
+            // reads would bypass the read policies it opted into.
+            // \`composeShapeReadWhere\` evaluates them under this same trusted ctx
             // and fails closed under a \`.rls("required")\` schema for a
-            // non-\`.public()\`, policy-less table.
+            // non-\`.public()\` table the shape declared no read policy for.
+            //
+            // The registry is the shape's OWN — never one folded from every
+            // registered function. A project-wide union let one admin-only
+            // procedure's allow-all read policy unrestrict every shape on the
+            // table; see the SCOPE note in \`shape-read-base.ts\`.
             //
             // It is NOT identical to the request-time path, and must not be
             // described as such: roles come from the identity's \`roles\` claim
             // only, because no middleware runs here to contribute
             // \`ctx.auth.roles\`. Derive roles at the identity if a policy gates
             // on them — see \`shape-read-base.ts\`.
-            const effectiveWhere = composeShapeReadWhere(LUNORA_RLS_READ_REGISTRY, {
+            const effectiveWhere = composeShapeReadWhere(shape.rlsRegistry, {
                 ctx,
                 identity: identity?.identity ?? null,
                 rlsRequired: (schema as unknown as { rlsMode?: string }).rlsMode === "required",
@@ -4622,16 +4628,6 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
 `
         : "";
 
-    // Module-scope, built once: the per-table RLS read policies (hoisted from
-    // each function's `.use(rls(...))` chain onto `fn.rls`) the shape resolver
-    // AND-merges into every `defineShape` predicate, so partial replication
-    // honours the table's read policies. Only emitted when the project has shapes.
-    const shapeReadRegistryConst = hasShapes
-        ? `
-/** Per-table RLS read policies (hoisted from \`.use(rls(...))\` chains) the shape resolver AND-merges into each \`defineShape\` predicate so partial replication honours read policies. */
-const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCTIONS));
-`
-        : "";
     /* eslint-enable no-secrets/no-secrets */
 
     // The cross-shard-join guard (`assertShapeShardable`) is a value import,
@@ -4654,7 +4650,7 @@ const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCT
         // read-registry builder + `composeShapeReadWhere` so `resolveShape` can
         // AND-merge a shape's predicate with the table's read base-where.
         hasShapes
-            ? `import { asBucketStorage, beginDeferredSchedules, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`
+            ? `import { asBucketStorage, beginDeferredSchedules, composeShapeReadWhere, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`
             : `import { asBucketStorage, beginDeferredSchedules, createSecrets, flushDeferredDeletes, LunoraError, withDeferredDeletes, withDeferredSchedules } from "${base.server}";`,
     ];
 
@@ -5400,7 +5396,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = ${JSON.stringify(storageRulesDa
 
 /** Which optional package-backed features this app wires up (discovered from imports / \`ctx.*\` reads / schema signals) served via \`__lunora_admin__:studioFeatures\` so the studio hides nav pages whose package isn't enabled. */
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = ${JSON.stringify(studioFeaturesData, undefined, 4)};
-${schemaSnapshotConst}${flagsOverrides.constant}${shapeReadRegistryConst}${workflowsMetadataConst}${queuesMetadataConst}${containerSpecs}${workflowSpecs}${queueSpecs}${agentSpecs}
+${schemaSnapshotConst}${flagsOverrides.constant}${workflowsMetadataConst}${queuesMetadataConst}${containerSpecs}${workflowSpecs}${queueSpecs}${agentSpecs}
 export interface ShardDOConfig {
     /** Opt into change-data-capture: records a post-image to \`__cdc_log\` on every write (backs streaming export + replay-PITR). */
     cdc?: boolean;

--- a/packages/server/__tests__/builder.test.ts
+++ b/packages/server/__tests__/builder.test.ts
@@ -534,6 +534,44 @@ describe("builder middleware", () => {
         await expect(fn.handler({}, {})).rejects.toThrow(/next\(\) called multiple times/u);
     });
 
+    /**
+     * A middleware that resolves without calling `next()` used to look like a
+     * short-circuit but was an authorization bypass: the terminal is what builds
+     * the handler's context, so the handler ran anyway — with every later
+     * `.use()` (`rls()`, `mask()`, `storageRules()`) skipped and `ctx.db` still
+     * the unwrapped writer, while the hoisted `fn.rls` kept advertising the
+     * procedure as guarded to studio and the shape registry. Returning
+     * `undefined` instead only produced a bare `TypeError` deeper in.
+     */
+    it("rejects a middleware that resolves without calling next(), and does not run the handler", async () => {
+        expect.assertions(3);
+
+        const handler = vi.fn<() => string>(() => "secret");
+        const later = vi.fn<() => void>();
+
+        const fn = c.query
+            .use(({ ctx }) => ctx)
+            .use(async ({ next }) => {
+                later();
+
+                return next();
+            })
+            .query(handler);
+
+        await expect(fn.handler({}, {})).rejects.toThrow(/resolved without calling next\(\)/u);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(later).not.toHaveBeenCalled();
+    });
+
+    it("rejects a middleware that returns undefined with the same clear error, not a TypeError", async () => {
+        expect.assertions(1);
+
+        const fn = c.query.use(() => undefined).query(() => "ok");
+
+        await expect(fn.handler({}, {})).rejects.toThrow(/resolved without calling next\(\)/u);
+    });
+
     it("a middleware that throws aborts before the handler runs", async () => {
         expect.assertions(2);
 

--- a/packages/server/__tests__/builder.test.ts
+++ b/packages/server/__tests__/builder.test.ts
@@ -572,6 +572,94 @@ describe("builder middleware", () => {
         await expect(fn.handler({}, {})).rejects.toThrow(/resolved without calling next\(\)/u);
     });
 
+    /**
+     * `void next()` satisfies the "did it call next()?" guard while still
+     * resolving the chain early: `next()` hands back the downstream promise and
+     * nothing awaits it, so the handler runs against a half-built context — the
+     * later `.use()` steps (`rls()`, `mask()`, `storageRules()`) are still in
+     * flight — and a downstream rejection detaches into an unhandled rejection.
+     */
+    it("does not resolve the chain before a fire-and-forget next() has run the rest of it", async () => {
+        expect.assertions(2);
+
+        const order: string[] = [];
+        // Fire-and-forget: the promise is kept, and nothing ever awaits it.
+        const dropped: unknown[] = [];
+
+        const fn = c.query
+            .use(({ ctx, next }) => {
+                dropped.push(next());
+
+                return ctx;
+            })
+            .use(async ({ next }) => {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 5);
+                });
+
+                order.push("downstream");
+
+                return next();
+            })
+            .query(() => {
+                order.push("handler");
+
+                return "ok";
+            });
+
+        await fn.handler({}, {});
+
+        expect(dropped).toHaveLength(1);
+        expect(order).toStrictEqual(["downstream", "handler"]);
+    });
+
+    it("surfaces the rejection a fire-and-forget next() detached, instead of running the handler", async () => {
+        expect.assertions(3);
+
+        const handler = vi.fn<() => string>(() => "secret");
+        const dropped: unknown[] = [];
+
+        const fn = c.query
+            .use(({ ctx, next }) => {
+                dropped.push(next());
+
+                return ctx;
+            })
+            .use(() => {
+                throw new LunoraError("FORBIDDEN");
+            })
+            .query(handler);
+
+        await expect(fn.handler({}, {})).rejects.toThrow(/FORBIDDEN/u);
+
+        expect(dropped).toHaveLength(1);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The other side of that fix: a middleware that AWAITED `next()` owns the
+     * outcome, including a rejection it deliberately swallowed. Re-awaiting the
+     * downstream promise on its behalf would re-throw what it just handled.
+     */
+    it("keeps a middleware that catches a downstream rejection and returns a fallback context", async () => {
+        expect.assertions(1);
+
+        const fn = c.query
+            .use(async ({ ctx, next }) => {
+                try {
+                    return await next();
+                } catch {
+                    return { ...ctx, fallback: true };
+                }
+            })
+            .use(() => {
+                throw new LunoraError("FORBIDDEN");
+            })
+            .query(({ ctx }) => ((ctx as { fallback?: boolean }).fallback === true ? "fallback" : "ok"));
+
+        await expect(fn.handler({}, {})).resolves.toBe("fallback");
+    });
+
     it("a middleware that throws aborts before the handler runs", async () => {
         expect.assertions(2);
 

--- a/packages/server/__tests__/builder.test.ts
+++ b/packages/server/__tests__/builder.test.ts
@@ -641,9 +641,18 @@ describe("builder middleware", () => {
      * outcome, including a rejection it deliberately swallowed. Re-awaiting the
      * downstream promise on its behalf would re-throw what it just handled.
      */
-    it("keeps a middleware that catches a downstream rejection and returns a fallback context", async () => {
-        expect.assertions(1);
+    it("refuses to let a middleware swallow a later step's denial", async () => {
+        expect.assertions(2);
 
+        const handler = vi.fn<() => string>(() => "secret");
+
+        // The shape reads like error handling and is an authorization bypass.
+        // This chain's terminal only BUILDS the context and the handler runs
+        // after it resolves, so a rejection arriving here is never a handler
+        // error a middleware could legitimately recover from — it is a later
+        // step refusing (an `rls()` denial, or the no-next() guard one link
+        // down). Catching it and returning a fallback context would run the
+        // handler against exactly the context the denial existed to prevent.
         const fn = c.query
             .use(async ({ ctx, next }) => {
                 try {
@@ -655,9 +664,10 @@ describe("builder middleware", () => {
             .use(() => {
                 throw new LunoraError("FORBIDDEN");
             })
-            .query(({ ctx }) => ((ctx as { fallback?: boolean }).fallback === true ? "fallback" : "ok"));
+            .query(handler);
 
-        await expect(fn.handler({}, {})).resolves.toBe("fallback");
+        await expect(fn.handler({}, {})).rejects.toBeInstanceOf(LunoraError);
+        expect(handler).not.toHaveBeenCalled();
     });
 
     it("a middleware that throws aborts before the handler runs", async () => {

--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -2114,6 +2114,31 @@ describe("mask — get() table resolution", () => {
 
         expect(result?.row["email"]).toBe("raw@x.com");
     });
+
+    /**
+     * `lookupById` is SHARD-LOCAL: a `.global()` row lives in D1, so it misses
+     * the seam while `get`/`findFirst` still resolve it through the writer's own
+     * global fallback. Reading that miss as "no such row" made `ctx.db.get(id)`
+     * answer `null` for every global row inside a `mask()` procedure.
+     */
+    it("falls back to the probe path when lookupById misses (a .global() row is not absent)", async () => {
+        expect.assertions(2);
+
+        const rows = [{ _id: "u1", email: "a@x.com", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        // The seam is installed but resolves nothing — exactly a global row.
+
+        database.writer.lookupById = async () => null;
+
+        const handler = lunora.query.use(maskForTest({ users: { email: "redact" } })).query(async ({ ctx }) => (ctx as unknown as TestContext).db.get("u1"));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(result?.["_id"]).toBe("u1");
+
+        expect(result?.["email"]).toBeNull();
+    });
 });
 
 describe("mask — opt-in scope & stored data", () => {

--- a/packages/server/__tests__/plugin.test.ts
+++ b/packages/server/__tests__/plugin.test.ts
@@ -534,12 +534,15 @@ describe("composePluginMiddleware", () => {
         await expect(procedure.handler({}, {})).rejects.toThrow(/next\(\) called multiple times/u);
     });
 
-    it("short-circuits later plugins when one returns without calling next()", async () => {
-        expect.assertions(1);
+    it("rejects a plugin that returns without calling next() instead of silently skipping the rest", async () => {
+        expect.assertions(2);
 
-        // `stop` returns its context without calling next() — the composed chain
-        // must not advance to `after`, matching how a `.use()` link that never
-        // calls next() halts the chain.
+        // `stop` returns its context without calling next(). That is NOT a
+        // short-circuit: the chain's terminal is what builds the handler's
+        // context, so letting it through ran the handler with `after` — and, in a
+        // real chain, `rls()`/`mask()` — never applied, while the hoisted `fn.rls`
+        // still advertised the procedure as guarded. It must be a loud error, the
+        // same class as the double-next() tripwire above.
         const ran: string[] = [];
         const stop = definePlugin("stop", {
             middleware: ({ ctx }) => {
@@ -559,7 +562,7 @@ describe("composePluginMiddleware", () => {
         const c = initLunora.dataModel<Record<string, never>>().create();
         const procedure = c.query.use(composePluginMiddleware([stop, after])).query(() => "ok");
 
-        await procedure.handler({}, {});
+        await expect(procedure.handler({}, {})).rejects.toThrow(/resolved without calling next\(\)/u);
 
         expect(ran).toEqual(["stop"]);
     });

--- a/packages/server/__tests__/rls-global-rows.test.ts
+++ b/packages/server/__tests__/rls-global-rows.test.ts
@@ -1,0 +1,259 @@
+/**
+ * A `.global()` row addressed by id must still be located, read-filtered and
+ * write-gated by `rls()`.
+ *
+ * `@lunora/shard-engine`'s `lookupById` is the one-round-trip seam the RLS
+ * middleware prefers over its `get` + per-table `findFirst` probe. That seam is
+ * SHARD-LOCAL: a `.global()` row lives in D1, so its owning table is not
+ * resolvable from the DO's index and every global id misses. `null` from it
+ * therefore means "not resolvable here", not "no such row" — and the middleware
+ * that read it as the latter classified every global row as "in no policy-gated
+ * table", which made `get()` answer `null` and `patch`/`delete`/`deleteAll` skip
+ * the write policy entirely.
+ *
+ * The fake writer below reproduces exactly that split: `lookupById` answers only
+ * for shard-local rows, while `get`/`findFirst` (which reach the global backend
+ * through the writer's own fallback) answer for both.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Middleware, Policy } from "../src/index";
+import { definePolicy, initLunora, rls } from "../src/index";
+
+const rlsForTest = <Context>(policies: ReadonlyArray<Policy<Context>>): Middleware<any, any> =>
+    (rls as unknown as (p: ReadonlyArray<Policy<Context>>) => Middleware<any, any>)(policies);
+
+interface SeedRow extends Record<string, unknown> {
+    _id: string;
+    global: boolean;
+    table: string;
+}
+
+interface TestContext {
+    auth: { userId: null | string };
+    db: unknown;
+}
+
+/**
+ * Writer whose `lookupById` resolves shard-local rows only — the shape
+ * `createShardCtxDb` really has. `deleted` records the ids the writer was asked
+ * to erase so a test can prove a denied delete never reached it.
+ */
+const createSplitWriter = (seed: ReadonlyArray<SeedRow>) => {
+    const rows = new Map(seed.map((row) => [row._id, { ...row }] as const));
+    const deleted: string[] = [];
+    const patched: string[] = [];
+
+    const rowsOfTable = (tableName: string): SeedRow[] => [...rows.values()].filter((row) => row.table === tableName);
+
+    const writer = {
+        async aggregate(tableName: string) {
+            return rowsOfTable(tableName).length;
+        },
+
+        async count(tableName: string) {
+            return rowsOfTable(tableName).length;
+        },
+
+        async delete(id: string) {
+            deleted.push(id);
+            rows.delete(id);
+        },
+
+        async deleteAll() {
+            return { deleted: 0 };
+        },
+
+        async deleteMany(ids: ReadonlyArray<string>) {
+            return { deleted: ids.length };
+        },
+        async findFirst(tableName: string, args?: { where?: { _id?: string } }) {
+            const page = await writer.findMany(tableName, args);
+
+            return page.page[0] ?? null;
+        },
+
+        async findMany(tableName: string, args?: { baseWhere?: Record<string, unknown>; where?: { _id?: string } }) {
+            let page = rowsOfTable(tableName);
+            const wantedId = args?.where?._id;
+
+            if (typeof wantedId === "string") {
+                page = page.filter((row) => row._id === wantedId);
+            }
+
+            // Only the one predicate shape these tests build is honoured.
+            const owner = args?.baseWhere?.["userId"];
+
+            if (typeof owner === "string") {
+                page = page.filter((row) => row["userId"] === owner);
+            }
+
+            return { continueCursor: null, isDone: true, page };
+        },
+        // `get` reaches BOTH backends — the writer falls back to the global one.
+
+        async get(id: string) {
+            return rows.get(id) ?? null;
+        },
+
+        async groupBy() {
+            return [];
+        },
+
+        async insert(_tableName: string, document: Record<string, unknown>) {
+            return (document["_id"] as string | undefined) ?? "new-id";
+        },
+
+        async insertMany() {
+            return [];
+        },
+
+        async insertManyUnsafe() {
+            return [];
+        },
+        // SHARD-LOCAL ONLY: a global row misses, exactly like the real seam.
+
+        async lookupById(id: string) {
+            const row = rows.get(id);
+
+            return row && !row.global ? { row, tableName: row.table } : null;
+        },
+
+        async patch(id: string, patch: Record<string, unknown>) {
+            patched.push(id);
+
+            const row = rows.get(id);
+
+            if (row) {
+                rows.set(id, { ...row, ...patch });
+            }
+        },
+
+        async patchMany() {
+            return { patched: 0 };
+        },
+        query() {
+            throw new Error("query() not used in these tests");
+        },
+
+        async rank() {
+            return null;
+        },
+
+        async rankPage() {
+            return { continueCursor: null, isDone: true, page: [] };
+        },
+
+        async replace() {
+            // no-op
+        },
+    };
+
+    return { deleted, patched, rows, writer };
+};
+
+const lunora = initLunora.dataModel<Record<string, never>>().create();
+
+const makeContext = (writer: unknown, userId: null | string): TestContext => {
+    return { auth: { userId }, db: writer };
+};
+
+/** `read` allows everything, `update`/`delete` deny everything — so any write that lands is a bypass. */
+const readOnlyPolicies: ReadonlyArray<Policy<TestContext>> = [
+    definePolicy<TestContext>({ on: "read", table: "profiles", when: () => true }),
+    definePolicy<TestContext>({ on: "delete", table: "profiles", when: () => false }),
+    definePolicy<TestContext>({ on: "update", table: "profiles", when: () => false }),
+];
+
+const seed: ReadonlyArray<SeedRow> = [
+    { _creationTime: 1, _id: "p1", global: true, table: "profiles", userId: "victim" },
+    { _creationTime: 1, _id: "p2", global: true, table: "profiles", userId: "victim2" },
+];
+
+describe("rls — .global() rows addressed by id", () => {
+    it("get() returns a global row the read policy admits (it is not 'absent')", async () => {
+        expect.assertions(1);
+
+        const database = createSplitWriter(seed);
+        const handler = lunora.query.use(rlsForTest<TestContext>(readOnlyPolicies)).query(async ({ ctx }) => (ctx as TestContext & { db: any }).db.get("p1"));
+
+        await expect(handler.handler(makeContext(database.writer, "attacker"), {})).resolves.toMatchObject({ _id: "p1", userId: "victim" });
+    });
+
+    it("patch() on a global row runs the update policy and is denied", async () => {
+        expect.assertions(2);
+
+        const database = createSplitWriter(seed);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(readOnlyPolicies))
+            .mutation(async ({ ctx }) => (ctx as TestContext & { db: any }).db.patch("p1", { userId: "attacker" }));
+
+        await expect(handler.handler(makeContext(database.writer, "attacker"), {})).rejects.toThrow(/denied by policy/u);
+
+        expect(database.patched).toStrictEqual([]);
+    });
+
+    it("delete() on a global row runs the delete policy and is denied", async () => {
+        expect.assertions(2);
+
+        const database = createSplitWriter(seed);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(readOnlyPolicies))
+            .mutation(async ({ ctx }) => (ctx as TestContext & { db: any }).db.delete("p1"));
+
+        await expect(handler.handler(makeContext(database.writer, "attacker"), {})).rejects.toThrow(/denied by policy/u);
+
+        expect(database.deleted).toStrictEqual([]);
+    });
+
+    it("deleteAll() over a global table gates every row and erases none when the policy denies", async () => {
+        expect.assertions(2);
+
+        const database = createSplitWriter(seed);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(readOnlyPolicies))
+            .mutation(async ({ ctx }) => (ctx as TestContext & { db: any }).db.deleteAll("profiles"));
+
+        await expect(handler.handler(makeContext(database.writer, "attacker"), {})).rejects.toThrow(/denied by policy/u);
+
+        expect(database.rows.size).toBe(2);
+    });
+
+    it("a global row the read policy hides is not returned by get()", async () => {
+        expect.assertions(1);
+
+        const scoped: ReadonlyArray<Policy<TestContext>> = [
+            definePolicy<TestContext>({
+                on: "read",
+                table: "profiles",
+                when: ({ auth }) => {
+                    return { userId: auth.userId };
+                },
+            }),
+        ];
+        const database = createSplitWriter(seed);
+        const handler = lunora.query.use(rlsForTest<TestContext>(scoped)).query(async ({ ctx }) => (ctx as TestContext & { db: any }).db.get("p1"));
+
+        await expect(handler.handler(makeContext(database.writer, "attacker"), {})).resolves.toBeNull();
+    });
+
+    it("still resolves a shard-local row through the one-round-trip seam (no probe fan-out)", async () => {
+        expect.assertions(2);
+
+        const database = createSplitWriter([{ _creationTime: 1, _id: "s1", global: false, table: "profiles", userId: "victim" }]);
+        const probes: string[] = [];
+        const spied = {
+            ...database.writer,
+            findFirst: async (tableName: string, args?: { where?: { _id?: string } }) => {
+                probes.push(tableName);
+
+                return database.writer.findFirst(tableName, args);
+            },
+        };
+        const handler = lunora.query.use(rlsForTest<TestContext>(readOnlyPolicies)).query(async ({ ctx }) => (ctx as TestContext & { db: any }).db.get("s1"));
+
+        await expect(handler.handler(makeContext(spied, "attacker"), {})).resolves.toMatchObject({ _id: "s1" });
+
+        expect(probes).toStrictEqual([]);
+    });
+});

--- a/packages/server/__tests__/rls-global-rows.test.ts
+++ b/packages/server/__tests__/rls-global-rows.test.ts
@@ -257,3 +257,70 @@ describe("rls — .global() rows addressed by id", () => {
         expect(probes).toStrictEqual([]);
     });
 });
+
+/**
+ * The cost of the fallback above, bounded.
+ *
+ * A `.global()` row always misses `lookupById`, so every id falls through to the
+ * probe path. `deleteAll`/`deleteWhere` must leave `expectedTable` unpinned —
+ * pinning it blocks the writer's global fallback and makes every global delete a
+ * silent no-op — and unpinned USED to mean "probe every policy-gated table", so a
+ * chunked erase of N rows over a T-table schema issued N × T `findFirst` round
+ * trips (2 + T subrequests per row) and hit workerd's 1000-subrequest ceiling
+ * partway through an account deletion. Both callers know the table their ids came
+ * from, so it rides along as a probe scope that pins nothing.
+ */
+describe("rls — probe scope on chunked erases", () => {
+    /** Three policy-gated tables; only `profiles` is ever erased. */
+    const manyTablePolicies: ReadonlyArray<Policy<TestContext>> = [
+        definePolicy<TestContext>({ on: "delete", table: "profiles", when: () => true }),
+        definePolicy<TestContext>({ on: "read", table: "profiles", when: () => true }),
+        definePolicy<TestContext>({ on: "read", table: "audits", when: () => true }),
+        definePolicy<TestContext>({ on: "read", table: "notes", when: () => true }),
+    ];
+
+    const spyProbes = (database: ReturnType<typeof createSplitWriter>) => {
+        const probes: string[] = [];
+
+        return {
+            probes,
+            writer: {
+                ...database.writer,
+                findFirst: async (tableName: string, args?: { where?: { _id?: string } }) => {
+                    probes.push(tableName);
+
+                    return database.writer.findFirst(tableName, args);
+                },
+            },
+        };
+    };
+
+    it("deleteAll() probes only the table it erases, once per row", async () => {
+        expect.assertions(3);
+
+        const database = createSplitWriter(seed);
+        const spied = spyProbes(database);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(manyTablePolicies))
+            .mutation(async ({ ctx }) => (ctx as TestContext & { db: any }).db.deleteAll("profiles"));
+
+        await expect(handler.handler(makeContext(spied.writer, "admin"), {})).resolves.toStrictEqual({ deleted: 2 });
+
+        expect(spied.probes).toStrictEqual(["profiles", "profiles"]);
+        expect(database.rows.size).toBe(0);
+    });
+
+    it("deleteWhere() probes only the matched table, once per row", async () => {
+        expect.assertions(2);
+
+        const database = createSplitWriter(seed);
+        const spied = spyProbes(database);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(manyTablePolicies))
+            .mutation(async ({ ctx }) => (ctx as TestContext & { db: any }).db.deleteWhere("profiles", { global: true }));
+
+        await expect(handler.handler(makeContext(spied.writer, "admin"), {})).resolves.toStrictEqual({ deleted: 2 });
+
+        expect(spied.probes).toStrictEqual(["profiles", "profiles"]);
+    });
+});

--- a/packages/server/__tests__/rls-secure-by-default.test.ts
+++ b/packages/server/__tests__/rls-secure-by-default.test.ts
@@ -146,9 +146,8 @@ const guard = (raw: RawWriter, protectedTables: Set<string>, tableOfId: (id: str
         }
     };
 
-    return {
+    const guarded = {
         ...raw,
-        [RLS_UNWRAP_SYMBOL]: raw,
         aggregate: (tableName: string) => {
             deny(tableName);
 
@@ -204,7 +203,14 @@ const guard = (raw: RawWriter, protectedTables: Set<string>, tableOfId: (id: str
 
             return raw.replace(id);
         },
-    } as unknown as RawWriter;
+    };
+
+    // NON-enumerable, mirroring the real `guardWriter`. An enumerable escape
+    // hatch rides the `{ ...ctx.db }` spread the RLS wrapper is built from, which
+    // re-published the unguarded writer off the wrapper.
+    Object.defineProperty(guarded, RLS_UNWRAP_SYMBOL, { configurable: true, enumerable: false, value: raw });
+
+    return guarded;
 };
 
 const lunora = initLunora.dataModel<Record<string, never>>().create();
@@ -363,5 +369,129 @@ describe("rls — secure-by-default routing over a guarded writer", () => {
         expect.assertions(1);
 
         expect(LunoraError).toBeTypeOf("function");
+    });
+});
+
+/**
+ * Several `.use(rls(...))` steps in one chain must COMPOSE.
+ *
+ * The guarded writer publishes the unwrapped one under `RLS_UNWRAP_SYMBOL`, and
+ * the RLS wrapper is built with `{ ...ctx.db }`. While that property was
+ * enumerable the wrapper re-published it, so a SECOND `rls()` step recovered the
+ * raw writer and wrapped THAT — routing around step one entirely, which turned
+ * `rls([tenantScope])` followed by any other `rls(...)` into a full-table read.
+ * Multiple steps are a shipped shape (`protectPublic({ use })`,
+ * `composePluginMiddleware`, plain chained `.use()`), so the fix is composition,
+ * not merely hiding the symbol.
+ */
+describe("rls — chained rls() steps compose", () => {
+    const protectedTables = new Set(["posts", "secrets"]);
+    const tableOfId = (id: string): string | undefined => (id.startsWith("post_") ? "posts" : undefined);
+
+    const tenantPosts = definePolicy<TestContext>({
+        on: "read",
+        table: "posts",
+        when: ({ auth }) => {
+            return { ownerId: auth.userId };
+        },
+    });
+
+    /** A second, broader bundle — the kind a feature flag or a plugin contributes. */
+    const allPosts = definePolicy<TestContext>({ on: "read", table: "posts", when: () => true });
+
+    const readSecrets = definePolicy<TestContext>({ on: "read", table: "secrets", when: () => true });
+
+    /** Record what the underlying writer was actually asked for. */
+    const recording = (raw: RawWriter): { args: unknown[]; writer: RawWriter } => {
+        const args: unknown[] = [];
+
+        return {
+            args,
+            writer: {
+                ...raw,
+                findMany: (tableName: string, callArgs?: unknown) => {
+                    args.push(callArgs);
+
+                    return raw.findMany(tableName);
+                },
+            },
+        };
+    };
+
+    it("and-merges both steps' read filters (a later step cannot widen an earlier one)", async () => {
+        expect.assertions(1);
+
+        const { args, writer } = recording(createRawWriter([{ _id: "post_1", table: "posts" }], []));
+        const guarded = guard(writer, protectedTables, tableOfId);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>(definePolicies([tenantPosts])))
+            .use(rlsForTest<TestContext>(definePolicies([allPosts])))
+            .query(async ({ ctx }) => ctx.db.findMany("posts"));
+
+        await handler.handler({ auth: { userId: "u1" }, db: guarded }, {});
+
+        // Step two grants unrestricted access, so it adds no predicate — but step
+        // one's tenant scope must survive it.
+        expect(args[0]).toMatchObject({ baseWhere: { ownerId: "u1" } });
+    });
+
+    it("intersects a second step's narrower filter with the first rather than replacing it", async () => {
+        expect.assertions(1);
+
+        const draftsOnly = definePolicy<TestContext>({
+            on: "read",
+            table: "posts",
+            when: () => {
+                return { status: "draft" };
+            },
+        });
+        const { args, writer } = recording(createRawWriter([{ _id: "post_1", table: "posts" }], []));
+        const guarded = guard(writer, protectedTables, tableOfId);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>(definePolicies([tenantPosts])))
+            .use(rlsForTest<TestContext>(definePolicies([draftsOnly])))
+            .query(async ({ ctx }) => ctx.db.findMany("posts"));
+
+        await handler.handler({ auth: { userId: "u1" }, db: guarded }, {});
+
+        expect(args[0]).toMatchObject({ baseWhere: { AND: [{ ownerId: "u1" }, { status: "draft" }] } });
+    });
+
+    it("routes a table only the SECOND step gates around the guard", async () => {
+        expect.assertions(1);
+
+        const log: string[] = [];
+        const guarded = guard(createRawWriter([{ _id: "secret_1", table: "secrets" }], log), protectedTables, tableOfId);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>(definePolicies([tenantPosts])))
+            .use(rlsForTest<TestContext>(definePolicies([readSecrets])))
+            .query(async ({ ctx }) => ctx.db.findMany("secrets"));
+
+        await handler.handler({ auth: { userId: "u1" }, db: guarded }, {});
+
+        expect(log).toContain("raw.findMany:secrets");
+    });
+
+    it("requires a write to satisfy every step that gates the table", async () => {
+        expect.assertions(2);
+
+        const log: string[] = [];
+        const permissive = definePolicies([
+            definePolicy<TestContext>({ on: "read", table: "posts", when: () => true }),
+            definePolicy<TestContext>({ on: "update", table: "posts", when: () => true }),
+        ]);
+        const restrictive = definePolicies([
+            definePolicy<TestContext>({ on: "read", table: "posts", when: () => true }),
+            definePolicy<TestContext>({ on: "update", table: "posts", when: () => false }),
+        ]);
+        const guarded = guard(createRawWriter([{ _id: "post_1", table: "posts" }], log), protectedTables, tableOfId);
+        const handler = lunora.mutation
+            .use(rlsForTest<TestContext>(permissive))
+            .use(rlsForTest<TestContext>(restrictive))
+            .mutation(async ({ ctx }) => ctx.db.patch("post_1", { title: "x" }));
+
+        await expect(handler.handler({ auth: { userId: "u1" }, db: guarded }, {})).rejects.toThrow(/denied by policy/u);
+
+        expect(log).not.toContain("raw.patch:post_1");
     });
 });

--- a/packages/server/__tests__/rls-shape-read-base.test.ts
+++ b/packages/server/__tests__/rls-shape-read-base.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    assertShapesDeclareReadPolicies,
     buildRlsReadRegistry,
     composeShapeReadWhere,
     definePermission,
@@ -337,5 +338,110 @@ describe("defineShape — RLS scope is the shape's own use() guards", () => {
         });
 
         expect(composeShapeReadWhere(shape.rlsRegistry, { ...request, rlsRequired: true })).toStrictEqual({ OR: [] });
+    });
+});
+
+/**
+ * The OTHER direction of that scoping: a shape that declares no `use` at all.
+ *
+ * Under `.rls("required")` it denies, which is safe. Under the opt-in default it
+ * replicates on its own `where` alone — so an app whose `messages` table is
+ * tenant-scoped on every query, and whose shape only narrows to a channel, went
+ * from `{ AND: [{ channelId }, { tenantId }] }` to `{ channelId }` with no error
+ * and no diagnostic. `assertShapesDeclareReadPolicies` is what makes that loud:
+ * codegen stamps it into the generated shard with the tables the project's
+ * `rls()` chains govern on read, and it refuses to boot.
+ */
+describe("assertShapesDeclareReadPolicies", () => {
+    const tenantMessages = definePolicy({
+        on: "read",
+        table: "messages",
+        when: ({ auth }) => {
+            return { tenantId: (auth.identity as null | { tenantId?: string })?.tenantId };
+        },
+    });
+
+    const channelMessages = defineShape({
+        table: "messages",
+        where: () => {
+            return { channelId: "c1" };
+        },
+    });
+
+    it("a guard-less shape on a governed table replicates unfiltered — and is refused at boot", () => {
+        expect.assertions(3);
+
+        // The fail-open, concretely: the project's tenant policy exists (a query
+        // declares it), the shape declares no `use`, and what replicates is the
+        // channel filter alone — every tenant's messages in that channel.
+        const composed = composeShapeReadWhere(channelMessages.rlsRegistry, {
+            ctx: {},
+            identity: { tenantId: "t1" },
+            rlsRequired: false,
+            shapeWhere: { channelId: "c1" },
+            table: "messages",
+            tablePublic: false,
+            userId: "u1",
+        });
+
+        expect(composed).toStrictEqual({ channelId: "c1" });
+
+        // The equivalent query IS tenant-scoped, which is the asymmetry.
+        const viaQuery = buildRlsReadRegistry([guardedQuery(definePolicies([tenantMessages]))]);
+
+        expect(
+            composeShapeReadWhere(viaQuery, {
+                ctx: {},
+                identity: { tenantId: "t1" },
+                rlsRequired: false,
+                shapeWhere: { channelId: "c1" },
+                table: "messages",
+                tablePublic: false,
+                userId: "u1",
+            }),
+        ).toStrictEqual({ AND: [{ tenantId: "t1" }, { channelId: "c1" }] });
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ channelMessages }, ["messages"], false);
+        }).toThrow(/"channelMessages" \(table "messages"\)/u);
+    });
+
+    it("accepts a shape that names its guards, and `use: []` as the explicit acknowledgement", () => {
+        expect.assertions(2);
+
+        const guarded = defineShape({
+            table: "messages",
+            use: [rls(definePolicies([tenantMessages]))],
+            where: () => {
+                return { channelId: "c1" };
+            },
+        });
+        const acknowledged = defineShape({
+            table: "messages",
+            use: [],
+            where: () => {
+                return { channelId: "c1" };
+            },
+        });
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ guarded }, ["messages"], false);
+        }).not.toThrow();
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ acknowledged }, ["messages"], false);
+        }).not.toThrow();
+    });
+
+    it("stays quiet for an ungoverned table, and under .rls('required') where the omission already denies", () => {
+        expect.assertions(2);
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ channelMessages }, ["notes"], false);
+        }).not.toThrow();
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ channelMessages }, ["messages"], true);
+        }).not.toThrow();
     });
 });

--- a/packages/server/__tests__/rls-shape-read-base.test.ts
+++ b/packages/server/__tests__/rls-shape-read-base.test.ts
@@ -433,6 +433,40 @@ describe("assertShapesDeclareReadPolicies", () => {
         }).not.toThrow();
     });
 
+    /**
+     * A non-empty `use` used to satisfy the check on its own, which is the same
+     * fail-open one level down: what the list has to produce is a READ-policy
+     * group for THIS shape's table. A guard for a different table, or a plain
+     * authorization middleware a shape cannot even run, produces none — so the
+     * shape replicates on its own `where` alone, exactly as if `use` were absent.
+     */
+    it("refuses a `use` list whose guards declare no read policy for the shape's own table", () => {
+        expect.assertions(2);
+
+        const otherTable = defineShape({
+            table: "messages",
+            use: [rls(definePolicies([definePolicy({ on: "read", table: "notes", when: () => true })]))],
+            where: () => {
+                return { channelId: "c1" };
+            },
+        });
+        const notRls = defineShape({
+            table: "messages",
+            use: [({ next }) => next()],
+            where: () => {
+                return { channelId: "c1" };
+            },
+        });
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ otherTable }, ["messages"], false);
+        }).toThrow(/"otherTable" \(table "messages"\)/u);
+
+        expect(() => {
+            assertShapesDeclareReadPolicies({ notRls }, ["messages"], false);
+        }).toThrow(/"notRls" \(table "messages"\)/u);
+    });
+
     it("stays quiet for an ungoverned table, and under .rls('required') where the omission already denies", () => {
         expect.assertions(2);
 

--- a/packages/server/__tests__/rls-shape-read-base.test.ts
+++ b/packages/server/__tests__/rls-shape-read-base.test.ts
@@ -3,16 +3,27 @@
  * security gap).
  *
  * A `defineShape` replicates a table partition to a client but runs NO
- * procedure, so the `.use(rls(...))` middleware never fires. The fix hoists each
- * function's read policies onto `fn.rls` (the procedure builder) and AND-merges
- * the table's read base-where into the shape's predicate at resolve time. These
- * tests pin both halves: the registry build (policy discovery + role union) and
- * the compose (AND-merge, unrestricted pass-through, and fail-closed parity with
- * a `.rls("required")` schema).
+ * procedure, so the `.use(rls(...))` middleware never fires. A shape therefore
+ * names its own guards (`defineShape({ use: [rls(...)] })`), whose read policies
+ * are AND-merged into its predicate at resolve time. These tests pin both
+ * halves: the registry build (policy discovery + per-tag role scoping) and the
+ * compose (AND-merge, unrestricted pass-through, and fail-closed parity with a
+ * `.rls("required")` schema) — plus, at the bottom, that the scope really is
+ * per-shape and not project-wide.
  */
 import { describe, expect, it } from "vitest";
 
-import { buildRlsReadRegistry, composeShapeReadWhere, definePermission, definePolicies, definePolicy, defineRole, initLunora, rls } from "../src/index";
+import {
+    buildRlsReadRegistry,
+    composeShapeReadWhere,
+    definePermission,
+    definePolicies,
+    definePolicy,
+    defineRole,
+    defineShape,
+    initLunora,
+    rls,
+} from "../src/index";
 
 const builders = initLunora.dataModel<unknown>().create();
 
@@ -252,5 +263,79 @@ describe("composeShapeReadWhere", () => {
         });
 
         expect(asUser).toStrictEqual({ AND: [{ ownerId: "u1" }, shapeWhere] });
+    });
+});
+
+/**
+ * A shape's read policies are the ones IT declares, not the project's.
+ *
+ * The registry ORs its groups and treats an unrestricted group as unrestricting
+ * the whole table, so a registry folded from every registered function collapsed
+ * a tenant shape's filter to nothing the moment ANY procedure named the table
+ * with an allow-all read policy — typically an admin listing whose real gate is
+ * a `requireAdmin` middleware a shape cannot run. Every row then replicated to
+ * every socket.
+ */
+describe("defineShape — RLS scope is the shape's own use() guards", () => {
+    const tenantDocs = definePolicy({
+        on: "read",
+        table: "docs",
+        when: ({ auth }) => {
+            return { ownerId: auth.userId };
+        },
+    });
+    const anyDoc = definePolicy({ on: "read", table: "docs", when: () => true });
+
+    const request = { ctx: {}, identity: null, rlsRequired: false, shapeWhere: {}, table: "docs", tablePublic: false, userId: "u1" } as const;
+
+    it("keeps a shape's tenant filter when an unrelated procedure declares an allow-all read policy", () => {
+        expect.assertions(2);
+
+        const tenantGuard = rls(definePolicies([tenantDocs]));
+        const shape = defineShape({
+            table: "docs",
+            use: [tenantGuard],
+            where: () => {
+                return {};
+            },
+        });
+
+        // The project ALSO registers an admin-only listing with an allow-all
+        // policy. Folding both into one registry is what used to happen.
+        const projectWide = buildRlsReadRegistry([guardedQuery(definePolicies([tenantDocs])), guardedQuery(definePolicies([anyDoc]))]);
+
+        expect(composeShapeReadWhere(projectWide, request)).toStrictEqual({});
+
+        expect(composeShapeReadWhere(shape.rlsRegistry, request)).toStrictEqual({ ownerId: "u1" });
+    });
+
+    it("composes several declared guards, and ignores non-rls middlewares in the list", () => {
+        expect.assertions(1);
+
+        const noop = async ({ next }: { next: () => Promise<unknown> }) => next();
+        const shape = defineShape({
+            table: "docs",
+            use: [rls(definePolicies([tenantDocs])), noop as never],
+            where: () => {
+                return { archived: false };
+            },
+        });
+
+        expect(composeShapeReadWhere(shape.rlsRegistry, { ...request, shapeWhere: { archived: false } })).toStrictEqual({
+            AND: [{ ownerId: "u1" }, { archived: false }],
+        });
+    });
+
+    it("replicates nothing under .rls('required') when a shape declares no guard for a protected table", () => {
+        expect.assertions(1);
+
+        const shape = defineShape({
+            table: "docs",
+            where: () => {
+                return {};
+            },
+        });
+
+        expect(composeShapeReadWhere(shape.rlsRegistry, { ...request, rlsRequired: true })).toStrictEqual({ OR: [] });
     });
 });

--- a/packages/server/__tests__/rls.test.ts
+++ b/packages/server/__tests__/rls.test.ts
@@ -1706,6 +1706,22 @@ describe("rls — analytical reads (baseWhere on the full facade)", () => {
         await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toMatchObject({ isDone: true });
     });
 
+    it("forwards the caller's own rank() baseWhere untouched — the guard contributes none", async () => {
+        expect.assertions(1);
+
+        // `assertUnrestrictedReadBase` is a check, not a producer: reaching past it
+        // means the read base is unrestricted, so there is nothing to AND in and the
+        // caller's `options` go through as written.
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([allowAllPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("documents", "byScore", { baseWhere: { ownerId: "u1" }, row: "d1" }));
+
+        await handler.handler(makeContext(database, "u1"), {});
+
+        expect(database.calls.find((entry) => entry.method === "rank")?.args).toStrictEqual({ baseWhere: { ownerId: "u1" }, row: "d1" });
+    });
+
     it("serves rank() under a read policy whose predicate is an empty (match-everything) WhereInput", async () => {
         expect.assertions(1);
 

--- a/packages/server/__tests__/rls.test.ts
+++ b/packages/server/__tests__/rls.test.ts
@@ -539,7 +539,7 @@ describe("rls — read path", () => {
         expect((database.calls.at(-1)?.args as { baseWhere?: unknown }).baseWhere).toBeUndefined();
     });
 
-    it("count() throws COUNT_RLS_UNSUPPORTED when a policy applies", async () => {
+    it("count() throws COUNT_RLS_UNSUPPORTED when a policy narrows the table", async () => {
         expect.hasAssertions();
 
         // We can't observe the underlying LunoraError here without wiring the
@@ -547,10 +547,15 @@ describe("rls — read path", () => {
         // *passes* `restrictsCounts: true` down to the writer — the ORM is
         // responsible for converting that into the thrown LunoraError, and
         // we assert that in the ORM tests below.
+        //
+        // The policy has to NARROW for the flag to be set; an allow-all read
+        // policy leaves the count exactly computable and is asserted separately.
         const policy = definePolicy<TestContext>({
             on: "read",
             table: "documents",
-            when: () => true,
+            when: () => {
+                return { ownerId: "u1" };
+            },
         });
         const database = createFakeDatabase([]);
 
@@ -1651,6 +1656,75 @@ describe("rls — analytical reads (baseWhere on the full facade)", () => {
         const call = database.calls.find((entry) => entry.method === "groupBy");
 
         expect(call?.args).toMatchObject({ baseWhere: { ownerId: "u1" }, by: ["status"] });
+    });
+
+    /**
+     * A read policy that grants unconditionally for this request produces no
+     * `baseWhere`: the caller sees the whole partition, so a count or a rank
+     * over it is exact. Failing those closed on the mere PRESENCE of a policy
+     * made `count()`/`rank()`/`rankPage()` unreachable from the very procedures
+     * the policy admits — including every admin/`can(...)` branch.
+     */
+    const allowAllPolicy = definePolicy<TestContext>({ on: "read", table: "documents", when: () => true });
+
+    it("serves count() under an allow-all read policy without flagging restrictsCounts", async () => {
+        expect.assertions(2);
+
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([allowAllPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.count("documents"));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toBe(1);
+
+        const call = database.calls.find((entry) => entry.method === "count");
+
+        expect((call?.args as { restrictsCounts?: boolean }).restrictsCounts).toBe(false);
+    });
+
+    it("serves rank() under an allow-all read policy", async () => {
+        expect.assertions(2);
+
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([allowAllPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("documents", "byScore", { row: "d1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toMatchObject({ position: 1 });
+
+        expect(database.calls.some((entry) => entry.method === "rank")).toBe(true);
+    });
+
+    it("serves rankPage() under an allow-all read policy", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([allowAllPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPage("documents", "byScore"));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toMatchObject({ isDone: true });
+    });
+
+    it("serves rank() under a read policy whose predicate is an empty (match-everything) WhereInput", async () => {
+        expect.assertions(1);
+
+        // `{}` matches every row and `mergeBaseWhere` already drops it, so the
+        // fail-closed guard has to read it the same way or it blocks a rank it
+        // does not restrict.
+        const emptyPredicate = definePolicy<TestContext>({
+            on: "read",
+            table: "documents",
+            when: () => {
+                return {};
+            },
+        });
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([emptyPredicate]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("documents", "byScore", { row: "d1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toMatchObject({ position: 1 });
     });
 
     it("fails rank() closed with COUNT_RLS_UNSUPPORTED under a read policy", async () => {

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -183,8 +183,8 @@ would be.
 Declare a **shape**: a named, partial replication of a table for the
 [local-first sync engine](/docs/concepts/local-first). A client subscribes by
 name + validated `args`; the DO resolves the predicate server-side and
-AND-composes it with the table's RLS read base-where. Declared in
-`lunora/shapes.ts`.
+AND-composes it with the read policies the shape itself declares (`use`).
+Declared in `lunora/shapes.ts`.
 
 ```ts title="lunora/shapes.ts"
 import { defineShape, v } from "@lunora/server";
@@ -192,6 +192,7 @@ import { defineShape, v } from "@lunora/server";
 export const messagesByChannel = defineShape({
     table: "messages",
     args: { channelId: v.id("channels") }, // optional — omit for a parameterless shape
+    use: [tenantScoped], // the rls(...) guards whose read policies gate this shape
     where: (ctx, { channelId }) => ({ channelId }), // runs on the DO with a trusted ctx
     columns: ["text", "authorId", "channelId"], // optional projection; _id/_creationTime always included
 });
@@ -199,8 +200,16 @@ export const messagesByChannel = defineShape({
 
 `where` returns the same `WhereInput` the RLS DSL uses, so there is no second
 predicate implementation. Because it runs with an identity the client can't
-forge, a shape is a _read-as-permission_. See
-[Local-first sync](/docs/concepts/local-first#shapes--partial-replication).
+forge, a shape is a _read-as-permission_.
+
+RLS on a shape is **opt-in through `use`**, exactly as it is on a procedure: a
+shape runs no procedure, so policies declared elsewhere in the project never
+reach it. A shape that names no guard replicates on its `where` alone — under
+`.rls("required")` that is a hard denial for a non-`.public()` table, and
+otherwise codegen refuses to boot the app when the shape's table is governed on
+read, naming the shape and the table (`use: []` acknowledges a deliberately
+ungoverned shape). See
+[Local-first sync](/docs/concepts/local-first#opting-a-shape-into-rls-use).
 
 ## `defineMutator(definition)` — custom mutators
 

--- a/packages/server/src/builder/run-middleware.ts
+++ b/packages/server/src/builder/run-middleware.ts
@@ -50,73 +50,44 @@ const runMiddlewareChain = async (
             return terminal(context);
         }
 
-        // A holder rather than plain `let`s: both fields are written inside
-        // `next`, and control-flow analysis would otherwise pin a local to its
-        // initializer and read the checks below as statically true.
-        const downstream: { observed: boolean; promise: Promise<unknown> | undefined } = { observed: false, promise: undefined };
+        // A holder rather than a plain `let`: the field is written inside `next`,
+        // and control-flow analysis would otherwise pin a local to its
+        // initializer and read the check below as statically true.
+        const downstream: { promise: Promise<unknown> | undefined } = { promise: undefined };
 
         const next = ((options?: { ctx: Record<string, unknown> }) => {
-            const running = dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context);
+            downstream.promise = dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context);
 
-            downstream.promise = running;
-
-            // Hand back a thenable rather than `running` itself. Whether the
-            // middleware READ the downstream result is the one bit that separates
-            // the two shapes below, and a bare native promise offers no hook to
-            // observe it — `await p` unwraps a native promise through an internal
-            // slot, never through its `then`. A plain thenable has no such slot,
-            // so `await` has to go through the `then` below, which is the signal.
-            //
-            //   `return await next()`, or `try { return await next() } catch
-            //   { return fallback }` — observed. The middleware owns the outcome,
-            //   including a rejection it deliberately swallowed; awaiting
-            //   `downstream.promise` again below would re-throw what it just
-            //   handled and break error-handling middleware.
-            //
-            //   `void next(); return ctx;` — NOT observed. Only the flag was set,
-            //   so the old guard passed while the chain resolved early: the handler
-            //   ran against a context the later `.use()` steps had not finished
-            //   building, and a downstream rejection detached into an unhandled
-            //   rejection. That is the case the await below closes.
-            //
-            // A `Proxy` over `running` is the other way to see the read, and the
-            // one this started as; it measured ~15% slower per guarded call than
-            // the literal, on a path `__bench__/rls-overhead.bench.ts` watches.
-            const observable: Promise<unknown> = {
-                [Symbol.toStringTag]: "Promise",
-                catch: (onRejected) => {
-                    downstream.observed = true;
-
-                    return running.catch(onRejected);
-                },
-                finally: (onFinally) => {
-                    downstream.observed = true;
-
-                    return running.finally(onFinally);
-                },
-                // eslint-disable-next-line unicorn/no-thenable -- deliberate: `then` IS the interface here, and being awaited through it rather than unwrapped as a native promise is the whole mechanism
-                then: (onFulfilled, onRejected) => {
-                    downstream.observed = true;
-
-                    return running.then(onFulfilled, onRejected);
-                },
-            };
-
-            return observable;
+            return downstream.promise;
         }) as MiddlewareNext<unknown>;
 
         const result = await middleware({ ctx: context, next });
 
-        if (!downstream.promise) {
+        if (downstream.promise === undefined) {
             throw new LunoraError(
                 "INTERNAL",
                 `middleware at position ${String(index)} resolved without calling next(): every later .use() step (rls/mask/storageRules) and the handler's context were skipped. Return next() — or next({ ctx }) to extend the context — and throw to deny.`,
             );
         }
 
-        if (!downstream.observed) {
-            await downstream.promise;
-        }
+        // Await the rest of the chain unconditionally, INCLUDING when the
+        // middleware already awaited it and swallowed a rejection.
+        //
+        // `void next(); return ctx;` satisfied the check above while the chain
+        // resolved early — the handler then ran against a context the later
+        // `.use()` steps had not finished building, and a downstream rejection
+        // detached into an unhandled rejection.
+        //
+        // Re-throwing something a middleware deliberately caught is the point,
+        // not a cost. The terminal here only BUILDS the context
+        // (`(context) => context` in the builder; the composer forwards to its
+        // surrounding `next`) and the handler runs after this resolves — so a
+        // rejection reaching here is never a handler error a middleware might
+        // legitimately recover from. It is a later middleware refusing: an
+        // `rls()` denial, or this very guard firing one link down. Letting a
+        // link swallow that and return a fallback context is the authorization
+        // bypass this function exists to prevent.
+        await downstream.promise;
 
         return result;
     };

--- a/packages/server/src/builder/run-middleware.ts
+++ b/packages/server/src/builder/run-middleware.ts
@@ -20,6 +20,12 @@ import type { Middleware, MiddlewareNext } from "./types";
  * into a bare `TypeError` deeper in the handler. To deny a request, THROW (a
  * `LunoraError("FORBIDDEN")`); to change the context, `return next({ ctx })`.
  *
+ * Calling `next()` without awaiting it (`void next(); return ctx;`) is the same
+ * bypass one step subtler — the call happened, but the chain would resolve while
+ * the rest of it is still running. A link that never read its `next()` result is
+ * therefore held open until the downstream chain settles, and a rejection it
+ * dropped is propagated rather than left to detach (see `next` below).
+ *
  * `terminal` runs when the chain is exhausted, with the fully accumulated
  * context: the builder returns it verbatim; the plugin composer hands it to the
  * surrounding builder's own `next` so the composed unit is transparent.
@@ -44,24 +50,72 @@ const runMiddlewareChain = async (
             return terminal(context);
         }
 
-        // A holder rather than a plain `let`: the flag is written inside `next`,
-        // and control-flow analysis would otherwise pin a local to its
-        // initializer and read the check below as statically true.
-        const advanced = { byThisLink: false };
+        // A holder rather than plain `let`s: both fields are written inside
+        // `next`, and control-flow analysis would otherwise pin a local to its
+        // initializer and read the checks below as statically true.
+        const downstream: { observed: boolean; promise: Promise<unknown> | undefined } = { observed: false, promise: undefined };
 
         const next = ((options?: { ctx: Record<string, unknown> }) => {
-            advanced.byThisLink = true;
+            const running = dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context);
 
-            return dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context);
+            downstream.promise = running;
+
+            // Hand back a thenable rather than `running` itself. Whether the
+            // middleware READ the downstream result is the one bit that separates
+            // the two shapes below, and a bare native promise offers no hook to
+            // observe it — `await p` unwraps a native promise through an internal
+            // slot, never through its `then`. A plain thenable has no such slot,
+            // so `await` has to go through the `then` below, which is the signal.
+            //
+            //   `return await next()`, or `try { return await next() } catch
+            //   { return fallback }` — observed. The middleware owns the outcome,
+            //   including a rejection it deliberately swallowed; awaiting
+            //   `downstream.promise` again below would re-throw what it just
+            //   handled and break error-handling middleware.
+            //
+            //   `void next(); return ctx;` — NOT observed. Only the flag was set,
+            //   so the old guard passed while the chain resolved early: the handler
+            //   ran against a context the later `.use()` steps had not finished
+            //   building, and a downstream rejection detached into an unhandled
+            //   rejection. That is the case the await below closes.
+            //
+            // A `Proxy` over `running` is the other way to see the read, and the
+            // one this started as; it measured ~15% slower per guarded call than
+            // the literal, on a path `__bench__/rls-overhead.bench.ts` watches.
+            const observable: Promise<unknown> = {
+                [Symbol.toStringTag]: "Promise",
+                catch: (onRejected) => {
+                    downstream.observed = true;
+
+                    return running.catch(onRejected);
+                },
+                finally: (onFinally) => {
+                    downstream.observed = true;
+
+                    return running.finally(onFinally);
+                },
+                // eslint-disable-next-line unicorn/no-thenable -- deliberate: `then` IS the interface here, and being awaited through it rather than unwrapped as a native promise is the whole mechanism
+                then: (onFulfilled, onRejected) => {
+                    downstream.observed = true;
+
+                    return running.then(onFulfilled, onRejected);
+                },
+            };
+
+            return observable;
         }) as MiddlewareNext<unknown>;
 
         const result = await middleware({ ctx: context, next });
 
-        if (!advanced.byThisLink) {
+        if (!downstream.promise) {
             throw new LunoraError(
                 "INTERNAL",
                 `middleware at position ${String(index)} resolved without calling next(): every later .use() step (rls/mask/storageRules) and the handler's context were skipped. Return next() — or next({ ctx }) to extend the context — and throw to deny.`,
             );
+        }
+
+        if (!downstream.observed) {
+            await downstream.promise;
         }
 
         return result;

--- a/packages/server/src/builder/run-middleware.ts
+++ b/packages/server/src/builder/run-middleware.ts
@@ -10,6 +10,16 @@ import type { Middleware, MiddlewareNext } from "./types";
  * guard both the builder's `.use()` chain and the plugin-middleware composer
  * must share so they behave identically.
  *
+ * Resolving WITHOUT calling `next()` is the same class of error and throws too.
+ * A middleware is not a short-circuit: the chain's terminal is what produces the
+ * handler's context, so a link that returns `ctx` instead of `next()` skipped
+ * every later `.use()` — `rls()`, `mask()`, `storageRules()` — and the handler
+ * then ran against the UNWRAPPED `ctx.db` while `fn.rls` stayed hoisted, so
+ * studio and the shape registry still reported the procedure as guarded. That is
+ * a silent authorization bypass, and returning `undefined` instead only turned it
+ * into a bare `TypeError` deeper in the handler. To deny a request, THROW (a
+ * `LunoraError("FORBIDDEN")`); to change the context, `return next({ ctx })`.
+ *
  * `terminal` runs when the chain is exhausted, with the fully accumulated
  * context: the builder returns it verbatim; the plugin composer hands it to the
  * surrounding builder's own `next` so the composed unit is transparent.
@@ -34,10 +44,27 @@ const runMiddlewareChain = async (
             return terminal(context);
         }
 
-        const next = ((options?: { ctx: Record<string, unknown> }) =>
-            dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context)) as MiddlewareNext<unknown>;
+        // A holder rather than a plain `let`: the flag is written inside `next`,
+        // and control-flow analysis would otherwise pin a local to its
+        // initializer and read the check below as statically true.
+        const advanced = { byThisLink: false };
 
-        return await middleware({ ctx: context, next });
+        const next = ((options?: { ctx: Record<string, unknown> }) => {
+            advanced.byThisLink = true;
+
+            return dispatch(index + 1, options?.ctx ? { ...(context as Record<string, unknown>), ...options.ctx } : context);
+        }) as MiddlewareNext<unknown>;
+
+        const result = await middleware({ ctx: context, next });
+
+        if (!advanced.byThisLink) {
+            throw new LunoraError(
+                "INTERNAL",
+                `middleware at position ${String(index)} resolved without calling next(): every later .use() step (rls/mask/storageRules) and the handler's context were skipped. Return next() — or next({ ctx }) to extend the context — and throw to deny.`,
+            );
+        }
+
+        return result;
     };
 
     return dispatch(0, baseContext);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -76,12 +76,14 @@ export type {
     RlsOptions,
     RlsReadRegistry,
     Role,
+    ShapeGuardDeclaration,
     ShapeReadWhereRequest,
     TypedDefinePolicyInput,
     WhereInput,
 } from "./rls/index";
 export {
     allowAll,
+    assertShapesDeclareReadPolicies,
     buildRlsReadRegistry,
     composeShapeReadWhere,
     createPolicyDsl,

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -600,6 +600,13 @@ const wrapDatabase = <Context>(
      * row and probe the masked tables concurrently. Only masked tables are
      * probed: a row in no masked table needs no masking. The unwrapped `base.*`
      * is used so the probe itself isn't masked.
+     *
+     * A `lookupById` MISS falls through to the probe path instead of answering
+     * "absent": the seam is shard-local, so a `.global()` row always misses it
+     * and only `get`/`findFirst` reach those rows (through the writer's global
+     * fallback). Treating the miss as absent made `ctx.db.get(id)` return `null`
+     * for every global row inside a `mask()` procedure. The fast path still
+     * settles the common case — a shard-local hit — in one round-trip.
      */
     const locate = async (id: string, expectedTable?: string): Promise<{ row: null | Record<string, unknown>; tableName: string | undefined }> => {
         if (base.lookupById) {
@@ -608,12 +615,9 @@ const wrapDatabase = <Context>(
             // mask (IDOR).
             const located = await base.lookupById(id, expectedTable);
 
-            if (!located) {
-                // eslint-disable-next-line unicorn/no-null -- absent row mirrors @lunora/do's writer null sentinel
-                return { row: null, tableName: undefined };
+            if (located) {
+                return { row: located.row, tableName: perTable.has(located.tableName) ? located.tableName : undefined };
             }
-
-            return { row: located.row, tableName: perTable.has(located.tableName) ? located.tableName : undefined };
         }
 
         const row = await base.get(id, expectedTable);

--- a/packages/server/src/rls/index.ts
+++ b/packages/server/src/rls/index.ts
@@ -48,8 +48,8 @@
 export { createPolicyDsl, definePermission, definePolicies, definePolicy, defineRole } from "./define";
 export { rls } from "./middleware";
 export { allowAll, deny, isDeny, toWhereInput } from "./predicates";
-export type { RlsReadRegistry, ShapeReadWhereRequest } from "./shape-read-base";
-export { buildRlsReadRegistry, composeShapeReadWhere } from "./shape-read-base";
+export type { RlsReadRegistry, ShapeGuardDeclaration, ShapeReadWhereRequest } from "./shape-read-base";
+export { assertShapesDeclareReadPolicies, buildRlsReadRegistry, composeShapeReadWhere } from "./shape-read-base";
 export type {
     DefinePolicyInput,
     Permission,

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -893,11 +893,24 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
      * keeps the common case — a shard-local row that hits — at the ONE round-trip
      * the seam exists for, and charges the extra probes only to a miss.
      *
+     * `probeTable` narrows the FALLBACK probe set without pinning the lookup.
+     * `expectedTable` does both, which `deleteAll`/`deleteWhere` cannot use: a
+     * pinned table blocks the writer's global fallback and turns every delete on
+     * a `.global()` table into a silent no-op. Those callers know the table
+     * anyway (their ids came from that table's own filtered read), so they pass
+     * it here instead — one probe per row rather than one per policy-gated
+     * table, which is what put a chunked erase into workerd's 1000-subrequest
+     * ceiling partway through.
+     *
      * `row` is `null` when the id doesn't exist. `tableName` is `undefined` when
      * the row exists but isn't in any policy-gated table (no policy applies →
      * callers fall through unrestricted).
      */
-    const locateRow = async (id: string, expectedTable?: string): Promise<{ row: null | Record<string, unknown>; tableName: string | undefined }> => {
+    const locateRow = async (
+        id: string,
+        expectedTable?: string,
+        probeTable?: string,
+    ): Promise<{ row: null | Record<string, unknown>; tableName: string | undefined }> => {
         if (raw.lookupById) {
             // Pin the lookup to the bound table when the by-id facade forwards
             // one, so a foreign id resolves to "absent" rather than another
@@ -924,10 +937,11 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
 
         // Ids are globally unique, so at most one probe hits; settle all of
         // them in parallel and pick the hit instead of serializing the
-        // round-trips. When the facade pinned a table, only that table's policy
-        // can apply — restrict the probe set to it.
-        const pinnedProbe = expectedTable !== undefined && policyTables.has(expectedTable) ? [expectedTable] : [];
-        const probeTables = expectedTable === undefined ? [...policyTables] : pinnedProbe;
+        // round-trips. When the caller named a table — pinned via `expectedTable`
+        // or scoped via `probeTable` — only that table's policy can apply, so the
+        // probe set is that one table (or none, when it carries no policy).
+        const scopedTable = expectedTable ?? probeTable;
+        const probeTables = scopedTable === undefined ? [...policyTables] : [scopedTable].filter((table) => policyTables.has(table));
         const probes = await Promise.all(
             probeTables.map(async (tableName) => {
                 const probe = await raw.findFirst(tableName, { limit: 1, where: { _id: id } });
@@ -944,8 +958,12 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
      * wrapper over {@link locateRow} that drops the unguarded-row case — a write
      * to a row in no policy-gated table needs no policy check.
      */
-    const findRowTable = async (id: string, expectedTable?: string): Promise<undefined | { row: Record<string, unknown>; tableName: string }> => {
-        const located = await locateRow(id, expectedTable);
+    const findRowTable = async (
+        id: string,
+        expectedTable?: string,
+        probeTable?: string,
+    ): Promise<undefined | { row: Record<string, unknown>; tableName: string }> => {
+        const located = await locateRow(id, expectedTable, probeTable);
 
         return located.row && located.tableName !== undefined ? { row: located.row, tableName: located.tableName } : undefined;
     };
@@ -975,8 +993,9 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
         perform: (writer: RlsDatabase) => Promise<R>,
         computeNextRow?: (preRow: Record<string, unknown>) => Record<string, unknown>,
         expectedTable?: string,
+        probeTable?: string,
     ): Promise<R> => {
-        const located = await findRowTable(id, expectedTable);
+        const located = await findRowTable(id, expectedTable, probeTable);
 
         if (!located) {
             // The id is in no policy-gated table (a non-policy table or absent).
@@ -1086,10 +1105,22 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
                     // survive. It costs nothing here: these ids came from this table's
                     // own policy-filtered read, so they are provably its rows, and
                     // `gateById` still resolves each row's real table and applies that
-                    // table's delete policy. Same reasoning as `deleteWhere`, which hands
-                    // its ids to `deleteMany` unpinned.
+                    // table's delete policy. Same reasoning as `deleteWhere`.
+                    //
+                    // `tableName` rides along as the PROBE scope, which pins nothing:
+                    // unpinned, a row that misses the shard-local `lookupById` seam is
+                    // probed against every policy-gated table, so a chunked erase of N
+                    // global rows costs N × (policy tables) subrequests and trips
+                    // workerd's 1000-subrequest ceiling mid-erase.
                     // eslint-disable-next-line no-await-in-loop -- sequential per-row policy gate, mirrors looped single deletes
-                    await gateById(id, "delete", (writer) => writer.delete(id, undefined, options?.hard === undefined ? undefined : { hard: options.hard }));
+                    await gateById(
+                        id,
+                        "delete",
+                        (writer) => writer.delete(id, undefined, options?.hard === undefined ? undefined : { hard: options.hard }),
+                        undefined,
+                        undefined,
+                        tableName,
+                    );
                     deleted += 1;
                 }
 
@@ -1132,7 +1163,17 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
 
             assertBatchLimit(ids.length, options?.limit, "deleteWhere");
 
-            return wrapped.deleteMany(ids, options);
+            // Gated per id here rather than through `deleteMany` so `tableName` can
+            // ride along as the probe scope: `expectedTable` must stay unpinned (it
+            // would block the writer's global fallback and make every global delete a
+            // silent no-op), and unpinned means every policy-gated table gets probed
+            // for every row. See `locateRow`.
+            for (const id of ids) {
+                // eslint-disable-next-line no-await-in-loop -- sequential per-row policy gate, mirrors looped single deletes
+                await gateById(id, "delete", (writer) => writer.delete(id), undefined, undefined, tableName);
+            }
+
+            return { deleted: ids.length };
         },
 
         async findFirst(tableName, args) {

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -14,8 +14,11 @@
  * and the reduction only sees policy-visible rows. `count` and the rank family
  * (`rank`/`rankBefore`/`rankPage`) are counts-of-partition that can't be safely
  * narrowed, so they fail closed with `COUNT_RLS_UNSUPPORTED` (kitcn's
- * documented constraint). Every method the wrapper doesn't override (e.g.
- * `normalizeId`, `system`) passes through untouched.
+ * documented constraint) — but only when the request's policies actually
+ * NARROW the table. A read policy that resolves to `true` here (an admin
+ * branch, a permission grant, a plain allow-all) yields no `baseWhere`, the
+ * count is exact, and it is served. Every method the wrapper doesn't override
+ * (e.g. `normalizeId`, `system`) passes through untouched.
  *
  * 2. **Writes** — wraps `insert`/`patch`/`replace`/`delete`. For an
  * `update`/`delete` it fetches the pre-write row through the *unwrapped* writer
@@ -28,6 +31,12 @@
  * chain includes this middleware. The `rls()` call site is the boundary;
  * procedures without it see the unwrapped `ctx.db` and ignore every policy in
  * the list. This is by design (PLAN2 §3.2).
+ *
+ * 4. **Composition** — several `rls()` steps in one chain COMPOSE. Reads
+ * AND-merge (each step narrows further; within a step the table's policies
+ * still OR) and a write must be allowed by every step that gates its table.
+ * A later step can therefore only tighten what an earlier one permitted, never
+ * widen it.
  *
  * What it deliberately does **not** touch:
  *
@@ -350,6 +359,52 @@ const FALSE_PREDICATE: WhereInput = deny();
 const RLS_UNWRAP_SYMBOL = Symbol.for("lunora.ctxdb.rls-unwrap");
 
 /**
+ * Key a wrapped writer carries its own accumulated policy chain under, so a
+ * SECOND `.use(rls(...))` step composes with the first instead of replacing it.
+ *
+ * Without it the second step recovered the raw writer and wrapped THAT, routing
+ * around step one entirely — a `rls([tenantScope])` followed by any other
+ * `rls(...)` served the whole table. Multiple steps are a supported shape
+ * (`protectPublic({ use })`, `composePluginMiddleware`, plain chained `.use`),
+ * so the chain has to be visible to the next step. Non-enumerable for the same
+ * reason {@link RLS_UNWRAP_SYMBOL} is: the wrapper is republished by spread.
+ *
+ * A `mask()` step BETWEEN two `rls()` steps ends the chain, on purpose. `mask()`
+ * republishes `ctx.db` by spread, which does not carry a non-enumerable key, so
+ * the second `rls()` wraps the MASK wrapper instead of resuming. That nesting is
+ * the correct one: resuming from the pre-mask writers would route policy tables
+ * around the mask and hand back the columns it redacts. The cost is that under
+ * `.rls("required")` a table only the LATER step gates is then reached through
+ * the earlier wrapper, which does not know it and defers to the guard — so it
+ * denies. Fail-closed, and the remedy is to declare both tables in one bundle.
+ */
+const RLS_CHAIN_SYMBOL = Symbol.for("lunora.rls.wrapped-chain");
+
+/**
+ * One `.use(rls(...))` step: the policies it declared, indexed by table, plus
+ * the request context they evaluate under. Contexts are erased to `unknown`
+ * because a chain's steps are independently typed — the same erasure the policy
+ * tag already applies (see {@link tagRlsMiddleware}).
+ */
+interface RlsStep {
+    readonly context: PolicyContext;
+    readonly perTable: ReadonlyMap<string, ReadonlyArray<Policy>>;
+}
+
+/** The chain a wrapped writer republishes so the next `rls()` step can extend it. */
+interface RlsChain {
+    /** The writer the FIRST step was handed — the guarded one under `.rls("required")`. */
+    readonly base: RlsDatabase;
+    /** The unwrapped writer every step's authorized reads/writes route through. */
+    readonly raw: RlsDatabase;
+    readonly steps: ReadonlyArray<RlsStep>;
+}
+
+/** Read the accumulated chain off a writer a previous `rls()` step wrapped; `undefined` for a bare writer. */
+const readChain = (database: RlsDatabase): RlsChain | undefined =>
+    (database as unknown as Record<PropertyKey, unknown>)[RLS_CHAIN_SYMBOL] as RlsChain | undefined;
+
+/**
  * Collect a per-table map from a flat policy list. Order within each table
  * is preserved so the merge below honors author-declared precedence.
  */
@@ -629,8 +684,27 @@ const intoCountArgs = (argument: CountArgs | undefined | WhereInput): CountArgs 
     return { where: argument as WhereInput };
 };
 
+/**
+ * Whether a computed read base actually narrows the rows a caller sees.
+ * `undefined` is "no policy predicate"; an EMPTY `WhereInput` is a predicate
+ * that matches every row, which {@link mergeBaseWhere} already drops on the
+ * floor — so the two are the same answer, and the count/rank fail-closed guard
+ * has to agree with the merge or a `when: () => ({})` policy would block counts
+ * it does not restrict.
+ */
+const narrowsReads = (baseWhere: undefined | WhereInput): baseWhere is WhereInput => baseWhere !== undefined && Object.keys(baseWhere).length > 0;
+
+/** AND together the per-step read bases of one table; `undefined` when no step contributed a predicate. */
+const intersectBaseWheres = (predicates: WhereInput[]): undefined | WhereInput => {
+    if (predicates.length === 0) {
+        return undefined;
+    }
+
+    return predicates.length === 1 ? predicates[0] : { AND: predicates };
+};
+
 const mergeBaseWhere = (caller: undefined | WhereInput, injected: undefined | WhereInput): undefined | WhereInput => {
-    if (!injected || Object.keys(injected).length === 0) {
+    if (!narrowsReads(injected)) {
         return caller;
     }
 
@@ -675,8 +749,19 @@ const isFacadeEntry = (value: unknown): value is Record<string, unknown> => {
  * middleware's own policy-filtered reads/writes and membership probes don't
  * trip the guard. For a non-guarded (non-`required`) schema `base === raw`, so
  * the routing is a no-op and behavior is identical to before.
+ *
+ * `steps` is the WHOLE `.use(rls(...))` chain so far, not just this step's
+ * bundle: a second step rebuilds the wrapper over the same `base`/`raw` pair
+ * with its own step appended, so reads AND-compose and a write must satisfy
+ * every step (see `readBase` and `allowsWrite` below). Rebuilding rather than
+ * nesting is what keeps guard routing right — nesting would send a table only
+ * the SECOND step gates back through the first wrapper, which knows nothing
+ * about it and would hand it to the guard.
  */
-const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Map<string, Policy<Context>[]>, context: PolicyContext<Context>): RlsDatabase => {
+const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<RlsStep>): RlsDatabase => {
+    /** Every table any step in the chain gates. Replaces a single step's `perTable.has`. */
+    const policyTables = new Set<string>(steps.flatMap((step) => [...step.perTable.keys()]));
+
     /**
      * Cached effective read `baseWhere` per table. Cached for the lifetime
      * of one wrapped writer — i.e. one request — so a single procedure
@@ -684,6 +769,22 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
      */
     const readBaseCache = new Map<string, { baseWhere: undefined | WhereInput; restricts: boolean }>();
 
+    /**
+     * The effective read filter for a table across the WHOLE chain.
+     *
+     * Within one `rls()` step the table's read policies OR (any matching policy
+     * reveals the row — {@link computeReadBaseWhere}). Across steps they AND:
+     * each `.use(rls(...))` is an additional restriction the request has to
+     * satisfy, exactly like stacking two `WHERE` clauses. A step that grants
+     * unrestricted access (`true`) contributes no predicate, so it narrows
+     * nothing; a step that denies contributes the FALSE sentinel and the AND
+     * denies.
+     *
+     * `restricts` says "some step declares a read policy on this table", which
+     * is what decides guard routing ({@link route}). It is deliberately NOT the
+     * same question as "is the result narrowed" — an allow-all policy on a
+     * protected table restricts nothing yet must still route around the guard.
+     */
     const readBase = (tableName: string): { baseWhere: undefined | WhereInput; restricts: boolean } => {
         const cached = readBaseCache.get(tableName);
 
@@ -691,22 +792,55 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             return cached;
         }
 
-        const policies = perTable.get(tableName);
+        const predicates: WhereInput[] = [];
+        let restricts = false;
 
-        if (!policies || policies.length === 0 || !policies.some((policy) => policy.on === "read")) {
-            const result = { baseWhere: undefined, restricts: false };
+        for (const step of steps) {
+            const policies = step.perTable.get(tableName);
 
-            readBaseCache.set(tableName, result);
+            if (!policies || policies.length === 0 || !policies.some((policy) => policy.on === "read")) {
+                continue;
+            }
 
-            return result;
+            restricts = true;
+
+            const stepBaseWhere = computeReadBaseWhere(policies, step.context);
+
+            if (stepBaseWhere !== undefined) {
+                predicates.push(stepBaseWhere);
+            }
         }
 
-        const baseWhere = computeReadBaseWhere(policies, context);
-        const result = { baseWhere, restricts: true };
+        const result = { baseWhere: intersectBaseWheres(predicates), restricts };
 
         readBaseCache.set(tableName, result);
 
         return result;
+    };
+
+    /**
+     * Run the write policies of every step that gates `tableName` for `op`.
+     * ALL of them must allow — the same "most restrictive wins" rule
+     * {@link evaluateWrite} applies within a step, lifted across the chain, so a
+     * second `.use(rls(...))` can only ever narrow what the first permits.
+     *
+     * A step whose policy bundle never names the table abstains: it neither
+     * grants nor denies. Note the corollary — a step that DOES name the table
+     * but declares no policy for this `op` denies it (`evaluateWrite`'s
+     * default-DENY), so chaining a read-only bundle with a write bundle over the
+     * same table denies the write. Declare the write policy in the same step
+     * that gates the table.
+     */
+    const allowsWrite = (tableName: string, op: Exclude<Policy["on"], "read">, row: Record<string, unknown>, nextRow?: Record<string, unknown>): boolean => {
+        for (const step of steps) {
+            const policies = step.perTable.get(tableName);
+
+            if (policies && !evaluateWrite(policies, op, { ...step.context, row }, nextRow)) {
+                return false;
+            }
+        }
+
+        return true;
     };
 
     /**
@@ -748,6 +882,17 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
      * single probe, not their sum). The unwrapped `base.*` is intentionally
      * used so policy enforcement on writes doesn't recurse through itself.
      *
+     * A `lookupById` MISS falls through to the probe path rather than reporting
+     * "no such row": the seam is shard-local, so every `.global()` row misses it
+     * (those rows live in D1 and only `get`/`findFirst` reach them through the
+     * writer's global fallback). Reporting the miss as absent is what let
+     * `gateById` classify a global row as "in no policy-gated table" and perform
+     * update/delete with the policy never evaluated. Resolving global rows inside
+     * `lookupById` itself was the alternative; it would have to probe every
+     * global table across the D1 hop for a bare id, whereas falling through here
+     * keeps the common case — a shard-local row that hits — at the ONE round-trip
+     * the seam exists for, and charges the extra probes only to a miss.
+     *
      * `row` is `null` when the id doesn't exist. `tableName` is `undefined` when
      * the row exists but isn't in any policy-gated table (no policy applies →
      * callers fall through unrestricted).
@@ -761,13 +906,13 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             // not be denied by the secure-by-default guard.
             const located = await raw.lookupById(id, expectedTable);
 
-            if (!located) {
-                // eslint-disable-next-line unicorn/no-null -- absent row mirrors @lunora/do's writer null sentinel
-                return { row: null, tableName: undefined };
+            if (located) {
+                // Owned by a table that isn't policy-gated → tableName undefined.
+                return { row: located.row, tableName: policyTables.has(located.tableName) ? located.tableName : undefined };
             }
 
-            // Owned by a table that isn't policy-gated → tableName undefined.
-            return { row: located.row, tableName: perTable.has(located.tableName) ? located.tableName : undefined };
+            // A miss is NOT "absent" — see the docblock: a `.global()` row can
+            // only be reached through the probe path below.
         }
 
         const row = await raw.get(id, expectedTable);
@@ -781,8 +926,8 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
         // them in parallel and pick the hit instead of serializing the
         // round-trips. When the facade pinned a table, only that table's policy
         // can apply — restrict the probe set to it.
-        const pinnedProbe = expectedTable !== undefined && perTable.has(expectedTable) ? [expectedTable] : [];
-        const probeTables = expectedTable === undefined ? [...perTable.keys()] : pinnedProbe;
+        const pinnedProbe = expectedTable !== undefined && policyTables.has(expectedTable) ? [expectedTable] : [];
+        const probeTables = expectedTable === undefined ? [...policyTables] : pinnedProbe;
         const probes = await Promise.all(
             probeTables.map(async (tableName) => {
                 const probe = await raw.findFirst(tableName, { limit: 1, where: { _id: id } });
@@ -842,21 +987,16 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             return perform(base);
         }
 
-        const policies = perTable.get(located.tableName);
+        const nextRow = computeNextRow ? computeNextRow(located.row) : undefined;
 
-        if (policies) {
-            const nextRow = computeNextRow ? computeNextRow(located.row) : undefined;
-            const writeOk = evaluateWrite(policies, op, { ...context, row: located.row }, nextRow);
-
-            if (!writeOk) {
-                // Reject the denied write with FORBIDDEN — the intended, tested
-                // contract for an authorized-but-policy-denied mutation. SECURITY:
-                // do NOT interpolate the owning table name into the message (it was
-                // formerly `${op} on "${located.tableName}" denied by policy`) — an
-                // attacker holding a candidate id could otherwise learn which table
-                // a hidden record lives in. The generic message is table-agnostic.
-                throw new LunoraError("FORBIDDEN", `${op} denied by policy`);
-            }
+        if (!allowsWrite(located.tableName, op, located.row, nextRow)) {
+            // Reject the denied write with FORBIDDEN — the intended, tested
+            // contract for an authorized-but-policy-denied mutation. SECURITY:
+            // do NOT interpolate the owning table name into the message (it was
+            // formerly `${op} on "${located.tableName}" denied by policy`) — an
+            // attacker holding a candidate id could otherwise learn which table
+            // a hidden record lives in. The generic message is table-agnostic.
+            throw new LunoraError("FORBIDDEN", `${op} denied by policy`);
         }
 
         // Policy table, write authorized: perform on the UNGUARDED `raw` writer
@@ -866,20 +1006,28 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
 
     /**
      * Fail a count-of-partition read (`rank`/`rankBefore`/`rankPage`) closed
-     * when the table carries an active read policy. These depend on the full
-     * partition — a position or sorted page computed over rows the policy hides
-     * would either undercount or leak, so under RLS they're unsupported (the
-     * same `COUNT_RLS_UNSUPPORTED` constraint `count()` enforces). Returns the
-     * effective read `baseWhere` for the non-restricted pass-through case.
+     * when the table's read policies NARROW the visible rows. These depend on
+     * the full partition — a position or sorted page computed over rows the
+     * policy hides would either undercount or leak, so under a narrowing policy
+     * they're unsupported (the same `COUNT_RLS_UNSUPPORTED` constraint `count()`
+     * enforces).
+     *
+     * The test is the computed base, not the mere presence of a policy. A read
+     * policy that resolves to `true` for this request (`when: () => true`, an
+     * admin branch, a permission grant) produces NO `baseWhere` — the partition
+     * the caller sees is the whole partition, so the position and the page are
+     * exact and there is nothing to fail closed about. Keying off "a read policy
+     * exists" instead made every rank/count unreachable the moment a table was
+     * governed at all, including from the very procedures the policy admits.
      */
     const requireUnrestrictedReadBase = (tableName: string, method: string): undefined | WhereInput => {
-        const { baseWhere, restricts } = readBase(tableName);
+        const { baseWhere } = readBase(tableName);
 
-        if (restricts) {
+        if (narrowsReads(baseWhere)) {
             throw new LunoraError("COUNT_RLS_UNSUPPORTED", `${method}() is not supported on "${tableName}" inside an RLS-restricted context`);
         }
 
-        return baseWhere;
+        return undefined;
     };
 
     // `rankBefore`/`rankPageRows` are the two analytical methods that may be
@@ -891,14 +1039,18 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
     const wrapped: RlsDatabase = {
         ...base,
         async count(tableName, whereOrArgs) {
-            const { baseWhere, restricts } = readBase(tableName);
+            const { baseWhere } = readBase(tableName);
             const args = intoCountArgs(whereOrArgs);
 
             return route(tableName).count(tableName, {
                 ...args,
                 baseWhere: mergeBaseWhere(args.baseWhere, baseWhere),
                 relationBaseWhere: relationReadFilter,
-                restrictsCounts: (args.restrictsCounts ?? false) || restricts,
+                // Flagged only when the policies actually NARROW the table — the
+                // writer refuses a count it cannot compute exactly, and an
+                // allow-all policy leaves it exactly computable. Same test as
+                // `requireUnrestrictedReadBase`; see its docblock.
+                restrictsCounts: (args.restrictsCounts ?? false) || narrowsReads(baseWhere),
             });
         },
 
@@ -1109,12 +1261,8 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
         },
 
         async insert(tableName, document) {
-            const policies = perTable.get(tableName);
-
-            if (policies) {
-                const writeOk = evaluateWrite(policies, "insert", { ...context, row: document });
-
-                if (!writeOk) {
+            if (policyTables.has(tableName)) {
+                if (!allowsWrite(tableName, "insert", document)) {
                     throw new LunoraError("FORBIDDEN", `insert on "${tableName}" denied by policy`);
                 }
 
@@ -1134,18 +1282,14 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             // the writer's own batch method, which re-checks it today).
             assertBatchLimit(documents.length, options?.limit, "insertMany");
 
-            const policies = perTable.get(tableName);
-
-            if (policies) {
+            if (policyTables.has(tableName)) {
                 // Evaluate the insert policy against each candidate row, then
                 // delegate the whole batch to the UNGUARDED `raw` writer (whose
                 // batch method re-checks the payload cap). A single denial throws;
                 // in a mutation the DO's BEGIN/COMMIT span rolls the whole batch
                 // back, in an action (no span) prior inserts persist.
                 for (const document of documents) {
-                    const writeOk = evaluateWrite(policies, "insert", { ...context, row: document });
-
-                    if (!writeOk) {
+                    if (!allowsWrite(tableName, "insert", document)) {
                         throw new LunoraError("FORBIDDEN", `insert on "${tableName}" denied by policy`);
                     }
                 }
@@ -1160,18 +1304,14 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
         async insertManyUnsafe(tableName, documents, options) {
             assertBatchLimit(documents.length, options?.limit, "insertManyUnsafe");
 
-            const policies = perTable.get(tableName);
-
-            if (policies) {
+            if (policyTables.has(tableName)) {
                 // "Unsafe" skips per-row validators/triggers at the writer, NOT the
                 // insert policy: each candidate row is still authorized here before
                 // the batch routes to the UNGUARDED `raw` writer. (Overriding this is
                 // mandatory — the `...base` spread would otherwise expose the guard's
                 // version, which checks only the table, skipping the row policy.)
                 for (const document of documents) {
-                    const writeOk = evaluateWrite(policies, "insert", { ...context, row: document });
-
-                    if (!writeOk) {
+                    if (!allowsWrite(tableName, "insert", document)) {
                         throw new LunoraError("FORBIDDEN", `insert on "${tableName}" denied by policy`);
                     }
                 }
@@ -1403,13 +1543,25 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
     // the runtime's own bindings untouched.
     const writableFacade = wrapped as unknown as Record<string, unknown>;
 
-    if (perTable.size > 0) {
+    if (policyTables.size > 0) {
         for (const [tableName, entry] of Object.entries(base as unknown as Record<string, unknown>)) {
             if (isFacadeEntry(entry)) {
                 writableFacade[tableName] = bindTableFacade(wrapped, tableName);
             }
         }
     }
+
+    // Publish the chain so a following `.use(rls(...))` extends it rather than
+    // replacing it. Non-enumerable: a wrapper is republished by spread (this
+    // function's own `...base`, and the facade binder's), and a chain that rode
+    // one of those spreads would attach a stale request's policies to a writer
+    // that is not this one.
+    Object.defineProperty(wrapped, RLS_CHAIN_SYMBOL, {
+        configurable: true,
+        enumerable: false,
+        value: { base, raw, steps } satisfies RlsChain,
+        writable: false,
+    });
 
     return wrapped;
 };
@@ -1569,7 +1721,11 @@ const resolvePolicyAuth = async (
 };
 
 const rls = <Context extends RlsContextIn = RlsContextIn>(policies: ReadonlyArray<Policy<Context>>, options: RlsOptions = {}): Middleware<Context, Context> => {
-    const perTable = indexByTable(policies);
+    // Erased once here (rather than at each use) so the per-request step can be
+    // carried alongside steps declared by other `rls()` calls with their own
+    // context types — the same erasure `tagRlsMiddleware` stores.
+    const erased = policies as ReadonlyArray<Policy>;
+    const perTable = indexByTable(erased);
     const rolePermissions = indexRolePermissions(options.roles);
 
     const middleware: Middleware<Context, Context> = async ({ ctx, next }) => {
@@ -1580,9 +1736,16 @@ const rls = <Context extends RlsContextIn = RlsContextIn>(policies: ReadonlyArra
         // tables it authorizes without tripping the guard. A non-guarded writer
         // doesn't carry the symbol, so `raw` falls back to `ctx.db` and the
         // wrapper behaves exactly as before (`base === raw`).
+        //
+        // When `ctx.db` is itself a wrapper an earlier `.use(rls(...))` built, its
+        // chain supplies the ORIGINAL base/raw pair and the steps so far, and this
+        // step is appended — policies compose instead of the later step routing
+        // around the earlier one.
         const guarded = ctx.db;
-        const raw = ((guarded as unknown as Record<PropertyKey, unknown>)[RLS_UNWRAP_SYMBOL] as RlsDatabase | undefined) ?? guarded;
-        const wrapped = wrapDatabase<Context>(guarded, raw, perTable, policyContext);
+        const chain = readChain(guarded);
+        const base = chain?.base ?? guarded;
+        const raw = chain?.raw ?? ((guarded as unknown as Record<PropertyKey, unknown>)[RLS_UNWRAP_SYMBOL] as RlsDatabase | undefined) ?? guarded;
+        const wrapped = wrapDatabase(base, raw, [...(chain?.steps ?? []), { context: policyContext, perTable }]);
         // `next({ ctx: extension })` expects an extension shape. We replace
         // `db` (carrying the re-bound per-table facade), and — when present —
         // `orm`: it's a sibling ctx field (codegen's `bindOrm`) bound to the
@@ -1610,7 +1773,7 @@ const rls = <Context extends RlsContextIn = RlsContextIn>(policies: ReadonlyArra
     // these (see `shape-read-base.ts`). Cast to the erased `Policy<unknown>`
     // the tag stores; the closures are evaluated against a structurally-built
     // PolicyContext, exactly like this middleware does at request time.
-    return tagRlsMiddleware(middleware, [{ policies: policies as ReadonlyArray<Policy>, roles: options.roles ?? [] }]);
+    return tagRlsMiddleware(middleware, [{ policies: erased, roles: options.roles ?? [] }]);
 };
 
 export { rls };

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -759,8 +759,18 @@ const isFacadeEntry = (value: unknown): value is Record<string, unknown> => {
  * about it and would hand it to the guard.
  */
 const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<RlsStep>): RlsDatabase => {
-    /** Every table any step in the chain gates. Replaces a single step's `perTable.has`. */
-    const policyTables = new Set<string>(steps.flatMap((step) => [...step.perTable.keys()]));
+    /**
+     * Every table any step in the chain gates. Replaces a single step's
+     * `perTable.has`.
+     *
+     * One step is the overwhelming majority of chains, and its `perTable` is
+     * already a keyed Map — so reuse it rather than copying its keys through an
+     * intermediate array into a fresh Set on every wrapper install (i.e. on every
+     * guarded query). Measured at ~17% of this path before the fast path.
+     */
+    const [onlyStep] = steps;
+    const policyTables: ReadonlyMap<string, unknown> | ReadonlySet<string> =
+        steps.length === 1 && onlyStep !== undefined ? onlyStep.perTable : new Set<string>(steps.flatMap((step) => [...step.perTable.keys()]));
 
     /**
      * Cached effective read `baseWhere` per table. Cached for the lifetime
@@ -941,7 +951,7 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
         // or scoped via `probeTable` — only that table's policy can apply, so the
         // probe set is that one table (or none, when it carries no policy).
         const scopedTable = expectedTable ?? probeTable;
-        const probeTables = scopedTable === undefined ? [...policyTables] : [scopedTable].filter((table) => policyTables.has(table));
+        const probeTables = scopedTable === undefined ? [...policyTables.keys()] : [scopedTable].filter((table) => policyTables.has(table));
         const probes = await Promise.all(
             probeTables.map(async (tableName) => {
                 const probe = await raw.findFirst(tableName, { limit: 1, where: { _id: id } });

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -1038,15 +1038,17 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
      * exact and there is nothing to fail closed about. Keying off "a read policy
      * exists" instead made every rank/count unreachable the moment a table was
      * governed at all, including from the very procedures the policy admits.
+     *
+     * Returns nothing on purpose: not throwing MEANS the base is unrestricted,
+     * so there is no `baseWhere` for a caller to merge and each one forwards its
+     * own `options` untouched.
      */
-    const requireUnrestrictedReadBase = (tableName: string, method: string): undefined | WhereInput => {
+    const assertUnrestrictedReadBase = (tableName: string, method: string): void => {
         const { baseWhere } = readBase(tableName);
 
         if (narrowsReads(baseWhere)) {
             throw new LunoraError("COUNT_RLS_UNSUPPORTED", `${method}() is not supported on "${tableName}" inside an RLS-restricted context`);
         }
-
-        return undefined;
     };
 
     // `rankBefore`/`rankPageRows` are the two analytical methods that may be
@@ -1068,7 +1070,7 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
                 // Flagged only when the policies actually NARROW the table — the
                 // writer refuses a count it cannot compute exactly, and an
                 // allow-all policy leaves it exactly computable. Same test as
-                // `requireUnrestrictedReadBase`; see its docblock.
+                // `assertUnrestrictedReadBase`; see its docblock.
                 restrictsCounts: (args.restrictsCounts ?? false) || narrowsReads(baseWhere),
             });
         },
@@ -1478,7 +1480,7 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
         // `groupBy` are scoped to `where`, so the read `baseWhere` is AND-merged
         // and the reduction only sees policy-visible rows. `rank` / `rankPage`
         // are counts-of-partition that can't be safely narrowed, so they fail
-        // closed under a read policy (see `requireUnrestrictedReadBase`).
+        // closed under a read policy (see `assertUnrestrictedReadBase`).
         aggregate(tableName, options) {
             const { baseWhere } = readBase(tableName);
 
@@ -1500,15 +1502,15 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
         },
 
         rank(tableName, indexName, options) {
-            const baseWhere = requireUnrestrictedReadBase(tableName, "rank");
+            assertUnrestrictedReadBase(tableName, "rank");
 
-            return route(tableName).rank(tableName, indexName, { ...options, baseWhere: mergeBaseWhere(options.baseWhere, baseWhere) });
+            return route(tableName).rank(tableName, indexName, options);
         },
 
         rankPage(tableName, indexName, options) {
-            const baseWhere = requireUnrestrictedReadBase(tableName, "rankPage");
+            assertUnrestrictedReadBase(tableName, "rankPage");
 
-            return route(tableName).rankPage(tableName, indexName, { ...options, baseWhere: mergeBaseWhere(options?.baseWhere, baseWhere) });
+            return route(tableName).rankPage(tableName, indexName, options);
         },
 
         wipeShard() {
@@ -1534,7 +1536,7 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
         // closed for the same reason `rankPage` does: its rows carry partition
         // rank keys that cannot be reduced under a row policy.
         ...optionalWriterOverride("rankBefore", baseRankBefore, (rankBefore) => (tableName: string, indexName: string, options: RankBeforeArgs) => {
-            requireUnrestrictedReadBase(tableName, "rankBefore");
+            assertUnrestrictedReadBase(tableName, "rankBefore");
 
             // Route to the policy/non-policy writer; both carry `rankBefore` when `base` does (the guard spreads `raw`).
             const target = route(tableName);
@@ -1542,15 +1544,12 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
             return (target.rankBefore ?? rankBefore)(tableName, indexName, options);
         }),
         ...optionalWriterOverride("rankPageRows", baseRankPageRows, (rankPageRows) => (tableName: string, indexName: string, options?: RankPageArgs) => {
-            const baseWhere = requireUnrestrictedReadBase(tableName, "rankPageRows");
+            assertUnrestrictedReadBase(tableName, "rankPageRows");
 
             // Route to the policy/non-policy writer; both carry `rankPageRows` when `base` does (the guard spreads `raw`).
             const target = route(tableName);
 
-            return (target.rankPageRows ?? rankPageRows)(tableName, indexName, {
-                ...options,
-                baseWhere: mergeBaseWhere(options?.baseWhere, baseWhere),
-            });
+            return (target.rankPageRows ?? rankPageRows)(tableName, indexName, options);
         }),
     };
 

--- a/packages/server/src/rls/shape-read-base.ts
+++ b/packages/server/src/rls/shape-read-base.ts
@@ -285,10 +285,12 @@ const buildRlsReadRegistry = (guards: Iterable<unknown>): RlsReadRegistry => {
 
 /** One entry of the generated `LUNORA_SHAPES` registry, as {@link assertShapesDeclareReadPolicies} reads it. */
 interface ShapeGuardDeclaration {
+    /** The registry `defineShape` already built from `use` — the authority on what those guards actually govern. */
+    readonly rlsRegistry: RlsReadRegistry;
     /** Logical table the shape replicates. */
     readonly table: string;
     /** Present (even as `[]`) exactly when the declaration wrote `use` — the acknowledgement bit. */
-    readonly use?: unknown;
+    readonly use?: ReadonlyArray<unknown>;
 }
 
 /**
@@ -314,6 +316,12 @@ interface ShapeGuardDeclaration {
  * `use: []` is the explicit acknowledgement ("this shape's own `where` is the
  * whole filter") and a missing `use` on a governed table is the accident.
  *
+ * A non-empty `use` has to earn it: the shape's own `rlsRegistry` must hold a
+ * read-policy group for its table. A list naming a guard for a DIFFERENT table,
+ * or a middleware with no `rls()` policies on it at all, produces no group and
+ * leaves the shape filtered by its `where` alone — the same fail-open, hidden
+ * behind a `use` that looks answered.
+ *
  * Skipped under `.rls("required")`: there a guard-less shape over a non-`.public()`
  * table already replicates nothing (see `resolveReadBaseWhere`), so the omission
  * cannot leak — it is the secure-by-default answer, not a fail-open.
@@ -333,18 +341,33 @@ const assertShapesDeclareReadPolicies = (
     }
 
     const governed = new Set(readPolicyTables);
-    const unguarded = Object.entries(shapes)
-        .filter(([, shape]) => shape.use === undefined && governed.has(shape.table))
-        .map(([name, shape]) => `"${name}" (table "${shape.table}")`);
+    const onGovernedTable = Object.entries(shapes).filter(([, shape]) => governed.has(shape.table));
+    const list = (entries: typeof onGovernedTable): string => entries.map(([name, shape]) => `"${name}" (table "${shape.table}")`).join(", ");
 
-    if (unguarded.length === 0) {
-        return;
+    const unguarded = onGovernedTable.filter(([, shape]) => shape.use === undefined);
+
+    if (unguarded.length > 0) {
+        throw new LunoraError(
+            "INTERNAL",
+            `defineShape ${list(unguarded)} replicate${unguarded.length === 1 ? "s" : ""} a table this project's rls() read policies restrict, but declare${unguarded.length === 1 ? "s" : ""} no \`use\` — a shape runs no procedure, so those policies never reach it and every subscriber would replicate every row the shape's own \`where\` admits. Name the guards the equivalent query lists: \`defineShape({ use: [<the rls() guard>], ... })\`. If the shape really is meant to be ungoverned (its own \`where\` is the whole filter), say so with \`use: []\`.`,
+        );
     }
 
-    throw new LunoraError(
-        "INTERNAL",
-        `defineShape ${unguarded.join(", ")} replicate${unguarded.length === 1 ? "s" : ""} a table this project's rls() read policies restrict, but declare${unguarded.length === 1 ? "s" : ""} no \`use\` — a shape runs no procedure, so those policies never reach it and every subscriber would replicate every row the shape's own \`where\` admits. Name the guards the equivalent query lists: \`defineShape({ use: [<the rls() guard>], ... })\`. If the shape really is meant to be ungoverned (its own \`where\` is the whole filter), say so with \`use: []\`.`,
-    );
+    // A NON-EMPTY `use` is not the acknowledgement either — what governs the
+    // shape is the read-policy group its guards produce for THIS table, and a
+    // list can easily produce none: an `rls()` guard for a different table, or a
+    // plain authorization middleware (`requireAdmin`) a shape cannot even run.
+    // The shape then replicates on its own `where` alone, which is exactly the
+    // fail-open the branch above exists to catch, one level down. `use: []`
+    // stays the documented opt-out and is excluded here.
+    const ineffective = onGovernedTable.filter(([, shape]) => shape.use !== undefined && shape.use.length > 0 && !shape.rlsRegistry.byTable.has(shape.table));
+
+    if (ineffective.length > 0) {
+        throw new LunoraError(
+            "INTERNAL",
+            `defineShape ${list(ineffective)} name \`use\` guards that declare no \`on: "read"\` policy for that table, so nothing governs what replicates and the shape's own \`where\` is the whole filter — the same gap a missing \`use\` leaves, on a table this project's rls() read policies restrict. A guard for a different table, or a middleware carrying no rls() policies at all, does not count: name the same rls() guard the equivalent query lists. If the shape really is meant to be ungoverned, say so with \`use: []\`.`,
+        );
+    }
 };
 
 /**

--- a/packages/server/src/rls/shape-read-base.ts
+++ b/packages/server/src/rls/shape-read-base.ts
@@ -4,22 +4,36 @@
  * A shape names a table + predicate and replicates the matching rows to a
  * client (the local-first sync engine). Unlike a `query`, a shape runs no
  * procedure, so the `.use(rls(...))` middleware never executes and its
- * membership reads would bypass every read policy on the table — leaking rows
- * the caller can't see. This module closes that hole: it collects the project's
- * read policies (hoisted onto each registered function by the procedure builder,
- * keyed by the {@link readRlsTags} the `rls()` middleware stamps) into a
- * table-indexed registry, then — at `resolveShape` time, under the socket's
- * verified identity — evaluates the table's read policies into a base-where and
- * AND-merges it with the shape's own predicate.
+ * membership reads would bypass every read policy the shape is meant to honour.
+ * This module closes that hole: it collects the read policies of the `rls()`
+ * guards a declaration names (keyed by the {@link readRlsTags} the `rls()`
+ * middleware stamps) into a table-indexed registry, then — at `resolveShape`
+ * time, under the socket's verified identity — evaluates them into a base-where
+ * and AND-merges it with the shape's own predicate.
+ *
+ * SCOPE. The registry is built from ONE declaration's guards
+ * (`defineShape({ use })`), never from every registered function in the project.
+ * A project-wide registry is a union, and `resolveReadBaseWhere` treats a group
+ * that grants unrestricted access as unrestricting the whole table — so one
+ * admin-only procedure carrying `rls([{ on: "read", when: () => true }])`
+ * collapsed every tenant shape on that table to "no filter", for every
+ * subscriber. It could not be otherwise: an `rls()` bundle is only half of a
+ * procedure's authorization, the other half being the middlewares around it
+ * (`requireAdmin`) that a shape cannot run. Request-time scope is per-procedure,
+ * so a shape's has to be per-shape.
  *
  * Fail-closed parity with `@lunora/do`'s `guardWriter`: under a
- * `.rls("required")` schema a non-`.public()` table with NO read policy is
- * denied (the shape replicates nothing), never silently unrestricted.
+ * `.rls("required")` schema a non-`.public()` table the shape declares no read
+ * policy for is denied (the shape replicates nothing), never silently
+ * unrestricted. Under an opt-in schema a shape that names no guard is filtered
+ * by its own `where` alone — the same opt-in deal a query without
+ * `.use(rls(...))` gets.
  *
- * The evaluation mirrors the `rls()` middleware's request-time path exactly —
- * the same `computeReadBaseWhere` / `indexRolePermissions` / `permissionName`
- * primitives — so a shape's filter has zero semantic drift from an equivalent
- * `query` guarded by the same policies.
+ * Within that scope the evaluation mirrors the `rls()` middleware's
+ * request-time path — the same `computeReadBaseWhere` / `indexRolePermissions` /
+ * `permissionName` primitives — with ONE documented divergence: roles come from
+ * the identity claim only, because no middleware runs to contribute
+ * `ctx.auth.roles` (see the KNOWN DIVERGENCE note on `evaluateGroupBaseWhere`).
  */
 
 import { computeReadBaseWhere, indexRolePermissions, readIdentityRoles, resolveCan } from "./middleware";
@@ -230,19 +244,26 @@ const resolveReadBaseWhere = (registry: RlsReadRegistry, request: ShapeReadWhere
 };
 
 /**
- * Build the read-policy registry from the registered functions (pass
- * `Object.values(LUNORA_FUNCTIONS)`). Only `on: "read"` policies are collected,
- * grouped per `rls()` middleware so each group keeps its own role→permission map
- * (a `(table, when)` pair is de-duplicated within a tag). A tag reused across
- * several procedures (a shared `const guard = rls(...)`) is folded once. This
- * mirrors the request-time `rls()` path exactly: a policy's `auth.can(...)`
- * resolves against the roles of the middleware that declared it, never a union.
+ * Build the read-policy registry for ONE consumer from the `rls()` guards it
+ * declares — `defineShape({ use })` passes its own list, and `defineShape` calls
+ * this once at declaration time. Accepts either the tagged middlewares
+ * themselves or anything carrying hoisted `fn.rls.tags`.
+ *
+ * Only `on: "read"` policies are collected, grouped per `rls()` middleware so
+ * each group keeps its own role→permission map (a `(table, when)` pair is
+ * de-duplicated within a tag). The same tag listed twice (a shared
+ * `const guard = rls(...)`) is folded once. Within a group this mirrors the
+ * request-time `rls()` path: a policy's `auth.can(...)` resolves against the
+ * roles of the middleware that declared it, never a union.
+ *
+ * Do NOT hand this every registered function in the project — see the SCOPE
+ * paragraph in the module docblock for what that silently did to tenant shapes.
  */
-const buildRlsReadRegistry = (functions: Iterable<unknown>): RlsReadRegistry => {
+const buildRlsReadRegistry = (guards: Iterable<unknown>): RlsReadRegistry => {
     const byTable = new Map<string, ScopedReadPolicies[]>();
     const seenTags = new Set<RlsTag>();
 
-    for (const entry of functions) {
+    for (const entry of guards) {
         for (const tag of readEntryTags(entry)) {
             if (seenTags.has(tag)) {
                 continue;

--- a/packages/server/src/rls/shape-read-base.ts
+++ b/packages/server/src/rls/shape-read-base.ts
@@ -22,6 +22,10 @@
  * (`requireAdmin`) that a shape cannot run. Request-time scope is per-procedure,
  * so a shape's has to be per-shape.
  *
+ * Fail-open is the other direction, and it is NOT silent: see
+ * `assertShapesDeclareReadPolicies`, which refuses to boot an app whose shape
+ * omits `use` on a table the project's own read policies govern.
+ *
  * Fail-closed parity with `@lunora/do`'s `guardWriter`: under a
  * `.rls("required")` schema a non-`.public()` table the shape declares no read
  * policy for is denied (the shape replicates nothing), never silently
@@ -35,6 +39,8 @@
  * the identity claim only, because no middleware runs to contribute
  * `ctx.auth.roles` (see the KNOWN DIVERGENCE note on `evaluateGroupBaseWhere`).
  */
+
+import { LunoraError } from "@lunora/errors";
 
 import { computeReadBaseWhere, indexRolePermissions, readIdentityRoles, resolveCan } from "./middleware";
 import type { RlsTag } from "./policy-tag";
@@ -277,6 +283,70 @@ const buildRlsReadRegistry = (guards: Iterable<unknown>): RlsReadRegistry => {
     return { byTable };
 };
 
+/** One entry of the generated `LUNORA_SHAPES` registry, as {@link assertShapesDeclareReadPolicies} reads it. */
+interface ShapeGuardDeclaration {
+    /** Logical table the shape replicates. */
+    readonly table: string;
+    /** Present (even as `[]`) exactly when the declaration wrote `use` — the acknowledgement bit. */
+    readonly use?: unknown;
+}
+
+/**
+ * Fail a project's startup closed when a shape would replicate AROUND the read
+ * policies its table is governed by.
+ *
+ * Scoping shape RLS to `defineShape({ use })` fixed one direction (a project-wide
+ * union let one admin-only `rls([{ on: "read", when: () => true }])` unrestrict
+ * every tenant shape) and opened the other: under the OPT-IN default a shape that
+ * names no guard has an empty registry, `resolveReadBaseWhere` returns
+ * `undefined`, and the shape replicates on its own `where` alone. An app whose
+ * `messages` table is tenant-scoped on its queries and exposes
+ * `defineShape({ table: "messages", where: (_c, { channelId }) => ({ channelId }) })`
+ * therefore replicated `{ channelId }` where it used to replicate
+ * `{ AND: [{ channelId }, { tenantId }] }` — every tenant's messages, to every
+ * subscriber, with no error and no diagnostic. Silence is the defect; this is the
+ * noise.
+ *
+ * `readPolicyTables` is the set of tables the project's `.use(rls(...))` chains
+ * declare an `on: "read"` policy for — statically discovered by codegen, which
+ * stamps the call into the generated shard. The registry is the authority on the
+ * other half: `use` is present exactly when the declaration wrote it, so
+ * `use: []` is the explicit acknowledgement ("this shape's own `where` is the
+ * whole filter") and a missing `use` on a governed table is the accident.
+ *
+ * Skipped under `.rls("required")`: there a guard-less shape over a non-`.public()`
+ * table already replicates nothing (see `resolveReadBaseWhere`), so the omission
+ * cannot leak — it is the secure-by-default answer, not a fail-open.
+ *
+ * Throws at module scope in the generated shard, so it surfaces the moment the
+ * worker boots rather than on the first subscription. A codegen-time check would
+ * be louder still, but codegen sees only the shape IR, which does not lift `use`
+ * — and the registry, which does, exists only at runtime.
+ */
+const assertShapesDeclareReadPolicies = (
+    shapes: Readonly<Record<string, ShapeGuardDeclaration>>,
+    readPolicyTables: Iterable<string>,
+    rlsRequired: boolean,
+): void => {
+    if (rlsRequired) {
+        return;
+    }
+
+    const governed = new Set(readPolicyTables);
+    const unguarded = Object.entries(shapes)
+        .filter(([, shape]) => shape.use === undefined && governed.has(shape.table))
+        .map(([name, shape]) => `"${name}" (table "${shape.table}")`);
+
+    if (unguarded.length === 0) {
+        return;
+    }
+
+    throw new LunoraError(
+        "INTERNAL",
+        `defineShape ${unguarded.join(", ")} replicate${unguarded.length === 1 ? "s" : ""} a table this project's rls() read policies restrict, but declare${unguarded.length === 1 ? "s" : ""} no \`use\` — a shape runs no procedure, so those policies never reach it and every subscriber would replicate every row the shape's own \`where\` admits. Name the guards the equivalent query lists: \`defineShape({ use: [<the rls() guard>], ... })\`. If the shape really is meant to be ungoverned (its own \`where\` is the whole filter), say so with \`use: []\`.`,
+    );
+};
+
 /**
  * Compute the effective `where` a shape replicates: the table's RLS read
  * base-where AND the shape's own predicate. Returns the shape predicate
@@ -287,5 +357,5 @@ const buildRlsReadRegistry = (guards: Iterable<unknown>): RlsReadRegistry => {
 const composeShapeReadWhere = (registry: RlsReadRegistry, request: ShapeReadWhereRequest): WhereInput =>
     andMerge(resolveReadBaseWhere(registry, request), request.shapeWhere);
 
-export type { RlsReadRegistry, ShapeReadWhereRequest };
-export { buildRlsReadRegistry, composeShapeReadWhere };
+export type { RlsReadRegistry, ShapeGuardDeclaration, ShapeReadWhereRequest };
+export { assertShapesDeclareReadPolicies, buildRlsReadRegistry, composeShapeReadWhere };

--- a/packages/server/src/shapes.ts
+++ b/packages/server/src/shapes.ts
@@ -42,15 +42,32 @@
  *     table: "messages",
  *     where: (ctx, { channelId }) => (ctx.auth.userId === null ? deny() : { channelId }),
  * });
+ *
+ * // 4. Governed by RLS. `use` names the same `rls(...)` guards a query would
+ * //    `.use(...)`; their read policies AND-compose with `where`.
+ * export const channelMessages = defineShape({
+ *     args: { channelId: v.string() },
+ *     table: "messages",
+ *     use: [memberOfChannel],
+ *     where: (_ctx, { channelId }) => ({ channelId }),
+ * });
  * ```
+ *
+ * RLS on a shape is OPT-IN through `use`, exactly as it is on a procedure —
+ * policies declared elsewhere in the project do not reach a shape that did not
+ * ask for them. Under a `.rls("required")` schema the omission is not silent: a
+ * shape over a non-`.public()` table with no `use` replicates nothing.
  */
 
 import { LunoraError } from "@lunora/errors";
 import type { InferValidatorMap, ValidatorMap } from "@lunora/values";
 
+import type { Middleware } from "./builder/types";
 import contextUserId from "./context-identity";
 import { validateArgs } from "./functions";
 import { deny, toWhereInput } from "./rls/predicates";
+import type { RlsReadRegistry } from "./rls/shape-read-base";
+import { buildRlsReadRegistry } from "./rls/shape-read-base";
 import type { WhereInput } from "./rls/types";
 import type { QueryCtx as QueryContext } from "./types";
 
@@ -100,6 +117,30 @@ export interface ShapeDefinition<Args extends ValidatorMap = ValidatorMap, Conte
     readonly table: string;
 
     /**
+     * The `rls(...)` guards whose **read** policies gate this shape, exactly as
+     * a procedure lists them with `.use(rls(...))`.
+     *
+     * A shape runs no procedure, so it has no `.use()` chain to inherit from —
+     * it has to name its own guards. Their read policies are evaluated under the
+     * socket's verified identity and AND-composed with `where` before a single
+     * row replicates, and (like a procedure's chain) several guards compose:
+     * every one of them must admit a row.
+     *
+     * SCOPE, and why it is per-shape: an `rls()` bundle is scoped to the
+     * procedures that opt into it. A shape naming no guard therefore replicates
+     * on `where` alone — the same deal a query with no `.use(rls(...))` gets.
+     * Under a `.rls("required")` schema that is a hard denial for any
+     * non-`.public()` table (nothing replicates), which is the secure-by-default
+     * answer and the reason `required` exists.
+     *
+     * Only `rls()` middlewares are read here — their policies, not their bodies.
+     * A shape cannot run an authorization middleware, so a procedure-level gate
+     * (`requireAdmin`, a rate limiter) has no effect on a shape and must not be
+     * relied on to protect one.
+     */
+    readonly use?: ReadonlyArray<Middleware<never, unknown>>;
+
+    /**
      * Predicate selecting the rows this shape replicates. AND-composed with the
      * table's RLS read base-where on the DO. Runs server-side with a trusted
      * `ctx` (identity/auth the client can't forge) and the validated client
@@ -131,6 +172,19 @@ export interface RegisteredShape<Args extends ValidatorMap = ValidatorMap, Conte
      * `owner: true` shape. Omitted for an `owner: "field"` or plain `where` shape.
      */
     readonly compileWhere: (context: unknown, rawArgs: Record<string, unknown>, options?: { ownerField?: string }) => WhereInput;
+
+    /**
+     * Read-policy registry built from THIS shape's `use` guards — the argument
+     * the DO's `resolveShape` hands `composeShapeReadWhere`.
+     *
+     * Built here, per shape, and not project-wide: the registry is a union, so a
+     * project-wide one folded in the read policies of every procedure that names
+     * the table, and a single `rls([{ on: "read", when: () => true }])` inside an
+     * admin-only procedure collapsed a tenant shape's filter to "no filter" for
+     * every subscriber. Request-time scope is per-procedure; a shape's scope is
+     * its own `use` list.
+     */
+    readonly rlsRegistry: RlsReadRegistry;
 }
 
 /** Declare a replication shape. See the module docs for runtime semantics. */
@@ -183,5 +237,5 @@ export const defineShape = <Args extends ValidatorMap = ValidatorMap, Context = 
         return shapeWhere === undefined ? ownerWhere : { AND: [ownerWhere, shapeWhere] };
     };
 
-    return { __lunoraShape: true, ...definition, compileWhere };
+    return { __lunoraShape: true, ...definition, compileWhere, rlsRegistry: buildRlsReadRegistry(definition.use ?? []) };
 };

--- a/packages/server/src/shapes.ts
+++ b/packages/server/src/shapes.ts
@@ -55,8 +55,12 @@
  *
  * RLS on a shape is OPT-IN through `use`, exactly as it is on a procedure —
  * policies declared elsewhere in the project do not reach a shape that did not
- * ask for them. Under a `.rls("required")` schema the omission is not silent: a
- * shape over a non-`.public()` table with no `use` replicates nothing.
+ * ask for them. The omission is never silent: under a `.rls("required")` schema a
+ * shape over a non-`.public()` table with no `use` replicates nothing, and
+ * otherwise codegen stamps `assertShapesDeclareReadPolicies` into the generated
+ * DO, which refuses to boot when the shape's table IS governed on read and the
+ * shape named no guard. `use: []` is the acknowledgement that the omission is
+ * deliberate.
  */
 
 import { LunoraError } from "@lunora/errors";
@@ -131,7 +135,10 @@ export interface ShapeDefinition<Args extends ValidatorMap = ValidatorMap, Conte
      * on `where` alone — the same deal a query with no `.use(rls(...))` gets.
      * Under a `.rls("required")` schema that is a hard denial for any
      * non-`.public()` table (nothing replicates), which is the secure-by-default
-     * answer and the reason `required` exists.
+     * answer and the reason `required` exists. Otherwise it is a boot failure
+     * whenever the table IS governed on read (see
+     * `assertShapesDeclareReadPolicies`); write `use: []` for a shape that is
+     * meant to be ungoverned.
      *
      * Only `rls()` middlewares are read here — their policies, not their bodies.
      * A shape cannot run an authorization middleware, so a procedure-level gate

--- a/packages/shard-engine/__tests__/rls-guard.test.ts
+++ b/packages/shard-engine/__tests__/rls-guard.test.ts
@@ -504,4 +504,23 @@ describe("guardWriter — unwrap seam", () => {
 
         expect(RLS_UNWRAP_SYMBOL).toBe(Symbol.for("lunora.ctxdb.rls-unwrap"));
     });
+
+    /**
+     * NON-enumerable, and that is security-relevant. `@lunora/server`'s `rls()`
+     * builds its wrapped writer with `{ ...ctx.db }`; while this property was
+     * enumerable the wrapper re-published the UNGUARDED writer, so a second
+     * `.use(rls(...))` step recovered it, wrapped that instead of the first
+     * wrapper, and silently dropped step one's row filter.
+     */
+    it("hides the raw writer from a spread of the guarded one", () => {
+        expect.assertions(2);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId);
+        const republished = { ...(guarded as unknown as Record<PropertyKey, unknown>) };
+
+        expect(Object.getOwnPropertySymbols(republished)).not.toContain(RLS_UNWRAP_SYMBOL);
+
+        expect(Object.propertyIsEnumerable.call(guarded, RLS_UNWRAP_SYMBOL)).toBe(false);
+    });
 });

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -3670,11 +3670,22 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // The optional fast-path seam the RLS + mask middleware probe for: the
             // writer already knows a row's owning table from its internal index, so
             // the middleware gets `{ row, tableName }` in one round-trip instead of a
-            // `get` plus a `findFirst` probe across every policy table. Shard-local
-            // only — a global row's table isn't resolvable here, so it returns `null`
-            // and the caller keeps its probe fallback. `onRead` fires exactly as in
-            // `get`, so swapping the fallback for this path preserves subscription
-            // dependency tracking (and matches what the write-gate fallback did).
+            // `get` plus a `findFirst` probe across every policy table.
+            //
+            // SHARD-LOCAL ONLY, and `null` here means "not resolvable through this
+            // seam" — NOT "no such row". A `.global()` row lives in D1, so its table
+            // is not resolvable from this DO's index and every global id misses. A
+            // caller MUST therefore fall through to its own `get`/`findFirst` probe
+            // path (which does reach D1 via `globalFallbackFor`) on a miss; treating
+            // the miss as an absent row is what let the RLS write gate classify every
+            // global row as "in no policy-gated table" and skip its update/delete
+            // policy. Deliberately not resolved here: a bare id would have to probe
+            // every global table across the D1 hop, taxing the shard-local hit this
+            // seam exists to make cheap.
+            //
+            // `onRead` fires exactly as in `get`, so swapping the fallback for this
+            // path preserves subscription dependency tracking (and matches what the
+            // write-gate fallback did).
             const located = locateRowById(id, expectedTable);
 
             if (!located) {

--- a/packages/shard-engine/src/rls-guard.ts
+++ b/packages/shard-engine/src/rls-guard.ts
@@ -25,6 +25,11 @@ import type { DatabaseWriterLike } from "./schema-types";
  * (the cross-realm global registry) lets `@lunora/server`'s RLS middleware read
  * it WITHOUT importing this module — both sides reference the same registered
  * symbol by key, dodging a `server → do` dependency.
+ *
+ * The property is NON-ENUMERABLE, which is load-bearing: every consumer that
+ * re-publishes the guarded writer does so with a spread, and an enumerable
+ * escape hatch travels with it (see the `Object.defineProperty` call in
+ * {@link guardWriter}).
  */
 const RLS_UNWRAP_SYMBOL: symbol = Symbol.for("lunora.ctxdb.rls-unwrap");
 
@@ -328,8 +333,6 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId, t
 
     const guarded: Record<PropertyKey, unknown> = {
         ...(raw as Record<string, unknown>),
-        [RLS_UNWRAP_SYMBOL]: raw,
-
         delete: async (id: string, expectedTable?: string, options?: { hard?: boolean }) => {
             await guardById(id, expectedTable);
 
@@ -440,6 +443,16 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId, t
             return wipeShard.call(base, options);
         };
     }
+
+    // NON-ENUMERABLE on purpose. `@lunora/server`'s `rls()` middleware builds its
+    // wrapped writer with `{ ...ctx.db }`, and an enumerable escape hatch rides
+    // that spread: the wrapper ended up re-publishing the UNGUARDED writer, so a
+    // second `.use(rls(...))` step recovered it, wrapped that instead of the first
+    // wrapper, and silently dropped step one's filter. Defined after the literal
+    // rather than in it because an object literal's computed symbol key is always
+    // enumerable. Direct property reads (the middleware's own lookup, the test
+    // harness's `rawDatabase`) are unaffected.
+    Object.defineProperty(guarded, RLS_UNWRAP_SYMBOL, { configurable: true, enumerable: false, value: raw, writable: false });
 
     return guarded as unknown as W;
 };


### PR DESCRIPTION
First of three. **Base `alpha`.** The chain: this → #PR2 → #PR3.

Closes six authorization holes found by a core-package hunt, plus the three
follow-ups a review of this branch turned up — including a fail-open this
branch's own shape-scoping change introduces, which is why they land together
rather than in a later PR.

## `.global()` rows addressed by id were ungoverned by RLS write policies

`lookupById` is a shard-local seam and returns `null` for a global row. Its
docblock promised *"the caller keeps its probe fallback"* — `locateRow` had no
fallback, because the probe path ran only when `lookupById` was **absent**, and
the real shard writer always has it. `gateById` then hit
`return perform(base)` under the comment *"the id is in no policy-gated table"*,
which for a global row is false: it **is** gated.

With `update: () => false` and `delete: () => false` on a global table:

```
before   patch/delete/deleteAll → RESOLVED
         global writer saw 4 ops · rows left: 0   (destroyed)
after    all four → THREW FORBIDDEN
         global writer saw []   · rows left: 2   (intact)
```

Affects `patch`, `replace`, `delete`, `deleteMany`, `restore`, `deleteAll`,
`hardDelete` and the facade `upsert`'s patch step. `insert` was never affected —
it is table-addressed. `ctx.db.get()` returned `null` for the same rows under
both `rls()` and `mask()`; it now returns the row, subject to policy.

The existing suite passed because `rls.test.ts:1232` uses a fake writer with no
`lookupById` — it exercises the probe path production never takes.

## Live subscription shapes took the OR of every procedure's read policies

The registry was built from `Object.values(LUNORA_FUNCTIONS)` — every function
naming the table, internal ones included — while request-time scope is
per-procedure. One group granting unconditionally unrestricted the shape:

```
tenant procedure alone      → {"ownerId":"u1"}
+ one admin-list procedure  → {}      every row to every socket
```

Now scoped per shape via `defineShape({ use: [guard] })`.

**Breaking:** a shape no longer inherits project-wide policies.

## …and that scoping introduced a fail-open, fixed here

Under `.rls("required")` a shape with no `use` denies — fail-closed. Under the
**opt-in default** it replicated *unfiltered*: an app whose table is tenant-scoped
by `rls()` on its queries plus a `defineShape` with no `use` went from
`{AND: [{channelId}, {tenantId}]}` to `{channelId}` — silently, no error.

The generated DO now refuses to boot, naming every offending shape and its
table, when the project's own read policies govern a table a shape replicates
without declaring `use`. `use: []` is the explicit *"this shape is deliberately
ungoverned"* opt-out. Skipped under `required`, where omission already denies.

Emitted only when a project has both shapes and read policies, so a shape-free
or policy-free project's `shard.ts` is byte-identical.

## Also

- **A second `rls()` step dropped the first's filter** under `.rls("required")`
  (`["mine"]` → `["mine","theirs"]`). `RLS_UNWRAP_SYMBOL` is now non-enumerable
  so it cannot ride a spread, and the wrapper carries its accumulated chain;
  reads AND-compose across steps, and a write must be allowed by every step
  gating its table.
- **A middleware that never calls `next()`** skipped every later `.use()` —
  `rls`, `mask`, `storageRules` — while the handler still ran on the unwrapped
  `ctx.db`, and `fn.rls` was still hoisted so studio believed it guarded. Now a
  clear error.
- **`count`/`rank` failed closed under an allow-all policy.** The test is now
  whether the computed base *narrows*, matching `mergeBaseWhere`.
- **The A1 probe fallback** cost `2 + N` subrequests per row on a chunked
  `deleteAll` over global tables — ~960 for 80 rows, past workerd's 1000
  ceiling mid-erase. Both callers know the table, so the probe scope is now
  separate from `expectedTable` (which must stay unpinned for the global
  fallback): `2 + N` → `3`.
- `requireUnrestrictedReadBase` could only ever return `undefined` while three
  call sites still threaded it into `mergeBaseWhere`. Now an assertion; −15 lines.
- Docblocks that asserted the opposite of the code, rewritten. `use` is
  documented on the docs site for the first time, and the RLS caution — which
  said only *roles* fail to reach shapes — corrected.

## Not changed, deliberately

`deleteMany`'s `deleted` count. It looked like an over-report, but
`packages/server/src/types.ts:1170` documents it as the number of ids
**requested**, and the unwrapped writer matches. Changing only the RLS path
would make the same call report different numbers with and without a policy.

## Verification

Every regression test was run against the unfixed code first and observed to
fail. Gates green with the cache disabled: `vis run test --no-cache` (175),
`lint:types`, `lint:eslint`, `lint:prettier`, `api:check`, `lint:package-json`,
`check-generated-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shapes can opt into specific row-level security policies for replication and reads.
  * Multiple row-level security middleware steps can be combined, with all applicable policies enforced.
  * Added validation to prevent startup when governed shapes omit required read-policy declarations.

* **Bug Fixes**
  * Fixed global records incorrectly appearing unavailable inside masked procedures.
  * Improved count and ranking operations when policies do not restrict returned rows.
  * Middleware now reports an error when a step does not call `next()`.

* **Documentation**
  * Clarified middleware usage, policy behavior, and database lookup semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->