### PR TITLE
fix(config,cli,nuxt): decide build-time gates on code, not on comments

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -1323,6 +1323,18 @@ const formatAdvisories: (findings: ReadonlyArray<Finding>) => string;
 const generateSdk: (document: OpenRpcDocument, target: SdkTarget) => Promise<SdkResult>;
 ```
 
+### `isD1GlobalTable` (const)
+
+```ts
+const isD1GlobalTable: (table: TableIR) => boolean;
+```
+
+### `isHyperdriveGlobalTable` (const)
+
+```ts
+const isHyperdriveGlobalTable: (table: TableIR) => boolean;
+```
+
 ### `isTypedSchema` (const)
 
 ```ts

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -897,7 +897,8 @@ interface SchemaIndex {
 
 ```ts
 interface SchemaInfo {
-    hasGlobalTable: boolean;
+    hasD1GlobalTable: boolean;
+    hasHyperdriveGlobalTable: boolean;
     vectorIndexNames?: ReadonlyArray<string>;
     vectorMetadata?: ReadonlyArray<VectorMetadataDeclaration>;
 }

--- a/packages/astro/__tests__/code-only.test.ts
+++ b/packages/astro/__tests__/code-only.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { codeOnly, withoutComments } from "../../../shared/code-only";
+
+/**
+ * `shared/code-only.ts` is bundler-inlined into `@lunora/astro` and
+ * `@lunora/nuxt`, so it has no package of its own to be tested from. Tested here
+ * — the package it was extracted from — following the precedent set by
+ * `@lunora/flags`' `stable-key.test.ts`.
+ *
+ * Both consumers are build-time gates that decide whether a project is wired
+ * correctly, so what they need from this file is exact: a marker written in a
+ * COMMENT must not satisfy a check, and (for the star-export probe in
+ * `@lunora/nuxt`) offsets must survive blanking so a match can be located back
+ * in the original source.
+ */
+describe("codeOnly", () => {
+    it("blanks comments and string literals but keeps their length and line structure", () => {
+        expect.assertions(3);
+
+        // `starExportsLunoraBarrel` in `@lunora/nuxt` compares
+        // `codeOnly(source)[i]` against `source[i]` to decide whether a regex
+        // match landed in code or inside a string. That is only sound while
+        // blanking is a per-character substitution — the invariant this asserts.
+        const source = 'const a = 1; // note\nconst b = "text";\n/* block */\n';
+        const code = codeOnly(source);
+
+        expect(code).toHaveLength(source.length);
+        expect(code.split("\n")).toHaveLength(source.split("\n").length);
+
+        // Every blanked position is a space, and every surviving position holds
+        // the character the source had there — the offset guarantee, stated as
+        // the property rather than as a hand-counted literal.
+        const misaligned = [...Array.from({ length: source.length }).keys()].filter((index) => code[index] !== " " && code[index] !== source[index]);
+
+        expect(misaligned).toStrictEqual([]);
+    });
+
+    it("lets whichever construct opens first win", () => {
+        expect.assertions(3);
+
+        // The single-alternation ordering is what a hand-rolled mode machine
+        // buys; these are the three cases that distinguish it from running the
+        // patterns one after another.
+        expect(codeOnly('// a quote " does not open a string\nkeep()')).toContain("keep()");
+        expect(codeOnly('const url = "https://example.com"; keep()')).toContain("keep()");
+        expect(codeOnly(String.raw`const s = "a \" b"; keep()`)).toContain("keep()");
+    });
+
+    it("blanks a plain template literal but leaves an interpolating one alone", () => {
+        expect.assertions(2);
+
+        // Blanking an interpolating template would hide real code written inside
+        // `${...}` — the documented ceiling, asserted so it stays deliberate.
+        expect(codeOnly("const s = `.vectors(x)`;")).not.toContain(".vectors(");
+        expect(codeOnly(`const s = \`a \${call()} .vectors(x)\`;`)).toContain(".vectors(");
+    });
+
+    it("keeps a marker out of the answer when only a comment names it", () => {
+        expect.assertions(2);
+
+        // The defect every consumer of this file exists to catch: delete the
+        // load-bearing line, keep the comment explaining it was load-bearing.
+        const source = '/** Re-exports ShardDO. */\nexport { default } from "./nitro";\n';
+
+        expect(/\bShardDO\b/u.test(source)).toBe(true);
+        expect(/\bShardDO\b/u.test(codeOnly(source))).toBe(false);
+    });
+});
+
+describe("withoutComments", () => {
+    it("blanks comments and keeps string literals, at the same offsets", () => {
+        expect.assertions(2);
+
+        const source = '// drop me\nexport * from "./lunora/server";\n';
+        const kept = withoutComments(source);
+
+        expect(kept).toHaveLength(source.length);
+        expect(kept).toContain('export * from "./lunora/server";');
+    });
+
+    it("does not treat a `//` inside a string as a comment", () => {
+        expect.assertions(1);
+
+        expect(withoutComments('const u = "https://lunora.sh"; keep()')).toContain("keep()");
+    });
+});

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -22,6 +22,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { codeOnly } from "../../../shared/code-only";
+
 /**
  * Structural subset of Astro's `AstroIntegration`. Declared locally (rather than
  * importing `astro`'s type) so `@lunora/astro`'s public surface stays decoupled
@@ -89,57 +91,6 @@ const WITH_LUNORA_SNIPPET = [
  * that composed nothing.
  */
 const WITH_LUNORA_CALL_PATTERN = /\b(?:withLunora|withFrameworkWorker|buildFrameworkWorker)\s*\(/u;
-
-/** `/* … *\/`, non-greedy so it ends at the FIRST `*\/`. */
-const BLOCK_COMMENT = String.raw`\/\*[\s\S]*?\*\/`;
-/** `// …` to end of line. */
-const LINE_COMMENT = String.raw`\/\/[^\n]*`;
-/** `"…"`, honouring backslash escapes and never crossing a newline. */
-const DOUBLE_QUOTED = String.raw`"(?:[^"\\\n]|\\.)*"`;
-/** `'…'`, the same rules as {@link DOUBLE_QUOTED}. */
-const SINGLE_QUOTED = String.raw`'(?:[^'\\\n]|\\.)*'`;
-
-/**
- * A template literal with NO `${…}` in it (that is what the `\$(?!\{)` guard
- * costs). One that interpolates is deliberately left alone: its interpolations
- * are real code, and blanking the whole literal would hide a composition call
- * written inside one.
- *
- * The delimiter is written `\x60` rather than an escaped backtick because
- * `String.raw` would keep that backslash, and `\`` is not a legal escape in a
- * unicode-mode pattern.
- */
-const PLAIN_TEMPLATE = String.raw`\x60(?:[^\x60\\$]|\\.|\$(?!\{))*\x60`;
-
-/**
- * Comments and string literals, matched left to right in ONE alternation so
- * whichever construct OPENS first wins: a quote inside a comment is part of that
- * comment, and a `//` inside a string is part of that string. That ordering is
- * the whole trick — it is what a hand-rolled mode machine buys you, without the
- * machine. Assembled from the named parts above rather than written as one
- * literal, because as a literal it is unreadable.
- */
-const SKIPPABLE_RE = new RegExp([BLOCK_COMMENT, LINE_COMMENT, DOUBLE_QUOTED, SINGLE_QUOTED, PLAIN_TEMPLATE].join("|"), "gu");
-
-/** Every character except a newline — line structure survives when a span is blanked. */
-const NON_NEWLINE_RE = /[^\n]/gu;
-
-/**
- * The source with its comments and string literals blanked out, so the call
- * probe above sees code and only code.
- *
- * A scan rather than a parser: this package has no parser dependency and would
- * not add one for a build-time warning, and the check only has to answer "is
- * this identifier followed by `(` somewhere that executes".
- *
- * Spans are replaced with spaces rather than deleted, so nothing that was
- * separated becomes adjacent.
- *
- * Known ceiling: a template literal that BOTH interpolates and mentions one of
- * the names in its string part still reads as a call. Narrowing that needs real
- * parsing, and this check only drives a warning.
- */
-const codeOnly = (source: string): string => source.replaceAll(SKIPPABLE_RE, (span) => span.replaceAll(NON_NEWLINE_RE, " "));
 
 /**
  * Where the composition lives when the caller names nothing.

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -1,8 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem, so neither is load-bearing
+        // here. A set `rootDir` would raise TS6059 for the inlined
+        // `../../../shared/code-only` import (a file outside this package, bundled in
+        // at build time). See shared/code-only.ts.
         "moduleResolution": "bundler",
         "types": ["node"]
     },

--- a/packages/cli/__tests__/util/patch-vite-config.test.ts
+++ b/packages/cli/__tests__/util/patch-vite-config.test.ts
@@ -75,6 +75,27 @@ describe("patchViteConfig", () => {
             expect(result.reason).toBe("lunora plugin already present");
         });
 
+        it("patches a config that only MENTIONS lunora() in a comment or a string", () => {
+            expect.assertions(3);
+
+            // A commented-out plugin line, or a note about it, is not a call.
+            // Matching one made this report the config already wired and leave
+            // the project's dev server with no Lunora plugin in it at all.
+            const source = `import react from "@vitejs/plugin-react";
+
+// TODO: put lunora() back once the upgrade lands.
+export default defineConfig({
+    plugins: [react()],
+});
+`;
+
+            const result = patchViteConfig(source);
+
+            expect(result.changed).toBe(true);
+            expect(result.code).toContain('import { lunora } from "@lunora/vite";');
+            expect(result.code).toContain("plugins: [lunora(), react()]");
+        });
+
         it("is idempotent when called twice on the same source", () => {
             expect.assertions(2);
 

--- a/packages/cli/skills/lunora-setup-hyperdrive-global/SKILL.md
+++ b/packages/cli/skills/lunora-setup-hyperdrive-global/SKILL.md
@@ -70,6 +70,11 @@ Add the binding to `wrangler.jsonc` (use `localConnectionString` for `lunora dev
 }
 ```
 
+The binding is required, not optional: with no `hyperdrive` entry at all,
+`lunora dev` and `lunora deploy` both refuse to start. The NAME is yours — the
+validator only checks that some binding exists, because your `exec` selector is
+what picks it.
+
 > **Read-your-writes:** point the Hyperdrive config at the **primary** (or pin
 > writes to it) so a write then immediate read isn't served by a stale replica.
 

--- a/packages/cli/src/util/patch-vite-config.ts
+++ b/packages/cli/src/util/patch-vite-config.ts
@@ -9,8 +9,8 @@
  * - `export default defineConfig({})` (no plugins key yet)
  * - `export default { plugins: [...] }` / `export default {}`
  *
- * Idempotent: returns `changed: false` when `lunora(` already appears in the
- * source or when no recognisable config shape can be found.
+ * Idempotent: returns `changed: false` when the parsed config already CALLS
+ * `lunora(...)` or when no recognisable config shape can be found.
  */
 // eslint-disable-next-line import/no-named-as-default -- magic-string's default export IS the MagicString class; this is the documented, idiomatic import
 import MagicString from "magic-string";
@@ -25,13 +25,8 @@ interface PatchViteConfigResult {
 
 const LUNORA_CALL = "lunora()";
 const LUNORA_IMPORT = 'import { lunora } from "@lunora/vite";';
-
-/** Hoisted regex — matches a `lunora(` call anywhere in the source. */
-const LUNORA_CALL_RE = /\blunora\s*\(/u;
-
-/** Hoisted check for the lunora/vite import specifier. */
-const LUNORA_VITE_DOUBLE = '"@lunora/vite"';
-const LUNORA_VITE_SINGLE = "'@lunora/vite'";
+const LUNORA_VITE_SPECIFIER = "@lunora/vite";
+const LUNORA_PLUGIN = "lunora";
 
 /**
  * Locate the config object inside a ts-morph SourceFile for a defineConfig
@@ -84,6 +79,23 @@ const findPlainExportObject = (sf: SourceFile): ObjectLiteralExpression | undefi
 
     return undefined;
 };
+
+/**
+ * Whether the config already CALLS `lunora(...)` — parsed, so a comment or a
+ * string naming the plugin is not a call.
+ *
+ * This decides whether the file is left alone, and the caller then reports the
+ * plugin present. A substring match therefore handed a project whose config
+ * merely mentions `lunora()` — a commented-out line, a note explaining the
+ * plugin — a dev server with no Lunora plugin in it at all, and said the config
+ * was already wired.
+ */
+const callsLunoraPlugin = (sf: SourceFile): boolean =>
+    sf.getDescendantsOfKind(SyntaxKind.CallExpression).some((call) => call.getExpression().getText() === LUNORA_PLUGIN);
+
+/** Whether the config already imports `@lunora/vite` — parsed, for the same reason as {@link callsLunoraPlugin}, and quote style comes free. */
+const importsLunoraVite = (sf: SourceFile): boolean =>
+    sf.getImportDeclarations().some((declaration) => declaration.getModuleSpecifierValue() === LUNORA_VITE_SPECIFIER);
 
 /** Parse the config source into a single in-memory ts-morph SourceFile. */
 const parseConfigSource = (sourceText: string): SourceFile =>
@@ -170,11 +182,12 @@ const patchPluginsArray = (ms: MagicString, configObject: ObjectLiteralExpressio
  * Returns `{ code: source, changed: false, reason }` for any no-op path.
  */
 const patchViteConfig = (source: string): PatchViteConfigResult => {
-    if (LUNORA_CALL_RE.test(source)) {
+    const sf = parseConfigSource(source);
+
+    if (callsLunoraPlugin(sf)) {
         return { changed: false, code: source, reason: "lunora plugin already present" };
     }
 
-    const sf = parseConfigSource(source);
     const configObject = findDefineConfigObject(sf) ?? findPlainExportObject(sf);
 
     if (configObject === undefined) {
@@ -183,7 +196,7 @@ const patchViteConfig = (source: string): PatchViteConfigResult => {
 
     const ms = new MagicString(source);
 
-    if (!source.includes(LUNORA_VITE_DOUBLE) && !source.includes(LUNORA_VITE_SINGLE)) {
+    if (!importsLunoraVite(sf)) {
         addImport(ms, sf);
     }
 

--- a/packages/cli/src/util/schema-snapshot.ts
+++ b/packages/cli/src/util/schema-snapshot.ts
@@ -8,7 +8,7 @@
  * that provisions itself; neither needs a D1 migration.
  */
 import type { FieldSnapshot, SchemaIR, ValidatorIR } from "@lunora/codegen";
-import { buildSchemaSnapshot } from "@lunora/codegen";
+import { buildSchemaSnapshot, isD1GlobalTable } from "@lunora/codegen";
 
 import type { ColumnSnapshot, IndexSnapshot, SchemaSnapshot, TableSnapshot } from "./migration-diff";
 import { validatorKindToSqlType } from "./migration-diff";
@@ -59,7 +59,7 @@ const isNullable = (validator: ValidatorIR, field: FieldSnapshot | undefined): b
  * `@lunora/d1/dialect` directly), so the honest answer is to leave those tables
  * out of the snapshot entirely.
  */
-const isGlobal = (table: SchemaIR["tables"][number]): boolean => table.shardMode === "global" && table.globalBackend !== "hyperdrive";
+const isGlobal = isD1GlobalTable;
 
 const schemaIrToSnapshot = (ir: SchemaIR): SchemaSnapshot => {
     const tables: Record<string, TableSnapshot> = {};

--- a/packages/codegen/src/assert-required-packages.ts
+++ b/packages/codegen/src/assert-required-packages.ts
@@ -2,6 +2,7 @@ import { LunoraError } from "@lunora/errors";
 
 import { CAPABILITIES } from "./capabilities";
 import type { FeatureUsage } from "./discover/feature-usage";
+import { isD1GlobalTable, isHyperdriveGlobalTable } from "./global-backend";
 import type { SchemaIR } from "./ir";
 
 /** One package the emitted `_generated/` will import, and the schema feature that pulls it in. */
@@ -75,16 +76,14 @@ interface RequiredPackageSignals {
 const requiredPackagesFor = (schema: SchemaIR, signals: RequiredPackageSignals = {}): RequiredPackage[] => {
     const { hasVectors = true, scheduler = false, storage = false, usage } = signals;
     const required: RequiredPackage[] = [];
-    const globalTables = schema.tables.filter((table) => table.shardMode === "global");
-
-    if (globalTables.some((table) => table.globalBackend !== "hyperdrive")) {
+    if (schema.tables.some((table) => isD1GlobalTable(table))) {
         required.push({
             name: "@lunora/d1",
             reason: "`.global()` tables are D1-backed, so `_generated/app.ts` imports the D1 `ctx.db` adapter",
         });
     }
 
-    if (globalTables.some((table) => table.globalBackend === "hyperdrive")) {
+    if (schema.tables.some((table) => isHyperdriveGlobalTable(table))) {
         required.push(
             {
                 name: "@lunora/hyperdrive",

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -19,6 +19,7 @@ import { hashSchemaSnapshot, serializeSchemaSnapshot } from "../../../shared/sch
 import type { CapabilityKey, CapabilityTier } from "./capabilities";
 import { SERVER_CTX_FIELDS } from "./capabilities";
 import compileArgsValidator from "./compile-validator";
+import { isD1GlobalTable, isHyperdriveGlobalTable } from "./global-backend";
 import type {
     AgentIR,
     ContainerIR,
@@ -4506,8 +4507,8 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
     // to D1; `.global({ backend: "hyperdrive" })` routes it to a Postgres/MySQL
     // database via Hyperdrive. Both stay reactive — the writer is injected as
     // `globalDb` and the broadcast hook drives live queries.
-    const hasHyperdriveGlobal = schema.tables.some((table) => table.shardMode === "global" && table.globalBackend === "hyperdrive");
-    const hasD1Global = schema.tables.some((table) => table.shardMode === "global" && table.globalBackend !== "hyperdrive");
+    const hasHyperdriveGlobal = schema.tables.some((table) => isHyperdriveGlobalTable(table));
+    const hasD1Global = schema.tables.some((table) => isD1GlobalTable(table));
     // External-source ingest (plan 077): `.source(...)` tables are materialized from
     // Hyperdrive into this DO's SQLite by the poll alarm. Everything below is gated on
     // this, so a schema with no sourced table emits a byte-identical `shard.ts`.

--- a/packages/codegen/src/global-backend.ts
+++ b/packages/codegen/src/global-backend.ts
@@ -1,0 +1,27 @@
+/**
+ * Which backend a `.global()` table lives on, asked as a predicate rather than
+ * re-derived per call site.
+ *
+ * The two facts drive different wiring everywhere they are read — the D1 flavour
+ * needs the `DB` binding, `@lunora/d1` and the app's `.global({ d1 })` chain; the
+ * Hyperdrive flavour needs the `HYPERDRIVE` binding, `@lunora/hyperdrive` and
+ * `.hyperdriveGlobal(...)` — and codegen, the CLI and `@lunora/config` all have
+ * to agree on which table is which, or a project is told to add a binding it
+ * does not need and blocked for missing a chain it should never write.
+ *
+ * The correctness detail worth centralising: the D1 side reads `!== "hyperdrive"`
+ * rather than `=== "d1"`, because {@link TableIR.globalBackend} is optional and
+ * hand-built IR may omit it. Discovery normalises it (`globalBackend: shardMode
+ * === "global" ? (accumulator.globalBackend ?? "d1") : undefined`), so the two
+ * forms agree on discovered schemas and only the negative form is right for the
+ * rest.
+ */
+import type { TableIR } from "./ir";
+
+/** A `.global()` table backed by D1 — the default when no `backend` is named. */
+const isD1GlobalTable = (table: TableIR): boolean => table.shardMode === "global" && table.globalBackend !== "hyperdrive";
+
+/** A `.global({ backend: "hyperdrive" })` table — Postgres/MySQL via Cloudflare Hyperdrive. */
+const isHyperdriveGlobalTable = (table: TableIR): boolean => table.shardMode === "global" && table.globalBackend === "hyperdrive";
+
+export { isD1GlobalTable, isHyperdriveGlobalTable };

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -69,6 +69,7 @@ export {
 } from "./emit";
 export type { EmitAppOptions } from "./emit-app";
 export { emitApp } from "./emit-app";
+export { isD1GlobalTable, isHyperdriveGlobalTable } from "./global-backend";
 export type {
     AgentIR,
     AuthApiCallIR,

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -229,13 +229,18 @@ export interface TableIR {
      */
     externalSource?: ExternalSourceIR;
 
+    /** Geospatial indexes declared inline via `.geoIndex(name, …)`. Optional so hand-built IR may omit it (discovery always sets it). */
+    geoIndexes?: ReadonlyArray<GeoIndexIR>;
+
     /**
      * Storage backend for a `.global()` table: `"d1"` (default) or
      * `"hyperdrive"` (a Postgres/MySQL database via Cloudflare Hyperdrive). Only
      * meaningful when `shardMode === "global"`; absent for sharded/root tables.
+     *
+     * Read it through `isD1GlobalTable` / `isHyperdriveGlobalTable` rather than
+     * comparing here — discovery normalises the absent case to `"d1"`, and only
+     * those predicates encode which comparison is right for hand-built IR.
      */
-    /** Geospatial indexes declared inline via `.geoIndex(name, …)`. Optional so hand-built IR may omit it (discovery always sets it). */
-    geoIndexes?: ReadonlyArray<GeoIndexIR>;
     globalBackend?: "d1" | "hyperdrive";
     indexes: ReadonlyArray<IndexIR>;
 

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -94,6 +94,7 @@ import {
     emitWranglerCronTriggers,
 } from "./emit";
 import { emitApp } from "./emit-app";
+import { isD1GlobalTable, isHyperdriveGlobalTable } from "./global-backend";
 import type {
     AgentIR,
     ContainerIR,
@@ -932,9 +933,9 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         // `hasGlobal` means **D1-backed** global tables (the `.global()` / D1
         // app-builder wiring); Hyperdrive-backed globals are gated separately by
         // `hasHyperdriveGlobal` so an app picks the right binding+package.
-        hasGlobal: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend !== "hyperdrive"),
+        hasGlobal: schema.tables.some((table) => isD1GlobalTable(table)),
         hasHyperdrive: featureUsage.hyperdrive,
-        hasHyperdriveGlobal: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend === "hyperdrive"),
+        hasHyperdriveGlobal: schema.tables.some((table) => isHyperdriveGlobalTable(table)),
         hasImages: featureUsage.images,
         // The `.kv()` builder's parameter type reads `ShardConfig["kv"]`, and that
         // config field is emitted on the usage signal — so this MUST stay

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -72,7 +72,7 @@ If you already hold a parsed config object, `validateWranglerConfig` (aliased as
 ```ts
 import { validateWranglerConfig } from "@lunora/config/cloudflare";
 
-const report = validateWranglerConfig(wrangler, { hasGlobalTable: true });
+const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false });
 // report: { valid: boolean; errors: string[]; warnings: string[] }
 ```
 

--- a/packages/config/__tests__/infer-bindings.test.ts
+++ b/packages/config/__tests__/infer-bindings.test.ts
@@ -16,6 +16,14 @@ export const schema = defineSchema({
 });
 `;
 
+const SCHEMA_HYPERDRIVE_GLOBAL = `import { defineSchema, defineTable, v } from "@lunora/server";
+
+export const schema = defineSchema({
+    messages: defineTable({ channelId: v.id("channels"), text: v.string() }).shardBy("channelId"),
+    users: defineTable({ email: v.string() }).global({ backend: "hyperdrive" }),
+});
+`;
+
 const SCHEMA_NO_GLOBAL = `import { defineSchema, defineTable, v } from "@lunora/server";
 
 export const schema = defineSchema({
@@ -109,6 +117,22 @@ describe("inferLunoraBindings", () => {
         write("wrangler.jsonc", WRANGLER);
         write("src/server/index.ts", ENTRY_SHARD_ONLY);
         write("lunora/schema.ts", SCHEMA_NO_GLOBAL);
+
+        const result = await inferLunoraBindings({ projectRoot: root });
+
+        expect(result.needsD1).toBe(false);
+    });
+
+    it("does not infer D1 for a Hyperdrive-backed .global() table", async () => {
+        expect.assertions(1);
+
+        // `.global({ backend: "hyperdrive" })` lives on Postgres/MySQL behind the
+        // HYPERDRIVE binding and touches no D1 database. Reading "declares a global
+        // table" as "needs D1" provisioned a database the app never opens, and the
+        // wrangler validator then demanded a `DB` binding of a project with none.
+        write("wrangler.jsonc", WRANGLER);
+        write("src/server/index.ts", ENTRY_SHARD_ONLY);
+        write("lunora/schema.ts", SCHEMA_HYPERDRIVE_GLOBAL);
 
         const result = await inferLunoraBindings({ projectRoot: root });
 

--- a/packages/config/__tests__/schema-info.test.ts
+++ b/packages/config/__tests__/schema-info.test.ts
@@ -132,6 +132,34 @@ describe("schema info", () => {
             expect(discoverSchemaInfo(workdir, "lunora").info?.hasD1GlobalTable).toBe(true);
         });
 
+        it("separates a Hyperdrive-backed global from a D1-backed one — they need different bindings and different chains", () => {
+            expect.assertions(4);
+
+            seedSchema(`${SCHEMA_HEADER}
+    export const schema = defineSchema({
+        users: defineTable({ email: v.string() }).global({ backend: "hyperdrive" }),
+    });
+    `);
+
+            const hyperdrive = discoverSchemaInfo(workdir, "lunora").info;
+
+            // No D1 database is involved, so demanding a `DB` binding (or the
+            // app's `.global({ d1 })` chain) would block a correctly wired project.
+            expect(hyperdrive?.hasD1GlobalTable).toBe(false);
+            expect(hyperdrive?.hasHyperdriveGlobalTable).toBe(true);
+
+            seedSchema(`${SCHEMA_HEADER}
+    export const schema = defineSchema({
+        users: defineTable({ email: v.string() }).global(),
+    });
+    `);
+
+            const d1 = discoverSchemaInfo(workdir, "lunora").info;
+
+            expect(d1?.hasD1GlobalTable).toBe(true);
+            expect(d1?.hasHyperdriveGlobalTable).toBe(false);
+        });
+
         it("degrades to empty information on a schema it cannot make sense of, rather than throwing", () => {
             expect.assertions(3);
 

--- a/packages/config/__tests__/schema-info.test.ts
+++ b/packages/config/__tests__/schema-info.test.ts
@@ -121,7 +121,7 @@ describe("schema info", () => {
     });
     `);
 
-            expect(discoverSchemaInfo(workdir, "lunora").info?.hasGlobalTable).toBe(false);
+            expect(discoverSchemaInfo(workdir, "lunora").info?.hasD1GlobalTable).toBe(false);
 
             seedSchema(`${SCHEMA_HEADER}
     export const schema = defineSchema({
@@ -129,7 +129,7 @@ describe("schema info", () => {
     });
     `);
 
-            expect(discoverSchemaInfo(workdir, "lunora").info?.hasGlobalTable).toBe(true);
+            expect(discoverSchemaInfo(workdir, "lunora").info?.hasD1GlobalTable).toBe(true);
         });
 
         it("degrades to empty information on a schema it cannot make sense of, rather than throwing", () => {
@@ -145,7 +145,7 @@ describe("schema info", () => {
             // `lint:types`' and codegen's to report, not this one's.
             expect(result.error).toBeUndefined();
             expect(result.info?.vectorMetadata).toStrictEqual([]);
-            expect(result.info?.hasGlobalTable).toBe(false);
+            expect(result.info?.hasD1GlobalTable).toBe(false);
         });
     });
 });

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -168,7 +168,7 @@ describe("wrangler-validator", () => {
                 vectorize: [null],
             } as unknown as WranglerConfig;
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             // The null entry is skipped; the declared index is simply unmatched.
             expect(report.valid).toBe(false);
@@ -218,7 +218,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             } as unknown as WranglerConfig;
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: true, vectorIndexNames: [] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, vectorIndexNames: [] });
 
             // The null entry is skipped; the missing "DB" binding is reported structurally.
             expect(report.valid).toBe(false);
@@ -396,7 +396,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             };
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: true });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true });
 
             expect(report.errors.some((line) => line.includes("d1_databases"))).toBe(true);
         });
@@ -410,7 +410,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             };
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             expect(report.valid).toBe(false);
             expect(report.errors.some((line) => line.includes("docs-body"))).toBe(true);
@@ -427,7 +427,7 @@ describe("wrangler-validator", () => {
                 vectorize: [{ binding: "DOCS_BODY", index_name: "docs-body" }],
             };
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             expect(report.valid).toBe(true);
             expect(report.errors).toEqual([]);
@@ -570,7 +570,7 @@ describe("wrangler-validator", () => {
 
             wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
 
-            const report = validateWranglerConfig(wrangler, { hasGlobalTable: true }, "production");
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true }, "production");
 
             expect(report.valid).toBe(false);
             expect(report.errors.some((line) => line.includes('d1_databases must include a binding named "DB"'))).toBe(true);
@@ -588,7 +588,7 @@ describe("wrangler-validator", () => {
                 },
             };
 
-            expect(validateWranglerConfig(wrangler, { hasGlobalTable: true }, "production").valid).toBe(true);
+            expect(validateWranglerConfig(wrangler, { hasD1GlobalTable: true }, "production").valid).toBe(true);
         });
 
         // kv_namespaces — NON-inheritable, hint-only (warns on a missing id,
@@ -1089,6 +1089,120 @@ describe("wrangler-validator", () => {
 
                     expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
                 }
+            });
+        });
+
+        describe("a schema with .global() tables no source chains .global() onto", () => {
+            // Without the chain the shard gets no D1 writer, so every read or write
+            // of a global table throws INTERNAL — `lunora build`, `verify` and tsc
+            // all pass first. The wrangler check next to this one proves the `DB`
+            // BINDING exists, which is the half a project usually gets right.
+            const writeGlobalProject = (entry: string): void => {
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "x",
+    "main": "src/index.ts",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+    "d1_databases": [{ "binding": "DB", "database_name": "x", "database_id": "00000000-0000-0000-0000-000000000000" }]
+}
+`,
+                    "utf8",
+                );
+                mkdirSync(join(workdir, "src"), { recursive: true });
+                writeFileSync(join(workdir, "src", "index.ts"), entry, "utf8");
+            };
+
+            it("errors — and the schema's own `defineTable(...).global()` does not clear it", () => {
+                expect.assertions(2);
+
+                // `.global()` names two builders. The table form is what MAKES the
+                // schema declare a global table, so it is present in every project
+                // this check can fire on — matching it would mean the check never
+                // fires at all.
+                writeGlobalProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD);\nexport const { ShardDO } = app;\nexport default app;\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.valid).toBe(false);
+                expect(result.report.errors.join("\n")).toContain("nothing chains .global(...)");
+            });
+
+            it("passes once the app chains it", () => {
+                expect.assertions(1);
+
+                writeGlobalProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).global({ d1: (env) => env.DB });\nexport const { ShardDO } = app;\nexport default app;\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
+            });
+        });
+
+        describe("a schema whose .global() tables are Hyperdrive-backed", () => {
+            // `.global({ backend: "hyperdrive" })` lives on Postgres/MySQL behind a
+            // Hyperdrive binding: no D1 database, and a DIFFERENT builder method.
+            // Reading "declares a global table" as "needs D1" demanded a `DB`
+            // binding of a project that has none.
+            const HYPERDRIVE_SCHEMA = `import { defineSchema, defineTable, v } from "@lunora/server";
+
+export const schema = defineSchema({
+    users: defineTable({
+        email: v.string(),
+    }).global({ backend: "hyperdrive" }),
+});
+`;
+
+            const writeHyperdriveProject = (entry: string): void => {
+                writeSchema(HYPERDRIVE_SCHEMA);
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "x",
+    "main": "src/index.ts",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }]
+}
+`,
+                    "utf8",
+                );
+                mkdirSync(join(workdir, "src"), { recursive: true });
+                writeFileSync(join(workdir, "src", "index.ts"), entry, "utf8");
+            };
+
+            it("demands the .hyperdriveGlobal(...) chain, not a D1 binding or .global(...)", () => {
+                expect.assertions(3);
+
+                writeHyperdriveProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD);\nexport const { ShardDO } = app;\nexport default app;\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+                const errors = result.report.errors.join("\n");
+
+                expect(errors).toContain("nothing chains .hyperdriveGlobal(...)");
+                expect(errors).not.toContain('d1_databases must include a binding named "DB"');
+                expect(errors).not.toContain("nothing chains .global(...)");
+            });
+
+            it("passes once the app chains .hyperdriveGlobal(...)", () => {
+                expect.assertions(1);
+
+                writeHyperdriveProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).hyperdriveGlobal({ hyperdrive: (env) => env.HYPERDRIVE });\nexport const { ShardDO } = app;\nexport default app;\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
             });
         });
 
@@ -2298,7 +2412,7 @@ describe("wrangler-validator", () => {
                     r2_buckets: [{ binding: "FILES", bucket_name: "lunora-example-team-chat-files" }],
                     vars: { PUBLIC_STORAGE_BASE_URL: "http://localhost:5173" },
                 },
-                { hasGlobalTable: true },
+                { hasD1GlobalTable: true },
             );
 
             expect(report.errors).toEqual([]);

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -1200,7 +1200,7 @@ export const schema = defineSchema({
 });
 `;
 
-            const writeHyperdriveProject = (entry: string): void => {
+            const writeHyperdriveProject = (entry: string, { binding = true }: { binding?: boolean } = {}): void => {
                 writeSchema(HYPERDRIVE_SCHEMA);
                 writeFileSync(
                     join(workdir, "wrangler.jsonc"),
@@ -1209,7 +1209,7 @@ export const schema = defineSchema({
     "main": "src/index.ts",
     "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
     "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
-    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }]
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }]${binding ? ',\n    "hyperdrive": [{ "binding": "HYPERDRIVE", "id": "hd_123" }]' : ""}
 }
 `,
                     "utf8",
@@ -1253,6 +1253,80 @@ export const schema = defineSchema({
                 const result = validateWranglerProject({ projectRoot: workdir });
 
                 expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
+            });
+
+            it("demands SOME hyperdrive binding, without naming which", () => {
+                expect.assertions(3);
+
+                // Dropping the `DB` demand for these tables left them with no
+                // wrangler-level check at all: the chain is present, every gate
+                // passes, and `env.<BINDING>` is `undefined` at the first global
+                // read — inside the user's own `exec`, where nothing here can say
+                // what went wrong.
+                //
+                // Unlike D1 the name is not fixed: `.hyperdriveGlobal({ exec })`
+                // builds the driver from the user's selector, so naming one would
+                // false-error a project that called its binding something else.
+                const CHAIN = `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).hyperdriveGlobal({ engine: "postgres", exec: (env) => buildPgExec(env.PG) });\nexport const { ShardDO } = app;\nexport default app;\n`;
+
+                writeHyperdriveProject(CHAIN, { binding: false });
+
+                const missing = validateWranglerProject({ projectRoot: workdir });
+
+                expect(missing.report.valid).toBe(false);
+                expect(missing.report.errors.join("\n")).toContain("wrangler must declare a hyperdrive binding");
+
+                // A differently-named binding satisfies it; only absence is the defect.
+                writeHyperdriveProject(CHAIN);
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "x",
+    "main": "src/index.ts",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+    "hyperdrive": [{ "binding": "PG", "id": "hd_123" }]
+}
+`,
+                    "utf8",
+                );
+
+                const named = validateWranglerProject({ projectRoot: workdir });
+
+                expect(named.report.errors.join("\n")).not.toContain("wrangler must declare a hyperdrive binding");
+            });
+
+            it("says nothing about a hyperdrive binding for a D1-backed global schema", () => {
+                expect.assertions(1);
+
+                // The mirror of the D1 check's own scoping: a `.global()` table on
+                // D1 needs no Hyperdrive binding, and demanding one would block the
+                // common case.
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "x",
+    "main": "src/index.ts",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+    "d1_databases": [{ "binding": "DB", "database_name": "x", "database_id": "00000000-0000-0000-0000-000000000000" }]
+}
+`,
+                    "utf8",
+                );
+                mkdirSync(join(workdir, "src"), { recursive: true });
+                writeFileSync(
+                    join(workdir, "src", "index.ts"),
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).global({ d1: (env) => env.DB });\nexport const { ShardDO } = app;\nexport default app;\n`,
+                    "utf8",
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).not.toContain("wrangler must declare a hyperdrive binding");
             });
         });
 

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -168,7 +168,7 @@ describe("wrangler-validator", () => {
                 vectorize: [null],
             } as unknown as WranglerConfig;
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, hasHyperdriveGlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             // The null entry is skipped; the declared index is simply unmatched.
             expect(report.valid).toBe(false);
@@ -218,7 +218,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             } as unknown as WranglerConfig;
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, vectorIndexNames: [] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false, vectorIndexNames: [] });
 
             // The null entry is skipped; the missing "DB" binding is reported structurally.
             expect(report.valid).toBe(false);
@@ -396,7 +396,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             };
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false });
 
             expect(report.errors.some((line) => line.includes("d1_databases"))).toBe(true);
         });
@@ -410,7 +410,7 @@ describe("wrangler-validator", () => {
                 durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
             };
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, hasHyperdriveGlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             expect(report.valid).toBe(false);
             expect(report.errors.some((line) => line.includes("docs-body"))).toBe(true);
@@ -427,7 +427,7 @@ describe("wrangler-validator", () => {
                 vectorize: [{ binding: "DOCS_BODY", index_name: "docs-body" }],
             };
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, vectorIndexNames: ["docs-body"] });
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: false, hasHyperdriveGlobalTable: false, vectorIndexNames: ["docs-body"] });
 
             expect(report.valid).toBe(true);
             expect(report.errors).toEqual([]);
@@ -570,7 +570,7 @@ describe("wrangler-validator", () => {
 
             wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
 
-            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true }, "production");
+            const report = validateWranglerConfig(wrangler, { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false }, "production");
 
             expect(report.valid).toBe(false);
             expect(report.errors.some((line) => line.includes('d1_databases must include a binding named "DB"'))).toBe(true);
@@ -588,7 +588,7 @@ describe("wrangler-validator", () => {
                 },
             };
 
-            expect(validateWranglerConfig(wrangler, { hasD1GlobalTable: true }, "production").valid).toBe(true);
+            expect(validateWranglerConfig(wrangler, { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false }, "production").valid).toBe(true);
         });
 
         // kv_namespaces — NON-inheritable, hint-only (warns on a missing id,
@@ -1090,6 +1090,25 @@ describe("wrangler-validator", () => {
                     expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
                 }
             });
+
+            it("says nothing when whitespace separates the chain from its parentheses", () => {
+                expect.assertions(1);
+
+                // The text prefilter only decides which files are worth parsing;
+                // the parse decides the answer. An exact `.vectors(` substring made
+                // the prefilter STRICTER than the parser, so a formatting variant
+                // skipped the file and hard-errored a correctly wired project.
+                writeVectorProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n` +
+                        `\n` +
+                        `const app = defineApp()\n    .shard((env) => env.SHARD)\n    . vectors ((env) => ({ "docs-body": env.DOCS_BODY }));\n` +
+                        `export const { ShardDO } = app;\nexport default app;\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
+            });
         });
 
         describe("a schema with .global() tables no source chains .global() onto", () => {
@@ -1144,6 +1163,27 @@ describe("wrangler-validator", () => {
 
                 expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
             });
+
+            it("still errors when the table builder is imported under an alias", () => {
+                expect.assertions(1);
+
+                // The table-form exclusion reads the file's LOCAL names for
+                // `defineTable`, the same way the `defineApp` probe does. Keying
+                // it on the bare identifier let `import { defineTable as table }`
+                // hide the table form, so `table({...}).global()` counted as the
+                // APP chaining `.global(...)` and the gate cleared on the schema
+                // itself — silence for a shard with no global writer.
+                writeGlobalProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD);\nexport const { ShardDO } = app;\nexport default app;\n`,
+                );
+                writeSchema(
+                    `import { defineSchema, defineTable as table, v } from "@lunora/server";\n\nexport const schema = defineSchema({\n    users: table({ email: v.string() }).global(),\n});\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("nothing chains .global(...)");
+            });
         });
 
         describe("a schema whose .global() tables are Hyperdrive-backed", () => {
@@ -1179,7 +1219,7 @@ export const schema = defineSchema({
             };
 
             it("demands the .hyperdriveGlobal(...) chain, not a D1 binding or .global(...)", () => {
-                expect.assertions(3);
+                expect.assertions(5);
 
                 writeHyperdriveProject(
                     `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD);\nexport const { ShardDO } = app;\nexport default app;\n`,
@@ -1191,13 +1231,23 @@ export const schema = defineSchema({
                 expect(errors).toContain("nothing chains .hyperdriveGlobal(...)");
                 expect(errors).not.toContain('d1_databases must include a binding named "DB"');
                 expect(errors).not.toContain("nothing chains .global(...)");
+                // The suggested fix has to match `HyperdriveGlobalDeclaration`
+                // (`engine` + `exec`). The D1 line's `d1: (env) => env.DB` shape
+                // does not exist on this builder, and a blocking error whose fix
+                // does not compile costs the round trip it exists to save.
+                expect(errors).toContain('.hyperdriveGlobal({ engine: "postgres", exec:');
+                expect(errors).not.toContain("hyperdrive: (env) => env.HYPERDRIVE");
             });
 
             it("passes once the app chains .hyperdriveGlobal(...)", () => {
                 expect.assertions(1);
 
                 writeHyperdriveProject(
-                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).hyperdriveGlobal({ hyperdrive: (env) => env.HYPERDRIVE });\nexport const { ShardDO } = app;\nexport default app;\n`,
+                    // The real `HyperdriveGlobalDeclaration` shape (`engine` +
+                    // `exec`), not a `hyperdrive:` selector — detection only
+                    // reads the method name, so a wrong fixture would pass while
+                    // pinning a remediation string that does not compile.
+                    `import { defineApp } from "../lunora/_generated/app";\n\nconst app = defineApp().shard((env) => env.SHARD).hyperdriveGlobal({ engine: "postgres", exec: (env) => buildPgExec(env.HYPERDRIVE) });\nexport const { ShardDO } = app;\nexport default app;\n`,
                 );
 
                 const result = validateWranglerProject({ projectRoot: workdir });
@@ -2412,7 +2462,7 @@ export const schema = defineSchema({
                     r2_buckets: [{ binding: "FILES", bucket_name: "lunora-example-team-chat-files" }],
                     vars: { PUBLIC_STORAGE_BASE_URL: "http://localhost:5173" },
                 },
-                { hasD1GlobalTable: true },
+                { hasD1GlobalTable: true, hasHyperdriveGlobalTable: false },
             );
 
             expect(report.errors).toEqual([]);

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -1045,6 +1045,28 @@ describe("wrangler-validator", () => {
                 expect(result.report.errors.filter((error) => error.includes("nothing chains"))).toEqual([]);
             });
 
+            it("still fires when only a comment or a string mentions the chain", () => {
+                expect.assertions(1);
+
+                // The file that chains `.vectors()` is the likeliest one to carry a
+                // comment saying so, so "delete the call, keep the warning about
+                // deleting the call" is the realistic path back to the outage — and
+                // a substring match cleared the gate on exactly that tree.
+                writeVectorProject(
+                    `import { defineApp } from "../lunora/_generated/app";\n` +
+                        `\n` +
+                        `// Load-bearing: without .vectors((env) => ({ "docs-body": env.DOCS_BODY }))\n` +
+                        `// every request 500s.\n` +
+                        `const hint = "add .vectors(...) to the chain";\n` +
+                        `const app = defineApp().shard((env) => env.SHARD);\n` +
+                        `export const { ShardDO } = app;\nexport default app;\nexport { hint };\n`,
+                );
+
+                const result = validateWranglerProject({ projectRoot: workdir });
+
+                expect(result.report.errors.join("\n")).toContain("nothing chains .vectors(...)");
+            });
+
             it("says nothing when the chain lives in a .server directory or a .mjs module", () => {
                 expect.assertions(2);
 

--- a/packages/config/src/cloudflare/worker-entry-checks.ts
+++ b/packages/config/src/cloudflare/worker-entry-checks.ts
@@ -357,22 +357,63 @@ const chainRoot = (node: Node): Node => {
 };
 
 /**
- * Whether the chain `node` belongs to is rooted at `defineTable(...)`.
+ * Whether the chain `node` belongs to is rooted at a `defineTable(...)` call.
  *
  * `.global()` names two different builders — the app's (`.global({ d1 })`) and a
  * table's (`defineTable({…}).global()`, which is what MAKES the schema declare a
  * global table). Every project this check fires on therefore contains the table
  * form, so without this the schema would clear the gate on itself.
+ *
+ * Takes the file's LOCAL names for the factory rather than the bare string, the
+ * same way {@link localNamesFor} feeds the `defineApp` probe: `import
+ * { defineTable as table }` would otherwise leave the chain unrecognised, and a
+ * table's own `.global()` would clear the app's gate.
  */
-const rootsAtTableFactory = (node: Node): boolean => {
+const rootsAtTableFactory = (node: Node, factoryNames: ReadonlySet<string>): boolean => {
     const root = chainRoot(node);
 
-    return TsNode.isIdentifier(root) && root.getText() === TABLE_FACTORY;
+    return TsNode.isIdentifier(root) && factoryNames.has(root.getText());
 };
 
+/**
+ * A builder method a schema declaration can require the app to chain. Closed on
+ * purpose: {@link CHAIN_PREFILTERS} is keyed by it, so adding a capability
+ * without its prefilter is a compile error rather than a gate that never fires.
+ */
+type CapabilityMethod = "global" | "hyperdriveGlobal" | "vectors";
+
+/**
+ * `.<method>(` with whitespace allowed on either side of the name — the text
+ * prefilter deciding which files are worth a parse, deliberately LOOSER than the
+ * parsed check that follows it. An exact `.vectors(` substring made the prefilter
+ * stricter than the parser instead: the method never reached
+ * {@link chainedMethods}, so a formatting variant reported a correctly wired
+ * project as unchained and blocked its deploy.
+ *
+ * A fixed record rather than patterns built per method, so the key set is the
+ * type and a capability nobody wrote a prefilter for is a compile error, not a
+ * gate that silently never fires.
+ *
+ * Still narrower than the parser in one shape: `.global<T>({…})` skips the file
+ * and hard-errors a project that chains it. Unreachable today — no generated
+ * builder method takes type parameters — but that is the direction to widen if
+ * one ever does.
+ */
+const CHAIN_PREFILTERS: Record<CapabilityMethod, RegExp> = {
+    global: /\.\s*global\s*\(/u,
+    hyperdriveGlobal: /\.\s*hyperdriveGlobal\s*\(/u,
+    vectors: /\.\s*vectors\s*\(/u,
+};
+
+const isCapabilityMethod = (name: string): name is CapabilityMethod => Object.hasOwn(CHAIN_PREFILTERS, name);
+
 /** Which of `methods` the file CALLS as `.<method>(...)` — parsed, so a comment or a string naming one is not a call site. */
-const chainedMethods = (sourceFile: SourceFile, methods: ReadonlySet<string>): Set<string> => {
-    const found = new Set<string>();
+const chainedMethods = (sourceFile: SourceFile, methods: ReadonlySet<CapabilityMethod>): Set<CapabilityMethod> => {
+    const found = new Set<CapabilityMethod>();
+    // The literal name UNION the file's local aliases: `localNamesFor` reads
+    // named imports only, and a file that reaches the factory some other way must
+    // not lose the un-aliased exclusion this guard has always made.
+    const tableFactoryNames = new Set([TABLE_FACTORY, ...localNamesFor(sourceFile, TABLE_FACTORY)]);
 
     sourceFile.forEachDescendant((descendant) => {
         if (!TsNode.isCallExpression(descendant)) {
@@ -381,8 +422,14 @@ const chainedMethods = (sourceFile: SourceFile, methods: ReadonlySet<string>): S
 
         const callee = descendant.getExpression();
 
-        if (TsNode.isPropertyAccessExpression(callee) && methods.has(callee.getName()) && !rootsAtTableFactory(callee)) {
-            found.add(callee.getName());
+        if (!TsNode.isPropertyAccessExpression(callee) || rootsAtTableFactory(callee, tableFactoryNames)) {
+            return;
+        }
+
+        const name = callee.getName();
+
+        if (isCapabilityMethod(name) && methods.has(name)) {
+            found.add(name);
         }
     });
 
@@ -412,7 +459,7 @@ const chainedMethods = (sourceFile: SourceFile, methods: ReadonlySet<string>): S
  * chain and does not parse counts as chaining it: unparseable is not evidence the
  * call is gone, and this half fails open.
  */
-const readMarkers = (file: string, methods: ReadonlySet<string>): { chained: Set<string>; composes: boolean } | undefined => {
+const readMarkers = (file: string, methods: ReadonlySet<CapabilityMethod>): { chained: Set<CapabilityMethod>; composes: boolean } | undefined => {
     let source: string;
 
     try {
@@ -421,7 +468,7 @@ const readMarkers = (file: string, methods: ReadonlySet<string>): { chained: Set
         return undefined;
     }
 
-    const mentioned = new Set([...methods].filter((method) => source.includes(`.${method}(`)));
+    const mentioned = new Set([...methods].filter((method) => CHAIN_PREFILTERS[method].test(source)));
 
     if (mentioned.size === 0 && !source.includes(APP_FACTORY)) {
         return undefined;
@@ -438,7 +485,7 @@ const readMarkers = (file: string, methods: ReadonlySet<string>): { chained: Set
 
 /** Where the app is composed, and which of the requested builder methods the project chains anywhere. */
 interface ChainScan {
-    chained: ReadonlySet<string>;
+    chained: ReadonlySet<CapabilityMethod>;
     site: string;
 }
 
@@ -461,10 +508,16 @@ interface ChainScan {
  * no `defineApp` call here and is not judged.
  *
  * Both give-up routes — the file budget and an unparseable file — report nothing.
+ *
+ * Stops as soon as the answer is settled — the app is composed and every requested
+ * method is chained. Nothing read later can change it (`site` keeps the FIRST
+ * composing file, `chained` only grows), and a correctly wired project is the
+ * common case, so without this every `verify` / `doctor` / `build` / `deploy` read
+ * and scanned the whole tree to reach a conclusion it already had.
  */
-const scanAppChains = (projectRoot: string, methods: ReadonlySet<string>): ChainScan | undefined => {
+const scanAppChains = (projectRoot: string, methods: ReadonlySet<CapabilityMethod>): ChainScan | undefined => {
     const pending: string[] = [projectRoot];
-    const chained = new Set<string>();
+    const chained = new Set<CapabilityMethod>();
     let scanned = 0;
     let site: string | undefined;
 
@@ -495,13 +548,19 @@ const scanAppChains = (projectRoot: string, methods: ReadonlySet<string>): Chain
 
         pending.push(...subdirectories);
 
-        if (!files.every((file) => take(file))) {
-            return undefined;
+        for (const file of files) {
+            if (!take(file)) {
+                return undefined;
+            }
+
+            if (site !== undefined && chained.size === methods.size) {
+                return { chained, site };
+            }
         }
     }
 
     return site === undefined ? undefined : { chained, site };
 };
 
-export type { ChainScan, WorkerEntry };
+export type { CapabilityMethod, WorkerEntry };
 export { readWorkerEntry, scanAppChains };

--- a/packages/config/src/cloudflare/worker-entry-checks.ts
+++ b/packages/config/src/cloudflare/worker-entry-checks.ts
@@ -6,10 +6,10 @@
  * which Durable Object / Workflow classes it exports — since wrangler binds
  * exactly what that file exports.
  *
- * {@link findUnchainedVectorsSite} answers the question the entry is the wrong
- * place to ask: does anything in the project bind the vector indexes its schema
- * declares. That is a project-wide fact, and reading it off the entry silently
- * disabled the check for every Vite-first layout.
+ * {@link scanAppChains} answers the question the entry is the wrong place to ask:
+ * does anything in the project chain the builder call a schema declaration needs
+ * (`.vectors(...)`, `.global(...)`). That is a project-wide fact, and reading it
+ * off the entry silently disabled the check for every Vite-first layout.
  *
  * The checks that consume them stay next to the wrangler config types they also read.
  */
@@ -263,11 +263,8 @@ const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts"
  */
 const MAX_SCANNED_FILES = 2000;
 
-/** Cheap prefilter for the binding marker — only a file whose text contains this is worth parsing. */
-const VECTORS_CHAIN = ".vectors(";
-
-/** The builder method that binds the schema's vector indexes. */
-const VECTORS_METHOD = "vectors";
+/** The generated schema's table builder. A `defineTable(...).global()` chain is the SCHEMA declaring a global table, not the app binding one. */
+const TABLE_FACTORY = "defineTable";
 
 /** The generated app-composition factory, whatever a file chose to call it locally. */
 const APP_FACTORY = "defineApp";
@@ -345,20 +342,47 @@ const callsAnyOf = (sourceFile: SourceFile, names: ReadonlySet<string>): boolean
     return found;
 };
 
-/** Whether the file CALLS `.vectors(...)` on something — parsed, so a comment or a string naming it is not a call site. */
-const chainsVectors = (sourceFile: SourceFile): boolean => {
-    let found = false;
+/**
+ * The expression a member-call chain starts from: for
+ * `defineTable({…}).global().index(…)` that is the `defineTable({…})` call.
+ */
+const chainRoot = (node: Node): Node => {
+    let current = node;
 
-    sourceFile.forEachDescendant((descendant, traversal) => {
+    while (TsNode.isCallExpression(current) || TsNode.isPropertyAccessExpression(current)) {
+        current = current.getExpression();
+    }
+
+    return current;
+};
+
+/**
+ * Whether the chain `node` belongs to is rooted at `defineTable(...)`.
+ *
+ * `.global()` names two different builders — the app's (`.global({ d1 })`) and a
+ * table's (`defineTable({…}).global()`, which is what MAKES the schema declare a
+ * global table). Every project this check fires on therefore contains the table
+ * form, so without this the schema would clear the gate on itself.
+ */
+const rootsAtTableFactory = (node: Node): boolean => {
+    const root = chainRoot(node);
+
+    return TsNode.isIdentifier(root) && root.getText() === TABLE_FACTORY;
+};
+
+/** Which of `methods` the file CALLS as `.<method>(...)` — parsed, so a comment or a string naming one is not a call site. */
+const chainedMethods = (sourceFile: SourceFile, methods: ReadonlySet<string>): Set<string> => {
+    const found = new Set<string>();
+
+    sourceFile.forEachDescendant((descendant) => {
         if (!TsNode.isCallExpression(descendant)) {
             return;
         }
 
         const callee = descendant.getExpression();
 
-        if (TsNode.isPropertyAccessExpression(callee) && callee.getName() === VECTORS_METHOD) {
-            found = true;
-            traversal.stop();
+        if (TsNode.isPropertyAccessExpression(callee) && methods.has(callee.getName()) && !rootsAtTableFactory(callee)) {
+            found.add(callee.getName());
         }
     });
 
@@ -366,8 +390,8 @@ const chainsVectors = (sourceFile: SourceFile): boolean => {
 };
 
 /**
- * What one file contributes: it `binds` the vector indexes, `composes` the app,
- * or neither. An unreadable file contributes nothing.
+ * What one file contributes: which of `methods` it chains, and whether it
+ * composes the app. An unreadable file contributes nothing.
  *
  * Both markers are PARSED rather than text-matched, for opposite reasons.
  *
@@ -377,18 +401,18 @@ const chainsVectors = (sourceFile: SourceFile): boolean => {
  * import — none of which a project can edit its way out of. Keying on the IMPORT
  * also means the generated `app.ts` that declares the factory cannot arm anything.
  *
- * `.vectors(` CLEARS it, and a substring was too coarse there too, in the way that
- * matters most: the file that chains `.vectors()` is the likeliest file to also
- * carry a comment saying the chain is load-bearing, so deleting the call and
+ * A chained method CLEARS it, and a substring was too coarse there too, in the way
+ * that matters most: the file that chains `.vectors()` is the likeliest file to
+ * also carry a comment saying the chain is load-bearing, so deleting the call and
  * keeping the warning about deleting it disarmed the check — precisely the path
  * back to the outage it exists to prevent.
  *
  * A parse costs a `Project` per file, but only files whose text mentions a marker
- * at all get one, which in a real project is one or two. A file that mentions the
- * chain and does not parse still counts as binding: unparseable is not evidence
- * the call is gone, and this half fails open.
+ * at all get one, which in a real project is one or two. A file that mentions a
+ * chain and does not parse counts as chaining it: unparseable is not evidence the
+ * call is gone, and this half fails open.
  */
-const readMarker = (file: string): "binds" | "composes" | undefined => {
+const readMarkers = (file: string, methods: ReadonlySet<string>): { chained: Set<string>; composes: boolean } | undefined => {
     let source: string;
 
     try {
@@ -397,28 +421,30 @@ const readMarker = (file: string): "binds" | "composes" | undefined => {
         return undefined;
     }
 
-    const mentionsChain = source.includes(VECTORS_CHAIN);
+    const mentioned = new Set([...methods].filter((method) => source.includes(`.${method}(`)));
 
-    if (!mentionsChain && !source.includes(APP_FACTORY)) {
+    if (mentioned.size === 0 && !source.includes(APP_FACTORY)) {
         return undefined;
     }
 
     const sourceFile = parseSource(basename(file), source);
 
     if (sourceFile === undefined) {
-        return mentionsChain ? "binds" : undefined;
+        return { chained: mentioned, composes: false };
     }
 
-    if (mentionsChain && chainsVectors(sourceFile)) {
-        return "binds";
-    }
-
-    return callsAnyOf(sourceFile, localNamesFor(sourceFile, APP_FACTORY)) ? "composes" : undefined;
+    return { chained: chainedMethods(sourceFile, mentioned), composes: callsAnyOf(sourceFile, localNamesFor(sourceFile, APP_FACTORY)) };
 };
 
+/** Where the app is composed, and which of the requested builder methods the project chains anywhere. */
+interface ChainScan {
+    chained: ReadonlySet<string>;
+    site: string;
+}
+
 /**
- * The file composing this project's app, when nothing in the project chains
- * `.vectors(...)` — otherwise `undefined`, meaning "nothing to report".
+ * Scan the project for the builder methods a schema declaration requires the app
+ * to chain. `undefined` means "nothing to report".
  *
  * Read from the whole project rather than from the worker entry, and that is the
  * whole point in both directions. The builder returns `this`, so
@@ -430,16 +456,38 @@ const readMarker = (file: string): "binds" | "composes" | undefined => {
  * read as "composes nothing" from the entry alone, which turned this check off for
  * exactly the Vite-first projects it exists to protect.
  *
- * Both markers are parsed calls ({@link readMarker}) — a comment or a string
+ * Both markers are parsed calls ({@link readMarkers}) — a comment or a string
  * naming either one decides nothing. A worker composed in another package leaves
  * no `defineApp` call here and is not judged.
  *
  * Both give-up routes — the file budget and an unparseable file — report nothing.
  */
-const findUnchainedVectorsSite = (projectRoot: string): string | undefined => {
+const scanAppChains = (projectRoot: string, methods: ReadonlySet<string>): ChainScan | undefined => {
     const pending: string[] = [projectRoot];
+    const chained = new Set<string>();
     let scanned = 0;
     let site: string | undefined;
+
+    /** Fold one file into the running answer; `false` means the budget is spent. */
+    const take = (file: string): boolean => {
+        scanned += 1;
+
+        if (scanned > MAX_SCANNED_FILES) {
+            return false;
+        }
+
+        const markers = readMarkers(file, methods);
+
+        for (const method of markers?.chained ?? []) {
+            chained.add(method);
+        }
+
+        if (markers?.composes) {
+            site ??= file;
+        }
+
+        return true;
+    };
 
     while (pending.length > 0) {
         const directory = pending.pop() as string;
@@ -447,27 +495,13 @@ const findUnchainedVectorsSite = (projectRoot: string): string | undefined => {
 
         pending.push(...subdirectories);
 
-        for (const file of files) {
-            scanned += 1;
-
-            if (scanned > MAX_SCANNED_FILES) {
-                return undefined;
-            }
-
-            const marker = readMarker(file);
-
-            if (marker === "binds") {
-                return undefined;
-            }
-
-            if (marker === "composes") {
-                site ??= file;
-            }
+        if (!files.every((file) => take(file))) {
+            return undefined;
         }
     }
 
-    return site;
+    return site === undefined ? undefined : { chained, site };
 };
 
-export type { WorkerEntry };
-export { findUnchainedVectorsSite, readWorkerEntry };
+export type { ChainScan, WorkerEntry };
+export { readWorkerEntry, scanAppChains };

--- a/packages/config/src/cloudflare/worker-entry-checks.ts
+++ b/packages/config/src/cloudflare/worker-entry-checks.ts
@@ -263,8 +263,11 @@ const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts"
  */
 const MAX_SCANNED_FILES = 2000;
 
-/** The literal a project's source must contain somewhere for the vector indexes to count as bound. */
+/** Cheap prefilter for the binding marker — only a file whose text contains this is worth parsing. */
 const VECTORS_CHAIN = ".vectors(";
+
+/** The builder method that binds the schema's vector indexes. */
+const VECTORS_METHOD = "vectors";
 
 /** The generated app-composition factory, whatever a file chose to call it locally. */
 const APP_FACTORY = "defineApp";
@@ -342,26 +345,49 @@ const callsAnyOf = (sourceFile: SourceFile, names: ReadonlySet<string>): boolean
     return found;
 };
 
+/** Whether the file CALLS `.vectors(...)` on something — parsed, so a comment or a string naming it is not a call site. */
+const chainsVectors = (sourceFile: SourceFile): boolean => {
+    let found = false;
+
+    sourceFile.forEachDescendant((descendant, traversal) => {
+        if (!TsNode.isCallExpression(descendant)) {
+            return;
+        }
+
+        const callee = descendant.getExpression();
+
+        if (TsNode.isPropertyAccessExpression(callee) && callee.getName() === VECTORS_METHOD) {
+            found = true;
+            traversal.stop();
+        }
+    });
+
+    return found;
+};
+
 /**
- * Whether this file CALLS the imported `defineApp` — parsed, not text-matched.
+ * What one file contributes: it `binds` the vector indexes, `composes` the app,
+ * or neither. An unreadable file contributes nothing.
  *
- * The precision is the point, because this is the half of the vectors check that
- * fails CLOSED: what it finds ARMS a deploy-blocking error. A substring match
- * armed it on Nuxt's unrelated `defineAppConfig`, on a doc comment naming
+ * Both markers are PARSED rather than text-matched, for opposite reasons.
+ *
+ * `defineApp` ARMS the deploy-blocking error, so a substring is too coarse: it
+ * armed on Nuxt's unrelated `defineAppConfig`, on a doc comment naming
  * `defineApp()` (which two of this repo's own templates carry), and on a type-only
  * import — none of which a project can edit its way out of. Keying on the IMPORT
  * also means the generated `app.ts` that declares the factory cannot arm anything.
  *
- * The parse costs a `Project` per file, but only files whose text mentions the
- * factory at all are ever handed here, which in a real project is one or two.
+ * `.vectors(` CLEARS it, and a substring was too coarse there too, in the way that
+ * matters most: the file that chains `.vectors()` is the likeliest file to also
+ * carry a comment saying the chain is load-bearing, so deleting the call and
+ * keeping the warning about deleting it disarmed the check — precisely the path
+ * back to the outage it exists to prevent.
+ *
+ * A parse costs a `Project` per file, but only files whose text mentions a marker
+ * at all get one, which in a real project is one or two. A file that mentions the
+ * chain and does not parse still counts as binding: unparseable is not evidence
+ * the call is gone, and this half fails open.
  */
-const composesApp = (file: string, source: string): boolean => {
-    const sourceFile = parseSource(basename(file), source);
-
-    return sourceFile !== undefined && callsAnyOf(sourceFile, localNamesFor(sourceFile, APP_FACTORY));
-};
-
-/** What one file contributes: it `binds` the vector indexes, `composes` the app, or neither. An unreadable file contributes nothing. */
 const readMarker = (file: string): "binds" | "composes" | undefined => {
     let source: string;
 
@@ -371,11 +397,23 @@ const readMarker = (file: string): "binds" | "composes" | undefined => {
         return undefined;
     }
 
-    if (source.includes(VECTORS_CHAIN)) {
+    const mentionsChain = source.includes(VECTORS_CHAIN);
+
+    if (!mentionsChain && !source.includes(APP_FACTORY)) {
+        return undefined;
+    }
+
+    const sourceFile = parseSource(basename(file), source);
+
+    if (sourceFile === undefined) {
+        return mentionsChain ? "binds" : undefined;
+    }
+
+    if (mentionsChain && chainsVectors(sourceFile)) {
         return "binds";
     }
 
-    return source.includes(APP_FACTORY) && composesApp(file, source) ? "composes" : undefined;
+    return callsAnyOf(sourceFile, localNamesFor(sourceFile, APP_FACTORY)) ? "composes" : undefined;
 };
 
 /**
@@ -392,12 +430,9 @@ const readMarker = (file: string): "binds" | "composes" | undefined => {
  * read as "composes nothing" from the entry alone, which turned this check off for
  * exactly the Vite-first projects it exists to protect.
  *
- * The two markers are deliberately asymmetric, because the caller BLOCKS a deploy.
- * `.vectors(` CLEARS the check and is a literal text match, so a comment mentioning
- * it clears too — a false negative that leaves the app exactly where it was before
- * this check existed, which is the trade a blocking gate should take. `defineApp`
- * ARMS it, so it is a parsed call ({@link composesApp}); a worker composed in
- * another package leaves no call here and is not judged.
+ * Both markers are parsed calls ({@link readMarker}) — a comment or a string
+ * naming either one decides nothing. A worker composed in another package leaves
+ * no `defineApp` call here and is not judged.
  *
  * Both give-up routes — the file budget and an unparseable file — report nothing.
  */

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -18,7 +18,7 @@ import { isEnvEnabled } from "../../../../shared/env-flag";
 import join from "../path";
 import type { SchemaInfo } from "../schema-info";
 import { discoverSchemaInfo } from "../schema-info";
-import type { WorkerEntry } from "./worker-entry-checks";
+import type { CapabilityMethod, WorkerEntry } from "./worker-entry-checks";
 import { readWorkerEntry, scanAppChains } from "./worker-entry-checks";
 import { isCacheEnabled, WORKERS_CACHE_MIN_DATE } from "./workers-cache";
 import { findWranglerFile, readWranglerJsonc } from "./wrangler-path";
@@ -1518,7 +1518,15 @@ const collectContainerImageErrors = (
  * unexported-class check validates, which is why it lives here rather than in the
  * runtime.
  *
- * Blocking, so it fails open both ways — see {@link scanAppChains}, which reads the
+ * Blocking — and not only at deploy: `@lunora/vite`'s wrangler-validator plugin
+ * throws on any reported problem at `configResolved`, so this also refuses to
+ * start `lunora dev`. Vector indexes are rare, but `.global()` tables are the
+ * common case, and unlike the `DB` binding validated next to it, Lunora cannot
+ * write the `.global(...)` chain into the user's `src/server.ts` for them. That
+ * is the intended trade — the alternative is a dev server whose every global read
+ * throws INTERNAL — but it is why every give-up route below reports nothing.
+ *
+ * It fails open both ways — see {@link scanAppChains}, which reads the
  * PROJECT rather than the worker entry. Keying "does this project compose an app"
  * on the entry is what silently disabled the check for the two commonest Vite-first
  * layouts: `main: "virtual:lunora/worker"` names no file at all, and a generated
@@ -1526,43 +1534,47 @@ const collectContainerImageErrors = (
  */
 const collectUnchainedCapabilityErrors = (schema: SchemaInfo | undefined, projectRoot: string): string[] => {
     const vectorIndexNames = schema?.vectorIndexNames ?? [];
-    const required = [
-        ...(vectorIndexNames.length > 0
-            ? [
-                  {
-                      message: (site: string): string =>
-                          `schema declares vector index(es) ${vectorIndexNames.map((name) => `"${name}"`).join(", ")} but nothing chains .vectors(...) onto defineApp() ` +
-                          `(composed in: ${site}) — \`ctx.vectors\` is then a throwing stub and buildWorkerOptions rejects EVERY request, /_lunora/health included. ` +
-                          `Add \`.vectors((env) => ({ ${String(vectorIndexNames[0])}: env.<BINDING> }))\` to the chain.`,
-                      method: "vectors",
-                  },
-              ]
-            : []),
-        ...(schema?.hasD1GlobalTable
-            ? [
-                  {
-                      message: (site: string): string =>
-                          `schema declares .global() table(s) but nothing chains .global(...) onto defineApp() (composed in: ${site}) — the shard then has no global writer, ` +
-                          `so every read or write of a global table throws INTERNAL ("requires a globalDb writer"). ` +
-                          `Add \`.global({ d1: (env) => env.DB })\` to the chain.`,
-                      method: "global",
-                  },
-              ]
-            : []),
-        // The Hyperdrive flavour of the same requirement: a different builder
-        // method, the same missing `globalDb` and the same INTERNAL throw.
-        ...(schema?.hasHyperdriveGlobalTable
-            ? [
-                  {
-                      message: (site: string): string =>
-                          `schema declares .global({ backend: "hyperdrive" }) table(s) but nothing chains .hyperdriveGlobal(...) onto defineApp() (composed in: ${site}) — ` +
-                          `the shard then has no global writer, so every read or write of those tables throws INTERNAL. ` +
-                          `Add \`.hyperdriveGlobal({ hyperdrive: (env) => env.HYPERDRIVE })\` to the chain.`,
-                      method: "hyperdriveGlobal",
-                  },
-              ]
-            : []),
-    ];
+    const required: { message: (site: string) => string; method: CapabilityMethod }[] = [];
+
+    if (vectorIndexNames.length > 0) {
+        required.push({
+            message: (site) =>
+                `schema declares vector index(es) ${vectorIndexNames.map((name) => `"${name}"`).join(", ")} but nothing chains .vectors(...) onto defineApp() ` +
+                `(composed in: ${site}) — \`ctx.vectors\` is then a throwing stub and buildWorkerOptions rejects EVERY request, /_lunora/health included. ` +
+                `Add \`.vectors((env) => ({ ${String(vectorIndexNames[0])}: env.<BINDING> }))\` to the chain.`,
+            method: "vectors",
+        });
+    }
+
+    if (schema?.hasD1GlobalTable) {
+        required.push({
+            message: (site) =>
+                `schema declares .global() table(s) but nothing chains .global(...) onto defineApp() (composed in: ${site}) — the shard then has no global writer, ` +
+                `so every read or write of a global table throws INTERNAL ("requires a globalDb writer"). ` +
+                `Add \`.global({ d1: (env) => env.DB })\` to the chain.`,
+            method: "global",
+        });
+    }
+
+    // The Hyperdrive flavour of the same requirement: a different builder
+    // method, the same missing `globalDb` and the same INTERNAL throw.
+    //
+    // The remediation is the shape `HyperdriveGlobalDeclaration` actually takes
+    // (`@lunora/codegen`'s `emit-app.ts`): `engine` plus an `exec` built from the
+    // binding, NOT a `hyperdrive: (env) => env.HYPERDRIVE` selector like the D1
+    // line above. A blocking error whose suggested fix does not compile costs the
+    // user the same round trip the error was meant to save.
+    if (schema?.hasHyperdriveGlobalTable) {
+        required.push({
+            message: (site) =>
+                `schema declares .global({ backend: "hyperdrive" }) table(s) but nothing chains .hyperdriveGlobal(...) onto defineApp() (composed in: ${site}) — ` +
+                `the shard then has no global writer, so every read or write of those tables throws INTERNAL. ` +
+                `Add \`.hyperdriveGlobal({ engine: "postgres", exec: (env) => buildPgExec(fromPostgresJs(postgres(` +
+                `env.HYPERDRIVE.connectionString))) })\` to the chain ` +
+                `(\`buildPgExec\` from \`@lunora/hyperdrive/global\`, \`fromPostgresJs\` from \`@lunora/hyperdrive\`).`,
+            method: "hyperdriveGlobal",
+        });
+    }
 
     if (required.length === 0) {
         return [];

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -905,6 +905,39 @@ const REQUIRED_FIELD_BINDING_RULES = [
 ] as const satisfies ReadonlyArray<RequiredFieldsRule & { key: keyof WranglerConfig }>;
 
 /**
+ * The binding each `.global()` backend needs in order to exist at all — the
+ * config half of the chain requirement the unchained-capability check below
+ * reads out of the source.
+ *
+ * The two halves are asymmetric because the builders are. `.global({ d1 })` is
+ * reconciled by the dev server onto a fixed `DB`, so the exact name is checkable.
+ * `.hyperdriveGlobal({ exec })` builds the driver from whatever the user's own
+ * selector reads — `env.HYPERDRIVE` in the docs, but the name is theirs — so the
+ * only static fact is that SOME Hyperdrive binding has to exist. Naming one would
+ * false-error a project that called it something else; demanding none left these
+ * tables with no config check at all, and `env.<BINDING>` is then `undefined` at
+ * the first global read, throwing inside the user's `exec` where nothing here can
+ * say what went wrong.
+ *
+ * A schema may declare both flavours, so these are independent, not exclusive.
+ */
+const validateGlobalBackendBindings = (wrangler: WranglerConfig, schema: SchemaInfo | undefined, errors: string[]): void => {
+    if (schema?.hasD1GlobalTable && !objectBindingEntries(wrangler.d1_databases).some((binding) => binding.binding === "DB")) {
+        errors.push(
+            'schema declares .global() tables; d1_databases must include a binding named "DB" — your dev server auto-reconciles this on startup, or add the binding manually',
+        );
+    }
+
+    if (schema?.hasHyperdriveGlobalTable && objectBindingEntries(wrangler.hyperdrive).length === 0) {
+        errors.push(
+            'schema declares .global({ backend: "hyperdrive" }) tables; wrangler must declare a hyperdrive binding for `.hyperdriveGlobal({ exec })` to read — ' +
+                "run `wrangler hyperdrive create <name> --connection-string=...` and add " +
+                '`"hyperdrive": [{ "binding": "HYPERDRIVE", "id": "<id>" }]` (any binding name works; your `exec` selector picks it)',
+        );
+    }
+};
+
+/**
  * Structural check for every `d1_databases[]` entry: a non-empty `binding`,
  * plus a `database_id` or a `database_name` identifying which database it
  * binds. Both are remote-ish (created via `wrangler d1 create`, which prints
@@ -1383,20 +1416,7 @@ const validateWranglerConfig = (wranglerInput: WranglerConfig | undefined, schem
     // the `>= REQUIRED_COMPATIBILITY_DATE` error above, so a separate flag error
     // adds no signal. We therefore neither require nor reject the flag here.
 
-    // D1-backed globals only: a `.global({ backend: "hyperdrive" })` table lives on
-    // Postgres/MySQL behind a Hyperdrive binding and needs no D1 database at all,
-    // so counting it here demanded a `DB` binding of a project that has none.
-    if (schema?.hasD1GlobalTable) {
-        const d1Bindings = objectBindingEntries(wrangler.d1_databases);
-        const databaseBinding = d1Bindings.find((binding) => binding.binding === "DB");
-
-        if (!databaseBinding) {
-            errors.push(
-                'schema declares .global() tables; d1_databases must include a binding named "DB" — your dev server auto-reconciles this on startup, or add the binding manually',
-            );
-        }
-    }
-
+    validateGlobalBackendBindings(wrangler, schema, errors);
     validateD1Databases(wrangler, errors);
     validateVectorizeBindings(wrangler, schema?.vectorIndexNames ?? [], errors);
     validateTailConsumers(wrangler, errors);

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -19,7 +19,7 @@ import join from "../path";
 import type { SchemaInfo } from "../schema-info";
 import { discoverSchemaInfo } from "../schema-info";
 import type { WorkerEntry } from "./worker-entry-checks";
-import { findUnchainedVectorsSite, readWorkerEntry } from "./worker-entry-checks";
+import { readWorkerEntry, scanAppChains } from "./worker-entry-checks";
 import { isCacheEnabled, WORKERS_CACHE_MIN_DATE } from "./workers-cache";
 import { findWranglerFile, readWranglerJsonc } from "./wrangler-path";
 
@@ -1383,7 +1383,10 @@ const validateWranglerConfig = (wranglerInput: WranglerConfig | undefined, schem
     // the `>= REQUIRED_COMPATIBILITY_DATE` error above, so a separate flag error
     // adds no signal. We therefore neither require nor reject the flag here.
 
-    if (schema?.hasGlobalTable) {
+    // D1-backed globals only: a `.global({ backend: "hyperdrive" })` table lives on
+    // Postgres/MySQL behind a Hyperdrive binding and needs no D1 database at all,
+    // so counting it here demanded a `DB` binding of a project that has none.
+    if (schema?.hasD1GlobalTable) {
         const d1Bindings = objectBindingEntries(wrangler.d1_databases);
         const databaseBinding = d1Bindings.find((binding) => binding.binding === "DB");
 
@@ -1497,40 +1500,81 @@ const collectContainerImageErrors = (
 };
 
 /**
- * Report a schema that declares vector indexes while nothing in the project ever
- * chains `.vectors(...)`.
+ * Report a schema declaration whose matching `defineApp()` chain is missing.
  *
- * The generated builder already throws for this — from `buildWorkerOptions`, which
- * runs on the first REQUEST. So `lunora codegen`, `build`, `verify`, `tsc` and the
- * test suite all pass on a tree where every HTTP request 500s, `/_lunora/health`
- * included, and the app ships in that state. The requirement is static: the schema
- * states the indexes, and whether anything binds them is readable from the source.
- * Same relationship the unexported-class check validates, which is why it lives
- * here rather than in the runtime.
+ * The generated builder already fails for these — but from the first REQUEST. So
+ * `lunora codegen`, `build`, `verify`, `tsc` and the test suite all pass on a tree
+ * where the app cannot answer, and it ships in that state.
  *
- * Blocking, so it fails open both ways — see {@link findUnchainedVectorsSite},
- * which reads the PROJECT rather than the worker entry. Keying "does this project
- * compose an app" on the entry is what silently disabled the check for the two
- * commonest Vite-first layouts: `main: "virtual:lunora/worker"` names no file at
- * all, and a generated `src/worker.ts` only re-exports the app composed in
- * `src/server.ts`.
+ * Without `.vectors()`, `ctx.vectors` is a throwing stub and `buildWorkerOptions`
+ * rejects EVERY request, `/_lunora/health` included. Without `.global()` (or
+ * `.hyperdriveGlobal()`), the shard gets no global writer, so every read or write
+ * of a global table throws `INTERNAL` ("requires a globalDb writer") — and nothing
+ * else says a word, because the wrangler check next to this one proves the `DB`
+ * BINDING exists, which is the half a project usually gets right.
+ *
+ * Both requirements are static: the schema states them, and whether the app chains
+ * the matching call is readable from the source. Same relationship the
+ * unexported-class check validates, which is why it lives here rather than in the
+ * runtime.
+ *
+ * Blocking, so it fails open both ways — see {@link scanAppChains}, which reads the
+ * PROJECT rather than the worker entry. Keying "does this project compose an app"
+ * on the entry is what silently disabled the check for the two commonest Vite-first
+ * layouts: `main: "virtual:lunora/worker"` names no file at all, and a generated
+ * `src/worker.ts` only re-exports the app composed in `src/server.ts`.
  */
-const collectUnchainedVectorsError = (vectorIndexNames: ReadonlyArray<string>, projectRoot: string): string[] => {
-    if (vectorIndexNames.length === 0) {
-        return [];
-    }
-
-    const site = findUnchainedVectorsSite(projectRoot);
-
-    if (site === undefined) {
-        return [];
-    }
-
-    return [
-        `schema declares vector index(es) ${vectorIndexNames.map((name) => `"${name}"`).join(", ")} but nothing chains .vectors(...) onto defineApp() ` +
-            `(composed in: ${site}) — \`ctx.vectors\` is then a throwing stub and buildWorkerOptions rejects EVERY request, /_lunora/health included. ` +
-            `Add \`.vectors((env) => ({ ${String(vectorIndexNames[0])}: env.<BINDING> }))\` to the chain.`,
+const collectUnchainedCapabilityErrors = (schema: SchemaInfo | undefined, projectRoot: string): string[] => {
+    const vectorIndexNames = schema?.vectorIndexNames ?? [];
+    const required = [
+        ...(vectorIndexNames.length > 0
+            ? [
+                  {
+                      message: (site: string): string =>
+                          `schema declares vector index(es) ${vectorIndexNames.map((name) => `"${name}"`).join(", ")} but nothing chains .vectors(...) onto defineApp() ` +
+                          `(composed in: ${site}) — \`ctx.vectors\` is then a throwing stub and buildWorkerOptions rejects EVERY request, /_lunora/health included. ` +
+                          `Add \`.vectors((env) => ({ ${String(vectorIndexNames[0])}: env.<BINDING> }))\` to the chain.`,
+                      method: "vectors",
+                  },
+              ]
+            : []),
+        ...(schema?.hasD1GlobalTable
+            ? [
+                  {
+                      message: (site: string): string =>
+                          `schema declares .global() table(s) but nothing chains .global(...) onto defineApp() (composed in: ${site}) — the shard then has no global writer, ` +
+                          `so every read or write of a global table throws INTERNAL ("requires a globalDb writer"). ` +
+                          `Add \`.global({ d1: (env) => env.DB })\` to the chain.`,
+                      method: "global",
+                  },
+              ]
+            : []),
+        // The Hyperdrive flavour of the same requirement: a different builder
+        // method, the same missing `globalDb` and the same INTERNAL throw.
+        ...(schema?.hasHyperdriveGlobalTable
+            ? [
+                  {
+                      message: (site: string): string =>
+                          `schema declares .global({ backend: "hyperdrive" }) table(s) but nothing chains .hyperdriveGlobal(...) onto defineApp() (composed in: ${site}) — ` +
+                          `the shard then has no global writer, so every read or write of those tables throws INTERNAL. ` +
+                          `Add \`.hyperdriveGlobal({ hyperdrive: (env) => env.HYPERDRIVE })\` to the chain.`,
+                      method: "hyperdriveGlobal",
+                  },
+              ]
+            : []),
     ];
+
+    if (required.length === 0) {
+        return [];
+    }
+
+    const scan = scanAppChains(projectRoot, new Set(required.map((entry) => entry.method)));
+
+    if (scan === undefined) {
+        return [];
+    }
+
+    return required.filter((entry) => !scan.chained.has(entry.method)).map((entry) => entry.message(scan.site));
 };
 
 /**
@@ -1674,7 +1718,7 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
 
     // Deliberately outside that guard: it reads the project, and an unresolvable
     // entry (class-A's virtual `main`) says nothing about the vector bindings.
-    report.errors.push(...collectUnchainedVectorsError(schemaInfo?.vectorIndexNames ?? [], options.projectRoot));
+    report.errors.push(...collectUnchainedCapabilityErrors(schemaInfo, options.projectRoot));
 
     // FS-aware: `assets.directory` is created by the client build, so it may
     // legitimately not exist at validation time (pre-build). Surface a *warning*

--- a/packages/config/src/infer-bindings.ts
+++ b/packages/config/src/infer-bindings.ts
@@ -760,7 +760,8 @@ const detectClassExports = <Definition extends ClassExportable>(
  * validator read the exact same fact. A missing or unparseable schema yields
  * `false` — codegen surfaces the actionable error elsewhere.
  */
-const schemaNeedsD1 = (projectRoot: string, schemaDirectory: string): boolean => discoverSchemaInfo(projectRoot, schemaDirectory).info?.hasGlobalTable ?? false;
+const schemaNeedsD1 = (projectRoot: string, schemaDirectory: string): boolean =>
+    discoverSchemaInfo(projectRoot, schemaDirectory).info?.hasD1GlobalTable ?? false;
 
 /** Union the capabilities imported across every scanned source file. */
 const scanCapabilities = (projectRoot: string, scanDirectories: ReadonlyArray<string>): Capabilities => {

--- a/packages/config/src/schema-info.ts
+++ b/packages/config/src/schema-info.ts
@@ -28,8 +28,15 @@ interface VectorMetadataDeclaration {
 }
 
 interface SchemaInfo {
-    /** Whether the lunora schema declares any `.global()` table. */
-    hasGlobalTable: boolean;
+    /**
+     * Whether the schema declares a **D1-backed** `.global()` table — the only
+     * flavour that needs the `DB` binding and the app's `.global({ d1 })` chain.
+     * A `.global({ backend: "hyperdrive" })` table needs neither, and counting it
+     * here demanded a D1 database of a project that has none.
+     */
+    hasD1GlobalTable: boolean;
+    /** Whether the schema declares a `.global({ backend: "hyperdrive" })` table — needs the app's `.hyperdriveGlobal(...)` chain instead. */
+    hasHyperdriveGlobalTable?: boolean;
     /** Names of vector indexes declared via `.vectorize()` / `defineVectorIndex()`. */
     vectorIndexNames?: ReadonlyArray<string>;
 
@@ -72,7 +79,8 @@ const discoverSchemaInfo = (projectRoot: string, schemaDirectory: string): Disco
 
         return {
             info: {
-                hasGlobalTable: schema.tables.some((table) => table.shardMode === "global"),
+                hasD1GlobalTable: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend !== "hyperdrive"),
+                hasHyperdriveGlobalTable: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend === "hyperdrive"),
                 vectorIndexNames: schema.vectorIndexes.map((index) => index.name),
                 vectorMetadata: schema.vectorIndexes.flatMap((index) =>
                     (index.metadata ?? []).map((property) => {

--- a/packages/config/src/schema-info.ts
+++ b/packages/config/src/schema-info.ts
@@ -7,7 +7,7 @@
  */
 import { existsSync } from "node:fs";
 
-import { discoverSchema } from "@lunora/codegen";
+import { discoverSchema, isD1GlobalTable, isHyperdriveGlobalTable } from "@lunora/codegen";
 import { Project } from "ts-morph";
 
 import join from "./path";
@@ -35,8 +35,8 @@ interface SchemaInfo {
      * here demanded a D1 database of a project that has none.
      */
     hasD1GlobalTable: boolean;
-    /** Whether the schema declares a `.global({ backend: "hyperdrive" })` table — needs the app's `.hyperdriveGlobal(...)` chain instead. */
-    hasHyperdriveGlobalTable?: boolean;
+    /** Whether the schema declares a `.global({ backend: "hyperdrive" })` table — needs the app's `.hyperdriveGlobal(...)` chain instead. Required, not optional: the only producer always knows the answer, and `?` made every consumer read a two-valued fact as three-valued. */
+    hasHyperdriveGlobalTable: boolean;
     /** Names of vector indexes declared via `.vectorize()` / `defineVectorIndex()`. */
     vectorIndexNames?: ReadonlyArray<string>;
 
@@ -79,8 +79,8 @@ const discoverSchemaInfo = (projectRoot: string, schemaDirectory: string): Disco
 
         return {
             info: {
-                hasD1GlobalTable: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend !== "hyperdrive"),
-                hasHyperdriveGlobalTable: schema.tables.some((table) => table.shardMode === "global" && table.globalBackend === "hyperdrive"),
+                hasD1GlobalTable: schema.tables.some((table) => isD1GlobalTable(table)),
+                hasHyperdriveGlobalTable: schema.tables.some((table) => isHyperdriveGlobalTable(table)),
                 vectorIndexNames: schema.vectorIndexes.map((index) => index.name),
                 vectorMetadata: schema.vectorIndexes.flatMap((index) =>
                     (index.metadata ?? []).map((property) => {

--- a/packages/nuxt/__tests__/module-worker-guard.test.ts
+++ b/packages/nuxt/__tests__/module-worker-guard.test.ts
@@ -175,4 +175,40 @@ describe("checkWorkerEntry", () => {
 
         expect(warn).not.toHaveBeenCalled();
     });
+
+    it("warns when a STRING LITERAL — not the file — carries the star export", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        // The star-export probe keeps string literals so it can read the
+        // specifier, which is exactly what lets a snippet held in a string pass
+        // for the wiring. A scaffolder that prints the line it wants the user to
+        // add exports no `ShardDO` itself.
+        writeFileSync(
+            join(directory, "worker.ts"),
+            `export const hint = 'add export * from "./lunora/server" to worker.ts';\nexport default { ...nitro, scheduled: (c, e, x) => app.scheduled(c, e, x) };\n`,
+        );
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn.mock.calls[0]?.[0]).toMatch(/does not appear to export `ShardDO`/u);
+    });
+
+    it("is silent when a real star export follows one quoted in a string (every match is considered, not just the first)", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        writeFileSync(
+            join(directory, "worker.ts"),
+            `export const hint = 'add export * from "./lunora/server" to worker.ts';\nexport * from "./lunora/server";\nexport default { ...nitro, scheduled: (c, e, x) => app.scheduled(c, e, x) };\n`,
+        );
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
 });

--- a/packages/nuxt/__tests__/module-worker-guard.test.ts
+++ b/packages/nuxt/__tests__/module-worker-guard.test.ts
@@ -133,19 +133,41 @@ describe("checkWorkerEntry", () => {
         expect(warn.mock.calls[0]?.[0]).toMatch(/could not read worker\.ts/u);
     });
 
-    it("known false positive (documented on looksLikeShardDoExport): a `ShardDO` mention inside a comment, anywhere in a file that also has a real `export`, silences the warning", () => {
+    it("warns when only a COMMENT mentions ShardDO and `scheduled` — the shape the shipped template makes likely", () => {
+        expect.assertions(2);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        // `templates/nuxt/worker.ts` carries a 30-line header explaining that
+        // both the `ShardDO` export and the `scheduled` forwarding are
+        // load-bearing. Delete the lines, keep the header, and a probe over the
+        // raw file reads the explanation as the wiring — silence for a worker
+        // that deploys without its Durable Object and runs no cron.
+        writeFileSync(
+            join(directory, "worker.ts"),
+            `/**\n * Re-exports ShardDO and forwards scheduled — both load-bearing.\n */\nexport { default } from "./.output/server/index.mjs";\n`,
+        );
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn.mock.calls[0]?.[0]).toMatch(/does not appear to export `ShardDO`/u);
+        expect(warn.mock.calls[1]?.[0]).toMatch(/does not forward `scheduled`/u);
+    });
+
+    it('is silent for a `export * from "./lunora/server"` whose specifier survives comment-blanking', () => {
         expect.assertions(1);
 
         directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
-        // The guard checks "has an export keyword" and "mentions ShardDO"
-        // independently, anywhere in the file — it does not verify ShardDO
-        // sits inside an actual export statement. A comment mentioning ShardDO,
-        // in a file that separately exports something else entirely, is
-        // indistinguishable from a real `export { ShardDO }`. This is the
-        // documented imprecision, not a regression; a real TS parse would not
-        // have this gap, which is exactly the tradeoff the pattern's docblock
-        // calls out (a build-time warning hook doesn't warrant one).
-        writeFileSync(join(directory, "worker.ts"), `// TODO: remember to export ShardDO from here\n${COMPOSED_TAIL}`);
+        // The star-export probe reads the SPECIFIER, so it runs over source with
+        // comments blanked and strings intact — blanking strings too would erase
+        // the very thing it matches on.
+        // No `ShardDO` identifier anywhere, so the star-export branch is the
+        // only thing that can clear the check.
+        writeFileSync(
+            join(directory, "worker.ts"),
+            '// the barrel below carries the Durable Object class\nexport * from "./lunora/server";\nexport default { ...nitro, scheduled: (c, e, x) => app.scheduled(c, e, x) };\n',
+        );
 
         const warn = vi.fn<(message: string) => void>();
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -72,6 +72,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { addServerHandler, createResolver, defineNuxtModule, useLogger } from "@nuxt/kit";
 
+import { codeOnly, withoutComments } from "../../../shared/code-only";
 import resolveTildePath from "./resolve-tilde-path";
 
 /** Matches a trailing `.js` extension so it can be swapped for `.ts` (module-scope: compiled once). */
@@ -183,22 +184,30 @@ const SCHEDULED_IDENTIFIER_PATTERN = /\bscheduled\b/u;
  * one combined regex trying to prove `ShardDO` sits INSIDE a specific `export`
  * statement — not a real TS parse (mirrors `@lunora/astro`'s
  * `WITH_LUNORA_CALL_PATTERN`: a documented regex is judged proportionate to a
- * build-time warning hook; ts-morph would be heavier than this hook
- * warrants). Known imprecisions: false-POSITIVE on `export { ShardDO as
- * Other }` (renames `ShardDO` away, so the binding wrangler needs is actually
- * named `Other` — not caught), on a `ShardDO` mention inside a comment
- * anywhere alongside an unrelated `export`, or in principle on `export`ing
- * something else entirely while `ShardDO` is merely imported (not exported)
- * elsewhere in the file. All are accepted trade-offs for a two-line worker
- * entry file, where the realistic failure mode is "forgot the line
- * entirely", not an adversarial one.
+ * build-time warning hook; ts-morph would be heavier than this hook warrants).
+ *
+ * Probed against blanked source, never the raw file, which is the same reason
+ * `@lunora/astro` runs its probe through `codeOnly`. This entry's whole job is
+ * `ShardDO` and `scheduled`, so it is the file most likely to carry a comment
+ * explaining that both lines are load-bearing — the template this module ships
+ * with does, at length — and matching the comment left the warning silent for a
+ * worker that had dropped the export. The star-export probe reads a SPECIFIER,
+ * so it gets {@link withoutComments} instead: string literals must survive.
+ *
+ * Remaining imprecision: false-POSITIVE on `export { ShardDO as Other }`
+ * (renames `ShardDO` away, so the binding wrangler needs is actually named
+ * `Other`), or in principle on `export`ing something else entirely while
+ * `ShardDO` is merely imported. Both are accepted trade-offs for a two-line
+ * worker entry file.
  */
 const looksLikeShardDoExport = (source: string): boolean => {
-    if (!EXPORT_KEYWORD_PATTERN.test(source)) {
+    const code = codeOnly(source);
+
+    if (!EXPORT_KEYWORD_PATTERN.test(code)) {
         return false;
     }
 
-    return SHARD_DO_IDENTIFIER_PATTERN.test(source) || LUNORA_STAR_EXPORT_PATTERN.test(source);
+    return SHARD_DO_IDENTIFIER_PATTERN.test(code) || LUNORA_STAR_EXPORT_PATTERN.test(withoutComments(source));
 };
 
 /**
@@ -252,7 +261,7 @@ export const checkWorkerEntry = (rootDirectory: string, warn: (message: string) 
     // from the same codegen discovery. The trigger exists, Cloudflare fires it,
     // the invocation succeeds, and the cron does nothing. Nothing else in the
     // build says a word about it, which is why it is worth a warning.
-    if (!SCHEDULED_IDENTIFIER_PATTERN.test(source)) {
+    if (!SCHEDULED_IDENTIFIER_PATTERN.test(codeOnly(source))) {
         warn(
             `worker.ts at the project root does not forward \`scheduled\` — re-exporting Nitro's \`default\` gives Cloudflare a \`scheduled\` entrypoint that only fires an empty \`cloudflare:scheduled\` hook, so a cron declared in \`lunora/crons.ts\` is provisioned and then runs nothing. Compose the two instead (\`${WORKER_TS_SNIPPET}\`), which forwards \`queue\` and \`email\` too — Nitro's exports for those fire empty hooks the same way, and a queue consumer that returns without throwing ACKS its batch.`,
         );
@@ -265,7 +274,7 @@ const CREATE_LUNORA_PATTERN = /\bcreateLunora\b/u;
 /** Read `path` and report whether it mentions `createLunora`; an unreadable file simply doesn't count as a provider. */
 const providesLunoraClient = (path: string): boolean => {
     try {
-        return CREATE_LUNORA_PATTERN.test(readFileSync(path, "utf8"));
+        return CREATE_LUNORA_PATTERN.test(codeOnly(readFileSync(path, "utf8")));
     } catch {
         return false;
     }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -165,8 +165,25 @@ const EXPORT_KEYWORD_PATTERN = /\bexport\b/u;
 /** Whether the source mentions the `ShardDO` identifier anywhere at all. */
 const SHARD_DO_IDENTIFIER_PATTERN = /\bShardDO\b/u;
 
-/** `export * from` a specifier containing "lunora" — re-exports everything (including `ShardDO`) from a barrel without naming it, the common case being `export * from "./lunora/server"`. */
-const LUNORA_STAR_EXPORT_PATTERN = /\bexport\s*\*\s*from\s*["'][^"']*lunora[^"']*["']/u;
+/** `export * from` a specifier containing "lunora" — re-exports everything (including `ShardDO`) from a barrel without naming it, the common case being `export * from "./lunora/server"`. Global: every match is checked for being real code, not just the first. */
+const LUNORA_STAR_EXPORT_PATTERN = /\bexport\s*\*\s*from\s*["'][^"']*lunora[^"']*["']/gu;
+
+/**
+ * Whether the entry really re-exports a lunora barrel wholesale.
+ *
+ * The probe has to read a SPECIFIER, so it runs over {@link withoutComments},
+ * which keeps string literals — and a string literal that happens to CONTAIN
+ * `export * from "@lunora/server"` (a docs snippet, a scaffolder template) would
+ * otherwise satisfy it and silence the warning for a worker that exports no
+ * `ShardDO` at all. {@link codeOnly} blanks in place, so offsets line up across
+ * both transforms and the raw source: a match whose first character survives
+ * `codeOnly` unchanged started outside any string.
+ */
+const starExportsLunoraBarrel = (source: string): boolean => {
+    const code = codeOnly(source);
+
+    return [...withoutComments(source).matchAll(LUNORA_STAR_EXPORT_PATTERN)].some(({ index }) => code[index] === source[index]);
+};
 
 /** Whether the entry mentions `scheduled` at all — the cron entrypoint a Nitro re-export silently swallows. */
 const SCHEDULED_IDENTIFIER_PATTERN = /\bscheduled\b/u;
@@ -192,7 +209,8 @@ const SCHEDULED_IDENTIFIER_PATTERN = /\bscheduled\b/u;
  * explaining that both lines are load-bearing — the template this module ships
  * with does, at length — and matching the comment left the warning silent for a
  * worker that had dropped the export. The star-export probe reads a SPECIFIER,
- * so it gets {@link withoutComments} instead: string literals must survive.
+ * so it needs string literals to survive — see {@link starExportsLunoraBarrel},
+ * which keeps them and then rejects a match that sits inside one.
  *
  * Remaining imprecision: false-POSITIVE on `export { ShardDO as Other }`
  * (renames `ShardDO` away, so the binding wrangler needs is actually named
@@ -207,7 +225,7 @@ const looksLikeShardDoExport = (source: string): boolean => {
         return false;
     }
 
-    return SHARD_DO_IDENTIFIER_PATTERN.test(code) || LUNORA_STAR_EXPORT_PATTERN.test(withoutComments(source));
+    return SHARD_DO_IDENTIFIER_PATTERN.test(code) || starExportsLunoraBarrel(source);
 };
 
 /**

--- a/shared/code-only.ts
+++ b/shared/code-only.ts
@@ -1,0 +1,66 @@
+/**
+ * Blank out a source file's comments and string literals, so an
+ * identifier-or-call probe over the result sees code and only code.
+ *
+ * A scan rather than a parser: its callers are build-time integration hooks with
+ * no parser dependency, and the question is only "does this name appear
+ * somewhere that executes". Matching the raw file instead is how a name written
+ * in a COMMENT came to satisfy a check — and the file explaining why a line is
+ * load-bearing is the same file whose comment then hides that the line is gone.
+ *
+ * Spans are replaced with spaces rather than deleted, so nothing that was
+ * separated becomes adjacent, and line structure survives.
+ *
+ * Known ceiling: a template literal that BOTH interpolates and mentions the name
+ * in its string part still reads as code. Narrowing that needs real parsing.
+ */
+
+/** `/* … *\/`, non-greedy so it ends at the FIRST `*\/`. */
+const BLOCK_COMMENT = String.raw`\/\*[\s\S]*?\*\/`;
+/** `// …` to end of line. */
+const LINE_COMMENT = String.raw`\/\/[^\n]*`;
+/** `"…"`, honouring backslash escapes and never crossing a newline. */
+const DOUBLE_QUOTED = String.raw`"(?:[^"\\\n]|\\.)*"`;
+/** `'…'`, the same rules as {@link DOUBLE_QUOTED}. */
+const SINGLE_QUOTED = String.raw`'(?:[^'\\\n]|\\.)*'`;
+
+/**
+ * A template literal with NO `${…}` in it (that is what the `\$(?!\{)` guard
+ * costs). One that interpolates is deliberately left alone: its interpolations
+ * are real code, and blanking the whole literal would hide a call written inside
+ * one.
+ *
+ * The delimiter is written `\x60` rather than an escaped backtick because
+ * `String.raw` would keep that backslash, and `\`` is not a legal escape in a
+ * unicode-mode pattern.
+ */
+const PLAIN_TEMPLATE = String.raw`\x60(?:[^\x60\\$]|\\.|\$(?!\{))*\x60`;
+
+/**
+ * Comments and string literals, matched left to right in ONE alternation so
+ * whichever construct OPENS first wins: a quote inside a comment is part of that
+ * comment, and a `//` inside a string is part of that string. That ordering is
+ * the whole trick — it is what a hand-rolled mode machine buys you, without the
+ * machine. Assembled from the named parts above rather than written as one
+ * literal, because as a literal it is unreadable.
+ */
+const SKIPPABLE_RE = new RegExp([BLOCK_COMMENT, LINE_COMMENT, DOUBLE_QUOTED, SINGLE_QUOTED, PLAIN_TEMPLATE].join("|"), "gu");
+
+/** Every character except a newline — line structure survives when a span is blanked. */
+const NON_NEWLINE_RE = /[^\n]/gu;
+
+const blanked = (span: string): string => span.replaceAll(NON_NEWLINE_RE, " ");
+
+const codeOnly = (source: string): string => source.replaceAll(SKIPPABLE_RE, blanked);
+
+/**
+ * Comments blanked, string literals kept — for a probe that has to read a
+ * specifier (`export * from "…/lunora/…"`), which {@link codeOnly} erases.
+ *
+ * Runs the same alternation so the same "whichever opens first wins" ordering
+ * applies: a `//` inside `"https://…"` belongs to the string and survives.
+ */
+const withoutComments = (source: string): string =>
+    source.replaceAll(SKIPPABLE_RE, (span) => (span.startsWith("//") || span.startsWith("/*") ? blanked(span) : span));
+
+export { codeOnly, withoutComments };

--- a/shared/code-only.ts
+++ b/shared/code-only.ts
@@ -11,8 +11,15 @@
  * Spans are replaced with spaces rather than deleted, so nothing that was
  * separated becomes adjacent, and line structure survives.
  *
- * Known ceiling: a template literal that BOTH interpolates and mentions the name
- * in its string part still reads as code. Narrowing that needs real parsing.
+ * Known ceilings. Narrowing either needs real parsing:
+ *
+ * - A template literal that BOTH interpolates and mentions the name in its
+ *   string part still reads as code, so a probe sees a marker that never runs —
+ *   the one direction that is SILENT, since a check clears on it.
+ * - A quote this scan cannot see as part of a literal opens a string match that
+ *   swallows real code up to the next quote: a regex literal (`/["']/u`), or JSX
+ *   text carrying an apostrophe. A probe then sees LESS than the file has, so a
+ *   check warns about wiring that is present — noisy, not silent.
  */
 
 /** `/* … *\/`, non-greedy so it ends at the FIRST `*\/`. */


### PR DESCRIPTION
Closes #674.

A build-time gate that reads its marker out of the raw file counts a **comment** as
the thing it is looking for. #674 reported it on the `.vectors()` check; the same
shape turned up in three more places, so all four are here — plus the two sibling
requirements the `.vectors()` gate turned out to have.

### `.vectors()` — the reported one

`readMarker` cleared the check on `source.includes(".vectors(")`. The correlation runs
the wrong way: the file that chains `.vectors()` is the likeliest one to also carry a
comment saying the chain is load-bearing, so "delete the call, keep the warning about
deleting the call" disarmed the gate on exactly the tree it exists to catch — one
where `ctx.vectors` is a throwing stub and every request, `/_lunora/health` included,
500s.

Both markers are parsed calls now. Text matching survives only as a prefilter deciding
which files are worth a parse, and a file that mentions the chain but does not parse
still counts as binding — that half fails open.

### The three siblings

- **`patchViteConfig`** matched `/\blunora\s*\(/` anywhere in the config. A
  commented-out plugin line, or a note about one, made `lunora init` report *"lunora
  plugin already present"* and write nothing — handing the project a dev server with
  no Lunora plugin in it. Now a parsed call expression; the import probe is a parsed
  module specifier too, which drops the hand-rolled quote-style pair.
- **`@lunora/nuxt`'s `checkWorkerEntry`** probed `ShardDO` and `scheduled` as bare
  identifiers. `templates/nuxt/worker.ts` ships a 30-line header explaining that both
  lines are load-bearing, so deleting them and keeping the header silenced the warning
  for a worker that deploys without its Durable Object and runs no cron.
- **The same package's client-provider probe**, for the same reason.

`@lunora/astro` already blanked comments and strings before probing. That helper moves
to `shared/code-only.ts` and both packages use it. The star-export probe reads a
SPECIFIER, so it keeps string literals and then rejects a match that sits inside one —
`codeOnly` and `withoutComments` blank in place, so a match whose first byte survives
`codeOnly` unchanged started outside a string.

### The gate had two siblings, not zero

`.vectors()` was one of three requirements a schema declaration places on the app
composition, and only it was checked. A schema declaring `.global()` tables needs
`.global(...)` chained; a `.global({ backend: "hyperdrive" })` schema needs
`.hyperdriveGlobal(...)`. Without either the shard gets no global writer and every
read or write of a global table throws `INTERNAL` ("requires a globalDb writer") —
while `lunora build`, `verify` and `tsc` all pass first, and the wrangler check next
to it proves the `DB` **binding** exists, which is the half a project usually gets
right.

`findUnchainedVectorsSite` becomes `scanAppChains(root, methods)`, and the caller
turns the result into one error per unmet requirement.

`.global()` names two different builders — the app's and a table's
(`defineTable({…}).global()`, which is what MAKES the schema declare a global table).
Every project the check can fire on therefore contains the table form, so the
chain-root guard is what keeps the schema from clearing the gate on itself. It reads
the file's LOCAL names for the factory, the same way the `defineApp` probe does:
keyed on the bare identifier, `import { defineTable as table }` hid the table form and
the gate cleared on the schema itself.

### Hyperdrive-backed globals are a different backend, not a flavour

`SchemaInfo.hasGlobalTable` splits into `hasD1GlobalTable` and
`hasHyperdriveGlobalTable`. A `.global({ backend: "hyperdrive" })` table lives on
Postgres/MySQL behind a Hyperdrive binding and needs no D1 database, so the old single
flag demanded a `DB` binding — and provisioned a database — for a project that has
neither.

Dropping that demand left those tables with **no** config check at all, so the
Hyperdrive half is now checked too. Unlike D1 it cannot name the binding:
`.global({ d1 })` is reconciled by the dev server onto a fixed `DB`, while
`.hyperdriveGlobal({ exec })` builds the driver from whatever the user's own selector
reads. Naming one would false-error a project that called it something else, so the
static fact is only that SOME `hyperdrive` binding exists — with none, `env.<BINDING>`
is `undefined` at the first global read and throws inside the user's `exec`, past
every build-time gate.

The `.hyperdriveGlobal(...)` remediation names the shape
`HyperdriveGlobalDeclaration` actually takes (`engine` + `exec`), not a `hyperdrive:`
selector that does not exist on the builder. A blocking error whose suggested fix does
not compile costs the user the same round trip the error was meant to save — the same
class as bc9efcdb2 on this branch — so a test pins the string.

### One predicate, not five

`isD1GlobalTable` / `isHyperdriveGlobalTable` move to `@lunora/codegen`, which owns
`TableIR`. The predicate had five byte-identical copies across codegen, the CLI and
config, and its D1 side reads `!== "hyperdrive"` only because discovery normalises the
absent case to `"d1"` — a detail none of the call sites referenced.

### Tests

Each new test was run against the unfixed code first and fails there.

The nuxt suite already asserted the comment false-positive as known behaviour, but its
fixture also carried a real `export { ShardDO }`, so it passed on the export and
proved nothing. Replaced with the failing shape, plus an isolated star-export case (no
`ShardDO` anywhere) that no previous fixture exercised.

`shared/code-only.ts` gets the direct test it never had — the "whichever construct
opens first wins" ordering, both documented ceilings, and the length-preservation
invariant the nuxt star-export probe depends on.

### Not changed

`registry/reconcile.ts` matches `createShardDO(` and an existing re-export line as
text. Same shape, but both failure directions are loud — wrangler refuses to bundle a
missing DO export, and a duplicated `export * from` is a syntax error — and the file
is not parsed at all today.

### Breaking

Pre-release branch, so no compatibility shims:

- `SchemaInfo.hasGlobalTable` → `hasD1GlobalTable`, with `hasHyperdriveGlobalTable`
  required alongside it (the only producer always knows the answer).
- `findUnchainedVectorsSite` → `scanAppChains`.

### Scope note

`@lunora/vite`'s wrangler-validator plugin throws on any reported problem at
`configResolved`, so these errors also refuse to start `lunora dev`, not just
`deploy`. Vector indexes are rare; `.global()` tables are the common case, and unlike
the `DB` binding validated next to it, Lunora cannot write the `.global(...)` chain
into the user's `src/server.ts` for them. That is the intended trade — the alternative
is a dev server whose every global read throws `INTERNAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
