### PR TITLE
ci: repair every shared-workflow caller — permissions and a stale pin

### DIFF
--- a/.github/workflows/allo-allo.yaml
+++ b/.github/workflows/allo-allo.yaml
@@ -24,7 +24,7 @@
             "contents": "read"
             "issues": "write" # to greet a first-time issue opener
             "pull-requests": "write" # to greet a first-time pull request
-        "uses": "anolilab/workflows/.github/workflows/allo-allo.yml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
+        "uses": "anolilab/workflows/.github/workflows/allo-allo.yml@9b64c8cea7da5e06a9d9fd6c741619172607037f" # main
         "with":
             "target-repo": "anolilab/lunora"
             "onboarding-lead": "prisis"

--- a/.github/workflows/allo-allo.yaml
+++ b/.github/workflows/allo-allo.yaml
@@ -11,11 +11,19 @@
             - "opened"
             - "closed"
 
-"permissions":
-    "contents": "read"
+# Empty at the top, scoped on the job — the shape the other shared-workflow
+# callers here use. The set mirrors what allo-allo.yml declares at the pinned SHA:
+# a caller cannot grant a called workflow more than it holds, and with only
+# `contents: read` every run was rejected before it started (startup_failure),
+# so no first-time contributor has ever actually been greeted.
+"permissions": {}
 
 "jobs":
     "allo-allo":
+        "permissions":
+            "contents": "read"
+            "issues": "write" # to greet a first-time issue opener
+            "pull-requests": "write" # to greet a first-time pull request
         "uses": "anolilab/workflows/.github/workflows/allo-allo.yml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
         "with":
             "target-repo": "anolilab/lunora"

--- a/.github/workflows/cache-clear.yml
+++ b/.github/workflows/cache-clear.yml
@@ -20,6 +20,6 @@
         "permissions":
             "actions": "write" # to delete the merged branch's Actions caches
             "contents": "read"
-        "uses": "anolilab/workflows/.github/workflows/cleanup-branch-cache.yaml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
+        "uses": "anolilab/workflows/.github/workflows/cleanup-branch-cache.yaml@9b64c8cea7da5e06a9d9fd6c741619172607037f" # main
         "with":
             "target-repo": "anolilab/lunora"

--- a/.github/workflows/cache-clear.yml
+++ b/.github/workflows/cache-clear.yml
@@ -10,11 +10,16 @@
             - "alpha"
             - "beta"
 
-"permissions":
-    "contents": "read"
+# Mirrors what cleanup-branch-cache.yaml declares at the pinned SHA. With only
+# `contents: read` every run was rejected before it started (startup_failure), so
+# no merged branch has ever had its caches cleaned up.
+"permissions": {}
 
 "jobs":
     "cleanup-branch-cache":
+        "permissions":
+            "actions": "write" # to delete the merged branch's Actions caches
+            "contents": "read"
         "uses": "anolilab/workflows/.github/workflows/cleanup-branch-cache.yaml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
         "with":
             "target-repo": "anolilab/lunora"

--- a/.github/workflows/lock-issues.yaml
+++ b/.github/workflows/lock-issues.yaml
@@ -4,14 +4,17 @@
     "schedule":
         - "cron": "0 * * * *"
 
-"permissions":
-    "contents": "read"
-    "discussions": "write"
-    "issues": "write"
-    "pull-requests": "write"
+# Mirrors what lock-closed.yml declares at the pinned SHA, scoped to the job like
+# the other shared-workflow callers here. No `contents`: the called workflow runs
+# harden-runner and the action, and checks nothing out.
+"permissions": {}
 
 "jobs":
     "lock-closed":
-        "uses": "anolilab/workflows/.github/workflows/lock-closed.yml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
+        "permissions":
+            "discussions": "write" # lock-threads locks inactive discussions by default
+            "issues": "write"
+            "pull-requests": "write"
+        "uses": "anolilab/workflows/.github/workflows/lock-closed.yml@9b64c8cea7da5e06a9d9fd6c741619172607037f" # main
         "with":
             "target-repo": "anolilab/lunora"

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -4,11 +4,17 @@
     "schedule":
         - "cron": "0 0 * * *"
 
-"permissions":
-    "contents": "read"
+# Mirrors what stale-issues.yml declares at the pinned SHA — each of its four jobs
+# (default/invalid/duplicate/wontfix) asks for both write scopes. With only
+# `contents: read` every run was rejected before it started (startup_failure).
+"permissions": {}
 
 "jobs":
     "stale-issues":
+        "permissions":
+            "contents": "read"
+            "issues": "write" # to label and close idle issues
+            "pull-requests": "write" # same, for idle pull requests
         "uses": "anolilab/workflows/.github/workflows/stale-issues.yml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
         "with":
             "target-repo": "anolilab/lunora"

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,6 +15,6 @@
             "contents": "read"
             "issues": "write" # to label and close idle issues
             "pull-requests": "write" # same, for idle pull requests
-        "uses": "anolilab/workflows/.github/workflows/stale-issues.yml@3c54b71af67bdd990513c4a17fa2fde078db7b74" # main
+        "uses": "anolilab/workflows/.github/workflows/stale-issues.yml@9b64c8cea7da5e06a9d9fd6c741619172607037f" # main
         "with":
             "target-repo": "anolilab/lunora"


### PR DESCRIPTION
Three callers of `anolilab/workflows` declare only `contents: read` while the
workflow they call asks for write scopes. **A caller cannot grant a called
workflow more than it holds**, so GitHub rejects each run *before it starts* — a
`startup_failure`, with no job, no log, and no annotation on the commit.

None of them have ever done the thing they were added to do:

| Caller | Callee needs | Consequence |
| --- | --- | --- |
| `allo-allo.yaml` | `issues: write`, `pull-requests: write` | no first-time contributor has been greeted |
| `stale-issues.yml` | both, on each of its four jobs | no idle issue labelled or closed |
| `cache-clear.yml` | `actions: write` | no merged branch has had its Actions caches deleted |

`allo-allo` has been failing since at least **2026-09-06** — before the dependency
sweep, so this is not fallout from it.

## Shape

Each set is **read from the callee at the SHA this repo pins**, not guessed, and
sits on the job with `permissions: {}` at the top — the shape `codeql`,
`dependency-review`, `scorecards` and `zizmor` already use here, so nothing
outside the called workflow ever holds a write scope.

## How `cache-clear` turned up

It never appeared in any branch's check list, because it only triggers on a closed
PR to a release branch. It surfaced by auditing **every** caller against its
callee rather than by reading the visible failures — the other five callers were
already correct, which is why the pattern was easy to miss.

## `lock-issues` — fixed too, by moving the pin

It held every scope `lock-closed` asks for and still failed *inside* it:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

`dessant/lock-threads` validated the token against `Joi.max(100)`, and the
`GITHUB_TOKEN` this repository issues is longer than that. **v6.0.2** raised the
cap to 1000 — *"update github-token validation schema"*, closing
[dessant/lock-threads#55](https://github.com/dessant/lock-threads/issues/55) —
and `anolilab/workflows` already carries that bump on `main`.

So nothing needed changing in the shared repo: what was stale is **the SHA pinned
here**. `3c54b71a` is from 2026-05-19, four days before the fix was published.

All four callers pinned at that SHA move to `9b64c8ce`. Verified at the new SHA
*before* bumping — every callee still takes `target-repo` as its only required
input, declares no secrets, and asks for the permissions its caller now grants.
`lock-closed` additionally wants `discussions: write`, which `lock-issues` already
held.

`lock-issues` also kept its scopes at the top of the file while every other caller
scopes them to the job; it now matches, and drops `contents` because the called
workflow runs harden-runner and the action and checks nothing out.

## Verification

All 20 workflow files parse; `lint:prettier` green. Every caller was re-audited
against its callee at the new SHA.

These are schedule- and event-triggered, so the real proof is their next run: the
hourly `lock-issues`, the nightly `stale-issues`, the next opened issue for
`allo-allo`, and the next closed PR to a release branch for `cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7jTddT11b56WCR9AUUgmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow access controls to apply permissions at the individual job level.
  - First-time issue and pull request greetings continue to work as expected.
  - Stale issue and pull request management continues with the required access.
  - Merged branch Actions-cache cleanup remains supported through the updated workflow permissions.
  - Closed discussions, issues, and pull requests continue to be locked automatically where configured.
  - Automated workflows now use updated shared workflow versions for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->