### PR TITLE
fix(sql-store): order an untyped global column's numbers numerically

### DIFF
--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -3660,6 +3660,12 @@ const decodeBigintSqlKey: (raw: string) => bigint | undefined;
 const decodeCursor: (cursor: string) => unknown[];
 ```
 
+### `decodeFloat64SqlKey` (const)
+
+```ts
+const decodeFloat64SqlKey: (raw: string) => number | undefined;
+```
+
 ### `deleteGlobalShapeSnapshot` (const)
 
 ```ts
@@ -3814,6 +3820,12 @@ const finishStreamRun: (sql: SqlExec, runKey: string, status: "complete" | "erro
     code: string;
     message: string;
 }) => void;
+```
+
+### `float64SqlKey` (const)
+
+```ts
+const float64SqlKey: (value: number) => string;
 ```
 
 ### `foldAggregateTally` (const)

--- a/packages/shard-engine/src/index-key-codec.ts
+++ b/packages/shard-engine/src/index-key-codec.ts
@@ -31,8 +31,12 @@
  * Ordering contract (matches SQLite's `NULL < INTEGER/REAL < TEXT`):
  *
  * - `null`   → tag `"0"`
- * - number   → tag `"1"` + 16 hex chars (order-preserving IEEE-754)
+ * - number   → tag `"1"` + `float64SqlKey` (16 hex chars, order-preserving IEEE-754)
  * - string   → tag `"2"` + UTF-8 bytes as hex
+ *
+ * The number half is `sql-projection.ts`'s key rather than a copy of it, because
+ * the `.global()` store writes that same key into an untyped column: narrowing
+ * is only correct while its numeric order and the stored one are one order.
  *
  * The tags are ASCII digits, so tag order alone already reproduces the storage
  * class order. Every emitted character is ASCII (`0-9a-f`, plus the separator
@@ -52,6 +56,8 @@
  * to the conservative whole-table dependency — never as "no match".
  */
 
+import { float64SqlKey } from "./sql-projection";
+
 /**
  * Separator between components of a compound index key. Must sort BELOW every
  * character {@link encodeIndexValue} can emit (lowest is the tag `"0"`, 0x30)
@@ -70,38 +76,6 @@ const KEY_HIGH = "￿";
 
 /** Returned when a value has no faithful order-preserving encoding. */
 const UNENCODABLE = undefined;
-
-/**
- * Encode a float64 so that lexicographic order over the hex output matches
- * numeric order over the input.
- *
- * The standard total-order transform: view the double as big-endian bits; for
- * negatives (sign bit set) flip every bit so more-negative sorts lower, for
- * non-negatives flip only the sign bit so they all sort above the negatives.
- * Fixed 16-char width keeps compound keys aligned.
- */
-/* eslint-disable no-bitwise -- the IEEE-754 total-order transform IS bit manipulation; expressing it any other way would obscure the one thing this function does. */
-const encodeNumber = (value: number): string => {
-    const view = new DataView(new ArrayBuffer(8));
-
-    view.setFloat64(0, value, false);
-
-    let high = view.getUint32(0, false);
-    let low = view.getUint32(4, false);
-
-    if ((high & 0x80_00_00_00) === 0) {
-        // Non-negative: set the sign bit so it sorts above every negative.
-        // `>>> 0` is load-bearing — JS bitwise ops yield a SIGNED int32, and a
-        // negative `high` would render as "-3ff00000" and destroy the ordering.
-        high = (high ^ 0x80_00_00_00) >>> 0;
-    } else {
-        // Negative: flip everything so larger magnitudes sort lower.
-        high = ~high >>> 0;
-        low = ~low >>> 0;
-    }
-
-    return high.toString(16).padStart(8, "0") + low.toString(16).padStart(8, "0");
-};
 
 /** UTF-8 bytes of `value` as lowercase hex — byte order == SQLite `BINARY` order. */
 const encodeString = (value: string): string => {
@@ -132,8 +106,9 @@ const encodeIndexValue = (value: unknown): string | undefined => {
             return UNENCODABLE;
         }
 
-        // -0 and +0 compare equal in SQL; normalize so they encode identically.
-        return `1${encodeNumber(value === 0 ? 0 : value)}`;
+        // `float64SqlKey` normalizes -0 to +0, which is what SQL needs — the
+        // two compare equal there, so two keys would split one value.
+        return `1${float64SqlKey(value)}`;
     }
 
     if (typeof value === "string") {

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -407,10 +407,11 @@ export type { SqlConsoleResult } from "./sql-console";
 export type { SqlLintResult } from "./sql-console";
 export { assertReadonly, MAX_SQL_ROWS, runReadonlySql } from "./sql-console";
 export { lintReadonlySql } from "./sql-console";
-// The canonical order-preserving bigint codec. `@lunora/sql-store` builds and
-// reverses the same key for the `.global()` plane and the two are compared by a
-// parity test, so there must be exactly one encoder and one decoder.
-export { BIGINT_KEY_DIGITS, bigintSqlKey, decodeBigintSqlKey } from "./sql-projection";
+// The canonical order-preserving bigint and float64 codecs. `@lunora/sql-store`
+// builds and reverses the same keys for the `.global()` plane and the two are
+// compared by a parity test, so there must be exactly one encoder and one
+// decoder of each.
+export { BIGINT_KEY_DIGITS, bigintSqlKey, decodeBigintSqlKey, decodeFloat64SqlKey, float64SqlKey } from "./sql-projection";
 export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 export type { ChangedKeys, SubscriptionReadFootprint } from "./subscription-range-gate";
 export { mergeChangedKeys, recordChangedKeys, writeTouchesMemo } from "./subscription-range-gate";

--- a/packages/shard-engine/src/sql-projection.ts
+++ b/packages/shard-engine/src/sql-projection.ts
@@ -144,6 +144,96 @@ const decodeBigintSqlKey = (raw: string): bigint | undefined => {
 };
 
 /**
+ * Hex digits one float64 key carries: the eight bytes of an IEEE-754 double,
+ * four bits per digit. Fixed, so equal-width keys compare digit by digit.
+ */
+const FLOAT64_KEY_DIGITS = 16;
+
+/** A key's shape: exactly {@link FLOAT64_KEY_DIGITS} lowercase hex digits, which is what `toString(16)` emits. */
+const FLOAT64_KEY_RE = /^[\da-f]{16}$/u;
+
+/* eslint-disable no-bitwise -- the IEEE-754 total-order transform IS bit manipulation; expressing it any other way would obscure the one thing these two functions do. */
+
+/**
+ * An order-preserving, exactly-reversible text key for a JS number — the
+ * float64 twin of {@link bigintSqlKey}, and the transform the reactive layer's
+ * range narrowing (`index-key-codec.ts`) already runs on.
+ *
+ * The standard total-order transform: view the double as big-endian bits; for
+ * negatives (sign bit set) flip every bit so more-negative sorts lower, for
+ * non-negatives flip only the sign bit so they all sort above the negatives.
+ * Lexicographic order over the fixed 16-character hex output is then exactly
+ * numeric order over the input, `-0` normalized to `0` so the two encode
+ * identically — SQL compares them equal, so two keys would make an `eq` binding
+ * miss half the rows it should match.
+ *
+ * Unlike {@link bigintSqlKey} there is no width to overflow, so every double is
+ * representable — including `NaN` and `±Infinity`, which have exact bit patterns
+ * and therefore exact round trips. IEEE's total order places `-Infinity` lowest,
+ * `+Infinity` above every finite value, and `NaN` above that; `undefined`, not
+ * being a number, never reaches here.
+ */
+const float64SqlKey = (value: number): string => {
+    const view = new DataView(new ArrayBuffer(8));
+
+    view.setFloat64(0, value === 0 ? 0 : value, false);
+
+    let high = view.getUint32(0, false);
+    let low = view.getUint32(4, false);
+
+    if ((high & 0x80_00_00_00) === 0) {
+        // Non-negative: set the sign bit so it sorts above every negative.
+        // `>>> 0` is load-bearing — JS bitwise ops yield a SIGNED int32, and a
+        // negative `high` would render as "-3ff00000" and destroy the ordering.
+        high = (high ^ 0x80_00_00_00) >>> 0;
+    } else {
+        // Negative: flip everything so larger magnitudes sort lower.
+        high = ~high >>> 0;
+        low = ~low >>> 0;
+    }
+
+    return high.toString(16).padStart(8, "0") + low.toString(16).padStart(8, "0");
+};
+
+/**
+ * Inverse of {@link float64SqlKey}, or `undefined` when `raw` is not a key.
+ *
+ * Lives beside the encoder for the reason {@link decodeBigintSqlKey} does: the
+ * two halves share the width and the bit transform, and a decoder a file away
+ * from them is how a change to either ships as a silent mis-read.
+ *
+ * The shape test is exact — 16 lowercase hex digits — but the encoding is
+ * total over doubles, so unlike the bigint key there is no value the encoder
+ * can produce that this refuses.
+ */
+const decodeFloat64SqlKey = (raw: string): number | undefined => {
+    if (!FLOAT64_KEY_RE.test(raw)) {
+        return undefined;
+    }
+
+    let high = Number.parseInt(raw.slice(0, 8), 16);
+    let low = Number.parseInt(raw.slice(8), 16);
+
+    if ((high & 0x80_00_00_00) === 0) {
+        // The sign bit is clear, so the encoder took its negative branch and
+        // flipped every bit. Flipping again is its own inverse.
+        high = ~high >>> 0;
+        low = ~low >>> 0;
+    } else {
+        high = (high ^ 0x80_00_00_00) >>> 0;
+    }
+
+    const view = new DataView(new ArrayBuffer(8));
+
+    view.setUint32(0, high, false);
+    view.setUint32(4, low, false);
+
+    return view.getFloat64(0, false);
+};
+
+/* eslint-enable no-bitwise -- back to ordinary code. */
+
+/**
  * The SQL-comparable scalar to store at `$.field` — and to bind against it — in
  * place of a value SQLite cannot compare in its wire-tagged form.
  * @returns the projected scalar, or `undefined` when the value already compares correctly and should be used as-is
@@ -194,9 +284,21 @@ const mayHoldProjectedValue = (validator: KindedValidator): boolean => {
     return isProjectedKind(validator) || kind === "any" || kind === "union" || kind === "from";
 };
 
-// The codec pair is exported for `@lunora/sql-store`, which must produce a
+// Both codec pairs are exported for `@lunora/sql-store`, which must produce a
 // BYTE-IDENTICAL key on the `.global()` plane — the two planes are compared
 // directly by a parity test, and a second copy of an order-preserving encoding
-// is precisely the thing that drifts. The sign characters and the width stay
+// is precisely the thing that drifts. `index-key-codec.ts` shares the float64
+// half for the same reason: the reactive layer decides whether a written row
+// falls inside a live query's range, and it can only get that right if its
+// numeric order IS the stored one. The sign characters and the widths stay
 // module-local: nothing outside needs them now that both halves live here.
-export { BIGINT_KEY_DIGITS, bigintSqlKey, decodeBigintSqlKey, isProjectedKind, mayHoldProjectedValue, sqlComparableProjection };
+export {
+    BIGINT_KEY_DIGITS,
+    bigintSqlKey,
+    decodeBigintSqlKey,
+    decodeFloat64SqlKey,
+    float64SqlKey,
+    isProjectedKind,
+    mayHoldProjectedValue,
+    sqlComparableProjection,
+};

--- a/packages/sql-store/__tests__/ctx-db.test.ts
+++ b/packages/sql-store/__tests__/ctx-db.test.ts
@@ -5,12 +5,13 @@ import { MAX_SEARCH_SCAN } from "@lunora/search-core";
 import type { SchemaLike, ValidatorLike } from "@lunora/shard-engine";
 import { CURSOR_PREFIX } from "@lunora/shard-engine";
 import { sql } from "drizzle-orm";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import type { SqlCtxExec } from "../src/ctx-db";
 import { createSqlCtxDb, readSqlCdcChanges } from "../src/ctx-db";
 import type { SqlDialect } from "../src/dialect";
 import { BACKFILL_BATCH_SIZE } from "../src/sql-exec";
+import { sqliteEncode } from "../src/value-codec";
 
 /**
  * In-package end-to-end coverage for the dialect-blind store core. The concrete
@@ -2009,17 +2010,27 @@ describe("createSqlCtxDb — recomputing an extreme over a large group", () => {
  * returned. The identical reads against the DO row store are correct, which is
  * what made moving a table to `.global()` change the answers.
  *
- * NOT fixed here, and asserted so it stays visible: the marked form is JSON
- * text, so SQLite orders an untyped column's numbers lexicographically. Ranges
- * and cursors are now consistent WITH that order — which is what makes paging
- * whole — but it is not numeric order, and making it numeric is a stored-format
- * change.
+ * The marked form a number takes is an order-preserving key, so that one order
+ * is NUMERIC. It was interim text order for one round — the assertions below
+ * pinned it deliberately, and now pin the numeric order they were placed to be
+ * replaced by.
  */
 const untypedFilterSchema: SchemaLike = {
     tables: {
         readings: {
             indexes: [],
             shape: { label: col("string"), value: col("union") },
+            shardMode: { kind: "global" },
+        },
+    },
+} as never;
+
+/** The same table with a NULLABLE untyped column, so a stored SQL NULL is part of the ordering under test. */
+const untypedMixedSchema: SchemaLike = {
+    tables: {
+        readings: {
+            indexes: [],
+            shape: { label: col("string"), value: col("union", { notNull: false }) },
             shardMode: { kind: "global" },
         },
     },
@@ -2078,7 +2089,7 @@ describe("createSqlCtxDb — filtering and paging an untyped column", () => {
     });
 
     it("returns every row across pages when the sort key is an untyped column", async () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const writer = makeWriter();
 
@@ -2108,17 +2119,21 @@ describe("createSqlCtxDb — filtering and paging an untyped column", () => {
         expect(seenLabels).toHaveLength(7);
         expect(new Set(seenLabels).size).toBe(7);
 
-        // The order the page walks is the STORAGE order, which for an untyped
-        // column is text order over the marked form. Pinned rather than papered
-        // over: what the fix guarantees is that paging agrees with it, not that
-        // it is numeric.
+        // The order the page walks is the STORAGE order, and for a number in an
+        // untyped column that is now the order-preserving key's — so it is
+        // numeric, and paging agrees with it. This assertion pinned the interim
+        // text order (`a, d, e, b, c`) for one round.
         const straight = await writer.findMany("readings", { limit: 100, orderBy: [{ value: "asc" }] });
 
         expect(seenLabels).toStrictEqual(straight.page.map((row) => String(row["label"])));
+
+        // 1.5 < 2 < 9 < 10 < 100, then `true`, then the string "10" — not
+        // `1.5, 10, 100, 2, 9` with the rest interleaved by text.
+        expect(seenLabels).toStrictEqual(["a", "b", "c", "d", "e", "f", "g"]);
     });
 
-    it("keeps a range filter on the same side of the order the sort uses", async () => {
-        expect.assertions(1);
+    it("selects a numeric range, not the rows a text comparison would put after the bound", async () => {
+        expect.assertions(2);
 
         const writer = makeWriter();
 
@@ -2128,10 +2143,376 @@ describe("createSqlCtxDb — filtering and paging an untyped column", () => {
         const pivotIndex = ordered.page.findIndex((row) => row["label"] === "c");
         const after = await writer.findMany("readings", { limit: 100, orderBy: [{ value: "asc" }], where: { value: { gt: 9 } } });
 
-        // `{ gt: 9 }` selects exactly the rows the ORDER BY places after `c`.
-        // Before the fix it bound a bare `9` against marked text and selected
-        // none of them.
+        // `{ gt: 9 }` still selects exactly the rows the ORDER BY places after
+        // `c` — the consistency the round before this one bought. Before that it
+        // bound a bare `9` against marked text and selected none of them.
         expect(after.page.map((row) => String(row["label"]))).toStrictEqual(ordered.page.slice(pivotIndex + 1).map((row) => String(row["label"])));
+
+        // And the rows it selects are the numerically greater ones. Under text
+        // order over the marked JSON this returned neither `d` (10) nor `e`
+        // (100), because `"1"` sorts below `"9"`.
+        expect(after.page.filter((row) => typeof row["value"] === "number").map((row) => row["value"])).toStrictEqual([10, 100]);
+    });
+});
+
+/**
+ * A `.global()` untyped column at a scale the planner actually has to choose a
+ * strategy for.
+ *
+ * The lexicographic-order defect this pins is invisible at five rows whose
+ * values are single digits — text order and numeric order agree there, so a
+ * small fixture reads correct against broken storage. The values below span
+ * 1e-3 to 1e6 with both signs across 2,000 rows, so the two orders disagree on
+ * most adjacent pairs, and a range predicate's MEMBERSHIP — not just its
+ * ordering — differs between the two encodings.
+ */
+const UNTYPED_SCALE_ROWS = 2000;
+
+/** A spread of magnitudes and signs whose text order is nothing like their numeric order. */
+const untypedScaleValue = (index: number): number => {
+    const magnitude = 10 ** (index % 10) / 1000;
+
+    return index % 3 === 0 ? -magnitude - index : magnitude + index;
+};
+
+/** A raw-SQL harness: the same in-memory database the store runs on, plus the statements it emitted. */
+const createRecordingSqliteHarness = (): {
+    close: () => void;
+    exec: SqlCtxExec;
+    raw: (query: string, ...parameters: unknown[]) => Record<string, unknown>[];
+    statements: { params: ReadonlyArray<unknown>; sql: string }[];
+} => {
+    const database = new DatabaseSync(":memory:");
+    const statements: { params: ReadonlyArray<unknown>; sql: string }[] = [];
+    const all = (query: string, parameters: ReadonlyArray<unknown>): Record<string, unknown>[] => {
+        statements.push({ params: parameters, sql: query });
+
+        return database.prepare(query).all(...(parameters as never[]));
+    };
+
+    return {
+        close: () => {
+            database.close();
+        },
+        exec: {
+            all: (query, parameters) => Promise.resolve(all(query, parameters)),
+            run: (query, parameters) => {
+                all(query, parameters);
+
+                return Promise.resolve();
+            },
+        },
+        raw: (query, ...parameters) => database.prepare(query).all(...(parameters as never[])),
+        statements,
+    };
+};
+
+describe("createSqlCtxDb — an untyped column orders numerically at scale", () => {
+    let harness: ReturnType<typeof createRecordingSqliteHarness>;
+    let writer: ReturnType<typeof createSqlCtxDb>;
+    let values: number[];
+
+    // Seeded once: every case below only reads, and 2,000 inserts per case would
+    // buy nothing but wall-clock.
+    beforeAll(async () => {
+        harness = createRecordingSqliteHarness();
+        writer = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+        values = [];
+
+        for (let index = 0; index < UNTYPED_SCALE_ROWS; index += 1) {
+            const value = untypedScaleValue(index);
+
+            values.push(value);
+            // eslint-disable-next-line no-await-in-loop -- a seed loop; sequential writes keep `_creationTime` and `id` deterministic.
+            await writer.insert("readings", { label: String(index).padStart(5, "0"), value });
+        }
+    }, 120_000);
+
+    afterAll(() => {
+        harness.close();
+    });
+
+    const numerically = (): number[] => values.toSorted((left, right) => left - right);
+
+    it("returns 2,000 rows in numeric order, which is not their text order", async () => {
+        expect.assertions(2);
+
+        const ordered = await writer.findMany("readings", { limit: UNTYPED_SCALE_ROWS, orderBy: [{ value: "asc" }] });
+
+        expect(ordered.page.map((row) => row["value"])).toStrictEqual(numerically());
+
+        // The assertion that makes the fixture worth its size: sorting the same
+        // values by the form an earlier build stored gives a DIFFERENT answer,
+        // so a pass above cannot be an accident of small, same-width numbers.
+        const byMarkedJson = values.toSorted((left, right) => `$lunora.wire$${JSON.stringify(left)}`.localeCompare(`$lunora.wire$${JSON.stringify(right)}`));
+
+        expect(byMarkedJson).not.toStrictEqual(numerically());
+    });
+
+    it("selects exactly the numerically-matching rows for a range spanning magnitudes", async () => {
+        expect.assertions(2);
+
+        const between = await writer.findMany("readings", { limit: UNTYPED_SCALE_ROWS, where: { value: { gt: 5, lt: 1000 } } });
+        const expected = values.filter((value) => value > 5 && value < 1000).toSorted((left, right) => left - right);
+
+        expect(between.page.map((row) => Number(row["value"])).toSorted((left, right) => left - right)).toStrictEqual(expected);
+
+        // Membership, not only order: text order puts `-1000.001` inside
+        // `(5, 1000)` and `9.009` outside it, so the count alone separates the
+        // two encodings.
+        expect(expected.length).toBeGreaterThan(100);
+    });
+
+    it("binds the range as the stored key and lets SQL order the column itself", async () => {
+        expect.assertions(5);
+
+        harness.statements.length = 0;
+
+        await writer.findMany("readings", { limit: 25, orderBy: [{ value: "asc" }], where: { value: { gt: 5 } } });
+
+        const select = harness.statements.find((statement) => statement.sql.startsWith("SELECT") && statement.sql.includes("ORDER BY"));
+
+        expect(select).toBeDefined();
+        // Ordering is delegated to SQL over the raw column — there is no
+        // decode-then-sort step that could paper over a wrong storage order, so
+        // the stored form IS the answer's order.
+        expect(select?.sql).toContain(`ORDER BY "value" ASC`);
+        // And the bound bound is the order-preserving key, so the comparison SQL
+        // makes is the one the caller asked for. A bare `5` (the kind-blind
+        // binding) or `$lunora.wire$5` (the marked JSON) compares as text.
+        // Spelled out rather than re-derived from `sqliteEncode`, which would
+        // make the assertion agree with whatever the encoder currently does.
+        expect(select?.params).toContain("$lunora.wire$#c014000000000000");
+        expect(sqliteEncode(5, "union")).toBe("$lunora.wire$#c014000000000000");
+        expect(select?.params).not.toContain(5);
+    });
+
+    it("walks every row across keyset pages in the same numeric order", async () => {
+        expect.assertions(2);
+
+        const seen: unknown[] = [];
+        let cursor: null | string = null;
+
+        for (let page = 0; page < 100; page += 1) {
+            // eslint-disable-next-line no-await-in-loop -- keyset pagination is sequential by construction.
+            const result: { continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] } = await writer.findMany("readings", {
+                cursor,
+                limit: 100,
+                orderBy: [{ value: "asc" }],
+            });
+
+            seen.push(...result.page.map((row) => row["value"]));
+            cursor = result.continueCursor;
+
+            if (result.isDone) {
+                break;
+            }
+        }
+
+        // A cursor pivot bound in a form that disagrees with `ORDER BY` drops
+        // every row after the page it first disagrees on.
+        expect(seen).toHaveLength(UNTYPED_SCALE_ROWS);
+        expect(seen).toStrictEqual(numerically());
+    });
+});
+
+describe("createSqlCtxDb — an untyped column stays totally ordered across types", () => {
+    let harness: ReturnType<typeof createRecordingSqliteHarness>;
+
+    beforeEach(() => {
+        harness = createRecordingSqliteHarness();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("places null, then every number, then booleans, then strings and composites, then bytes", async () => {
+        expect.assertions(2);
+
+        const writer = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedMixedSchema });
+
+        for (const [label, value] of [
+            ["a-null", null],
+            ["b-neg", -5],
+            ["c-frac", 0.25],
+            ["d-nine", 9],
+            ["e-big", 1000],
+            ["f-false", false],
+            ["g-true", true],
+            ["h-string", "zulu"],
+            ["i-object", { nested: 1 }],
+            ["j-bytes", new Uint8Array([1, 2, 3]).buffer],
+        ] as [string, unknown][]) {
+            // eslint-disable-next-line no-await-in-loop -- a seed loop; ordering the writes keeps `_creationTime` deterministic.
+            await writer.insert("readings", { label, value });
+        }
+
+        const ordered = await writer.findMany("readings", { limit: 100, orderBy: [{ value: "asc" }] });
+
+        /*
+         * The order this pins, and why each boundary lands where it does:
+         *
+         * - NULL is a real SQL NULL, which SQLite sorts below every value. Matches
+         *   the reference order `index-key-codec.ts` reproduces.
+         * - Every number is `$lunora.wire$#` + a fixed-width order-preserving key,
+         *   so the block is internally NUMERIC and contiguous.
+         * - `false`/`true` follow, because `#` sorts below `f` and `t`. That is the
+         *   position they already held when numbers were marked JSON too, so this
+         *   change moved the numbers without moving the boundary.
+         * - A string is stored verbatim (which is what `contains`/`startsWith` run
+         *   their substring test against) and a composite as its JSON, so both sort
+         *   by their own text.
+         * - Bytes bind as a BLOB, and SQLite sorts every BLOB above every TEXT.
+         *
+         * Across the whole column the order is therefore total, deterministic and
+         * stable — but it is NOT SQLite's own class order, because numbers live in
+         * the TEXT class at the `$` position rather than below every string. That
+         * is the price of storing strings verbatim, and it is the right way round:
+         * moving strings into a tagged encoding would order the classes correctly
+         * and break every substring filter in exchange.
+         */
+        expect(ordered.page.map((row) => row["label"])).toStrictEqual([
+            "a-null",
+            "b-neg",
+            "c-frac",
+            "d-nine",
+            "e-big",
+            "f-false",
+            "g-true",
+            "h-string",
+            "i-object",
+            "j-bytes",
+        ]);
+        // `9` before `1000`: the number block is internally numeric, not the
+        // text order (`0.25`, `1000`, `9`) the marked JSON gave it.
+        expect(ordered.page.slice(1, 5).map((row) => row["value"])).toStrictEqual([-5, 0.25, 9, 1000]);
+    });
+});
+
+/**
+ * The storage-format change above is only half a fix. A table written before it
+ * holds the marked JSON, and the new binding does not match that — so `eq` would
+ * start missing rows it used to find, and a range would run against a column
+ * holding two incomparable encodings. The rewrite walk in `ctx-db-migrations.ts`
+ * converts the stragglers from the same provisioning pass that creates the table.
+ */
+describe("createSqlCtxDb — a table written before the key encoding still reads back", () => {
+    let harness: ReturnType<typeof createRecordingSqliteHarness>;
+
+    beforeEach(() => {
+        harness = createRecordingSqliteHarness();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    /** Comfortably more than the 100 rows the rewrite converts per round trip, so the keyset walk pages several times. */
+    const LEGACY_ROWS = 450;
+
+    /**
+     * Provision the table, then fill it the way a pre-change build would have:
+     * the marked JSON form written straight in, with the completion marker
+     * cleared so the next ctx-db sees an unconverted table.
+     */
+    const seedLegacyTable = async (): Promise<number[]> => {
+        const provisioner = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+
+        await provisioner.insert("readings", { label: "provision", value: 1 });
+
+        harness.raw(`DELETE FROM "readings"`);
+        harness.raw(`DELETE FROM "__lunora_migration_state"`);
+
+        const legacyValues: number[] = [];
+
+        for (let index = 0; index < LEGACY_ROWS; index += 1) {
+            const value = untypedScaleValue(index);
+
+            legacyValues.push(value);
+            harness.raw(
+                `INSERT INTO "readings" ("id", "_creationTime", "label", "value") VALUES (?, ?, ?, ?)`,
+                `r${String(index).padStart(5, "0")}`,
+                1,
+                String(index).padStart(5, "0"),
+                `$lunora.wire$${JSON.stringify(value)}`,
+            );
+        }
+
+        // A marked boolean and a wire-encoded composite ride along: the probe
+        // matches both (SQL cannot tell them from a number) and the pass must
+        // leave them byte-identical rather than mangle them.
+        harness.raw(`INSERT INTO "readings" ("id", "_creationTime", "label", "value") VALUES (?, ?, ?, ?)`, "zz-bool", 1, "zz-bool", "$lunora.wire$true");
+        harness.raw(`INSERT INTO "readings" ("id", "_creationTime", "label", "value") VALUES (?, ?, ?, ?)`, "zz-json", 1, "zz-json", '{"a":1}');
+
+        return legacyValues;
+    };
+
+    it("converts every legacy row on the next cold start and reads it back numerically ordered", async () => {
+        expect.assertions(4);
+
+        const legacyValues = await seedLegacyTable();
+        // A fresh ctx-db over the same database IS the cold start that runs the
+        // provisioning pass.
+        const reader = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+        const ordered = await reader.findMany("readings", { limit: LEGACY_ROWS + 10, orderBy: [{ value: "asc" }] });
+
+        expect(ordered.page.filter((row) => typeof row["value"] === "number").map((row) => row["value"])).toStrictEqual(
+            legacyValues.toSorted((left, right) => left - right),
+        );
+        expect(ordered.page).toHaveLength(LEGACY_ROWS + 2);
+
+        // Every number is in the new form on disk, and the row that is correct
+        // as stored was not touched.
+        const stillLegacy = harness.raw(`SELECT "value" FROM "readings" WHERE "value" LIKE '$lunora.wire$%' AND "value" NOT LIKE '$lunora.wire$#%'`);
+
+        expect(stillLegacy.map((row) => row["value"])).toStrictEqual(["$lunora.wire$true"]);
+        expect(harness.raw(`SELECT "name" FROM "__lunora_migration_state" WHERE "name" = 'untyped-number-key:readings'`)).toHaveLength(1);
+    });
+
+    it("matches an equality and a range against a converted row, which the format change alone would have broken", async () => {
+        expect.assertions(3);
+
+        const legacyValues = await seedLegacyTable();
+        const reader = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+        const target = legacyValues[7] ?? 0;
+
+        // `eq` binds the key. Against an unconverted row it matches nothing —
+        // that row is still marked JSON — which is the silent read break the
+        // rewrite exists to prevent.
+        const matched = await reader.findMany("readings", { where: { value: target } });
+
+        expect(matched.page).toHaveLength(legacyValues.filter((value) => value === target).length);
+
+        const above = await reader.findMany("readings", { limit: LEGACY_ROWS + 10, where: { value: { gt: 100 } } });
+        const expected = legacyValues.filter((value) => value > 100);
+
+        expect(above.page.filter((row) => typeof row["value"] === "number")).toHaveLength(expected.length);
+        expect(expected.length).toBeGreaterThan(0);
+    });
+
+    it("does not re-scan a converted table on the cold start after it", async () => {
+        expect.assertions(2);
+
+        await seedLegacyTable();
+
+        const first = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+
+        await first.findMany("readings", { limit: 1 });
+
+        harness.statements.length = 0;
+
+        const second = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: harness.exec, schema: untypedFilterSchema });
+
+        await second.findMany("readings", { limit: 1 });
+
+        // The walk's probe can use no index, so leaving it armed would be a full
+        // table scan on every request against a Hyperdrive binding, forever, on
+        // a table where it can never match again.
+        expect(harness.statements.filter((statement) => statement.sql.includes("NOT LIKE"))).toHaveLength(0);
+        expect(
+            harness.statements.filter((statement) => statement.sql.includes("__lunora_migration_state") && statement.sql.startsWith("SELECT")).length,
+        ).toBeGreaterThan(0);
     });
 });
 

--- a/packages/sql-store/__tests__/value-codec.test.ts
+++ b/packages/sql-store/__tests__/value-codec.test.ts
@@ -119,6 +119,86 @@ describe("sqliteEncode", () => {
     });
 });
 
+/**
+ * An untyped column (`v.union()`/`v.any()`/`v.from()`) is TEXT on every engine,
+ * so a number written to one has to be stored as text — and the marked JSON that
+ * used to carry it (`$lunora.wire$42`) sorts `"10"` before `"2"`. The key form
+ * below is the same fix `bigintSqlKey` is, applied to the last column kind left
+ * on the lossy form.
+ */
+describe("sqliteEncode — untyped columns store a number as an order-preserving key", () => {
+    /** Text order over the stored forms, which is the order SQLite applies to the column. */
+    const byStorage = (values: ReadonlyArray<number>): number[] =>
+        values.toSorted((left, right) => {
+            const a = String(sqliteEncode(left, "union"));
+            const b = String(sqliteEncode(right, "union"));
+
+            if (a < b) {
+                return -1;
+            }
+
+            return a > b ? 1 : 0;
+        });
+
+    it("orders numbers numerically, across zero and across magnitudes", () => {
+        expect.assertions(1);
+
+        const values = [1.5, 2, 9, 10, 100, 0, -0.5, -7, -1000, 1e300, -1e300, 5e-324, 2 ** 53];
+
+        expect(byStorage(values)).toStrictEqual(values.toSorted((left, right) => left - right));
+    });
+
+    it("round-trips every number through the marker alone, no kind needed on the way out", () => {
+        expect.assertions(1);
+
+        const values = [0, -0, 1.5, -7, 1e300, 5e-324, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER];
+
+        // `-0` normalizes to `0`: SQL compares the two equal, so two distinct
+        // keys would make an `eq` binding miss half the rows it should match.
+        expect(values.map((value) => sqliteDecode(sqliteEncode(value, "union"), "union"))).toStrictEqual([
+            0,
+            0,
+            1.5,
+            -7,
+            1e300,
+            5e-324,
+            Number.MAX_SAFE_INTEGER,
+            Number.MIN_SAFE_INTEGER,
+        ]);
+    });
+
+    it("keeps every number sorting below `false` and `true`, the position they already held", () => {
+        expect.assertions(1);
+
+        // Asserted as already-ascending rather than by sorting: `<` on these
+        // ASCII forms is byte order, which is the order SQLite applies to the
+        // column, and no JS sort comparator reproduces that for arbitrary text.
+        const forms = [Number.MAX_VALUE, false, true].map((value) => String(sqliteEncode(value, "union")));
+
+        expect(forms.every((form, index) => index === 0 || (forms[index - 1] ?? "") < form)).toBe(true);
+    });
+
+    it("still reads back a number written in the marked JSON an earlier build wrote", () => {
+        expect.assertions(2);
+
+        // What makes a table correct between the format change and the rewrite
+        // pass that converts it — the read side accepts both forms.
+        expect(sqliteDecode("$lunora.wire$42", "union")).toBe(42);
+        expect(sqliteDecode("$lunora.wire$-1.5", "any")).toBe(-1.5);
+    });
+
+    it("leaves a string, a bigint and a composite in the form they already had", () => {
+        expect.assertions(3);
+
+        // The WHERE path binds through `sqliteEncode` for these too, and
+        // `contains`/`startsWith` run their substring test against the stored
+        // string — so only the numbers moved.
+        expect(sqliteEncode("42", "union")).toBe("42");
+        expect(sqliteEncode(42n, "union")).toBe(`1${"42".padStart(39, "0")}`);
+        expect(sqliteEncode({ x: 1 }, "union")).toBe('{"x":1}');
+    });
+});
+
 describe("sqliteDecode — round-trips with sqliteEncode by kind", () => {
     it("boolean: 1/0 → true/false; other values verbatim", () => {
         expect.assertions(3);

--- a/packages/sql-store/src/ctx-db-migrations.ts
+++ b/packages/sql-store/src/ctx-db-migrations.ts
@@ -3,9 +3,9 @@
  * rather than reads or writes a row.
  *
  * Table DDL and its drift repair, the declared/`.unique()`/default-order
- * indexes, the aggregate and rank companion tables, and the one-shot `v.bigint()`
- * storage rewrite — the cluster `ensureMigrated` runs once per ctx-db, and
- * nothing on a read or write path calls.
+ * indexes, the aggregate and rank companion tables, and the one-shot storage
+ * rewrites for `v.bigint()` and untyped columns — the cluster `ensureMigrated`
+ * runs once per ctx-db, and nothing on a read or write path calls.
  *
  * Split out of `ctx-db.ts` along the same seam as `ctx-db-search.ts` and for the
  * same reason: everything here reaches the engine through `sql-exec`, never
@@ -25,7 +25,15 @@ import { sql } from "drizzle-orm";
 import type { SqlDialect } from "./dialect";
 import type { SqlCtxExec } from "./sql-exec";
 import { columnRefSql, createIndexIfNotExists, OCC_VERSION_COLUMN, queryAll, queryBatch, queryRun, tableColumns } from "./sql-exec";
-import { BIGINT_KEY_LENGTH, bigintSqlKey, effectiveColumnKind } from "./value-codec";
+import {
+    BIGINT_KEY_LENGTH,
+    bigintSqlKey,
+    effectiveColumnKind,
+    isUntypedColumnKind,
+    rewriteLegacyUntypedNumber,
+    UNTYPED_NUMBER_PREFIX,
+    UNTYPED_WIRE_PREFIX,
+} from "./value-codec";
 
 /**
  * SQLite affinity for a column. Resolves the *effective* validator kind (so
@@ -380,18 +388,25 @@ const migrationCompleted = async (exec: SqlCtxExec, dialect: SqlDialect, marker:
 };
 
 /**
- * Record the bigint rewrite of one table as finished, and report the rows it
- * could not convert — once, here, rather than by re-scanning them on every cold
- * start from now on.
+ * Record one table's storage rewrite as finished, and report the rows it could
+ * not convert — once, here, rather than by re-scanning them on every cold start
+ * from now on.
  *
  * A concurrent cold start that inserted the same marker first is the expected
  * race, not a failure: both passes walked the same table to the same end.
  */
-const completeBigintRewrite = async (exec: SqlCtxExec, dialect: SqlDialect, marker: string, tableName: string, unconvertible: number): Promise<void> => {
-    if (unconvertible > 0) {
+const completeLegacyRewrite = async (
+    exec: SqlCtxExec,
+    dialect: SqlDialect,
+    marker: string,
+    tableName: string,
+    unconvertible: number,
+    describeUnconvertible: string | undefined,
+): Promise<void> => {
+    if (unconvertible > 0 && describeUnconvertible !== undefined) {
         // eslint-disable-next-line no-console -- the only channel a provisioning pass has; reported once per table rather than re-scanned every cold start.
         console.warn(
-            `[@lunora/sql-store] bigint storage migration on "${tableName}": ${String(unconvertible)} row(s) hold a value the order-preserving key cannot represent (non-numeric text, or a magnitude past 39 digits) and were left as stored — range filters and ORDER BY over them stay wrong until they are corrected by hand.`,
+            `[@lunora/sql-store] storage migration "${marker}" on "${tableName}": ${String(unconvertible)} row(s) ${describeUnconvertible} and were left as stored — range filters and ORDER BY over them stay wrong until they are corrected by hand.`,
         );
     }
 
@@ -405,7 +420,7 @@ const completeBigintRewrite = async (exec: SqlCtxExec, dialect: SqlDialect, mark
 };
 
 /**
- * Rows converted per pass by {@link rewriteLegacyBigintColumns}; keeps one
+ * Rows converted per pass by {@link runLegacyColumnRewrite}; keeps one
  * statement's bound-parameter count inside D1's budget.
  *
  * Rendered into the `LIMIT` inline (`sql.raw`) rather than bound: mysql2's
@@ -414,20 +429,40 @@ const completeBigintRewrite = async (exec: SqlCtxExec, dialect: SqlDialect, mark
  * provisioning pass down. It is a module constant, so nothing caller-supplied
  * reaches the statement text.
  */
-const BIGINT_REWRITE_PAGE = 100;
+const LEGACY_REWRITE_PAGE = 100;
 
 /**
- * The declared fields of `table` that are stored as a `bigint` key.
+ * One storage-format rewrite: which columns it touches, how it recognises a row
+ * still in the old form, and what the new form is.
  */
-const bigintFields = (definition: SchemaLike["tables"][string]): string[] =>
-    Object.entries(definition.shape)
-        .filter(([, validator]) => validator._meta?.column !== undefined && effectiveColumnKind(validator) === "bigint")
-        .map(([field]) => field);
+interface LegacyColumnRewrite {
+    /** New stored value for `raw`, or `undefined` to leave the column exactly as stored. */
+    convert: (raw: unknown) => unknown;
+
+    /**
+     * What an unconvertible row holds, for the one-shot warning — completing the
+     * sentence "N row(s) …".
+     *
+     * Omitted by a rewrite whose probe over-matches rows that are CORRECT as
+     * stored, where a warning would fire on every ordinary table and mean
+     * nothing.
+     */
+    describeUnconvertible?: string;
+
+    /** The declared columns this pass considers. Empty means the table has nothing to do. */
+    fields: string[];
+
+    /** Recorded in {@link MIGRATION_STATE_TABLE} once the walk finishes; unique per rewrite AND table. */
+    marker: string;
+
+    /** SQL matching a row whose `field` may still hold the old form. May over-match — `convert` decides per row. */
+    probe: (field: string) => SQL;
+}
 
 /**
- * The `SET` assignments that convert one row's legacy `bigint` columns, and the
- * `WHERE` guard that makes applying them safe — both empty when every column
- * already holds a key.
+ * The `SET` assignments that convert one row's legacy columns, and the `WHERE`
+ * guard that makes applying them safe — both empty when every column is already
+ * in the new form.
  *
  * The guard is the compare-and-swap the user write path already does
  * (`runGuardedWrite`, in `ctx-db.ts`). The page below is read, then written in a second
@@ -437,95 +472,79 @@ const bigintFields = (definition: SchemaLike["tables"][string]): string[] =>
  * column against the exact text the page read means the losing statement
  * updates nothing, and the row is already in the new encoding either way.
  *
- * A value this encoding cannot hold — non-numeric text no encoder here ever
- * wrote, or a magnitude past the 39-digit ceiling — contributes no assignment
- * and is left exactly as stored rather than aborting the pass.
+ * A value the new encoding cannot hold — one the rewrite's `convert` returns
+ * `undefined` for — contributes no assignment and is left exactly as stored
+ * rather than aborting the pass.
  */
-const legacyBigintRewrite = (row: Record<string, unknown>, fields: ReadonlyArray<string>): { assignments: SQL[]; guards: SQL[] } => {
+const legacyRewriteStatements = (row: Record<string, unknown>, rewrite: LegacyColumnRewrite): { assignments: SQL[]; guards: SQL[] } => {
     const assignments: SQL[] = [];
     const guards: SQL[] = [];
 
-    for (const field of fields) {
+    for (const field of rewrite.fields) {
         const raw = row[field];
+        const next = rewrite.convert(raw);
 
-        if (typeof raw !== "string" || raw.length === BIGINT_KEY_LENGTH) {
+        if (next === undefined) {
             continue;
         }
 
-        try {
-            const key = bigintSqlKey(BigInt(raw));
-
-            assignments.push(sql`${columnRefSql(field)} = ${key}`);
-            guards.push(sql`${columnRefSql(field)} = ${raw}`);
-        } catch {
-            // Not a value this encoding can hold. Left as stored.
-        }
+        assignments.push(sql`${columnRefSql(field)} = ${next}`);
+        guards.push(sql`${columnRefSql(field)} = ${raw}`);
     }
 
     return { assignments, guards };
 };
 
 /**
- * Rewrite any `v.bigint()` column still holding the plain decimal text an
- * earlier build stored into the order-preserving key {@link bigintSqlKey} now
- * writes.
+ * Walk one table and rewrite every column still holding a superseded storage
+ * form into the one this build writes.
  *
- * This is a **storage-format migration, and it is not optional**. Decimal text
- * is exact for `=` but sorts `"9"` after `"10"`, so every range filter,
- * `ORDER BY`, page cursor and `MIN`/`MAX` over such a column returned the wrong
- * rows. The fix changes what is written — which means a table holding both forms
- * has a worse problem than the one it started with: `where: { n: { eq: 10n } }`
- * binds the key and no longer matches a row stored as `"10"`. Converting the
- * stragglers is what keeps that from being a silent read break, so it runs from
- * the same provisioning pass that creates the table.
+ * **A storage-format change is not optional, and this is why.** Both rewrites
+ * below replace a form that is exact for `=` but sorts wrongly, so every range
+ * filter, `ORDER BY`, page cursor and `MIN`/`MAX` over such a column returned
+ * the wrong rows. Fixing the writer alone leaves a table holding BOTH forms,
+ * which is worse than where it started: the new binding does not match a row
+ * still in the old form, so `eq` starts missing rows it used to find. Converting
+ * the stragglers is what keeps that from being a silent read break, so it runs
+ * from the same provisioning pass that creates the table.
  *
  * **A converted table costs one primary-key lookup, and that is the point.**
  * `ensureMigrated` runs per ctx-db — per request on a Hyperdrive binding — and
- * the page probe (`WHERE LENGTH(col) <> 40 AND id > ?`) can use no index for
- * `LENGTH`, so it is a full table scan on every cold start, forever, on a table
- * where it will never match again. Worse, the rows it CANNOT convert keep
- * matching, so each start pages through them from the top. Completion is
- * therefore recorded per table in {@link MIGRATION_STATE_TABLE} and read back
- * before any of that: the walk runs once, and a table it has finished is a
- * single keyed lookup from then on.
+ * no probe here can use an index (`LENGTH(col)`, `col LIKE`), so it is a full
+ * table scan on every cold start, forever, on a table where it will never match
+ * again. Worse, the rows it CANNOT convert keep matching, so each start pages
+ * through them from the top. Completion is therefore recorded per table in
+ * {@link MIGRATION_STATE_TABLE} and read back before any of that: the walk runs
+ * once, and a table it has finished is a single keyed lookup from then on.
  *
  * Recording completion is sound because nothing writes the legacy form any more:
  * a row this pass could not convert is unconvertible for the same reason next
- * time (it is reported once, here, rather than re-scanned every start), and a
- * user write that races the pass writes the NEW encoding — the compare-and-swap
- * in {@link legacyBigintRewrite} is what stops this pass reverting it. The one
- * case that assumption does not cover is an isolate of a PRE-key build still
+ * time (it is reported once rather than re-scanned every start), and a user
+ * write that races the pass writes the NEW encoding — the compare-and-swap in
+ * {@link legacyRewriteStatements} is what stops this pass reverting it. The one
+ * case that assumption does not cover is an isolate of a PRE-change build still
  * writing while a new one finishes the walk; delete that table's row from
  * `__lunora_migration_state` to make the pass run again.
  *
  * It pages on a keyset cursor over `id`, so a value it cannot convert is stepped
  * over rather than retried forever within a run.
  */
-const rewriteLegacyBigintColumns = async (
-    exec: SqlCtxExec,
-    tableName: string,
-    definition: SchemaLike["tables"][string],
-    dialect: SqlDialect,
-): Promise<void> => {
-    const fields = bigintFields(definition);
-
-    if (fields.length === 0) {
+const runLegacyColumnRewrite = async (exec: SqlCtxExec, tableName: string, dialect: SqlDialect, rewrite: LegacyColumnRewrite): Promise<void> => {
+    if (rewrite.fields.length === 0) {
         return;
     }
 
     await ensureMigrationState(exec, dialect);
 
-    const marker = `bigint-key:${tableName}`;
-
-    if (await migrationCompleted(exec, dialect, marker)) {
+    if (await migrationCompleted(exec, dialect, rewrite.marker)) {
         return;
     }
 
     const legacy = sql.join(
-        fields.map((field) => sql`(${columnRefSql(field)} IS NOT NULL AND LENGTH(${columnRefSql(field)}) <> ${BIGINT_KEY_LENGTH})`),
+        rewrite.fields.map((field) => rewrite.probe(field)),
         sql` OR `,
     );
-    const selected = sql.join([columnRefSql("id"), ...fields.map((field) => columnRefSql(field))], sql`, `);
+    const selected = sql.join([columnRefSql("id"), ...rewrite.fields.map((field) => columnRefSql(field))], sql`, `);
     let cursor = "";
     let unconvertible = 0;
 
@@ -534,12 +553,12 @@ const rewriteLegacyBigintColumns = async (
         const rows = await queryAll(
             exec,
             dialect,
-            sql`SELECT ${selected} FROM ${sql.identifier(tableName)} WHERE (${legacy}) AND ${columnRefSql("id")} > ${cursor} ORDER BY ${columnRefSql("id")} LIMIT ${sql.raw(String(BIGINT_REWRITE_PAGE))}`,
+            sql`SELECT ${selected} FROM ${sql.identifier(tableName)} WHERE (${legacy}) AND ${columnRefSql("id")} > ${cursor} ORDER BY ${columnRefSql("id")} LIMIT ${sql.raw(String(LEGACY_REWRITE_PAGE))}`,
         );
 
         if (rows.length === 0) {
             // eslint-disable-next-line no-await-in-loop -- the loop's exit: one write, on the shared connection, and the pass is over.
-            await completeBigintRewrite(exec, dialect, marker, tableName, unconvertible);
+            await completeLegacyRewrite(exec, dialect, rewrite.marker, tableName, unconvertible, rewrite.describeUnconvertible);
 
             return;
         }
@@ -548,10 +567,10 @@ const rewriteLegacyBigintColumns = async (
 
         for (const row of rows) {
             const { id } = row;
-            const { assignments, guards } = typeof id === "string" ? legacyBigintRewrite(row, fields) : { assignments: [], guards: [] };
+            const { assignments, guards } = typeof id === "string" ? legacyRewriteStatements(row, rewrite) : { assignments: [], guards: [] };
 
             if (assignments.length === 0) {
-                // Matched the probe but holds nothing this encoding can write.
+                // Matched the probe but holds nothing the new encoding can write.
                 unconvertible += 1;
 
                 continue;
@@ -574,6 +593,96 @@ const rewriteLegacyBigintColumns = async (
         cursor = last;
     }
 };
+
+/**
+ * `prefix` as a SQL string literal matching every value that starts with it.
+ *
+ * Rendered into the statement, so it is only safe for a value that cannot close
+ * the quote or act as a wildcard. Both callers pass a module constant from
+ * `value-codec.ts` — `$lunora.wire$` and that plus `#` — which carry no quote,
+ * no backslash, and neither LIKE wildcard (`%`, `_`). Nothing caller-supplied
+ * reaches here; a schema field name never does.
+ */
+const likePrefixLiteral = (prefix: string): string => `'${prefix}%'`;
+
+/** The declared fields of `table` that are stored as a `bigint` key. */
+const bigintFields = (definition: SchemaLike["tables"][string]): string[] =>
+    Object.entries(definition.shape)
+        .filter(([, validator]) => validator._meta?.column !== undefined && effectiveColumnKind(validator) === "bigint")
+        .map(([field]) => field);
+
+/**
+ * The declared `v.any()` / `v.union()` / `v.from()` fields of `table` — the
+ * columns whose stored form keys off the runtime value's type, so a number
+ * written to one is kept as an order-preserving key.
+ */
+const untypedFields = (definition: SchemaLike["tables"][string]): string[] =>
+    Object.entries(definition.shape)
+        .filter(([, validator]) => validator._meta?.column !== undefined && isUntypedColumnKind(effectiveColumnKind(validator)))
+        .map(([field]) => field);
+
+/**
+ * Rewrite any `v.bigint()` column still holding the plain decimal text an
+ * earlier build stored into the order-preserving key {@link bigintSqlKey} now
+ * writes. Decimal text is exact for `=` but sorts `"9"` after `"10"`.
+ */
+const rewriteLegacyBigintColumns = async (exec: SqlCtxExec, tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): Promise<void> =>
+    runLegacyColumnRewrite(exec, tableName, dialect, {
+        convert: (raw) => {
+            if (typeof raw !== "string" || raw.length === BIGINT_KEY_LENGTH) {
+                return undefined;
+            }
+
+            try {
+                return bigintSqlKey(BigInt(raw));
+            } catch {
+                return undefined;
+            }
+        },
+        describeUnconvertible: "hold a value the order-preserving key cannot represent (non-numeric text, or a magnitude past 39 digits)",
+        fields: bigintFields(definition),
+        marker: `bigint-key:${tableName}`,
+        probe: (field) => sql`(${columnRefSql(field)} IS NOT NULL AND LENGTH(${columnRefSql(field)}) <> ${BIGINT_KEY_LENGTH})`,
+    });
+
+/**
+ * Rewrite any untyped column still holding a number as the marked JSON an
+ * earlier build wrote (`$lunora.wire$42`) into the order-preserving key form
+ * (`$lunora.wire$#3ff8…`).
+ *
+ * Same defect as the bigint rewrite above, in the last column kind that had been
+ * left on the lossy form: JSON text sorts `"10"` before `"2"`, so `orderBy`,
+ * ranges, cursors and `MIN`/`MAX` over a `.global()` `v.union()` column ran on
+ * text order — `where: { un: { gt: 5 } }` matched 1 of the 3 rows above it,
+ * while the identical read against the DO row store matched all 3.
+ *
+ * The probe over-matches on purpose: it selects every row whose column carries
+ * the wire marker without the number tag, which is also every marked BOOLEAN and
+ * every wire-encoded COMPOSITE. Narrowing it further would mean encoding the
+ * form rules into SQL, and the rewrite helper in `value-codec.ts` — the one
+ * place that knows both forms — decides per row anyway. Those rows convert to `undefined`
+ * and are left byte-identical, and this pass reports NO unconvertible count: a
+ * marked boolean and a wire-encoded composite are correct exactly as stored, so
+ * warning about them would fire on most tables and mean nothing.
+ *
+ * The two patterns are rendered into the statement rather than bound, for the
+ * reason the `LIMIT` above is: it keeps the probe's bound-parameter count at
+ * ZERO per column. Bound, a table near D1's 100-column ceiling would need 2
+ * placeholders per untyped column and blow the 100-parameter budget outright —
+ * a hard provisioning failure, not a wrong answer. See {@link likePrefixLiteral}
+ * for why rendering these two is safe.
+ */
+const rewriteLegacyUntypedNumbers = async (exec: SqlCtxExec, tableName: string, definition: SchemaLike["tables"][string], dialect: SqlDialect): Promise<void> =>
+    runLegacyColumnRewrite(exec, tableName, dialect, {
+        convert: rewriteLegacyUntypedNumber,
+        fields: untypedFields(definition),
+        marker: `untyped-number-key:${tableName}`,
+        // Two separate patterns rather than one concatenated expression: MySQL's
+        // `||` is logical OR, not string concatenation, so assembling the
+        // pattern in SQL would silently match nothing there.
+        probe: (field) =>
+            sql`(${columnRefSql(field)} LIKE ${sql.raw(likePrefixLiteral(UNTYPED_WIRE_PREFIX))} AND ${columnRefSql(field)} NOT LIKE ${sql.raw(likePrefixLiteral(UNTYPED_NUMBER_PREFIX))})`,
+    });
 
 /**
  * Add the columns a `.global()` table is missing.
@@ -672,6 +781,8 @@ const runSqlGlobalTableMigrations = async (exec: SqlCtxExec, schema: SchemaLike,
         await createGlobalTableIndexes(exec, tableName, definition, dialect);
         // eslint-disable-next-line no-await-in-loop -- runs on the same connection, after the columns exist.
         await rewriteLegacyBigintColumns(exec, tableName, definition, dialect);
+        // eslint-disable-next-line no-await-in-loop -- same connection, same reason; each pass records its own completion marker.
+        await rewriteLegacyUntypedNumbers(exec, tableName, definition, dialect);
     }
 };
 

--- a/packages/sql-store/src/value-codec.ts
+++ b/packages/sql-store/src/value-codec.ts
@@ -5,13 +5,16 @@
  * `serializeColumnValue`/`decodeGlobalRow` hard-code {@link sqliteEncode}
  * /{@link sqliteDecode}, so global-table storage is SQLite-shaped on D1,
  * Postgres, and MySQL alike (booleans as 1/0, JSON as TEXT, `bigint` as the
- * order-preserving text key {@link bigintSqlKey} builds). `SqlDialect` deliberately carries NO codec member: an engine-native
+ * order-preserving text key {@link bigintSqlKey} builds, and a number in an
+ * untyped column as the order-preserving `float64SqlKey` under
+ * {@link UNTYPED_NUMBER_PREFIX} — an untyped column is TEXT everywhere, so a
+ * number kept as JSON there sorted `"10"` before `"2"`). `SqlDialect` deliberately carries NO codec member: an engine-native
  * one there would never run, and a dialect author writing one would only learn
  * that at runtime. Adding one means routing the core through it first.
  */
 import { LunoraError } from "@lunora/errors";
 import type { ValidatorLike } from "@lunora/shard-engine";
-import { BIGINT_KEY_DIGITS, bigintSqlKey, decodeBigintSqlKey } from "@lunora/shard-engine";
+import { BIGINT_KEY_DIGITS, bigintSqlKey, decodeBigintSqlKey, decodeFloat64SqlKey, float64SqlKey } from "@lunora/shard-engine";
 
 import { effectiveKind } from "../../../shared/effective-kind";
 import { decodeWire, encodeWire, needsWireEncoding, WIRE_TAG } from "../../../shared/wire-codec";
@@ -23,6 +26,28 @@ import { decodeWire, encodeWire, needsWireEncoding, WIRE_TAG } from "../../../sh
  * `{`, `[`, `"`, a digit, `-`, `t`, `f`, or `n`, never `$`.
  */
 const WIRE_PREFIX = WIRE_TAG;
+
+/**
+ * Second marker character, after {@link WIRE_PREFIX}, on a number stored in an
+ * untyped column. What follows is `float64SqlKey`'s fixed-width, order-preserving
+ * hex rather than `JSON.stringify` output, so SQLite's text comparison over the
+ * column IS numeric comparison over the values.
+ *
+ * `"#"` is chosen for where it sorts, not for how it reads. It is below every
+ * first character `JSON.stringify` can emit (`-`, a digit, `"`, `[`, `{`, `t`,
+ * `f`, `n`), which does two things: it tells a new-form number apart from the
+ * marked JSON an earlier build wrote with certainty rather than by parsing, and
+ * it keeps every number sorting below `false`/`true` — the position they already
+ * held when both were JSON text, so switching the numbers to a key does not
+ * silently move the number/boolean boundary as well.
+ */
+const NUMBER_TAG = "#";
+
+/** The full marker a stored untyped number carries. Exported for the storage migration, which probes for the rows still missing it. */
+const UNTYPED_NUMBER_PREFIX: string = WIRE_TAG + NUMBER_TAG;
+
+/** The marker every wire-encoded stored value carries. Exported for the same probe — it is the half that narrows the scan to marked rows. */
+const UNTYPED_WIRE_PREFIX: string = WIRE_TAG;
 
 /**
  * Decode a stored JSON column, honouring the wire marker written by
@@ -40,8 +65,27 @@ const WIRE_PREFIX = WIRE_TAG;
  * ~1.25x on a 100-row page. A `startsWith` is O(1) against the O(n) scan a
  * content sniff needs.
  */
-const decodeJsonColumn = (raw: string, parse: (text: string) => unknown): unknown =>
-    raw.startsWith(WIRE_PREFIX) ? decodeWire(parse(raw.slice(WIRE_PREFIX.length))) : parse(raw);
+const decodeJsonColumn = (raw: string, parse: (text: string) => unknown): unknown => {
+    if (!raw.startsWith(WIRE_PREFIX)) {
+        return parse(raw);
+    }
+
+    const payload = raw.slice(WIRE_PREFIX.length);
+
+    // A number written by the CURRENT build: `NUMBER_TAG` plus the
+    // order-preserving key. Tested before the JSON path because the key is not
+    // JSON — `parse` would hand back the hex string.
+    if (payload.startsWith(NUMBER_TAG)) {
+        // A malformed key is returned as the stored text rather than as a wrong
+        // number; nothing this encoder writes can be one.
+        return decodeFloat64SqlKey(payload.slice(NUMBER_TAG.length)) ?? raw;
+    }
+
+    // A number written BEFORE the key encoding is marked JSON (`$lunora.wire$42`)
+    // and still decodes here, which is what lets a table read back correctly
+    // between the format change and the rewrite pass that converts it.
+    return decodeWire(parse(payload));
+};
 
 /**
  * Column kinds whose storage type is TEXT on every engine (see
@@ -50,22 +94,50 @@ const decodeJsonColumn = (raw: string, parse: (text: string) => unknown): unknow
  */
 const UNTYPED_KINDS = new Set(["any", "from", "union"]);
 
+/**
+ * The storage form of a scalar written to an untyped column, or `undefined` when
+ * the value takes the same form there as it would anywhere else.
+ *
+ * A number or boolean bound to one of those kinds' TEXT column is COERCED by the
+ * engine — `42` lands as the text `42.0`, `true` (encoded 1) as `1.0` — and the
+ * decode has no type to reverse it with, so the caller read back a string. Both
+ * go out marked and self-describing, so {@link sqliteDecode} reverses them by
+ * the marker alone and needs no kind.
+ *
+ * A NUMBER is marked AND ordered: {@link UNTYPED_NUMBER_PREFIX} plus the
+ * fixed-width `float64SqlKey`, whose byte order is numeric order. The marked
+ * JSON this used to write (`$lunora.wire$42`) is exact for `=` but sorts `"10"`
+ * before `"2"`, so `orderBy`, every range predicate, `MIN`/`MAX` and every page
+ * cursor over an untyped column ran on text order and returned the wrong rows —
+ * `where: { un: { gt: 5 } }` matched 1 of the 3 rows above it while the
+ * identical read against the DO row store matched all 3. The same defect
+ * `bigintSqlKey` exists for, in the one column kind that had been left on the
+ * lossy form.
+ *
+ * Strings, bigints and composites are NOT handled here and keep the storage form
+ * they already had: the WHERE path binds through {@link sqliteEncode} WITHOUT a
+ * kind, so changing them would stop every existing equality filter from
+ * matching — and a string stored verbatim is what `contains`/`startsWith` run
+ * their substring test against.
+ */
+const untypedStorageForm = (value: unknown, kind: string | undefined): string | undefined => {
+    if (kind === undefined || !UNTYPED_KINDS.has(kind)) {
+        return undefined;
+    }
+
+    if (typeof value === "number") {
+        return UNTYPED_NUMBER_PREFIX + float64SqlKey(value);
+    }
+
+    return typeof value === "boolean" ? WIRE_PREFIX + JSON.stringify(value) : undefined;
+};
+
 /** Map a JS value onto its SQLite storage form — SQLite has no boolean, so true/false → 1/0. */
 export const sqliteEncode = (value: unknown, kind?: string): unknown => {
-    // A number or boolean bound to one of the untyped kinds' TEXT column is
-    // COERCED by the engine — `42` lands as the text `42.0`, `true` (encoded 1)
-    // as `1.0` — and the decode has no type to reverse it with, so the caller
-    // read back a string. Store those two in the marked, self-describing form
-    // the composites already use; `sqliteDecode` reverses it by the marker
-    // alone, so no kind is needed on the way out.
-    //
-    // Strings, bigints and composites keep the storage form they already had:
-    // the WHERE path binds through this same function WITHOUT a kind, so
-    // changing them would stop every existing equality filter from matching.
-    // Equality on an untyped numeric column does not match today either (the
-    // stored `42.0` never equalled a bound `42`), so nothing regresses.
-    if (kind !== undefined && (typeof value === "number" || typeof value === "boolean") && UNTYPED_KINDS.has(kind)) {
-        return WIRE_PREFIX + JSON.stringify(value);
+    const untyped = untypedStorageForm(value, kind);
+
+    if (untyped !== undefined) {
+        return untyped;
     }
 
     if (typeof value === "boolean") {
@@ -127,6 +199,38 @@ export const tryJsonParse = (raw: string): unknown => {
 };
 
 /**
+ * Convert one stored untyped-column value from the marked JSON an earlier build
+ * wrote for a number (`$lunora.wire$42`) into the order-preserving key form
+ * {@link sqliteEncode} writes now — or `undefined` when `raw` is not one and
+ * must be left exactly as stored.
+ *
+ * Lives here rather than in the migration that calls it because it is the only
+ * place that knows both forms, and a rewrite pass that reconstructs a storage
+ * format from a second copy of the rules is how a migration corrupts the data
+ * it was written to repair.
+ *
+ * Deliberately narrow. A marked BOOLEAN (`true`/`false`) keeps its form — the
+ * key change moved only the numbers, and `NUMBER_TAG` was picked so the
+ * number/boolean order is the one it already was. A marked COMPOSITE parses to
+ * an array or object, not a number. A number an earlier build could not
+ * represent at all (`NaN`/`±Infinity` stringified to `null`) parses to `null`,
+ * so it is left alone and still reads back as the `null` it already read back
+ * as — the pass cannot invent a value the row never held.
+ */
+export const rewriteLegacyUntypedNumber = (raw: unknown): string | undefined => {
+    if (typeof raw !== "string" || !raw.startsWith(WIRE_PREFIX) || raw.startsWith(UNTYPED_NUMBER_PREFIX)) {
+        return undefined;
+    }
+
+    const parsed = tryJsonParse(raw.slice(WIRE_PREFIX.length));
+
+    return typeof parsed === "number" ? UNTYPED_NUMBER_PREFIX + float64SqlKey(parsed) : undefined;
+};
+
+/** Is `kind` one of the untyped column kinds whose stored form keys off the runtime value's type? */
+export const isUntypedColumnKind = (kind: string | undefined): boolean => kind !== undefined && UNTYPED_KINDS.has(kind);
+
+/**
  * Decode a `bigint` column: the order-preserving key {@link bigintSqlKey} writes,
  * or — for a row stored by a build that wrote plain decimal text — the decimal
  * string, else verbatim.
@@ -180,7 +284,10 @@ export const effectiveColumnKind = (validator: ValidatorLike): string | undefine
  *   A `number` or `boolean` does NOT round-trip through the column's native
  *   type — all three kinds store as TEXT on every engine, which coerces a bound
  *   `42` to the text `42.0` — so {@link sqliteEncode} writes those two in the
- *   marked form and this branch reverses them by the marker alone.
+ *   marked form and this branch reverses them by the marker alone. A number's
+ *   marked payload is `float64SqlKey`, so its text order is numeric order; the
+ *   marked JSON an earlier build wrote is still read back here, which is what
+ *   makes a table correct between the format change and the rewrite pass.
  *   `from` belongs to THIS group, not to `object`/`array`/`record`: an external
  *   Standard Schema can describe a string just as easily as an object, and
  *   {@link sqliteEncode} keys off the runtime JS type — so a `v.from(z.string())`
@@ -290,4 +397,5 @@ export const sqliteDecode = (raw: unknown, kind: string | undefined): unknown =>
  */
 export const BIGINT_KEY_LENGTH: number = BIGINT_KEY_DIGITS + 1;
 
+export { UNTYPED_NUMBER_PREFIX, UNTYPED_WIRE_PREFIX };
 export { bigintSqlKey } from "@lunora/shard-engine";


### PR DESCRIPTION
Finishes the half of the round-33 data-path fix that was deliberately left: an
untyped `.global()` column now orders its numbers numerically.

That round stopped the row LOSS — WHERE values and cursors began binding in the
column's storage form, so equality, ranges, cursors and `ORDER BY` agreed on one
order. But that order was lexicographic, and it turns out that is not only an
ordering wart. Measured against the shard-local plane, which is the reference:

```
                          GLOBAL (before)        DO (correct)
orderBy union asc         1.5,10,100,2,9         1.5,2,9,10,100
where un gt 5             9                      10,9,100
```

`{gt: 5}` returned **one of three** matching rows. A silent wrong answer on a
filter, and the identical read against the DO plane was right — so moving a
table to `.global()` still changed the answers. After this both lines match the
DO plane exactly.

## Encoding

A number in a `v.union()`/`v.any()`/`v.from()` column stores as the marker plus
an IEEE-754 total-order transform. That transform was not invented here: it
already existed as the private `encodeNumber` in `index-key-codec.ts` for
reactive range narrowing. It is lifted beside `bigintSqlKey` and
`index-key-codec.ts` now imports it — one encoder, one decoder, no second copy.
Booleans, strings, bigints, composites and bytes are untouched.

Across types the order is total, deterministic and stable: NULL, then every
number contiguously, then `false`/`true`, then strings and composites by their
own text, then bytes. It is deliberately **not** SQLite's own class order —
numbers sit inside the TEXT class rather than below every string, because
strings are stored verbatim and that is what `contains`/`startsWith` run their
substring test against. Tagging strings would fix the class order and break
every substring filter.

## Migration

Not optional: existing rows carry the old form, and a format change without one
silently reorders every `.global()` table that has such a column. The existing
bigint keyset walk is generalized so the untyped-number rewrite reuses its
compare-and-swap guard and completion marker. The read side still accepts the
old form, so a table reads correctly between deploy and walk.

Evidence, from raw-SQL-seeded old-format rows read through a fresh ctx-db:

```
BEFORE: $lunora.wire$1.5 | $lunora.wire$2 | … | $lunora.wire$true | {"a":1}
AFTER : $lunora.wire$#bff8000000000000 | … | $lunora.wire$true | {"a":1}
read back: -7,0,1.5,2,9,10,100,true,{"a":1}    marker: untyped-number-key:t
```

## Tests

11 of 15 new or changed tests fail against the unfixed source. The 4 that pass
both ways do so by construction and say why: one asserts numbers still sort
below `false`/`true` (i.e. that the boundary did *not* move), one is the
back-compat read that must pass on old code, one asserts strings, bigints and
composites did not move, and one is a regression guard the old code also
satisfied.

Scale is 2,000 rows spanning 1e-3…1e6 with both signs, so text and numeric order
disagree on most adjacent pairs — plus an explicit assertion that sorting the
same values by the OLD form gives a different answer, so a pass cannot be an
accident of small numbers. One test asserts the emitted SQL carries
`ORDER BY "value" ASC` and binds the literal stored key, so ordering is
delegated to SQL rather than decoded and re-sorted in memory.

## Side effects worth knowing

`NaN` and `±Infinity` now round-trip; they were `JSON.stringify`d to `null` and
silently lost. `-0` normalizes to `0`, matching SQL comparison and what
`JSON.stringify` already did. And a `contains`/`startsWith` term no longer
matches the decimal text of a number in an untyped column — that was only ever
an accident of the storage form.

## Rejected

Declaring untyped columns BLOB affinity would give SQLite's class order for
free, but Postgres and MySQL send a bound number to a TEXT column as text, so
storage would stop being SQLite-shaped on every engine — the invariant the whole
codec rests on.

## Verification

`build`, `test --no-cache` (175 tasks), `lint:types`, `lint:eslint`,
`lint:prettier`, `api:check`, `lint:package-json`, `check-generated-files`,
`vis secrets` — all green. The before/after above reproduces through the
round-33 hunt harness, repointed at this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUuYamsU1YLmAQhtut9PLZ
