### PR TITLE
fix(deps): hold the changelog preset at the major its writer can render

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ catalogs:
       specifier: ^7.1.0
       version: 7.1.0
     conventional-changelog-conventionalcommits:
-      specifier: 9.3.1
+      specifier: ^9.3.1
       version: 9.3.1
     cross-env:
       specifier: ^10.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ catalogs:
       specifier: ^7.1.0
       version: 7.1.0
     conventional-changelog-conventionalcommits:
-      specifier: 10.4.0
-      version: 10.4.0
+      specifier: 9.3.1
+      version: 9.3.1
     cross-env:
       specifier: ^10.1.0
       version: 10.1.0
@@ -1127,7 +1127,7 @@ importers:
         version: 4.0.2(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@shikijs/langs@4.4.3)(@shikijs/themes@4.4.3)(ai@7.0.93(zod@4.4.3))(cfonts@3.3.1)(diff@9.0.0)(fb-watchman@2.0.2)(marked@15.0.12)(mysql2@3.24.3(@types/node@26.4.1))(pg@8.23.0)(shiki@4.4.3)
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
-        version: 10.4.0
+        version: 9.3.1
       cz-conventional-changelog:
         specifier: catalog:prod
         version: 3.3.0(@types/node@26.4.1)(typescript@6.0.3)
@@ -6821,10 +6821,6 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
-
-  '@conventional-changelog/template@1.3.0':
-    resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
-    engines: {node: '>=22'}
 
   '@conventional-changelog/template@1.4.0':
     resolution: {integrity: sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==}
@@ -16805,10 +16801,6 @@ packages:
 
   conventional-changelog-angular@9.2.0:
     resolution: {integrity: sha512-2EihZvM1KmbBGwuUow8lNXLe+ECRFsyOcV8X0197/WI7Rvvgfi55Oicfw0wxJTXGGIVXSfj+xBoNj+cxLlIiVw==}
-    engines: {node: '>=22'}
-
-  conventional-changelog-conventionalcommits@10.3.0:
-    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
     engines: {node: '>=22'}
 
   conventional-changelog-conventionalcommits@10.4.0:
@@ -27011,7 +27003,7 @@ snapshots:
   '@commitlint/config-conventional@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-conventionalcommits: 10.3.0
+      conventional-changelog-conventionalcommits: 10.4.0
 
   '@commitlint/config-validator@21.2.0':
     dependencies:
@@ -27143,8 +27135,6 @@ snapshots:
       '@simple-libs/child-process-utils': 2.0.0
       '@simple-libs/stream-utils': 2.0.0
       semver: 7.8.5
-
-  '@conventional-changelog/template@1.3.0': {}
 
   '@conventional-changelog/template@1.4.0': {}
 
@@ -38908,11 +38898,7 @@ snapshots:
 
   conventional-changelog-angular@9.2.0:
     dependencies:
-      '@conventional-changelog/template': 1.3.0
-
-  conventional-changelog-conventionalcommits@10.3.0:
-    dependencies:
-      '@conventional-changelog/template': 1.3.0
+      '@conventional-changelog/template': 1.4.0
 
   conventional-changelog-conventionalcommits@10.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -239,7 +239,11 @@ catalogs:
     "@semantic-release/exec": ^7.1.0
     "@total-typescript/ts-reset": ^0.6.1
     "@tsconfig/node24": ^24.0.5
-    conventional-changelog-conventionalcommits: 10.4.0
+    # Held at 9.3.1: the preset's 10.x templates need conventional-changelog-writer@9,
+    # and @semantic-release/release-notes-generator (via semantic-release 25) pulls
+    # writer 8. On 10.x every release fails in generateNotes with `Missing helper`.
+    # Bump this only once the generator ships writer 9.
+    conventional-changelog-conventionalcommits: 9.3.1
     cross-env: ^10.1.0
   lint:
     # Held at 28.0.1: 28.1.x turns on ~20 new `unicorn/*` rules (filename-case,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -239,11 +239,12 @@ catalogs:
     "@semantic-release/exec": ^7.1.0
     "@total-typescript/ts-reset": ^0.6.1
     "@tsconfig/node24": ^24.0.5
-    # Held at 9.3.1: the preset's 10.x templates need conventional-changelog-writer@9,
-    # and @semantic-release/release-notes-generator (via semantic-release 25) pulls
-    # writer 8. On 10.x every release fails in generateNotes with `Missing helper`.
-    # Bump this only once the generator ships writer 9.
-    conventional-changelog-conventionalcommits: 9.3.1
+    # Held on the 9.x line: the preset's 10.x templates need
+    # conventional-changelog-writer@9, and @semantic-release/release-notes-generator
+    # (via semantic-release 25) pulls writer 8. On 10.x every release fails in
+    # generateNotes with `Missing helper`. 9.x is the newest major that writer 8
+    # renders — lift this range only once the generator ships writer 9.
+    conventional-changelog-conventionalcommits: ^9.3.1
     cross-env: ^10.1.0
   lint:
     # Held at 28.0.1: 28.1.x turns on ~20 new `unicorn/*` rules (filename-case,


### PR DESCRIPTION
The Semantic Release job on `alpha` fails for every package that has releasable
commits ([run 34163311535](https://github.com/anolilab/lunora/actions/runs/34163311535/job/101869373501)):

```
[@lunora/ai] ✘  Failed step "generateNotes" of plugin "Inline plugin"
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer)."
```

## Cause

`conventional-changelog-conventionalcommits` 10.x renders through helpers that
only exist in `conventional-changelog-writer@9`. The writer is not ours to
choose: `@semantic-release/release-notes-generator@14.1.1` (what semantic-release
25 installs) depends on `conventional-changelog-writer@8.4.0`. The preset is
resolved from the repo root, the writer from inside the generator, and the two
majors do not meet.

The catalog entry was pinned to `9.3.1` for exactly this reason. A `--latest`
sweep moved it to `10.4.0`, and the first release run after that failed.

## Change

`conventional-changelog-conventionalcommits` back to `9.3.1`, with the constraint
recorded at the entry the way the other held pins are, so the next sweep leaves
it alone. Lockfile regenerated — the only other movement is `@commitlint/config-conventional`
deduping its own transitive `10.3.0` onto `10.4.0`; commitlint reads the preset's
parser options, never its writer templates.

## Verification

Rendering one commit through `conventional-changelog-writer@8.4.0` — the exact
failing frame — with each preset major:

```
preset 9.3.1:  OK   -> ## 1.0.0-alpha.78 (2026-09-07)
preset 10.4.0: FAIL -> Missing helper: "conventional-changelog-conventionalcommits requires …"
```

`pnpm install --frozen-lockfile` green, root resolves the preset at 9.3.1,
`prettier --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gFuKKvsmhJZR1EnqqMNdi
