### PR TITLE
feat(config,cli): flag a missing CPU cap and R2 lifecycle rule

### DIFF
--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -1903,6 +1903,9 @@ interface WranglerConfig {
         binding?: string;
         id?: string;
     } | null | undefined>;
+    limits?: {
+        cpu_ms?: number;
+    };
     logpush?: boolean;
     main?: string;
     migrations?: ReadonlyArray<{
@@ -1924,6 +1927,7 @@ interface WranglerConfig {
         logs?: {
             enabled?: boolean;
             head_sampling_rate?: number;
+            invocation_logs?: boolean;
         };
     };
     pipelines?: ReadonlyArray<{

--- a/packages/cli/__tests__/commands/doctor.test.ts
+++ b/packages/cli/__tests__/commands/doctor.test.ts
@@ -133,6 +133,67 @@ describe("runDoctor", () => {
         expect(result.findings.some((finding) => finding.level === "warn")).toBe(false);
     });
 
+    describe("blast-radius guardrails", () => {
+        it("prompts for a CPU cap when none is set, without failing the run", async () => {
+            expect.assertions(3);
+
+            seed(workdir, CLEAN_WRANGLER);
+
+            const result = await runDoctor({ cwd: workdir, logger: makeLogger().logger });
+            const finding = result.findings.find((entry) => entry.code === "cpu-limit-missing");
+
+            expect(finding?.level).toBe("info");
+            expect(finding?.fix).toContain("cpu_ms");
+            // A guardrail prompt must not turn a healthy project red.
+            expect(result.code).toBe(0);
+        });
+
+        it("stays quiet once a CPU cap is configured", async () => {
+            expect.assertions(1);
+
+            seed(
+                workdir,
+                JSON.stringify({
+                    compatibility_date: "2026-04-07",
+                    d1_databases: [{ binding: "DB", database_id: "11111111-2222-3333-4444-555555555555" }],
+                    durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+                    limits: { cpu_ms: 30_000 },
+                    name: "demo",
+                }),
+            );
+
+            const result = await runDoctor({ cwd: workdir, logger: makeLogger().logger });
+
+            expect(result.findings.some((entry) => entry.code === "cpu-limit-missing")).toBe(false);
+        });
+
+        it("names R2 buckets whose lifecycle rules should be checked, and stays silent without one", async () => {
+            expect.assertions(3);
+
+            seed(
+                workdir,
+                JSON.stringify({
+                    compatibility_date: "2026-04-07",
+                    durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+                    name: "demo",
+                    r2_buckets: [{ binding: "UPLOADS", bucket_name: "demo-uploads" }],
+                }),
+            );
+
+            const withBucket = await runDoctor({ cwd: workdir, logger: makeLogger().logger });
+            const finding = withBucket.findings.find((entry) => entry.code === "r2-lifecycle-unset");
+
+            expect(finding?.message).toContain("demo-uploads");
+            expect(finding?.fix).toContain("lifecycle");
+
+            seed(workdir, CLEAN_WRANGLER);
+
+            const withoutBucket = await runDoctor({ cwd: workdir, logger: makeLogger().logger });
+
+            expect(withoutBucket.findings.some((entry) => entry.code === "r2-lifecycle-unset")).toBe(false);
+        });
+    });
+
     /**
      * The one check whose absence is invisible in production. Cloudflare only
      * filters on a Vectorize metadata property that has an explicit metadata

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -262,12 +262,14 @@ prose is not. New codes are added over time; treat an unknown one as advisory.
 | `admin-token-missing`            | info  | `LUNORA_ADMIN_TOKEN` is not set (studio / admin RPCs stay disabled).                |
 | `admin-token-set`                | pass  | `LUNORA_ADMIN_TOKEN` is set.                                                        |
 | `cli-shadowed`                   | warn  | The running `lunora` is not the project's own install.                              |
+| `cpu-limit-missing`              | info  | No `limits.cpu_ms` caps a runaway handler's CPU burn.                               |
 | `d1-placeholder-id`              | fail  | A D1 binding still carries a scaffold `database_id`.                                |
 | `declared-export-missing`        | fail  | A declared container / workflow / agent is not exported by the worker entry.        |
 | `declared-export-ok`             | pass  | A declared container / workflow / agent is exported by the worker entry.            |
 | `declared-export-unchecked`      | warn  | Binding inference failed, so the worker-entry export check could not run.           |
 | `dev-vars-missing-secret`        | warn  | `.dev.vars` has secret-looking keys left at placeholder values.                     |
 | `email-destination-placeholder`  | warn  | A `send_email` binding has a placeholder `destination_address`.                     |
+| `r2-lifecycle-unset`             | info  | An R2 bucket may lack an abort-incomplete-multipart lifecycle rule.                 |
 | `scheduler-origin-missing`       | warn  | A `SchedulerDO` is declared but `LUNORA_ORIGIN_URL` is missing from wrangler.       |
 | `schema-unreadable`              | fail  | `lunora/schema.ts` could not be parsed, so schema-derived checks were skipped.      |
 | `stale-lunora-json`              | warn  | `lunora.config.*` is present but no longer read (`lunora.config.*` replaced it).    |

--- a/packages/cli/src/commands/doctor/handler.ts
+++ b/packages/cli/src/commands/doctor/handler.ts
@@ -31,12 +31,14 @@ const DOCTOR_CODES = [
     "admin-token-missing",
     "admin-token-set",
     "cli-shadowed",
+    "cpu-limit-missing",
     "d1-placeholder-id",
     "declared-export-missing",
     "declared-export-ok",
     "declared-export-unchecked",
     "dev-vars-missing-secret",
     "email-destination-placeholder",
+    "r2-lifecycle-unset",
     "scheduler-origin-missing",
     "schema-unreadable",
     "stale-lunora-json",
@@ -229,6 +231,56 @@ const checkStaleProjectConfig = (cwd: string, findings: Finding[]): void => {
         fix: 'Move `target` / `remote` into `lunora.config.ts` (`export default { target: "…" }`), then delete lunora.json.',
         level: "warn",
         message: "lunora.json is present but no longer read — lunora.config.* replaced it, so any `target` or `remote` in it is being ignored.",
+    });
+};
+
+/**
+ * No `limits.cpu_ms` in the wrangler config → INFO.
+ *
+ * Alerting is lagging by definition: by the time a threshold trips, the runaway
+ * handler or retry storm has already run. A CPU cap is one of the few controls
+ * that bounds the blast radius rather than reporting on it after the fact, and
+ * it costs nothing to set. INFO rather than WARN because the platform default
+ * is a real (if generous) limit, so this is a tightening, not a missing
+ * requirement.
+ */
+const checkCpuLimit = (parsed: WranglerConfig | undefined, findings: Finding[]): void => {
+    if (parsed === undefined || parsed.limits?.cpu_ms !== undefined) {
+        return;
+    }
+
+    findings.push({
+        code: "cpu-limit-missing",
+        fix: 'Add `"limits": { "cpu_ms": 30000 }` to wrangler.jsonc, tuned to your slowest legitimate handler.',
+        level: "info",
+        message: "no limits.cpu_ms is set — a runaway handler can burn CPU up to the platform default before anything stops it.",
+    });
+};
+
+/**
+ * An R2 bucket with no lifecycle rule → INFO, once per config.
+ *
+ * Orphaned incomplete multipart uploads are a classic silent storage cost: they
+ * are billed, they never appear as objects a listing would show, and nothing
+ * surfaces them until the invoice does. Lifecycle rules are the fix, and they
+ * live in Cloudflare (dashboard/API), not in wrangler config — so this can only
+ * ever be a prompt to go check, which is why it names the command instead of
+ * asserting a config shape.
+ */
+const checkR2Lifecycle = (parsed: WranglerConfig | undefined, findings: Finding[]): void => {
+    // `r2_buckets` entries are typed nullable — the validator parses user JSON
+    // defensively, so a hand-edited config can carry a hole in the array.
+    const names = (parsed?.r2_buckets ?? []).map((entry) => entry?.bucket_name).filter((name): name is string => typeof name === "string" && name.length > 0);
+
+    if (names.length === 0) {
+        return;
+    }
+
+    findings.push({
+        code: "r2-lifecycle-unset",
+        fix: "wrangler r2 bucket lifecycle list <bucket> — add an abort-incomplete-multipart rule if none exists.",
+        level: "info",
+        message: `R2 bucket(s) ${names.join(", ")}: verify a lifecycle rule aborts incomplete multipart uploads — orphaned parts are billed but invisible in a listing.`,
     });
 };
 
@@ -657,6 +709,8 @@ const runDoctor = async (options: RunDoctorOptions): Promise<DoctorResult> => {
     checkWrangler(cwd, parsed, path, findings);
     checkD1Placeholders(parsed, findings);
     checkEmailDestination(parsed, findings);
+    checkCpuLimit(parsed, findings);
+    checkR2Lifecycle(parsed, findings);
     checkDevVariables(cwd, findings);
     checkAdminToken(cwd, findings);
     checkVersionSkew(cwd, findings);

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -2427,6 +2427,57 @@ export const schema = defineSchema({
         });
     });
 
+    describe("limits.cpu_ms", () => {
+        const withLimits = (limits: unknown): WranglerConfig => ({ compatibility_date: REQUIRED_COMPATIBILITY_DATE, limits }) as WranglerConfig;
+
+        it("accepts a positive integer cap", () => {
+            expect.assertions(1);
+
+            expect(validateWranglerConfig(withLimits({ cpu_ms: 30_000 })).errors.join(" ")).not.toContain("cpu_ms");
+        });
+
+        it("rejects a non-positive or fractional cap", () => {
+            expect.assertions(3);
+
+            for (const value of [0, -1, 1.5]) {
+                expect(validateWranglerConfig(withLimits({ cpu_ms: value })).errors.join(" ")).toContain("limits.cpu_ms must be a positive integer");
+            }
+        });
+
+        it("rejects a cap above Cloudflare's ceiling, which would fail at deploy", () => {
+            expect.assertions(1);
+
+            expect(validateWranglerConfig(withLimits({ cpu_ms: 300_001 })).errors.join(" ")).toContain("at most 300000");
+        });
+
+        it("rejects a non-object limits block", () => {
+            expect.assertions(1);
+
+            expect(validateWranglerConfig(withLimits(30_000)).errors.join(" ")).toContain("limits must be an object");
+        });
+    });
+
+    describe("observability.logs.invocation_logs", () => {
+        const withLogs = (logs: unknown): WranglerConfig =>
+            ({ compatibility_date: REQUIRED_COMPATIBILITY_DATE, observability: { enabled: true, logs } }) as WranglerConfig;
+
+        it("accepts the boolean that keeps per-invocation summaries", () => {
+            expect.assertions(1);
+
+            const report = validateWranglerConfig(withLogs({ invocation_logs: true }));
+
+            expect(report.errors.join(" ")).not.toContain("invocation_logs");
+        });
+
+        it("rejects a non-boolean, which wrangler would otherwise ignore silently", () => {
+            expect.assertions(1);
+
+            const report = validateWranglerConfig(withLogs({ invocation_logs: "true" }));
+
+            expect(report.errors.join(" ")).toContain("observability.logs.invocation_logs must be a boolean");
+        });
+    });
+
     describe("containers", () => {
         const baseConfig = (overrides: Partial<WranglerConfig>): WranglerConfig => {
             return {

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -140,6 +140,10 @@ interface WranglerConfig {
     // Workers KV namespaces. The namespace `id` is a remote resource Lunora
     // can't mint — warn, don't fail. See `validateKvNamespaces`.
     kv_namespaces?: ReadonlyArray<{ binding?: string; id?: string } | null | undefined>;
+    // Per-Worker runtime caps. `cpu_ms` bounds the blast radius of a runaway
+    // handler — detection is lagging by definition, so the cap is what actually
+    // limits the bill while an alert is still being written. See `validateLimits`.
+    limits?: { cpu_ms?: number };
     // Cloudflare Logpush toggle (jobs are created out-of-band via dashboard/API).
     logpush?: boolean;
     // The worker entry, relative to the config file. Read to check that every
@@ -164,7 +168,11 @@ interface WranglerConfig {
     // outbound fetch). Cert material lives in Cloudflare, referenced by id. See
     // `validateMtlsCertificates`.
     mtls_certificates?: ReadonlyArray<{ binding?: string; certificate_id?: string } | null | undefined>;
-    observability?: { enabled?: boolean; head_sampling_rate?: number; logs?: { enabled?: boolean; head_sampling_rate?: number } };
+    observability?: {
+        enabled?: boolean;
+        head_sampling_rate?: number;
+        logs?: { enabled?: boolean; head_sampling_rate?: number; invocation_logs?: boolean };
+    };
     // Pipelines (R2-backed streaming ingestion). The `pipeline` name is a remote
     // resource (`wrangler pipelines create`) Lunora can't mint — warn, don't
     // fail. See `validatePipelineBindings`.
@@ -181,7 +189,11 @@ interface WranglerConfig {
     };
     // Structural only (`validateR2Buckets`): a declared bucket needs a
     // `bucket_name` — the remote bucket itself (`wrangler r2 bucket create`) is
-    // out of scope for a pure validator.
+    // out of scope for a pure validator. `bucket_name` is the remote bucket the
+    // binding points at, projected here (wrangler has always required it) so a
+    // consumer can name the real bucket in a diagnostic instead of the binding
+    // alias. Entries stay nullable: the shared array validator reports a
+    // non-object entry itself, so narrowing here would only move the failure.
     r2_buckets?: ReadonlyArray<{ binding?: string; bucket_name?: string } | null | undefined>;
     // Cloudflare Secrets Store bindings (`env.<BINDING>.get()`). Each references a
     // remote store + secret by name (created out-of-band); `validateSecretsStore`
@@ -1024,6 +1036,49 @@ const validateLogpush = (wrangler: WranglerConfig, errors: string[]): void => {
     }
 };
 
+/** Cloudflare's own ceiling on `limits.cpu_ms`; a value above it is rejected at deploy rather than clamped. */
+const MAX_CPU_MS = 300_000;
+
+/**
+ * `limits` bounds a Worker's runtime consumption — today just `cpu_ms`.
+ *
+ * Worth validating rather than ignoring because it is a GUARDRAIL, and a
+ * guardrail that silently isn't applied is worse than none: alerting is lagging
+ * by definition, so the cap is what actually bounds the blast radius of a
+ * runaway handler or a retry storm while a human is still reading the alert. A
+ * mistyped `cpu_ms` (or a `limits` block wrangler drops) leaves the deployment
+ * uncapped while the config reads as though it isn't.
+ */
+const validateLimits = (wrangler: WranglerConfig, errors: string[]): void => {
+    const { limits } = wrangler;
+
+    if (limits === undefined) {
+        return;
+    }
+
+    if (typeof limits !== "object" || Array.isArray(limits)) {
+        errors.push('limits must be an object (e.g. { "cpu_ms": 30000 })');
+
+        return;
+    }
+
+    const cpuMs = limits.cpu_ms;
+
+    if (cpuMs === undefined) {
+        return;
+    }
+
+    if (typeof cpuMs !== "number" || !Number.isFinite(cpuMs) || !Number.isInteger(cpuMs) || cpuMs <= 0) {
+        errors.push("limits.cpu_ms must be a positive integer number of milliseconds");
+
+        return;
+    }
+
+    if (cpuMs > MAX_CPU_MS) {
+        errors.push(`limits.cpu_ms must be at most ${String(MAX_CPU_MS)} (Cloudflare's per-invocation ceiling)`);
+    }
+};
+
 /**
  * The `placement.mode` values wrangler's own config schema accepts:
  * `"smart"` opts into Smart Placement, `"targeted"` pins the Worker to a
@@ -1093,6 +1148,14 @@ const validateObservability = (wrangler: WranglerConfig, errors: string[]): void
             errors.push("observability.logs must be an object");
         } else {
             checkSamplingRate(observability.logs.head_sampling_rate, "observability.logs.head_sampling_rate");
+
+            // `invocation_logs` is the per-invocation summary line (status,
+            // duration, outcome) that the Workers Logs Query Builder groups on.
+            // Shape-checked rather than required: wrangler silently ignores a
+            // mistyped key, which is exactly the failure this catches.
+            if (observability.logs.invocation_logs !== undefined && typeof observability.logs.invocation_logs !== "boolean") {
+                errors.push('observability.logs.invocation_logs must be a boolean (set "invocation_logs": true to keep per-invocation summaries)');
+            }
         }
     }
 };
@@ -1454,6 +1517,7 @@ const validateWranglerConfig = (wranglerInput: WranglerConfig | undefined, schem
 
     validateSendEmail(wrangler, errors, warnings);
     validateLogpush(wrangler, errors);
+    validateLimits(wrangler, errors);
     validatePlacement(wrangler, errors);
     validateObservability(wrangler, errors);
     validateAssets(wrangler, errors);

--- a/templates/analog/wrangler.jsonc
+++ b/templates/analog/wrangler.jsonc
@@ -25,5 +25,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/astro/wrangler.jsonc
+++ b/templates/astro/wrangler.jsonc
@@ -26,5 +26,14 @@
     // the class-A Vite binding reconciler), so the template ships this explicitly —
     // matching the sveltekit/nuxt class-B templates.
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/expo/wrangler.jsonc
+++ b/templates/expo/wrangler.jsonc
@@ -13,7 +13,16 @@
         { "binding": "DB", "database_name": "{{name}}", "database_id": "REPLACE_WITH_D1_ID" },
     ],
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
     // `AUTH_SECRET` is a secret: `.dev.vars` locally (see `.dev.vars.example`),
     // `wrangler secret put AUTH_SECRET` in production.
     //

--- a/templates/next/wrangler.jsonc
+++ b/templates/next/wrangler.jsonc
@@ -25,5 +25,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/nuxt/wrangler.jsonc
+++ b/templates/nuxt/wrangler.jsonc
@@ -25,5 +25,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/react-router/wrangler.jsonc
+++ b/templates/react-router/wrangler.jsonc
@@ -8,5 +8,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/standalone/wrangler.jsonc
+++ b/templates/standalone/wrangler.jsonc
@@ -8,5 +8,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/sveltekit/wrangler.jsonc
+++ b/templates/sveltekit/wrangler.jsonc
@@ -30,5 +30,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/tanstack-start-react/wrangler.jsonc
+++ b/templates/tanstack-start-react/wrangler.jsonc
@@ -8,5 +8,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/tanstack-start-solid/wrangler.jsonc
+++ b/templates/tanstack-start-solid/wrangler.jsonc
@@ -8,5 +8,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/vinext-pages/wrangler.jsonc
+++ b/templates/vinext-pages/wrangler.jsonc
@@ -24,5 +24,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }

--- a/templates/vinext/wrangler.jsonc
+++ b/templates/vinext/wrangler.jsonc
@@ -24,5 +24,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }


### PR DESCRIPTION
Two blast-radius gaps a scaffold shipped with and nothing reported.

`cpu-limit-missing`: no `limits.cpu_ms`, so a runaway handler burns until the
platform stops it. Alerting is lagging by definition — by the time a threshold
trips the handler has already run — which makes a CPU ceiling one of the few
controls that bounds the damage rather than reporting it.

`r2-lifecycle-unset`: an R2 bucket with no abort-incomplete-multipart rule
accrues parts nobody can see and everybody pays for.

Both are `doctor` findings rather than hard failures, and every `lunora init`
template now ships the ceiling plus `observability.logs.invocation_logs` and the
`version_metadata` binding, so a fresh scaffold is production-shaped by
default.

## Linked issues

<!-- none -->

## Notes

Split out of #85 — this change has **no dependency on `apps/cloud`**; the cloud PR simply consumed it. Verified standalone on `alpha`: package tests, `lint:types`, `lint:eslint` and `api:check` all pass with only the files in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
