### PR TITLE
fix(config): fail validation on a Durable Object class the worker entry does not export

### DIFF
--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -692,13 +692,13 @@ export const transcoder = defineContainer({ image: "./containers/transcoder" });
                 expect(result.code).toBe(0);
             });
 
-            it("surfaces validator warnings on the command that actually ships", async () => {
+            it("blocks the deploy when the entry does not export a declared class", async () => {
                 expect.assertions(2);
 
-                // The unexported-class check is deliberately a WARNING so a
-                // scanner miss cannot block a working deploy — but `deploy`
-                // printed `report.errors` only, so on the one command that ships
-                // a Worker the warning was invisible and wrangler failed instead.
+                // wrangler refuses to bundle this Worker, so shipping it can only
+                // fail — the validator now parses the entry rather than scanning
+                // it, which is what makes the finding certain enough to block on
+                // the one command that ships.
                 writeFileSync(
                     join(workdir, "wrangler.jsonc"),
                     `{
@@ -717,12 +717,12 @@ export const transcoder = defineContainer({ image: "./containers/transcoder" });
                 writeFileSync(join(workdir, "src", "index.ts"), "export const ShardDO = class {};\nexport default { fetch() {} };\n", "utf8");
 
                 const { spawner } = createRecordingSpawner();
-                const { logger, warns } = silentLogger();
+                const { errors, logger } = silentLogger();
 
                 const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner });
 
-                expect(result.code).toBe(0);
-                expect(warns.join("\n")).toContain("SchedulerDO");
+                expect(result.code).toBe(1);
+                expect(errors.join("\n")).toContain("SchedulerDO");
             });
 
             it("blocks --env <name> that names no declared environment", async () => {

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -1511,13 +1511,12 @@ const abortResult = (error: string, extra?: Partial<DeployCommandResult>): Deplo
  * Log wrangler.jsonc validation problems (if any) and report whether the deploy
  * must abort.
  *
- * Warnings are printed too. The validator's unexported-class check is
- * deliberately a warning rather than an error (its scanner fails closed on
- * export forms it does not know, and blocking a working deploy is worse than
- * missing one) — but this command only ever printed `report.errors`, so on the
- * single command that actually ships a Worker the warning was invisible and the
- * user met wrangler's own bundle failure instead. Same for the `unverifiedKeys`
- * env-override notice and the missing-assets-directory warning.
+ * Warnings are printed too, not just `report.errors`. This command is the one
+ * that actually ships a Worker, so a warning it swallows is one the user meets
+ * as a wrangler failure instead — which is what happened while the
+ * unexported-class check was warning-level (it blocks now), and still applies to
+ * the `unverifiedKeys` env-override notice and the missing-assets-directory
+ * warning.
  */
 const reportWranglerProblems = (validation: { problems: ReadonlyArray<string>; report?: { warnings: ReadonlyArray<string> } }, logger: Logger): boolean => {
     for (const warning of validation.report?.warnings ?? []) {

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -1099,6 +1099,77 @@ describe("wrangler-validator", () => {
                 expect(result.report.errors.join("\n")).toContain("SchedulerDO");
             });
 
+            it("is not switched off by an `export {}` — only a star re-export is opaque", () => {
+                expect.assertions(1);
+
+                // `export {}` lists no names, exactly like `export * from`, but it
+                // forwards nothing and is a routine way to mark a file as a
+                // module. Treating it as opaque turned the whole check off and
+                // read as a pass — worse than the bug the check exists to catch.
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export {};\nexport { ShardDO } from "./shard";\nexport default { fetch() {} };\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
+            });
+
+            it("does not count a locally declared class that an export clause aliases away", () => {
+                expect.assertions(1);
+
+                // ts-morph answers `isExported()` true for a class named by ANY
+                // export clause, alias and all — so this read as exporting
+                // `SchedulerDO`, the one name wrangler does not bind.
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export { ShardDO } from "./shard";\nclass SchedulerDO {}\nexport { SchedulerDO as SomethingElse };\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
+            });
+
+            it("reports nothing when the entry does not parse — a blocking check must be sure", () => {
+                expect.assertions(2);
+
+                // ts-morph error-RECOVERS instead of throwing, and a recovered
+                // parse drops statements. Blocking on a half-typed file would
+                // stop `lunora dev` mid-keystroke.
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export { ShardDO } from "./shard";\nexport const broken = (\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
+                expect(result.report.valid).toBe(true);
+            });
+
+            it("does not judge a built worker artifact named by main", () => {
+                expect.assertions(1);
+
+                // A class-B `main` can name the framework adapter's build output,
+                // which exports only the SSR fetch handler — every declared class
+                // reads as unexported there.
+                writeSchema(SCHEMA_NO_GLOBAL);
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "x",
+    "main": "dist/_worker.js",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }, { "name": "SCHEDULER", "class_name": "SchedulerDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO", "SchedulerDO"] }]
+}
+`,
+                    "utf8",
+                );
+                mkdirSync(join(workdir, "dist"), { recursive: true });
+                writeFileSync(join(workdir, "dist", "_worker.js"), `export default { fetch() {} };\n`, "utf8");
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
+            });
+
             it("ignores a binding whose class lives in another script", () => {
                 expect.assertions(1);
 

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -938,11 +938,11 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                // A warning, not an error: the scanner cannot know every export
-                // form, and a miss must not block a deploy that would have worked.
-                expect(result.report.valid).toBe(true);
-                expect(result.report.warnings.join("\n")).toContain("SchedulerDO");
-                expect(result.report.warnings.join("\n")).toContain("does not export it");
+                // An ERROR: `verify` used to exit 0 on a tree `lunora build`
+                // rejects, so a PR check went green and the deploy job failed.
+                expect(result.report.valid).toBe(false);
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
+                expect(result.report.errors.join("\n")).toContain("does not export it");
             });
 
             it("passes once the class is exported", () => {
@@ -955,7 +955,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.filter((warning) => warning.includes("does not export it"))).toEqual([]);
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
             });
 
             it("treats a type-only export as unexported — it compiles away", () => {
@@ -966,7 +966,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.join("\n")).toContain("SchedulerDO");
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
             });
 
             it("does not accept a commented-out export, or the class named in prose", () => {
@@ -985,7 +985,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.join("\n")).toContain("SchedulerDO");
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
             });
 
             it("accepts a multi-line export list — the way prettier formats three or more", () => {
@@ -1000,7 +1000,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.filter((warning) => warning.includes("does not export it"))).toEqual([]);
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
             });
 
             it("does not let a type-only re-export elsewhere suppress a real value export", () => {
@@ -1018,7 +1018,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.filter((warning) => warning.includes("does not export it"))).toEqual([]);
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
             });
 
             it("resolves `export { Local as Bound }` by the EXPORTED name, which is what wrangler binds", () => {
@@ -1029,12 +1029,12 @@ describe("wrangler-validator", () => {
 
                 const accepted = validateWranglerProject({ projectRoot: workdir });
 
-                expect(accepted.report.warnings.filter((warning) => warning.includes("does not export it"))).toEqual([]);
+                expect(accepted.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
 
                 // The LOCAL name is not what is bound, so aliasing it away is a miss.
                 writeEntry(`export { ShardDO } from "./shard";\nexport { SchedulerDO as SomethingElse } from "./s";\nexport default { fetch() {} };\n`);
 
-                expect(validateWranglerProject({ projectRoot: workdir }).report.warnings.join("\n")).toContain("SchedulerDO");
+                expect(validateWranglerProject({ projectRoot: workdir }).report.errors.join("\n")).toContain("SchedulerDO");
             });
 
             it("stays silent when the entry has a star re-export", () => {
@@ -1048,7 +1048,55 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.filter((warning) => warning.includes("does not export it"))).toEqual([]);
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
+            });
+
+            it("accepts the app builder's own `export const { ShardDO } = app`", () => {
+                expect.assertions(1);
+
+                // The check now BLOCKS, so every form a real entry uses has to
+                // be understood. This one is generated, not hand-written.
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`const app = createApp();\nexport const { SchedulerDO, ShardDO } = app;\nexport default app;\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
+            });
+
+            it("accepts a class declared and exported in the entry itself", () => {
+                expect.assertions(1);
+
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export { ShardDO } from "./shard";\nexport class SchedulerDO extends Base {}\nexport default { fetch() {} };\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("does not export it"))).toEqual([]);
+            });
+
+            it("does not accept `export default class SchedulerDO` — that binds `default`", () => {
+                expect.assertions(1);
+
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export { ShardDO } from "./shard";\nexport default class SchedulerDO extends Base {}\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
+            });
+
+            it("does not treat `export * as ns from` as opaque — it binds only `ns`", () => {
+                expect.assertions(1);
+
+                // Unlike a bare star re-export, a namespace re-export forwards
+                // no top-level name, so absence is still a fact.
+                writeWrangler(`, { "name": "SCHEDULER", "class_name": "SchedulerDO" }`);
+                writeEntry(`export { ShardDO } from "./shard";\nexport * as scheduler from "./scheduler";\nexport default { fetch() {} };\n`);
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("SchedulerDO");
             });
 
             it("ignores a binding whose class lives in another script", () => {
@@ -1059,7 +1107,7 @@ describe("wrangler-validator", () => {
 
                 const result = validateWranglerProject({ projectRoot: workdir });
 
-                expect(result.report.warnings.filter((warning) => warning.includes("RemoteDO"))).toEqual([]);
+                expect(result.report.errors.filter((error) => error.includes("RemoteDO"))).toEqual([]);
             });
         });
 

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -12,7 +12,10 @@
  * `{ problems, wranglerPath }` shape kept for backward compatibility.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
+
+import type { SourceFile } from "ts-morph";
+import { Node, Project } from "ts-morph";
 
 import { isEnvEnabled } from "../../../../shared/env-flag";
 import { COMPOSED_WORKER_ENTRY, WORKER_ENTRY_FALLBACKS } from "../infer-bindings";
@@ -1518,171 +1521,110 @@ const resolveWorkerEntryPath = (main: string | undefined, projectRoot: string, w
 };
 
 /**
- * Blank out comments and string/template literals, preserving offsets.
- *
- * Without this, a commented-out export or a class named in prose reads as a real
- * export — and a worker entry that discusses its Durable Objects in comments is
- * the normal case, so the check would silently pass on exactly the tree it
- * exists to catch. Replacing with spaces rather than deleting keeps every offset
- * and line intact.
- *
- * Deliberately coarse on escapes (`"a\"b"` blanks only up to the inner quote):
- * the goal is that quoted text cannot pass for code, and blanking slightly less
- * of a string never turns a real export into a missing one.
+ * Every name a binding pattern binds — `{ ShardDO }`, `{ a: b }`, `[x]`, and
+ * nests of those. `export const { ShardDO } = app;` is the generated app
+ * builder's own pattern, so this is not an exotic form.
  */
-const COMMENT_OR_STRING_RE = /\/\/[^\n]*|\/\*.*?\*\/|"[^"\n]*"|'[^'\n]*'|`[^`]*`/gsu;
+const collectBindingNames = (nameNode: Node, names: Set<string>): void => {
+    if (Node.isIdentifier(nameNode)) {
+        names.add(nameNode.getText());
 
-const blankCommentsAndStrings = (code: string): string =>
-    // The alternation is scanned positionally, so a `//` inside a string literal
-    // is consumed as part of that string rather than starting a comment.
-    code.replaceAll(COMMENT_OR_STRING_RE, (match) => match.replaceAll(/[^\n]/gu, " "));
+        return;
+    }
 
-/**
- * A star re-export (`export * from "./lunora/_generated/workflows"`) forwards
- * names no per-name scan can see. When the entry has one, absence of a class
- * name proves nothing, so the check is skipped entirely — a false error on a
- * correctly-wired project is worse than a missed one, because it blocks a deploy
- * that would have worked.
- */
-const STAR_REEXPORT_RE = /\bexport\s*\*\s*(?:as\s+\w+\s*)?from\b/u;
+    if (Node.isObjectBindingPattern(nameNode) || Node.isArrayBindingPattern(nameNode)) {
+        for (const element of nameNode.getElements()) {
+            if (Node.isBindingElement(element)) {
+                collectBindingNames(element.getNameNode(), names);
+            }
+        }
+    }
+};
 
-/** Every `export` keyword position in the blanked source. */
-const EXPORT_KEYWORD_RE = /\bexport\b/gu;
+/** The names an `export { … }` / `export … from "…"` clause binds as values. */
+const collectClauseExports = (sourceFile: SourceFile, names: Set<string>): boolean => {
+    let opaque = false;
 
-/** Modifiers that may sit between `export` and the declaration keyword. */
-const EXPORT_MODIFIERS_RE = /^\s*(?:(?:abstract|async|declare|default)\s+)*/u;
+    for (const declaration of sourceFile.getExportDeclarations()) {
+        if (declaration.isTypeOnly()) {
+            continue;
+        }
 
-/** A declaration-form export, once its modifiers are stripped (`class X`, `const X`, `function X`). */
-const EXPORT_DECLARATION_RE = /^(?:class|const|function|let|var)\s+(?<name>[$A-Z_a-z][\w$]*)/u;
+        const namespaceExport = declaration.getNamespaceExport();
 
-/**
- * A destructuring export — `export const { ShardDO, SessionDO } = app;`.
- *
- * This is the generated app builder's OWN pattern, so it is not an exotic form:
- * `apps/playground/src/server/index.ts` ships exactly this. A scanner that only
- * understood `export const <identifier>` reported the repo's own playground as
- * missing `ShardDO`.
- */
-const EXPORT_DESTRUCTURE_RE = /^\s*(?:const|let|var)\s*\{/u;
+        if (namespaceExport !== undefined) {
+            // `export * as ns from "…"` binds only `ns`, so it forwards nothing
+            // a class name could hide behind.
+            names.add(namespaceExport.getName());
 
-/**
- * The names the worker entry exports as runtime VALUES.
- *
- * Deliberately a small scanner over export CLAUSES rather than a proximity
- * regex. The proximity form (`export…[^\n;]*Name`) gets two realistic cases
- * wrong, and both fail CLOSED — reporting a correctly-wired project as broken,
- * which blocks a deploy that would have worked:
- *
- * A brace clause wrapped across lines — how prettier formats three or more
- * exports — cannot be matched by a bound that stops at the newline. And a
- * type-only export ANYWHERE in the file suppressed the real value export of the
- * same name (`export type { ShardDO as T }` beside `export { ShardDO }`),
- * because the type check was whole-file rather than per clause.
- *
- * `es-module-lexer` would be the right tool and is a dependency, but its WASM
- * entry needs an awaited `init` (this validator is synchronous) and its pure-JS
- * entry emits a V8 asm.js warning to stderr on load, which would appear on every
- * `prepare` / `verify` / `deploy`.
- *
- * For `export { Local as Exported }` the EXPORTED name is what wrangler binds,
- * so that is what is collected.
- */
-/** The leading identifier of a binding, after any `:` rename. */
-const LEADING_IDENTIFIER_RE = /^[$A-Z_a-z][\w$]*/u;
+            continue;
+        }
 
-/** `export type …` — the whole clause compiles away. */
-const TYPE_CLAUSE_RE = /^type\b/u;
+        const named = declaration.getNamedExports();
 
-/** Split one export specifier into its words, so `X as Y` and `type X` are separable. */
-const SPECIFIER_WORDS_RE = /\s+/u;
+        if (named.length === 0) {
+            // A bare `export * from "./x"` forwards names that live in another
+            // module, so the ABSENCE of a class name proves nothing here.
+            opaque = true;
 
-/**
- * Names bound by a named-export clause body (`A, B as C, type D`).
- *
- * For `A as B` the EXPORTED name is `B`, which is what wrangler binds. A leading
- * `type` marks that one specifier type-only — scoped per specifier, because a
- * whole-file check let an unrelated `export type { X as … }` suppress a real
- * `export { X }`.
- */
-const namedClauseExports = (clauseBody: string): string[] => {
-    const names: string[] = [];
+            continue;
+        }
 
-    for (const specifier of clauseBody.split(",")) {
-        const words = specifier.trim().split(SPECIFIER_WORDS_RE).filter(Boolean);
-        const last = words.at(-1);
-
-        if (last !== undefined && words[0] !== "type") {
-            names.push(last);
+        for (const specifier of named) {
+            // For `export { Local as Bound }` the EXPORTED name is what wrangler
+            // binds. A leading `type` is scoped per specifier — a whole-file
+            // check let an unrelated `export type { X as … }` suppress a real
+            // `export { X }`.
+            if (!specifier.isTypeOnly()) {
+                names.add(specifier.getAliasNode()?.getText() ?? specifier.getName());
+            }
         }
     }
 
-    return names;
+    return opaque;
 };
 
-/**
- * Names bound by a destructuring export body (`A, B: C`).
- *
- * `export const { ShardDO } = app;` is the generated app builder's own pattern,
- * so this is not an exotic form — the repo's playground ships exactly it.
- */
-const destructuredExports = (patternBody: string): string[] => {
-    const names: string[] = [];
-
-    for (const binding of patternBody.split(",")) {
-        const bound = binding.includes(":") ? binding.slice(binding.indexOf(":") + 1) : binding;
-        const identifier = LEADING_IDENTIFIER_RE.exec(bound.trim());
-
-        if (identifier) {
-            names.push(identifier[0]);
+/** The names declaration-form exports bind (`export class X`, `export const { X } = app`). */
+const collectDeclarationExports = (sourceFile: SourceFile, names: Set<string>): void => {
+    for (const statement of sourceFile.getVariableStatements().filter((candidate) => candidate.isExported())) {
+        for (const declaration of statement.getDeclarations()) {
+            collectBindingNames(declaration.getNameNode(), names);
         }
     }
 
-    return names;
-};
+    for (const declaration of [...sourceFile.getClasses(), ...sourceFile.getFunctions(), ...sourceFile.getEnums()]) {
+        // `export default class X` binds `default`, not `X`, so a default
+        // export never satisfies a `class_name`.
+        const name = declaration.isExported() && !declaration.isDefaultExport() ? declaration.getName() : undefined;
 
-/** The body of the first `{…}` at the start of `source`, or `undefined`. */
-const braceBody = (source: string): string | undefined => {
-    const open = source.indexOf("{");
-    const close = source.indexOf("}", open);
-
-    return open === -1 || close === -1 ? undefined : source.slice(open + 1, close);
-};
-
-/** Names one `export` keyword contributes as runtime values. */
-const exportNamesAt = (after: string): string[] => {
-    const trimmed = after.trimStart();
-
-    if (TYPE_CLAUSE_RE.test(trimmed)) {
-        return [];
-    }
-
-    if (trimmed.startsWith("{")) {
-        const body = braceBody(trimmed);
-
-        return body === undefined ? [] : namedClauseExports(body);
-    }
-
-    if (EXPORT_DESTRUCTURE_RE.test(after)) {
-        const body = braceBody(after);
-
-        return body === undefined ? [] : destructuredExports(body);
-    }
-
-    const declaration = EXPORT_DECLARATION_RE.exec(after.replace(EXPORT_MODIFIERS_RE, ""));
-
-    return declaration?.groups?.["name"] === undefined ? [] : [declaration.groups["name"]];
-};
-
-const collectValueExportNames = (code: string): Set<string> => {
-    const names = new Set<string>();
-
-    for (const match of code.matchAll(EXPORT_KEYWORD_RE)) {
-        for (const name of exportNamesAt(code.slice(match.index + "export".length))) {
+        if (name !== undefined) {
             names.add(name);
         }
     }
+};
 
-    return names;
+/**
+ * The runtime VALUE exports of a worker entry, and whether the file forwards
+ * names this scan cannot see (`opaque`).
+ *
+ * Parsed with ts-morph rather than scanned with regexes. The scanner this
+ * replaces had to stay advisory precisely because every export form it did not
+ * know failed CLOSED — reporting a correctly-wired project as broken — and two
+ * such forms (a prettier-wrapped clause, and the app builder's own
+ * `export const { ShardDO } = app`) turned up in a single review pass. A real
+ * parser knows them all, which is what lets the check block. ts-morph is already
+ * loaded on this path: `discoverSchemaInfo` parses the schema with it a few
+ * lines below.
+ */
+const collectValueExports = (fileName: string, source: string): { names: Set<string>; opaque: boolean } => {
+    const project = new Project({ compilerOptions: { allowJs: true }, skipFileDependencyResolution: true, useInMemoryFileSystem: true });
+    const sourceFile = project.createSourceFile(fileName, source, { overwrite: true });
+    const names = new Set<string>();
+    const opaque = collectClauseExports(sourceFile, names);
+
+    collectDeclarationExports(sourceFile, names);
+
+    return { names, opaque };
 };
 
 /**
@@ -1701,7 +1643,7 @@ const collectValueExportNames = (code: string): Set<string> => {
  * own description is "validate wrangler.jsonc + codegen dry-run + tsc" — the
  * thing that is invalid IS the relationship between `wrangler.jsonc` and the
  * entry. Only `lunora build`, which shells out to `wrangler deploy --dry-run`,
- * caught it.
+ * caught it — so `verify` in a PR check went green and the deploy job failed.
  *
  * Both files are already parsed here, so this is a string-set comparison.
  */
@@ -1720,11 +1662,9 @@ const collectUnexportedClassErrors = (wrangler: WranglerConfig, projectRoot: str
         return [];
     }
 
-    // Comments and strings are blanked first, so a commented-out export or a
-    // class name mentioned in prose cannot pass for a real one.
-    const code = blankCommentsAndStrings(source);
+    const { names: exported, opaque } = collectValueExports(basename(entryPath), source);
 
-    if (STAR_REEXPORT_RE.test(code)) {
+    if (opaque) {
         return [];
     }
 
@@ -1747,7 +1687,6 @@ const collectUnexportedClassErrors = (wrangler: WranglerConfig, projectRoot: str
         }
     }
 
-    const exported = collectValueExportNames(code);
     const missing = declared.filter((entry) => !exported.has(entry.className));
 
     return missing.map(
@@ -1820,23 +1759,22 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
     // references are left to wrangler — pure shape checks already ran above.
     const configDirectory = dirname(wranglerPath);
 
-    report.errors.push(...collectContainerImageErrors(resolvedWrangler.containers ?? [], configDirectory, wranglerPath));
-
     // FS-aware: every declared Durable Object / Workflow class must be exported
     // by the worker entry, or wrangler refuses to bundle.
     //
-    // A WARNING, not an error, and deliberately so. `collectValueExportNames` is
-    // a scanner, not a parser, and every form it does not know fails CLOSED —
-    // reporting a correctly-wired project as broken, which blocks `prepare` /
-    // `deploy` and stops `lunora dev` from starting. Two such forms (a
-    // prettier-wrapped clause, and the generated app builder's own
-    // `export const { ShardDO } = app`) were found in a single review pass, which
-    // is enough evidence that more exist.
-    //
-    // Warning still closes the reported gap: `verify` and `doctor` used to print
-    // a clean bill of health on a tree that cannot deploy, and now they say so.
-    // The authoritative check remains wrangler's own, which `lunora build` runs.
-    report.warnings.push(...collectUnexportedClassErrors(resolvedWrangler, options.projectRoot, wranglerPath));
+    // An ERROR. This was a warning for as long as the export names came from a
+    // regex scanner, because every form the scanner did not know failed CLOSED —
+    // reporting a correctly-wired project as broken, which would block `prepare`
+    // / `deploy` and stop `lunora dev` from starting. `collectValueExports`
+    // parses instead, so the only case it cannot decide (a bare `export *`) is
+    // reported as opaque and skipped, and what is left is a fact: this entry
+    // does not export that class and wrangler will refuse to bundle it.
+    // Warning-level meant `verify` exited 0 on a tree `lunora build` rejects,
+    // which is the whole point of running `verify` in a PR check.
+    report.errors.push(
+        ...collectContainerImageErrors(resolvedWrangler.containers ?? [], configDirectory, wranglerPath),
+        ...collectUnexportedClassErrors(resolvedWrangler, options.projectRoot, wranglerPath),
+    );
 
     // FS-aware: `assets.directory` is created by the client build, so it may
     // legitimately not exist at validation time (pre-build). Surface a *warning*

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -12,13 +12,13 @@
  * `{ problems, wranglerPath }` shape kept for backward compatibility.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { basename, dirname } from "node:path";
+import { basename, dirname, extname } from "node:path";
 
 import type { SourceFile } from "ts-morph";
 import { Node, Project } from "ts-morph";
 
 import { isEnvEnabled } from "../../../../shared/env-flag";
-import { COMPOSED_WORKER_ENTRY, WORKER_ENTRY_FALLBACKS } from "../infer-bindings";
+import { COMPOSED_WORKER_ENTRY, LUNORA_WORKER_VIRTUAL_ID, WORKER_ENTRY_FALLBACKS } from "../infer-bindings";
 import join from "../path";
 import type { SchemaInfo } from "../schema-info";
 import { discoverSchemaInfo } from "../schema-info";
@@ -1499,10 +1499,23 @@ const collectContainerImageErrors = (
 };
 
 /**
+ * Extensions this check will read. A class-B `main` can name the framework
+ * adapter's BUILD OUTPUT (`.svelte-kit/cloudflare/_worker.js`, `dist/_worker.js`),
+ * which exports only the SSR fetch handler — every declared class reads as
+ * unexported there. Today the composed `src/worker.ts` shadows that case, but
+ * the finding now blocks a deploy, so a bundle is skipped rather than trusted:
+ * an authored Lunora entry is TypeScript.
+ */
+const WORKER_ENTRY_SOURCE_EXTENSIONS = new Set([".cts", ".mts", ".ts", ".tsx"]);
+
+/**
  * Resolve the worker entry the way `lunora deploy` bundles it: the class-B
  * composed entry when present (it is passed to wrangler as the positional
  * script, overriding `main`), else `wrangler.main` relative to the config file,
  * else the conventional fallbacks.
+ *
+ * Returns `undefined` for anything this check must not judge — a missing file, a
+ * build artifact, or the class-A virtual specifier, which names no file at all.
  */
 const resolveWorkerEntryPath = (main: string | undefined, projectRoot: string, wranglerPath: string): string | undefined => {
     const composed = join(projectRoot, COMPOSED_WORKER_ENTRY);
@@ -1511,10 +1524,14 @@ const resolveWorkerEntryPath = (main: string | undefined, projectRoot: string, w
         return composed;
     }
 
+    if (main === LUNORA_WORKER_VIRTUAL_ID) {
+        return undefined;
+    }
+
     if (typeof main === "string" && main.length > 0) {
         const resolved = join(dirname(wranglerPath), main);
 
-        return existsSync(resolved) ? resolved : undefined;
+        return existsSync(resolved) && WORKER_ENTRY_SOURCE_EXTENSIONS.has(extname(resolved)) ? resolved : undefined;
     }
 
     return WORKER_ENTRY_FALLBACKS.map((fallback) => join(projectRoot, fallback)).find((candidate) => existsSync(candidate));
@@ -1550,27 +1567,29 @@ const collectClauseExports = (sourceFile: SourceFile, names: Set<string>): boole
             continue;
         }
 
-        const namespaceExport = declaration.getNamespaceExport();
+        // Only a STAR re-export is opaque, and `isNamespaceExport()` is the one
+        // predicate that identifies it. Testing "no named exports" instead also
+        // caught `export {}` — which binds nothing and is a routine way to mark
+        // a file as a module — and one of those anywhere in the entry silently
+        // turned this whole check off. That is worse than the bug it exists to
+        // catch, because it reads as a pass.
+        if (declaration.isNamespaceExport()) {
+            const namespaceExport = declaration.getNamespaceExport();
 
-        if (namespaceExport !== undefined) {
-            // `export * as ns from "…"` binds only `ns`, so it forwards nothing
-            // a class name could hide behind.
-            names.add(namespaceExport.getName());
+            if (namespaceExport === undefined) {
+                // A bare `export * from "./x"` forwards names that live in
+                // another module, so the ABSENCE of a class name proves nothing.
+                opaque = true;
+            } else {
+                // `export * as ns from "…"` binds only `ns`, so it forwards
+                // nothing a class name could hide behind.
+                names.add(namespaceExport.getName());
+            }
 
             continue;
         }
 
-        const named = declaration.getNamedExports();
-
-        if (named.length === 0) {
-            // A bare `export * from "./x"` forwards names that live in another
-            // module, so the ABSENCE of a class name proves nothing here.
-            opaque = true;
-
-            continue;
-        }
-
-        for (const specifier of named) {
+        for (const specifier of declaration.getNamedExports()) {
             // For `export { Local as Bound }` the EXPORTED name is what wrangler
             // binds. A leading `type` is scoped per specifier — a whole-file
             // check let an unrelated `export type { X as … }` suppress a real
@@ -1584,9 +1603,19 @@ const collectClauseExports = (sourceFile: SourceFile, names: Set<string>): boole
     return opaque;
 };
 
-/** The names declaration-form exports bind (`export class X`, `export const { X } = app`). */
+/**
+ * The names declaration-form exports bind (`export class X`, `export const { X } = app`).
+ *
+ * Keyed on the `export` MODIFIER, never on `isExported()`. ts-morph answers
+ * `isExported()` true for a class named by any export clause, alias and all — so
+ * `class SchedulerDO {}` beside `export { SchedulerDO as SomethingElse }` read
+ * as exporting `SchedulerDO`, which is the one name wrangler does NOT bind. The
+ * clause walk above already records the exported name; this pass must only add
+ * declarations that carry the keyword themselves, or it double-counts the local
+ * one and misses the very rename the tests pin.
+ */
 const collectDeclarationExports = (sourceFile: SourceFile, names: Set<string>): void => {
-    for (const statement of sourceFile.getVariableStatements().filter((candidate) => candidate.isExported())) {
+    for (const statement of sourceFile.getVariableStatements().filter((candidate) => candidate.getExportKeyword() !== undefined)) {
         for (const declaration of statement.getDeclarations()) {
             collectBindingNames(declaration.getNameNode(), names);
         }
@@ -1595,7 +1624,7 @@ const collectDeclarationExports = (sourceFile: SourceFile, names: Set<string>): 
     for (const declaration of [...sourceFile.getClasses(), ...sourceFile.getFunctions(), ...sourceFile.getEnums()]) {
         // `export default class X` binds `default`, not `X`, so a default
         // export never satisfies a `class_name`.
-        const name = declaration.isExported() && !declaration.isDefaultExport() ? declaration.getName() : undefined;
+        const name = declaration.getExportKeyword() !== undefined && !declaration.isDefaultExport() ? declaration.getName() : undefined;
 
         if (name !== undefined) {
             names.add(name);
@@ -1615,16 +1644,43 @@ const collectDeclarationExports = (sourceFile: SourceFile, names: Set<string>): 
  * parser knows them all, which is what lets the check block. ts-morph is already
  * loaded on this path: `discoverSchemaInfo` parses the schema with it a few
  * lines below.
+ *
+ * `undefined` means "cannot be decided from this file" and the caller reports
+ * nothing. Two ways to get there, and both must FAIL OPEN now that the finding
+ * blocks: a bare `export *`, which forwards names from another module, and a
+ * file that does not parse. ts-morph error-RECOVERS rather than throwing, and a
+ * recovered parse silently drops statements — so a half-typed entry would
+ * otherwise report every class as unexported and stop `lunora dev` mid-keystroke.
+ * The lexer-based sibling in `infer-bindings` has the same carve-out (it catches
+ * and falls back); this is that carve-out, made explicit.
  */
-const collectValueExports = (fileName: string, source: string): { names: Set<string>; opaque: boolean } => {
-    const project = new Project({ compilerOptions: { allowJs: true }, skipFileDependencyResolution: true, useInMemoryFileSystem: true });
+const collectValueExports = (fileName: string, source: string): Set<string> | undefined => {
+    // `skipLoadingLibFiles` is load-bearing, not a micro-optimisation: asking for
+    // the program pulls in the full `lib.d.ts` set otherwise, which measured
+    // 571ms per call against 1.07ms without. Nothing here type-checks — the
+    // diagnostics read is SYNTACTIC, which is per-file parse errors and
+    // independent of the lib files.
+    const project = new Project({
+        compilerOptions: { allowJs: true },
+        skipFileDependencyResolution: true,
+        skipLoadingLibFiles: true,
+        useInMemoryFileSystem: true,
+    });
     const sourceFile = project.createSourceFile(fileName, source, { overwrite: true });
+
+    if (project.getProgram().compilerObject.getSyntacticDiagnostics(sourceFile.compilerNode).length > 0) {
+        return undefined;
+    }
+
     const names = new Set<string>();
-    const opaque = collectClauseExports(sourceFile, names);
+
+    if (collectClauseExports(sourceFile, names)) {
+        return undefined;
+    }
 
     collectDeclarationExports(sourceFile, names);
 
-    return { names, opaque };
+    return names;
 };
 
 /**
@@ -1645,7 +1701,8 @@ const collectValueExports = (fileName: string, source: string): { names: Set<str
  * entry. Only `lunora build`, which shells out to `wrangler deploy --dry-run`,
  * caught it — so `verify` in a PR check went green and the deploy job failed.
  *
- * Both files are already parsed here, so this is a string-set comparison.
+ * Reports nothing whenever the entry's exports cannot be decided — see
+ * {@link collectValueExports}. A check that blocks must be sure.
  */
 const collectUnexportedClassErrors = (wrangler: WranglerConfig, projectRoot: string, wranglerPath: string): string[] => {
     const entryPath = resolveWorkerEntryPath(wrangler.main, projectRoot, wranglerPath);
@@ -1662,9 +1719,9 @@ const collectUnexportedClassErrors = (wrangler: WranglerConfig, projectRoot: str
         return [];
     }
 
-    const { names: exported, opaque } = collectValueExports(basename(entryPath), source);
+    const exported = collectValueExports(basename(entryPath), source);
 
-    if (opaque) {
+    if (exported === undefined) {
         return [];
     }
 
@@ -1689,11 +1746,16 @@ const collectUnexportedClassErrors = (wrangler: WranglerConfig, projectRoot: str
 
     const missing = declared.filter((entry) => !exported.has(entry.className));
 
+    // The remedy names both wirings, because the blocked user is on one of two
+    // paths and the wrong instruction is worse than none: a hand-written entry
+    // re-exports the class, while the generated app builder hands it back on
+    // `app` and the entry destructures it.
     return missing.map(
         (entry) =>
             `${entry.label} declares class "${entry.className}" but the worker entry (${entryPath}) does not export it — ` +
             `wrangler refuses to bundle a Worker whose Durable Object classes are not exported. ` +
-            `Add \`export { ${entry.className} } from "…";\` to the entry.`,
+            `Re-export it from the module that defines it (\`export { ${entry.className} } from "./…";\`), ` +
+            `or add it to the app builder's own export (\`export const { ${entry.className} } = app;\`).`,
     );
 };
 
@@ -1754,23 +1816,16 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
         report.warnings.push(`schema parse failed in ${schemaDirectory}/schema.ts: ${schemaError}`);
     }
 
-    // FS-aware: a local-path container image must point at an existing
-    // Dockerfile (wrangler resolves it relative to the config file). Registry
-    // references are left to wrangler — pure shape checks already ran above.
     const configDirectory = dirname(wranglerPath);
 
-    // FS-aware: every declared Durable Object / Workflow class must be exported
-    // by the worker entry, or wrangler refuses to bundle.
-    //
-    // An ERROR. This was a warning for as long as the export names came from a
-    // regex scanner, because every form the scanner did not know failed CLOSED —
-    // reporting a correctly-wired project as broken, which would block `prepare`
-    // / `deploy` and stop `lunora dev` from starting. `collectValueExports`
-    // parses instead, so the only case it cannot decide (a bare `export *`) is
-    // reported as opaque and skipped, and what is left is a fact: this entry
-    // does not export that class and wrangler will refuse to bundle it.
-    // Warning-level meant `verify` exited 0 on a tree `lunora build` rejects,
-    // which is the whole point of running `verify` in a PR check.
+    // Both are FS-aware checks, so neither could run in `validateWranglerConfig`
+    // above. A local-path container image must point at an existing Dockerfile
+    // (wrangler resolves it relative to the config file; registry references are
+    // left to wrangler). And every declared Durable Object / Workflow class must
+    // be exported by the worker entry, or wrangler refuses to bundle — an error
+    // rather than a warning because `collectValueExports` reports nothing unless
+    // it is certain, so what reaches here is a fact, and a warning meant `verify`
+    // exited 0 on a tree `lunora build` rejects.
     report.errors.push(
         ...collectContainerImageErrors(resolvedWrangler.containers ?? [], configDirectory, wranglerPath),
         ...collectUnexportedClassErrors(resolvedWrangler, options.projectRoot, wranglerPath),

--- a/packages/config/src/infer-bindings.ts
+++ b/packages/config/src/infer-bindings.ts
@@ -1014,21 +1014,21 @@ export type {
     InferredWorkflow,
     WorkerEntry,
 };
-// `COMPOSED_WORKER_ENTRY`, `WORKER_ENTRY_FALLBACKS` and `isTypeOnlyExportEntry`
+// `COMPOSED_WORKER_ENTRY`, `WORKER_ENTRY_FALLBACKS` and `LUNORA_WORKER_VIRTUAL_ID`
 // are shared with the wrangler validator's exported-class check, which answers
 // the same question ("which classes does the entry export as runtime values?")
 // against the same file. The validator keeps its own path resolver because it
 // resolves `main` from the `--env` view relative to the config file, which this
 // one (deliberately projectRoot-relative, and reading the top level) does not.
+//
+// It also keeps its own READER: this side lexes with `es-module-lexer` (it is
+// already lexing the same file's IMPORTS for capability inference), the
+// validator parses with ts-morph. That is a real duplication and the two can
+// disagree — this one PROVISIONS a binding, the other now BLOCKS a deploy on
+// one — so they are worth collapsing onto the ts-morph reader. Not done here:
+// this side feeds `reconcile`, and changing what it provisions is a separate
+// change from fixing what the validator reports.
 // `resolveWorkerEntry` returns a {@link WorkerEntry}, not a path: the class-A
 // composed entry (`main: "virtual:lunora/worker"`) has no file, and reading that
 // as "no worker entry" is what left every container/workflow/agent unprovisioned.
-export {
-    COMPOSED_WORKER_ENTRY,
-    inferLunoraBindings,
-    isTypeOnlyExportEntry,
-    LUNORA_WORKER_VIRTUAL_ID,
-    packageNamesFromBindings,
-    resolveWorkerEntry,
-    WORKER_ENTRY_FALLBACKS,
-};
+export { COMPOSED_WORKER_ENTRY, inferLunoraBindings, LUNORA_WORKER_VIRTUAL_ID, packageNamesFromBindings, resolveWorkerEntry, WORKER_ENTRY_FALLBACKS };


### PR DESCRIPTION
Fixes #652.

`lunora verify` reported **"project is valid"** and exited 0 for a project `wrangler` refuses to bundle — a PR check went green and the deploy job failed with *"Your Worker depends on the following Durable Objects, which are not exported in your entrypoint file"*.

The cross-check itself already existed: `durable_objects.bindings[].class_name` and `workflows[].class_name` were compared against the worker entry's exports. It was only ever a **warning**, because the export names came from a regex scanner and every form the scanner did not know failed CLOSED — reporting a correctly-wired project as broken, which would block `prepare` / `deploy` and stop `lunora dev` from starting.

## What changed

Parse the entry with ts-morph instead of scanning it (ts-morph is already loaded on this path — the schema discovery a few lines below constructs one). Named clauses, aliases (`export { Local as Bound }`), per-specifier `type`, class/function/enum declarations and destructured `export const { ShardDO } = app` are now all exact. The one case that cannot be decided from the entry alone — a bare `export * from "…"`, which forwards names from another module — is reported as opaque and the check is skipped, as before.

With the detection exact, the finding is a fact rather than a guess, so it is now an **error**: `verify` exits 1 and names the missing export.

```
durable_objects.bindings declares class "SchedulerDO" but the worker entry
(src/server/index.ts) does not export it — wrangler refuses to bundle a Worker
whose Durable Object classes are not exported. Add `export { SchedulerDO } from "…";`
to the entry.
```

`export * as ns from "…"` is no longer treated as opaque either: it binds only `ns`, so absence of the class name is still a fact.

## Verification

- Ran the validator over all **27** wrangler projects in the repo (`examples/*`, `apps/*`, `templates/*`, `tests/*`) — zero false positives.
- Reproduced the original failure against `examples/blog` with its `export { SchedulerDO }` commented out: warning before, error after.
- `@lunora/config` (685 tests), `@lunora/cli` (1516), `@lunora/vite` (223) all green; eslint + `tsc --noEmit` clean.
- Net **−14 lines**: the regex scanner and its five helper patterns are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae

---

## Review round 2

Two ways the new hard block fired on the wrong tree, both regressions introduced by the switch to ts-morph and both now pinned by tests:

- **`export {}` disabled the whole check.** `getNamedExports()` is empty for it, exactly as for `export * from`, so a single `export {}` anywhere in the entry made the check vacuously pass — and it *reads* as a pass. The regex scanner this replaced only ever treated `export *` as opaque. Gated on `isNamespaceExport()` now (thanks CodeRabbit).
- **A locally declared class aliased away still counted as exported.** ts-morph answers `isExported()` true for a class named by *any* export clause, alias included, so `class SchedulerDO {}` beside `export { SchedulerDO as SomethingElse }` read as exporting `SchedulerDO` — the one name wrangler does not bind. Keyed on the `export` modifier now; the variable-statement path was already correct.

Two fail-open guards, because a check that blocks must be sure:

- An entry that **does not parse** is skipped. ts-morph error-recovers rather than throwing, and a recovered parse drops statements — blocking on a half-typed file would stop `lunora dev` mid-keystroke.
- A `main` naming a **build artifact** or the class-A virtual specifier is skipped: an adapter's `_worker.js` exports only the SSR handler, so every declared class reads as unexported there.

`skipLoadingLibFiles` on the parse — asking for the program otherwise loads the full `lib.d.ts` set, measured at **571ms per call against 1.07ms** without. The diagnostics read is syntactic, so the lib files are not needed.

The remedy text now names the app-builder wiring alongside the re-export, since the blocked user is on one of two paths. Re-verified against all 27 wrangler projects: still no false positives.
