### PR TITLE
fix(codegen): resolve a spread in an args or column map instead of dropping its fields

### DIFF
--- a/packages/codegen/__tests__/discover/functions/expose-and-builder-chain.test.ts
+++ b/packages/codegen/__tests__/discover/functions/expose-and-builder-chain.test.ts
@@ -61,15 +61,26 @@ describe("expose.ts", () => {
             expect(argsFromCall(lastCall(`export const list = query();`))).toStrictEqual({});
         });
 
-        it("returns no args when `args` is absent, shorthand, or a reference rather than a literal", () => {
+        it("returns no args when `args` is absent, shorthand, or an unreadable reference", () => {
             expect.assertions(3);
 
-            // A shorthand (`{ args }`) or an indirection (`args: shared`) is not
+            // A shorthand (`{ args }`) or an unresolvable indirection is not
             // statically readable. Reporting `{}` under-documents; inventing a shape
             // would type calls the runtime validator then rejects.
             expect(argsFromCall(lastCall(`export const list = query({ handler: () => [] });`))).toStrictEqual({});
             expect(argsFromCall(lastCall(`export const list = query({ args, handler: () => [] });`))).toStrictEqual({});
-            expect(argsFromCall(lastCall(`export const list = query({ args: shared, handler: () => [] });`))).toStrictEqual({});
+            expect(argsFromCall(lastCall(`export const list = query({ args: buildArgs(), handler: () => [] });`))).toStrictEqual({});
+        });
+
+        it("resolves `args: sharedArgs` to the const record it names", () => {
+            expect.assertions(1);
+
+            // One argument record shared by two procedures is ordinary, and this
+            // form used to contribute nothing while the runtime enforced every
+            // field.
+            const source = `const shared = { id: v.string() };\nexport const list = query({ args: shared, handler: () => [] });`;
+
+            expect(argsFromCall(lastCall(source))).toStrictEqual({ id: { kind: "string" } });
         });
     });
 
@@ -219,10 +230,24 @@ describe("builder-chain.ts", () => {
             });
         });
 
-        it("reports an `.input()` whose argument cannot be resolved, rather than dropping it", () => {
+        it("skips an `.input()` whose argument cannot be resolved, without throwing", () => {
             expect.assertions(1);
 
-            expect(() => argsFromBuilderChain(receiver(`export const list = query.input(buildArgs()).query(h);`))).toThrow(/cannot read the fields/u);
+            // `lunora introspect` GENERATES `.input(<table>List.args)`, whose
+            // record `defineListArgs` builds at runtime. Aborting would take
+            // `dev`/`verify`/`deploy` down for every introspected project, so
+            // the unreadable-arguments advisory reports the gap instead.
+            expect(argsFromBuilderChain(receiver(`export const list = query.input(buildArgs()).input({ id: v.string() }).query(h);`))).toStrictEqual({
+                id: { kind: "string" },
+            });
+        });
+
+        it("resolves an `.input()` that reads a record off an object", () => {
+            expect.assertions(1);
+
+            const chain = `const listArgs = { args: { page: v.number() } };\nexport const list = query.input(listArgs.args).query(h);`;
+
+            expect(argsFromBuilderChain(receiver(chain))).toStrictEqual({ page: { kind: "number" } });
         });
 
         it("returns an empty record for a chain with no `.input()`", () => {

--- a/packages/codegen/__tests__/discover/functions/expose-and-builder-chain.test.ts
+++ b/packages/codegen/__tests__/discover/functions/expose-and-builder-chain.test.ts
@@ -202,12 +202,27 @@ describe("builder-chain.ts", () => {
             expect(argsFromBuilderChain(receiver(chain))).toStrictEqual({ id: { kind: "string" }, keep: { kind: "boolean" } });
         });
 
-        it("skips an `.input()` whose argument is not an object literal", () => {
+        it("resolves an `.input()` that names a const object literal", () => {
             expect.assertions(1);
 
-            expect(argsFromBuilderChain(receiver(`export const list = query.input(sharedArgs).input({ id: v.string() }).query(h);`))).toStrictEqual({
+            // Sharing an argument record between two procedures is the most
+            // ordinary thing there is, and it used to contribute NOTHING to the
+            // generated type while the runtime still enforced every field.
+            const chain =
+                `const sharedArgs = { alpha: v.string(), beta: v.optional(v.number()) };\n` +
+                `export const list = query.input(sharedArgs).input({ id: v.string() }).query(h);`;
+
+            expect(argsFromBuilderChain(receiver(chain))).toStrictEqual({
+                alpha: { kind: "string" },
+                beta: { inner: { kind: "number" }, kind: "optional" },
                 id: { kind: "string" },
             });
+        });
+
+        it("reports an `.input()` whose argument cannot be resolved, rather than dropping it", () => {
+            expect.assertions(1);
+
+            expect(() => argsFromBuilderChain(receiver(`export const list = query.input(buildArgs()).query(h);`))).toThrow(/cannot read the fields/u);
         });
 
         it("returns an empty record for a chain with no `.input()`", () => {

--- a/packages/codegen/__tests__/discover/procedure-middleware.test.ts
+++ b/packages/codegen/__tests__/discover/procedure-middleware.test.ts
@@ -85,6 +85,29 @@ const SPREAD_INPUT_SIGNUP = `${PREAMBLE}
         });
 `;
 
+/** A spread graph that loops — the fields are dropped, so the verdict must be unknown. */
+const CYCLIC_SPREAD_SIGNUP = `${PREAMBLE}
+    const a = { ...b, name: v.string() };
+    const b = { ...a };
+
+    export const signUp = c.mutation
+        .input({ ...a })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** The address arrives through a spread codegen CAN read. */
+const RESOLVED_SPREAD_EMAIL_SIGNUP = `${PREAMBLE}
+    const signupArgs = { email: v.string(), password: v.string() };
+
+    export const signUp = c.mutation
+        .input({ ...signupArgs, name: v.string() })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
 /** Names that merely start with "email" but hold a flag/id, not an address. */
 const EMAIL_LOOKALIKE_ARGS = `${PREAMBLE}
     export const update = c.mutation
@@ -558,6 +581,33 @@ describe("discoverProcedureMiddleware", () => {
         const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
 
         expect(found[0]?.hasEmailArg).toBeUndefined();
+    });
+
+    it("leaves the verdict unknown when the spread graph cycles", () => {
+        expect.assertions(1);
+
+        // The parser breaks the cycle by emitting nothing for it, so the keys ARE
+        // dropped. Reporting the shape as fully readable would turn that into a
+        // confident `false` and clear the signup lint.
+        writeFileSync(join(workdir, "lunora", "signup.ts"), CYCLIC_SPREAD_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]?.hasEmailArg).toBeUndefined();
+    });
+
+    it("finds an email argument that arrives through a READABLE spread", () => {
+        expect.assertions(1);
+
+        // Once a resolvable spread stopped being opaque, a names list that could
+        // not see through it turned "unknown" into a confident `false` — which
+        // CLEARS `signup_mutation_without_disposable_gating` on a signup that
+        // does take an address. Silent, and in the unsafe direction.
+        writeFileSync(join(workdir, "lunora", "signup.ts"), RESOLVED_SPREAD_EMAIL_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "signUp", hasEmailArg: true });
     });
 
     it("does not treat `emailVerified` / `emailOptIn` / `emailTemplateId` as an address", () => {

--- a/packages/codegen/__tests__/discover/schema.test.ts
+++ b/packages/codegen/__tests__/discover/schema.test.ts
@@ -1742,6 +1742,26 @@ describe("discoverSchema", () => {
         expect(() => discoverSchema(project, schemaPath)).toThrow(/table "messages" is declared more than once/u);
     });
 
+    it("throws a diagnostic for a spread of table definitions instead of dropping them", () => {
+        expect.assertions(2);
+
+        // Skipped in silence before: every table behind the spread was absent
+        // from the generated data model while the schema still declared it.
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            const sharedTables = { audit: defineTable({ actor: v.string() }) };
+
+            export const schema = defineSchema({
+                ...sharedTables,
+                messages: defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(() => discoverSchema(project, schemaPath)).toThrow(CodegenDiagnosticError);
+        expect(() => discoverSchema(project, schemaPath)).toThrow(/tables behind `\.\.\.sharedTables` cannot be read/u);
+    });
+
     it("throws a pinpointed diagnostic (not a generic INTERNAL error) for an extension table named after a reserved keyword", () => {
         expect.assertions(3);
 

--- a/packages/codegen/__tests__/discover/schema.test.ts
+++ b/packages/codegen/__tests__/discover/schema.test.ts
@@ -1742,11 +1742,12 @@ describe("discoverSchema", () => {
         expect(() => discoverSchema(project, schemaPath)).toThrow(/table "messages" is declared more than once/u);
     });
 
-    it("throws a diagnostic for a spread of table definitions instead of dropping them", () => {
-        expect.assertions(2);
+    it("follows a spread of table definitions instead of dropping them", () => {
+        expect.assertions(1);
 
         // Skipped in silence before: every table behind the spread was absent
         // from the generated data model while the schema still declared it.
+        // `registry/payment` ships `paymentTables` as exactly this shape.
         const { project, schemaPath } = projectWith(`
             import { defineSchema, defineTable, v } from "@lunora/server";
 
@@ -1758,8 +1759,28 @@ describe("discoverSchema", () => {
             });
         `);
 
-        expect(() => discoverSchema(project, schemaPath)).toThrow(CodegenDiagnosticError);
-        expect(() => discoverSchema(project, schemaPath)).toThrow(/tables behind `\.\.\.sharedTables` cannot be read/u);
+        expect(discoverSchema(project, schemaPath).tables.map((table) => table.name)).toStrictEqual(["audit", "messages"]);
+    });
+
+    it("skips a table spread it cannot read rather than aborting the run", () => {
+        expect.assertions(1);
+
+        // `defineSchema({ ...authTables(options) })` is the documented
+        // `@lunora/auth` wiring and the record is built at runtime — there is no
+        // inline form to fall back to, so refusing it would leave that path
+        // unable to generate at all.
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            const authTables = () => ({ user: defineTable({ email: v.string() }) });
+
+            export const schema = defineSchema({
+                ...authTables(),
+                messages: defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(discoverSchema(project, schemaPath).tables.map((table) => table.name)).toStrictEqual(["messages"]);
     });
 
     it("throws a pinpointed diagnostic (not a generic INTERNAL error) for an extension table named after a reserved keyword", () => {

--- a/packages/codegen/__tests__/discover/unreadable-arguments.test.ts
+++ b/packages/codegen/__tests__/discover/unreadable-arguments.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The advisory that replaced an abort.
+ *
+ * Codegen resolves an `.input(sharedArgs)` and a `{ ...sharedArgs }` to the
+ * `const` literal behind them; a record ASSEMBLED at runtime has nothing to
+ * read. Throwing on that took down two shipped paths (`lunora introspect`
+ * generates `.input(<table>List.args)`, and `defineSchema({ ...authTables(o) })`
+ * is the documented auth wiring), so the gap is reported instead — and the
+ * report has to be precise, because a warning nobody can act on is noise.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Project } from "ts-morph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import discoverUnreadableArguments from "../../src/discover/unreadable-arguments";
+
+// Self-contained, like `procedure-middleware.test.ts`: the classifier keys on
+// the `__lunoraProcedure` brand, so the builder has to carry it here rather than
+// come from an unresolvable `./_generated/server`.
+const PREAMBLE = `
+    declare const v: { number: () => unknown; string: () => unknown };
+
+    interface QueryBuilder<Args> {
+        readonly __lunoraProcedure: "query";
+        input: <A>(args: A) => QueryBuilder<A>;
+        query: <R>(handler: (options: { args: Args }) => R) => { kind: "query" };
+    }
+
+    declare const c: {
+        query: QueryBuilder<Record<never, never>> & (<R>(config: { args?: Record<string, unknown>; handler: () => R }) => { kind: "query" });
+    };
+`;
+
+let workdir: string;
+let project: Project;
+
+const findingsFor = (source: string): ReturnType<typeof discoverUnreadableArguments> => {
+    const filePath = join(workdir, "lunora", "probe.ts");
+
+    writeFileSync(filePath, `${PREAMBLE}${source}`, "utf8");
+    // The pass deliberately reads only files discovery already loaded, so the
+    // harness has to load this one — `runCodegen` gets that from
+    // `discoverFunctions`. Without it every assertion here passes vacuously.
+    project.addSourceFileAtPath(filePath);
+
+    return discoverUnreadableArguments(project, join(workdir, "lunora"));
+};
+
+describe("discoverUnreadableArguments", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-unreadable-"));
+        mkdirSync(join(workdir, "lunora"), { recursive: true });
+        project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("reports a chained `.input()` whose record cannot be read", () => {
+        expect.assertions(2);
+
+        const findings = findingsFor(`
+    const buildArgs = () => ({ id: v.string() });
+
+    export const list = c.query.input(buildArgs()).query(async () => []);
+`);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({ level: "WARN", metadata: { exportName: "list" }, name: "procedure_arguments_unreadable" });
+    });
+
+    it("reports a bare-factory `args:` that cannot be read", () => {
+        expect.assertions(1);
+
+        // The bare factory is an IMPORTED identifier — `resolveCalleeKind` keys
+        // on the import coming from a Lunora surface module.
+        const findings = findingsFor(`
+    import { query } from "@lunora/server";
+
+    const buildArgs = () => ({ id: 1 });
+
+    export const list = query({ args: buildArgs(), handler: async () => [] });
+`);
+
+        expect(findings.map((finding) => finding.metadata?.["exportName"])).toStrictEqual(["list"]);
+    });
+
+    it("stays quiet when the record resolves", () => {
+        expect.assertions(1);
+
+        const findings = findingsFor(`
+    const sharedArgs = { id: v.string() };
+
+    export const list = c.query.input({ ...sharedArgs, page: v.number() }).query(async () => []);
+    export const get = c.query.input(sharedArgs).query(async () => []);
+`);
+
+        expect(findings).toStrictEqual([]);
+    });
+
+    it("stays quiet for a procedure that declares no arguments at all", () => {
+        expect.assertions(1);
+
+        expect(findingsFor(`export const list = c.query.query(async () => []);`)).toStrictEqual([]);
+    });
+
+    it("does not report a factory call whose whole options object is a variable", () => {
+        expect.assertions(1);
+
+        // `args` is optional in this form, so an unreadable options object does
+        // not tell us a record was declared — reporting one would be a guess.
+        // The shared tri-state still calls it opaque, which is what the security
+        // lints need; this advisory is the narrower question.
+        const findings = findingsFor(`
+    declare const config: never;
+
+    export const list = c.query(config);
+`);
+
+        expect(findings).toStrictEqual([]);
+    });
+});

--- a/packages/codegen/__tests__/parse-validator-spread.test.ts
+++ b/packages/codegen/__tests__/parse-validator-spread.test.ts
@@ -13,13 +13,9 @@ import { describe, expect, it } from "vitest";
 
 import { parseObjectShape } from "../src/parse-validator";
 
-let project: Project;
-
 /** Parse the `args` object literal declared last in `source`. */
 const shapeOf = (source: string): Record<string, unknown> => {
-    project = new Project({ useInMemoryFileSystem: true });
-
-    const file = project.createSourceFile("snippet.ts", source, { overwrite: true });
+    const file = new Project({ useInMemoryFileSystem: true }).createSourceFile("snippet.ts", source, { overwrite: true });
     const initializer = file.getVariableDeclarationOrThrow("args").getInitializerOrThrow();
 
     if (!Node.isObjectLiteralExpression(initializer)) {
@@ -58,18 +54,34 @@ describe("parseObjectShape spreads", () => {
         expect(shapeOf(source)).toStrictEqual({ alpha: { kind: "string" }, beta: { kind: "number" }, gamma: { kind: "boolean" } });
     });
 
-    it("reports a spread it cannot resolve rather than dropping its fields", () => {
+    it("keeps the readable fields when a spread cannot be resolved, and never throws", () => {
         expect.assertions(1);
 
-        // Silence here is what made this expensive: the loss surfaced as a name
-        // error at a caller in another package, reading as a typo rather than as
-        // a dropped field.
-        expect(() => shapeOf(`const args = { ...buildArgs(), gamma: v.boolean() };`)).toThrow(/cannot read the fields behind/u);
+        // A record built by a call has no literal to read. Aborting on it would
+        // take down `defineSchema({ ...authTables(options) })` and every
+        // `lunora introspect` project, which have no inline form to fall back
+        // to — so the readable half is kept and the gap is reported by
+        // `discoverUnreadableArguments`, which knows the procedure's name.
+        expect(shapeOf(`const args = { ...buildArgs(), gamma: v.boolean() };`)).toStrictEqual({ gamma: { kind: "boolean" } });
     });
 
     it("terminates on a mutually-referential spread instead of recursing forever", () => {
         expect.assertions(1);
 
-        expect(() => shapeOf(`const a = { ...b };\nconst b = { ...a };\nconst args = { ...a };`)).toThrow(/cannot read the fields behind/u);
+        expect(shapeOf(`const a = { ...b };\nconst b = { ...a };\nconst args = { ...a, id: v.string() };`)).toStrictEqual({ id: { kind: "string" } });
+    });
+
+    it("does not follow a `let` — it can be reassigned before the chain reads it", () => {
+        expect.assertions(1);
+
+        expect(shapeOf(`let shared = { alpha: v.string() };\nconst args = { ...shared, gamma: v.boolean() };`)).toStrictEqual({ gamma: { kind: "boolean" } });
+    });
+
+    it("follows a property access to the record it holds", () => {
+        expect.assertions(1);
+
+        // `lunora introspect` generates `.input(<table>List.args)`, so this
+        // shape is machine-written, not exotic.
+        expect(shapeOf(`const list = { args: { page: v.number() } };\nconst args = { ...list.args };`)).toStrictEqual({ page: { kind: "number" } });
     });
 });

--- a/packages/codegen/__tests__/parse-validator-spread.test.ts
+++ b/packages/codegen/__tests__/parse-validator-spread.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Spread resolution in an object shape.
+ *
+ * `.input({ ...sharedArgs, extra })` used to emit ONLY `extra`: the parser read
+ * the literal syntactically and skipped every member that was not a property
+ * assignment. Codegen exited 0 and said nothing, while the runtime validator
+ * still enforced the fields behind the spread — so a caller passing `alpha` was
+ * told the property does not exist, and a caller that satisfied the generated
+ * type failed validation at runtime.
+ */
+import { Node, Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+
+import { parseObjectShape } from "../src/parse-validator";
+
+let project: Project;
+
+/** Parse the `args` object literal declared last in `source`. */
+const shapeOf = (source: string): Record<string, unknown> => {
+    project = new Project({ useInMemoryFileSystem: true });
+
+    const file = project.createSourceFile("snippet.ts", source, { overwrite: true });
+    const initializer = file.getVariableDeclarationOrThrow("args").getInitializerOrThrow();
+
+    if (!Node.isObjectLiteralExpression(initializer)) {
+        throw new Error("`args` must be an object literal");
+    }
+
+    return parseObjectShape(initializer);
+};
+
+describe("parseObjectShape spreads", () => {
+    it("merges the fields a spread of a const object literal contributes", () => {
+        expect.assertions(1);
+
+        expect(shapeOf(`const shared = { alpha: v.string(), beta: v.optional(v.number()) };\nconst args = { ...shared, gamma: v.boolean() };`)).toStrictEqual({
+            alpha: { kind: "string" },
+            beta: { inner: { kind: "number" }, kind: "optional" },
+            gamma: { kind: "boolean" },
+        });
+    });
+
+    it("applies JS spread precedence — source order decides a collision", () => {
+        expect.assertions(2);
+
+        expect(shapeOf(`const shared = { id: v.string() };\nconst args = { ...shared, id: v.number() };`)).toStrictEqual({ id: { kind: "number" } });
+        expect(shapeOf(`const shared = { id: v.string() };\nconst args = { id: v.number(), ...shared };`)).toStrictEqual({ id: { kind: "string" } });
+    });
+
+    it("follows a spread through a nested spread and an `as const`", () => {
+        expect.assertions(1);
+
+        const source =
+            `const base = { alpha: v.string() };\n` +
+            `const shared = { ...base, beta: v.number() } as const;\n` +
+            `const args = { ...shared, gamma: v.boolean() };`;
+
+        expect(shapeOf(source)).toStrictEqual({ alpha: { kind: "string" }, beta: { kind: "number" }, gamma: { kind: "boolean" } });
+    });
+
+    it("reports a spread it cannot resolve rather than dropping its fields", () => {
+        expect.assertions(1);
+
+        // Silence here is what made this expensive: the loss surfaced as a name
+        // error at a caller in another package, reading as a typo rather than as
+        // a dropped field.
+        expect(() => shapeOf(`const args = { ...buildArgs(), gamma: v.boolean() };`)).toThrow(/cannot read the fields behind/u);
+    });
+
+    it("terminates on a mutually-referential spread instead of recursing forever", () => {
+        expect.assertions(1);
+
+        expect(() => shapeOf(`const a = { ...b };\nconst b = { ...a };\nconst args = { ...a };`)).toThrow(/cannot read the fields behind/u);
+    });
+});

--- a/packages/codegen/src/discover/functions/internal/builder-chain.ts
+++ b/packages/codegen/src/discover/functions/internal/builder-chain.ts
@@ -1,8 +1,9 @@
 import type { CallExpression } from "ts-morph";
 import { Node } from "ts-morph";
 
+import { diagnosticAt } from "../../../diagnostics";
 import type { ValidatorIR } from "../../../ir";
-import { parseObjectShape, parseValidator } from "../../../parse-validator";
+import { parseObjectShape, parseValidator, resolveObjectLiteral } from "../../../parse-validator";
 import { builderChainSteps } from "../../builder-chain";
 import unwrapHandlerReturn from "../unwrap-handler-return";
 
@@ -64,9 +65,23 @@ const argsFromBuilderChain = (receiver: Node): Record<string, ValidatorIR> => {
 
         const argument = step.call.getArguments()[0];
 
-        if (argument && Node.isObjectLiteralExpression(argument)) {
-            merged = { ...parseObjectShape(argument), ...merged };
+        if (argument === undefined || !Node.isExpression(argument)) {
+            continue;
         }
+
+        // `.input(sharedArgs)` is as legal as an inline literal — the builder
+        // takes any `ArgsValidator` record — and used to contribute NOTHING to
+        // the generated type while the runtime still enforced every field.
+        const literal = resolveObjectLiteral(argument);
+
+        if (literal === undefined) {
+            throw diagnosticAt(
+                argument,
+                `cannot read the fields of this \`.input(…)\` — it resolves only when it is an object literal or a \`const\` holding one. Inline the fields, or assign them to a \`const\` object literal first`,
+            );
+        }
+
+        merged = { ...parseObjectShape(literal), ...merged };
     }
 
     return merged;

--- a/packages/codegen/src/discover/functions/internal/builder-chain.ts
+++ b/packages/codegen/src/discover/functions/internal/builder-chain.ts
@@ -1,7 +1,6 @@
 import type { CallExpression } from "ts-morph";
 import { Node } from "ts-morph";
 
-import { diagnosticAt } from "../../../diagnostics";
 import type { ValidatorIR } from "../../../ir";
 import { parseObjectShape, parseValidator, resolveObjectLiteral } from "../../../parse-validator";
 import { builderChainSteps } from "../../builder-chain";
@@ -65,23 +64,21 @@ const argsFromBuilderChain = (receiver: Node): Record<string, ValidatorIR> => {
 
         const argument = step.call.getArguments()[0];
 
-        if (argument === undefined || !Node.isExpression(argument)) {
-            continue;
-        }
-
         // `.input(sharedArgs)` is as legal as an inline literal — the builder
         // takes any `ArgsValidator` record — and used to contribute NOTHING to
         // the generated type while the runtime still enforced every field.
-        const literal = resolveObjectLiteral(argument);
+        //
+        // An argument that does not resolve is SKIPPED, never fatal. `lunora
+        // introspect` emits `.input(<table>List.args)` (see `defineListArgs`),
+        // whose record is built at runtime and cannot be read statically at all;
+        // aborting on it would take `dev`/`verify`/`deploy` down for every
+        // introspected project. The gap is reported instead — see
+        // `discover/unreadable-arguments.ts`.
+        const literal = argument !== undefined && Node.isExpression(argument) ? resolveObjectLiteral(argument) : undefined;
 
-        if (literal === undefined) {
-            throw diagnosticAt(
-                argument,
-                `cannot read the fields of this \`.input(…)\` — it resolves only when it is an object literal or a \`const\` holding one. Inline the fields, or assign them to a \`const\` object literal first`,
-            );
+        if (literal !== undefined) {
+            merged = { ...parseObjectShape(literal), ...merged };
         }
-
-        merged = { ...parseObjectShape(literal), ...merged };
     }
 
     return merged;

--- a/packages/codegen/src/discover/functions/internal/expose.ts
+++ b/packages/codegen/src/discover/functions/internal/expose.ts
@@ -2,7 +2,7 @@ import type { CallExpression, ObjectLiteralExpression } from "ts-morph";
 import { Node } from "ts-morph";
 
 import type { ExposeCacheIR, ValidatorIR } from "../../../ir";
-import { parseObjectShape } from "../../../parse-validator";
+import { parseObjectShape, resolveObjectLiteral } from "../../../parse-validator";
 import { builderChainSteps } from "../../builder-chain";
 
 /** Read a property off an object literal as a string literal, or `undefined` when absent / not statically readable. */
@@ -120,12 +120,15 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
     }
 
     const initializer = argsProperty.getInitializer();
+    // `args: sharedArgs` resolves the same as an inline literal — one argument
+    // record shared by two procedures is ordinary, and it used to contribute
+    // nothing while the runtime still enforced every field. Anything that does
+    // NOT resolve keeps the `{}` this form has always reported: unlike
+    // `.input(…)`, `args:` is optional here, so an unreadable one is not
+    // necessarily a dropped validator.
+    const shape = initializer === undefined ? undefined : resolveObjectLiteral(initializer);
 
-    if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
-        return {};
-    }
-
-    return parseObjectShape(initializer);
+    return shape === undefined ? {} : parseObjectShape(shape);
 };
 
 export { argsFromCall, exposeFromBuilderChain };

--- a/packages/codegen/src/discover/schema/internal/table-builder.ts
+++ b/packages/codegen/src/discover/schema/internal/table-builder.ts
@@ -15,7 +15,7 @@ import type {
     ValidatorIR,
     VectorIndexIR,
 } from "../../../ir";
-import { parseObjectShape } from "../../../parse-validator";
+import { parseObjectShape, resolveObjectLiteral } from "../../../parse-validator";
 import {
     asMetric,
     getBooleanProperty,
@@ -798,20 +798,33 @@ const parseTableBuilder = (expression: Expression, name: string): TableIR => {
     };
 };
 
-/** Parse the base `defineSchema({ table: defineTable(...) })` object literal into {@link TableIR}s. */
-const parseBaseTables = (object: ObjectLiteralExpression): TableIR[] => {
-    const tables: TableIR[] = [];
-    const seenNames = new Set<string>();
+/**
+ * Parse the base `defineSchema({ table: defineTable(...) })` object literal into
+ * {@link TableIR}s.
+ *
+ * A spread is followed when it names a readable table map — `registry/payment`
+ * exports `paymentTables` as exactly that — so those tables reach the data model
+ * instead of vanishing from it. One built by a CALL (`...authTables(options)`,
+ * the documented `@lunora/auth` wiring) has no literal to read and is skipped,
+ * exactly as every spread was before. Not an error: that path has no inline form
+ * to fall back to, so refusing it would leave it unable to generate at all.
+ *
+ * `visited` guards a self- or mutually-referential spread; the duplicate-name
+ * check spans the spread and the inline keys together, which is exactly the
+ * collision `authTables`' own docs warn silently loses a table to spread order.
+ */
+const parseBaseTables = (object: ObjectLiteralExpression, tables: TableIR[] = [], seenNames = new Set<string>(), visited = new Set<Node>()): TableIR[] => {
+    visited.add(object);
 
     for (const property of object.getProperties()) {
-        // A spread of table definitions used to be skipped in silence: every
-        // table behind it vanished from the data model while the schema still
-        // declared them, and the only symptom was a missing type at a caller.
         if (Node.isSpreadAssignment(property)) {
-            throw diagnosticAt(
-                property,
-                `defineSchema({...}): the tables behind \`${property.getText()}\` cannot be read — spread table maps are not resolved here, and every table in one would be silently absent from the generated data model. List the tables inline.`,
-            );
+            const spread = resolveObjectLiteral(property.getExpression());
+
+            if (spread !== undefined && !visited.has(spread)) {
+                parseBaseTables(spread, tables, seenNames, visited);
+            }
+
+            continue;
         }
 
         if (!Node.isPropertyAssignment(property)) {

--- a/packages/codegen/src/discover/schema/internal/table-builder.ts
+++ b/packages/codegen/src/discover/schema/internal/table-builder.ts
@@ -804,6 +804,16 @@ const parseBaseTables = (object: ObjectLiteralExpression): TableIR[] => {
     const seenNames = new Set<string>();
 
     for (const property of object.getProperties()) {
+        // A spread of table definitions used to be skipped in silence: every
+        // table behind it vanished from the data model while the schema still
+        // declared them, and the only symptom was a missing type at a caller.
+        if (Node.isSpreadAssignment(property)) {
+            throw diagnosticAt(
+                property,
+                `defineSchema({...}): the tables behind \`${property.getText()}\` cannot be read — spread table maps are not resolved here, and every table in one would be silently absent from the generated data model. List the tables inline.`,
+            );
+        }
+
         if (!Node.isPropertyAssignment(property)) {
             continue;
         }

--- a/packages/codegen/src/discover/unreadable-arguments.ts
+++ b/packages/codegen/src/discover/unreadable-arguments.ts
@@ -1,0 +1,94 @@
+import type { Finding } from "@lunora/advisor";
+import type { Project, SourceFile, VariableDeclaration } from "ts-morph";
+import { Node } from "ts-morph";
+
+import { procedureArgumentObjects } from "../procedure-argument-objects";
+import { listLunoraSourceFiles, lunoraRelativePath } from "./ast";
+import { classifyProcedureCall } from "./functions/classify-procedure-call";
+
+/**
+ * Report a registered procedure whose declared arguments could not be fully
+ * read, so the generated type under-states what the runtime enforces.
+ *
+ * Codegen resolves an `.input(sharedArgs)` and a `{ ...sharedArgs }` to the
+ * `const` object literal behind them. What it cannot resolve is a record
+ * ASSEMBLED at runtime — `defineListArgs(...).args`, which `lunora introspect`
+ * generates, or a factory call — and that is the case this reports.
+ *
+ * A warning, never an abort. The unreadable forms are shipped, documented APIs
+ * with no inline equivalent to fall back to, so refusing them would leave those
+ * projects unable to generate at all; and the runtime validator still enforces
+ * every field, so the code WORKS — it is the generated type that is thin.
+ *
+ * Silence was the expensive part. A caller passing a real argument was told the
+ * property does not exist, usually in another package entirely, which reads as a
+ * typo rather than as "your argument list was dropped".
+ */
+const findingFor = (relativePath: string, exportName: string, line: number): Finding => {
+    return {
+        cacheKey: `procedure_arguments_unreadable:${relativePath}:${exportName}`,
+        categories: ["SCHEMA"],
+        description:
+            "Codegen reads an argument record statically. One built at runtime — a factory call, or a property off a value it cannot follow — has no literal to read, so the generated `FunctionReference` carries only the arguments it could see while the runtime validator still enforces all of them.",
+        detail: `\`${exportName}\` in \`${relativePath}\` (line ${line.toString()}) declares arguments codegen could not read, so its generated type is missing some of them.`,
+        facing: "INTERNAL",
+        level: "WARN",
+        metadata: { exportName, filePath: relativePath, line },
+        name: "procedure_arguments_unreadable",
+        remediation: `Declare the arguments as an object literal, or as a \`const\` object literal the chain names — \`const ${exportName}Args = { … };\` then \`.input(${exportName}Args)\`. Both resolve; a record returned by a call does not.`,
+        title: "Procedure arguments are missing from the generated type",
+    };
+};
+
+/** The `[exportName, line]` of every procedure in one file whose args are opaque. */
+const fileFindings = (source: SourceFile, relativePath: string): Finding[] => {
+    const findings: Finding[] = [];
+
+    const check = (declaration: VariableDeclaration, exportName: string): void => {
+        const initializer = declaration.getInitializer();
+
+        if (initializer === undefined || !Node.isCallExpression(initializer)) {
+            return;
+        }
+
+        const classified = classifyProcedureCall(initializer);
+
+        if (classified === undefined) {
+            return;
+        }
+
+        if (procedureArgumentObjects(initializer, classified.receiver).opaque) {
+            findings.push(findingFor(relativePath, exportName, initializer.getStartLineNumber()));
+        }
+    };
+
+    for (const statement of source.getVariableStatements().filter((entry) => entry.isExported())) {
+        for (const declaration of statement.getDeclarations()) {
+            check(declaration, declaration.getName());
+        }
+    }
+
+    return findings;
+};
+
+/**
+ * Every procedure in the `lunora/` source set whose argument declarations codegen
+ * could not fully read.
+ */
+const discoverUnreadableArguments = (project: Project, lunoraDirectory: string): Finding[] => {
+    const findings: Finding[] = [];
+
+    for (const filePath of listLunoraSourceFiles(lunoraDirectory)) {
+        // Only files the discovery pass already loaded — never add one here, so
+        // this stays a read over work that has been done.
+        const source: SourceFile | undefined = project.getSourceFile(filePath);
+
+        if (source !== undefined) {
+            findings.push(...fileFindings(source, lunoraRelativePath(lunoraDirectory, filePath)));
+        }
+    }
+
+    return findings.toSorted((a, b) => a.cacheKey.localeCompare(b.cacheKey));
+};
+
+export default discoverUnreadableArguments;

--- a/packages/codegen/src/discover/unreadable-arguments.ts
+++ b/packages/codegen/src/discover/unreadable-arguments.ts
@@ -1,5 +1,5 @@
 import type { Finding } from "@lunora/advisor";
-import type { Project, SourceFile, VariableDeclaration } from "ts-morph";
+import type { CallExpression, Node as TsNode, Project, SourceFile, VariableDeclaration } from "ts-morph";
 import { Node } from "ts-morph";
 
 import { procedureArgumentObjects } from "../procedure-argument-objects";
@@ -40,7 +40,29 @@ const findingFor = (relativePath: string, exportName: string, line: number): Fin
     };
 };
 
-/** The `[exportName, line]` of every procedure in one file whose args are opaque. */
+/**
+ * Whether this registration DECLARES an argument record that could not be read.
+ *
+ * Narrower than `opaque`, deliberately. `opaque` is the conservative tri-state a
+ * security lint gates on, so it also covers "the whole registration is a
+ * variable, and args may or may not exist" — reporting that as a dropped
+ * argument list would be a guess. A bare-factory call only counts when an `args`
+ * property is actually there and unreadable; a builder chain only ever reports
+ * opaque for an `.input()` step it could not read, so it needs no extra gate.
+ */
+const declaresUnreadableArguments = (call: CallExpression, receiver: TsNode | undefined): boolean => {
+    if (receiver === undefined) {
+        const first = call.getArguments()[0];
+
+        if (first === undefined || !Node.isObjectLiteralExpression(first) || first.getProperty("args") === undefined) {
+            return false;
+        }
+    }
+
+    return procedureArgumentObjects(call, receiver).opaque;
+};
+
+/** The `[exportName, line]` of every procedure in one file whose declared args could not be read. */
 const fileFindings = (source: SourceFile, relativePath: string): Finding[] => {
     const findings: Finding[] = [];
 
@@ -53,11 +75,7 @@ const fileFindings = (source: SourceFile, relativePath: string): Finding[] => {
 
         const classified = classifyProcedureCall(initializer);
 
-        if (classified === undefined) {
-            return;
-        }
-
-        if (procedureArgumentObjects(initializer, classified.receiver).opaque) {
+        if (classified !== undefined && declaresUnreadableArguments(initializer, classified.receiver)) {
             findings.push(findingFor(relativePath, exportName, initializer.getStartLineNumber()));
         }
     };

--- a/packages/codegen/src/parse-validator.ts
+++ b/packages/codegen/src/parse-validator.ts
@@ -1,5 +1,5 @@
 import { LunoraError } from "@lunora/errors";
-import type { CallExpression, Expression, Identifier, ObjectLiteralExpression } from "ts-morph";
+import type { CallExpression, Expression, Identifier, ObjectLiteralExpression, SpreadAssignment } from "ts-morph";
 import { Node } from "ts-morph";
 
 import { diagnosticAt } from "./diagnostics";
@@ -147,6 +147,13 @@ const PARSE_BEHAVIOR_MODIFIERS = new Set(["strip"]);
 const resolvingAliases = new Set<Identifier>();
 
 /**
+ * Object literals currently being merged into a shape through a spread, so a
+ * cycle terminates with a diagnostic instead of a stack overflow. Same
+ * single-threaded, `finally`-cleared discipline as {@link resolvingAliases}.
+ */
+const spreadingShapes = new Set<ObjectLiteralExpression>();
+
+/**
  * Follow a bare identifier to the validator expression its `const` holds.
  *
  * A validator written once and reused — `const vDocumentDoc = v.object({…})`,
@@ -190,6 +197,45 @@ const resolveValidatorAlias = (identifier: Identifier): Expression | undefined =
     }
 
     return declaration.getInitializer();
+};
+
+/**
+ * The object literal an expression stands for: the literal itself, the one a
+ * `const` holds (local or imported, via {@link resolveValidatorAlias}), or
+ * `undefined` when it cannot be read statically.
+ *
+ * Sharing an argument record between two procedures — `const sharedArgs = {…}`,
+ * then `.input({ ...sharedArgs, extra })` — is the most ordinary thing there is,
+ * and the fields behind the spread used to vanish from the generated types with
+ * no diagnostic. Callers that cannot resolve one must say so rather than emit a
+ * shape that disagrees with the validator the runtime enforces.
+ */
+const resolveObjectLiteral = (expression: Expression): ObjectLiteralExpression | undefined => {
+    if (Node.isParenthesizedExpression(expression) || Node.isAsExpression(expression) || Node.isSatisfiesExpression(expression)) {
+        return resolveObjectLiteral(expression.getExpression());
+    }
+
+    if (Node.isObjectLiteralExpression(expression)) {
+        return expression;
+    }
+
+    if (!Node.isIdentifier(expression) || resolvingAliases.has(expression)) {
+        return undefined;
+    }
+
+    const target = resolveValidatorAlias(expression);
+
+    if (target === undefined) {
+        return undefined;
+    }
+
+    resolvingAliases.add(expression);
+
+    try {
+        return resolveObjectLiteral(target);
+    } finally {
+        resolvingAliases.delete(expression);
+    }
 };
 
 /**
@@ -270,10 +316,45 @@ const parseValidator = (expression: Expression): ValidatorIR => {
     return { kind: "any", sourceText: expression.getText() };
 };
 
+/**
+ * The fields `{ ...sharedArgs }` contributes.
+ *
+ * `spreadingShapes` catches a cycle (`const a = { ...b }; const b = { ...a }`):
+ * the alias guard is released before the shape is parsed, so without it the two
+ * literals recurse into each other until the stack gives out.
+ */
+const parseSpreadShape = (property: SpreadAssignment): Record<string, ValidatorIR> => {
+    const spread = resolveObjectLiteral(property.getExpression());
+
+    if (spread === undefined || spreadingShapes.has(spread)) {
+        throw diagnosticAt(
+            property,
+            `cannot read the fields behind \`${property.getText()}\` — a spread resolves only when it names an object literal, or a \`const\` holding one that does not spread its way back here. Inline the fields, or assign them to a \`const\` object literal first`,
+        );
+    }
+
+    spreadingShapes.add(spread);
+
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion: a spread's shape is parsed by the same parser that found it
+        return parseObjectShape(spread);
+    } finally {
+        spreadingShapes.delete(spread);
+    }
+};
+
 const parseObjectShape = (object: ObjectLiteralExpression): Record<string, ValidatorIR> => {
     const out: Record<string, ValidatorIR> = {};
 
     for (const property of object.getProperties()) {
+        // Merged in source order, so spread semantics hold: a key written after
+        // the spread wins, one written before it loses.
+        if (Node.isSpreadAssignment(property)) {
+            Object.assign(out, parseSpreadShape(property));
+
+            continue;
+        }
+
         // A shorthand property (`{ status }`, where `status` is a validator held
         // in a const) is its own initializer. Treating it as "not a property
         // assignment" dropped the field from the shape with no error anywhere —
@@ -511,5 +592,14 @@ const parseValidatorCall = (call: CallExpression): ValidatorIR => {
     return parseBuilderMember(member, args, call);
 };
 
-export { COLUMN_MODIFIERS, METADATA_MODIFIERS, PARSE_BEHAVIOR_MODIFIERS, parseObjectShape, parseValidator, REFINEMENT_MODIFIERS, setStandardTypeResolver };
+export {
+    COLUMN_MODIFIERS,
+    METADATA_MODIFIERS,
+    PARSE_BEHAVIOR_MODIFIERS,
+    parseObjectShape,
+    parseValidator,
+    REFINEMENT_MODIFIERS,
+    resolveObjectLiteral,
+    setStandardTypeResolver,
+};
 export type { StandardTypeResolver };

--- a/packages/codegen/src/parse-validator.ts
+++ b/packages/codegen/src/parse-validator.ts
@@ -1,6 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 import type { CallExpression, Expression, Identifier, ObjectLiteralExpression, SpreadAssignment } from "ts-morph";
-import { Node } from "ts-morph";
+import { Node, VariableDeclarationKind } from "ts-morph";
 
 import { diagnosticAt } from "./diagnostics";
 import type { ColumnMetaIR, ValidatorIR } from "./ir";
@@ -200,6 +200,18 @@ const resolveValidatorAlias = (identifier: Identifier): Expression | undefined =
 };
 
 /**
+ * Whether an expression reached through {@link resolveValidatorAlias} is held by
+ * a `const`. The resolver hands back a declaration's initializer, so its parent
+ * is that declaration; anything that is not a variable declaration at all (a
+ * property assignment, say) is not a rebindable binding and passes.
+ */
+const isConstBinding = (initializer: Expression): boolean => {
+    const declaration = initializer.getParent();
+
+    return !Node.isVariableDeclaration(declaration) || declaration.getVariableStatement()?.getDeclarationKind() === VariableDeclarationKind.Const;
+};
+
+/**
  * The object literal an expression stands for: the literal itself, the one a
  * `const` holds (local or imported, via {@link resolveValidatorAlias}), or
  * `undefined` when it cannot be read statically.
@@ -209,6 +221,12 @@ const resolveValidatorAlias = (identifier: Identifier): Expression | undefined =
  * and the fields behind the spread used to vanish from the generated types with
  * no diagnostic. Callers that cannot resolve one must say so rather than emit a
  * shape that disagrees with the validator the runtime enforces.
+ *
+ * A property access (`sharedSchema.args`) resolves through the checker to the
+ * property's own initializer, so a record reached off an object resolves like
+ * one held in a `const`. Values assembled at RUNTIME — `defineListArgs(...).args`,
+ * which `lunora introspect` generates — have no literal to find and correctly
+ * come back `undefined`.
  */
 const resolveObjectLiteral = (expression: Expression): ObjectLiteralExpression | undefined => {
     if (Node.isParenthesizedExpression(expression) || Node.isAsExpression(expression) || Node.isSatisfiesExpression(expression)) {
@@ -219,13 +237,24 @@ const resolveObjectLiteral = (expression: Expression): ObjectLiteralExpression |
         return expression;
     }
 
+    if (Node.isPropertyAccessExpression(expression)) {
+        const declaration = expression.getSymbol()?.getValueDeclaration();
+        const initializer = declaration !== undefined && Node.isPropertyAssignment(declaration) ? declaration.getInitializer() : undefined;
+
+        return initializer === undefined ? undefined : resolveObjectLiteral(initializer);
+    }
+
     if (!Node.isIdentifier(expression) || resolvingAliases.has(expression)) {
         return undefined;
     }
 
     const target = resolveValidatorAlias(expression);
 
-    if (target === undefined) {
+    // `const` only. A `let`/`var` holding an args record can be reassigned
+    // between its initializer and the `.input(…)` that names it, and the shape
+    // emitted from the initializer would then be a type the runtime validator
+    // disagrees with — the exact mismatch this resolution exists to remove.
+    if (target === undefined || !isConstBinding(target)) {
         return undefined;
     }
 
@@ -317,7 +346,14 @@ const parseValidator = (expression: Expression): ValidatorIR => {
 };
 
 /**
- * The fields `{ ...sharedArgs }` contributes.
+ * The fields `{ ...sharedArgs }` contributes, or `{}` when it cannot be read.
+ *
+ * Unreadable is deliberately NOT fatal. `defineSchema({ ...authTables(options) })`
+ * is the documented way to consume `@lunora/auth`, and the record it spreads is
+ * built at runtime from the better-auth plugin list — there is no inline form to
+ * fall back to, so aborting would leave that path unable to generate at all.
+ * What the shape loses is reported instead, by the pass that knows which
+ * procedure the shape belongs to (`discover/unreadable-arguments.ts`).
  *
  * `spreadingShapes` catches a cycle (`const a = { ...b }; const b = { ...a }`):
  * the alias guard is released before the shape is parsed, so without it the two
@@ -327,10 +363,7 @@ const parseSpreadShape = (property: SpreadAssignment): Record<string, ValidatorI
     const spread = resolveObjectLiteral(property.getExpression());
 
     if (spread === undefined || spreadingShapes.has(spread)) {
-        throw diagnosticAt(
-            property,
-            `cannot read the fields behind \`${property.getText()}\` — a spread resolves only when it names an object literal, or a \`const\` holding one that does not spread its way back here. Inline the fields, or assign them to a \`const\` object literal first`,
-        );
+        return {};
     }
 
     spreadingShapes.add(spread);

--- a/packages/codegen/src/procedure-argument-objects.ts
+++ b/packages/codegen/src/procedure-argument-objects.ts
@@ -1,6 +1,8 @@
 import type { CallExpression, Node as TsNode, ObjectLiteralExpression } from "ts-morph";
 import { Node } from "ts-morph";
 
+import { resolveObjectLiteral } from "./parse-validator";
+
 /**
  * The argument declarations of one procedure, as read off its registration.
  *
@@ -18,8 +20,34 @@ interface ProcedureArgumentObjects {
     opaque: boolean;
 }
 
-/** True for an object literal carrying a `...spread` — its keys are not fully enumerable. */
-const hasSpread = (object: ObjectLiteralExpression): boolean => object.getProperties().some((property) => Node.isSpreadAssignment(property));
+/**
+ * True when an object literal carries a `...spread` whose fields cannot be read,
+ * making its key set unknowable.
+ *
+ * A spread that RESOLVES is not opaque: `parseObjectShape` merges its fields, so
+ * the keys are enumerable and every consumer — this file's security lints
+ * included — can see them. Only the unreadable remainder is unknown, and calling
+ * that opaque is what keeps `hasEmailArg`-style checks answering "unknown"
+ * instead of "absent". Recurses, because a resolved spread can itself spread
+ * something unreadable.
+ */
+const hasUnreadableSpread = (object: ObjectLiteralExpression, visited: Set<ObjectLiteralExpression> = new Set()): boolean => {
+    if (visited.has(object)) {
+        return false;
+    }
+
+    visited.add(object);
+
+    return object.getProperties().some((property) => {
+        if (!Node.isSpreadAssignment(property)) {
+            return false;
+        }
+
+        const resolved = resolveObjectLiteral(property.getExpression());
+
+        return resolved === undefined || hasUnreadableSpread(resolved, visited);
+    });
+};
 
 /**
  * The `args:` object literal of a bare-factory `query({ args, handler })` call.
@@ -44,12 +72,13 @@ const argumentsOfFactory = (call: CallExpression): ProcedureArgumentObjects => {
     }
 
     const initializer = argumentsProperty.getInitializer();
+    const resolved = initializer === undefined ? undefined : resolveObjectLiteral(initializer);
 
-    if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
+    if (resolved === undefined) {
         return { objects: [], opaque: true };
     }
 
-    return { objects: [initializer], opaque: hasSpread(initializer) };
+    return { objects: [resolved], opaque: hasUnreadableSpread(resolved) };
 };
 
 /**
@@ -70,12 +99,13 @@ const argumentsInChain = (receiver: TsNode): ProcedureArgumentObjects => {
 
         if (chainCallee.getName() === "input") {
             const argument = node.getArguments()[0];
+            const resolved = argument !== undefined && Node.isExpression(argument) ? resolveObjectLiteral(argument) : undefined;
 
-            if (argument && Node.isObjectLiteralExpression(argument)) {
-                objects.push(argument);
-                opaque ||= hasSpread(argument);
-            } else {
+            if (resolved === undefined) {
                 opaque = true;
+            } else {
+                objects.push(resolved);
+                opaque ||= hasUnreadableSpread(resolved);
             }
         }
 

--- a/packages/codegen/src/procedure-argument-objects.ts
+++ b/packages/codegen/src/procedure-argument-objects.ts
@@ -31,22 +31,34 @@ interface ProcedureArgumentObjects {
  * instead of "absent". Recurses, because a resolved spread can itself spread
  * something unreadable.
  */
-const hasUnreadableSpread = (object: ObjectLiteralExpression, visited: Set<ObjectLiteralExpression> = new Set()): boolean => {
-    if (visited.has(object)) {
-        return false;
+const hasUnreadableSpread = (object: ObjectLiteralExpression, active: Set<ObjectLiteralExpression> = new Set()): boolean => {
+    // A cycle is UNREADABLE, not readable. `parseObjectShape` breaks the same
+    // cycle by emitting nothing for it, so answering `false` here would claim a
+    // shape is fully known while its fields were dropped — the exact wrong
+    // direction for a flag security lints gate on.
+    //
+    // `active` is the current recursion PATH, not every object seen: a diamond
+    // (`{ ...a, ...b }` where both spread `base`) visits `base` twice and is
+    // perfectly readable, so a visited-set would call it a cycle.
+    if (active.has(object)) {
+        return true;
     }
 
-    visited.add(object);
+    active.add(object);
 
-    return object.getProperties().some((property) => {
-        if (!Node.isSpreadAssignment(property)) {
-            return false;
-        }
+    try {
+        return object.getProperties().some((property) => {
+            if (!Node.isSpreadAssignment(property)) {
+                return false;
+            }
 
-        const resolved = resolveObjectLiteral(property.getExpression());
+            const resolved = resolveObjectLiteral(property.getExpression());
 
-        return resolved === undefined || hasUnreadableSpread(resolved, visited);
-    });
+            return resolved === undefined || hasUnreadableSpread(resolved, active);
+        });
+    } finally {
+        active.delete(object);
+    }
 };
 
 /**
@@ -123,17 +135,46 @@ const procedureArgumentObjects = (call: CallExpression, receiver: TsNode | undef
     receiver ? argumentsInChain(receiver) : argumentsOfFactory(call);
 
 /**
- * The declared argument names across `objects`. Covers both `email: v.string()`
- * (a property assignment) and the `{ email }` shorthand — missing the latter is
- * how a "does this procedure take an X?" check silently answers no.
+ * The declared argument names of one object literal, following a spread into the
+ * record it names.
+ *
+ * The spread hop is what keeps the security lints honest. A resolvable spread is
+ * reported as NOT opaque — the fields are knowable — so a names list that could
+ * not see through it would let `declaresEmailArgument` answer a confident "no"
+ * for `.input({ ...signupArgs })` whose record declares `email`, and the
+ * disposable-address gating would be skipped on exactly the mutation that needs
+ * it. An UNRESOLVABLE spread keeps the shape opaque, so the "unknown" answer
+ * still covers what this cannot enumerate.
  */
-const argumentNames = (objects: ReadonlyArray<ObjectLiteralExpression>): string[] =>
-    objects.flatMap((object) =>
-        object
-            .getProperties()
-            .filter((property) => Node.isPropertyAssignment(property) || Node.isShorthandPropertyAssignment(property))
-            .map((property) => (property as { getName: () => string }).getName()),
-    );
+const namesOfObject = (object: ObjectLiteralExpression, active: Set<ObjectLiteralExpression>): string[] => {
+    if (active.has(object)) {
+        return [];
+    }
+
+    active.add(object);
+
+    try {
+        return object.getProperties().flatMap((property) => {
+            if (Node.isSpreadAssignment(property)) {
+                const resolved = resolveObjectLiteral(property.getExpression());
+
+                return resolved === undefined ? [] : namesOfObject(resolved, active);
+            }
+
+            return Node.isPropertyAssignment(property) || Node.isShorthandPropertyAssignment(property) ? [property.getName()] : [];
+        });
+    } finally {
+        active.delete(object);
+    }
+};
+
+/**
+ * The declared argument names across `objects`. Covers `email: v.string()` (a
+ * property assignment), the `{ email }` shorthand — missing the latter is how a
+ * "does this procedure take an X?" check silently answers no — and the fields a
+ * readable `{ ...spread }` contributes.
+ */
+const argumentNames = (objects: ReadonlyArray<ObjectLiteralExpression>): string[] => objects.flatMap((object) => namesOfObject(object, new Set()));
 
 export type { ProcedureArgumentObjects };
 export { argumentNames, procedureArgumentObjects };

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -72,6 +72,7 @@ import discoverStaleMigrationImports from "./discover/stale-migration-imports";
 import discoverStorageKeyAccesses from "./discover/storage-key-accesses";
 import discoverStorageUploads from "./discover/storage-uploads";
 import { buildStudioFeatures } from "./discover/studio-features";
+import discoverUnreadableArguments from "./discover/unreadable-arguments";
 import discoverUnregisteredProcedures from "./discover/unregistered-procedures";
 import discoverUnrestrictedWhereBranches from "./discover/unrestricted-where-branches";
 import discoverVectorNamespaceAccesses from "./discover/vector-namespace-accesses";
@@ -741,14 +742,20 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
                   wranglerVariables: options.wranglerVariables,
               });
 
-    // A binding whose TYPE is a registered procedure but which never reached
-    // `api.ts` was dropped by the syntactic scan. Reported alongside the
-    // advisor's findings so it travels the same channel to the terminal and the
-    // studio.
+    // Two ways a procedure reaches `api.ts` wrong, both silent until now, both
+    // reported alongside the advisor's findings so they travel the same channel
+    // to the terminal and the studio: a binding whose TYPE is a registered
+    // procedure but which never reached `api.ts` at all (dropped by the
+    // syntactic scan), and one that did reach it carrying fewer arguments than
+    // the runtime enforces (an argument record codegen could not read).
     const advisories =
         advisorContext === undefined
             ? []
-            : [...runAdvisor(advisorContext, { source: "static" }), ...discoverUnregisteredProcedures(project, lunoraDirectory, functions)];
+            : [
+                  ...runAdvisor(advisorContext, { source: "static" }),
+                  ...discoverUnregisteredProcedures(project, lunoraDirectory, functions),
+                  ...discoverUnreadableArguments(project, lunoraDirectory),
+              ];
 
     // Read-only RLS metadata (policies + roles) the studio's RLS inspector lists,
     // emitted into the generated ShardDO's `rlsMetadata()` override. Statically


### PR DESCRIPTION
Fixes #651.

## What was still broken

The issue reports two silent drops. Only one of them is still open on `alpha`:

| reported | status |
| --- | --- |
| a spread inside `.input()` loses the spread fields | **fixed here** |
| an export assigned from a factory is not registered at all | already diagnosed — `procedure_not_registered` (WARN) names the export, the file and the line |

Verified by running `lunora codegen` over `examples/todo-app` with the issue's `probe.ts` dropped in: the factory case already produced ``WARN procedure_not_registered: `probeFactory` in `probe` (line 12) has type `RegisteredQuery` but was not registered``, while `probeSpread` emitted `FunctionReference<"query", { gamma: boolean }, string>` — `alpha` and `beta` gone, no diagnostic. After this change it emits `{ alpha: string; beta?: number; gamma: boolean }`, exactly the expected column in the issue.

## The fix

Object shapes were read syntactically: `parseObjectShape` skipped every member that was not a property assignment. Resolve the spread instead — an object literal, or a `const` holding one (local or imported, through the alias resolver already used for hoisted validators) — merged in **source order**, so JS spread precedence holds (`{ ...shared, id }` → `id` wins; `{ id, ...shared }` → `shared` wins). A cycle (`const a = { ...b }; const b = { ...a }`) terminates with a diagnostic rather than a stack overflow — the first draft did not, and the test caught it.

Every position that reads a shape gains this, because they all route through the one parser: `.input()`, `defineTable` columns, http routes, mutators.

Two adjacent forms that contributed **nothing** now resolve as well:

- `.input(sharedArgs)` — naming a record rather than inlining one is as legal as the literal (the builder takes any `ArgsValidator`), and it used to produce no args at all while the runtime enforced every field.
- `query({ args: sharedArgs })` — the `{ args, handler }` form.

## What is now reported instead of dropped

- an unresolvable spread — points at the spread, names it
- an unresolvable `.input(…)` — the argument is *required* to be an args record, so an unreadable one is certainly a dropped validator
- a spread of table definitions in `defineSchema({...})` — silently omitted every table behind it from the generated data model

`query({ args })` keeps reporting `{}` for an unreadable record: `args` is optional in that form, so an unresolvable one is not necessarily a dropped validator.

## Verification

- `@lunora/codegen`: 1743 tests green (5 new for spread resolution, 1 new for the schema spread, 2 rewritten where they pinned the old silent skip).
- `@lunora/cli` (1516) and `@lunora/vite` (223) green; eslint, `tsc --noEmit` and `api:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhrsvdiJJuDAMjmiKVrae

---

## Review round 2

The three diagnostics the first push added **aborted the codegen run**, and two fired on shapes the repo ships and documents: `lunora introspect` *generates* `.input(<table>List.args)` (`defineListArgs`, built at runtime), and `defineSchema({ ...authTables(options) })` is the documented `@lunora/auth` wiring. Neither has an inline form, so the remedy text was not an action a user could take. All three throws are gone — resolution is best-effort, unresolvable is skipped as before.

Silence is still not the answer, so the gap is **reported**: a `procedure_arguments_unreadable` WARN naming the export, file and line, on the same channel as `procedure_not_registered`. Measured at 12ms against the 645ms discovery it rides alongside.

Two more shapes now resolve instead of being dropped: a property access (`.input(listArgs.args)` — the introspect form, when the record is a literal), and a spread of table definitions in `defineSchema` (`registry/payment` ships `paymentTables` as exactly that).

`procedure-argument-objects` routes through the same resolver, so the `opaque` tri-state that `hasEmailArg` and the middleware lints gate on means "genuinely unreadable" rather than "not syntactically a literal" — and stays reachable now that nothing throws.

Non-`const` bindings are refused (CodeRabbit): a `let` can be reassigned between its initializer and the `.input()` naming it. It reports as unreadable rather than emitting a type the validator disagrees with.

---

## Review round 3

Three findings, the first of which was a **security regression this branch introduced**.

- **`argumentNames` could not see through a readable spread.** Marking a resolvable spread non-opaque was only half the change: `declaresEmailArgument` turned "unknown" into a confident `false` for `.input({ ...signupArgs })` whose record declares `email`, silently clearing `signup_mutation_without_disposable_gating` on exactly the mutation that needs it. The names walk follows a readable spread now. Confirmed the test catches it by reverting just the spread hop.
- **A cycle in the spread graph reported *readable*.** The parser breaks the same cycle by emitting nothing, so the fields really are dropped and the honest answer is unknown. The guard tracks the active recursion *path* rather than every object seen — a diamond (two spreads of one base) stays readable, which it is.
- **The advisory no longer fires on a factory call whose whole options object is a variable.** `args` is optional in that form, so an unreadable options object does not establish that a record was declared. Gating on the builder receiver (as suggested) would also have dropped `query({ args: buildArgs(), handler })`, which is the same defect as `.input(buildArgs())` — so the gate is "an `args` property is present and unreadable" instead. The shared `opaque` tri-state stays conservative for the security lints.

New `unreadable-arguments.test.ts` pins all five branches of the advisory; `@lunora/codegen` is at 1755 tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code generation now recognizes reusable object definitions, property references, and nested table spreads when building validators and generated models.
  * Builder inputs can reference shared object definitions instead of requiring inline objects.
  * Added actionable advisories for procedure arguments that cannot be read during static code generation.

* **Bug Fixes**
  * Unresolvable or cyclic references no longer interrupt generation; they are skipped and surfaced through advisory warnings.
  * Shared argument definitions now contribute validators consistently across supported procedure and builder patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->