### PR TITLE
feat(cli): add dev --inspector-port

### DIFF
--- a/api-snapshots/cli.api.md
+++ b/api-snapshots/cli.api.md
@@ -193,6 +193,7 @@ interface DevCommandOptions {
     findFreePort?: (preferred: number) => Promise<number>;
     flavor?: DevFlavor;
     hasIpv6Loopback?: () => boolean;
+    inspectorPort?: number;
     jsonLogs?: boolean;
     logger: Logger;
     materializeRemote?: typeof materializeRemoteWranglerConfig;

--- a/apps/docs/src/content/docs/concepts/monorepos-and-iac.mdx
+++ b/apps/docs/src/content/docs/concepts/monorepos-and-iac.mdx
@@ -42,6 +42,32 @@ worker and Lunora keeps regenerating types and serving Studio:
 `--worker-port` still matters with `--no-worker`: Studio and the printed hints
 need to know where the externally-owned worker is listening.
 
+### Pin the inspector port too
+
+A repo running several Workers side by side has to pin both ports `wrangler dev`
+takes, not just the worker one. The devtools inspector starts at 9229 and climbs
+while ports are busy, so the Lunora worker's inspector walks straight into the
+port a sibling worker pinned — and the one that dies is whichever bound second,
+so the failure moves between runs and names a port that appears in no config
+you can grep.
+
+```jsonc
+// package.json — every worker owns both of its ports
+{
+    "scripts": {
+        "dev": "run-p dev:worker dev:lunora",
+        "dev:worker": "wrangler dev --port 8788 --inspector-port 9230",
+        "dev:lunora": "lunora dev --worker-port 8789 --inspector-port 9231",
+    },
+}
+```
+
+`--inspector-port` mirrors `--worker-port`: the flag wins, then
+`dev.inspector_port` in the project's `wrangler.jsonc`, and with neither set
+wrangler keeps its own default and walks. It applies to the `wrangler dev`
+spawn, so on the Vite flavors pass the port through the plugin instead
+(`lunora({ cloudflare: { inspectorPort: 9231 } })`).
+
 ### Telling the supervisor what to provide
 
 A task runner starting seven Workers needs two things from Lunora before it can

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -322,6 +322,38 @@ describe("lunora dev lifecycle", () => {
             expect(args?.[(args.indexOf("--target") ?? 0) + 1]).toBe("aws");
         });
 
+        it("forwards --inspector-port to the daemon, and omits it when unset", async () => {
+            expect.assertions(3);
+
+            const seen: ReadonlyArray<string>[] = [];
+
+            const run = (options: { command: { args: ReadonlyArray<string> } }): Promise<{ code: number }> => {
+                seen.push(options.command.args);
+
+                return Promise.resolve({ code: 0 });
+            };
+
+            await startBackground({
+                cwd: workdir,
+                jsonLogs: false,
+                logger: recordingLogger().logger,
+                options: { inspectorPort: 9235 } as DevOptions,
+                remote: false,
+                run,
+            });
+
+            clearDevServerState(workdir, process.pid);
+
+            await startBackground({ cwd: workdir, jsonLogs: false, logger: recordingLogger().logger, options: {} as DevOptions, remote: false, run });
+
+            // The daemon re-parses argv, so the flag has to be spelled out here —
+            // `--background` is the automatic path for an AI agent, which makes
+            // this the default way the pinned inspector port gets lost.
+            expect(seen[0]).toContain("--inspector-port");
+            expect(seen[0]?.[(seen[0]?.indexOf("--inspector-port") ?? 0) + 1]).toBe("9235");
+            expect(seen[1]).not.toContain("--inspector-port");
+        });
+
         it("forwards --no-codegen to the vite child as LUNORA_CODEGEN=0", async () => {
             expect.assertions(2);
 

--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -6,7 +6,15 @@ import { readDevServerState, writeDevServerState } from "@lunora/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DevCommandOptions } from "../../src/commands/dev/handler";
-import { defaultWorkerSpawner, detectDevFlavor, negatableDevFlags, planDevCommand, resolveWorkerPort, runDevCommand } from "../../src/commands/dev/handler";
+import {
+    defaultWorkerSpawner,
+    detectDevFlavor,
+    negatableDevFlags,
+    planDevCommand,
+    resolveInspectorPort,
+    resolveWorkerPort,
+    runDevCommand,
+} from "../../src/commands/dev/handler";
 import type { Logger } from "../../src/util/logger";
 
 const silentLogger = (): Logger => {
@@ -160,6 +168,42 @@ describe("lunora dev", () => {
             expect(plan.wrangler.args).toContain("9999");
             expect(plan.workerOrigin).toBe("http://localhost:9999");
             expect(plan.studioPort).toBe(7000);
+        });
+
+        it("routes a resolved inspector port into wrangler --inspector-port", () => {
+            expect.assertions(2);
+
+            const plan = planDevCommand({ cwd: workdir, inspectorPort: 9235, logger: silentLogger() });
+
+            expect(plan.wrangler.args.join(" ")).toContain("--inspector-port 9235");
+            // Still on the same `wrangler dev` invocation as the worker port.
+            expect(plan.wrangler.args.join(" ")).toContain("wrangler dev --port");
+        });
+
+        it("leaves --inspector-port out of the argv when nothing resolved one", () => {
+            expect.assertions(1);
+
+            // Wrangler's own 9229-and-upward probe stays in charge for every
+            // project that pinned nothing — forcing a default here would take a
+            // port away from whatever already holds it.
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.wrangler.args).not.toContain("--inspector-port");
+        });
+
+        it("refuses --inspector-port on the vite flavor and names the knob that works there", () => {
+            expect.assertions(2);
+
+            // `wrangler dev` is never spawned on this flavor, so the flag has no
+            // argv to reach: say where the port is set instead of dropping it.
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ devDependencies: { "@lunora/vite": "^1.0.0" } }), "utf8");
+
+            const messages: string[] = [];
+            const logger = { ...silentLogger(), warn: (message: string) => messages.push(message) };
+            const plan = planDevCommand({ cwd: workdir, inspectorPort: 9235, logger });
+
+            expect(plan.wrangler.args).not.toContain("--inspector-port");
+            expect(messages.join(" ")).toContain("cloudflare: { inspectorPort: 9235 }");
         });
 
         it("pins the worker to 127.0.0.1 when the host has no IPv6 loopback", () => {
@@ -520,6 +564,43 @@ describe("lunora dev", () => {
         });
     });
 
+    describe("resolveInspectorPort", () => {
+        it("uses an explicit inspector port", () => {
+            expect.assertions(1);
+
+            expect(resolveInspectorPort({ inspectorPort: 9235, logger: silentLogger() }, workdir)).toBe(9235);
+        });
+
+        it("falls back to `dev.inspector_port` in the wrangler config", () => {
+            expect.assertions(1);
+
+            writeFileSync(join(workdir, "wrangler.jsonc"), JSON.stringify({ dev: { inspector_port: 9240 }, name: "app" }), "utf8");
+
+            expect(resolveInspectorPort({ logger: silentLogger() }, workdir)).toBe(9240);
+        });
+
+        it("lets an explicit --inspector-port win over the wrangler config", () => {
+            expect.assertions(1);
+
+            // Same precedence as `--worker-port` over `dev.port` — the whole
+            // point of the flag is that it beats the file, not the reverse.
+            writeFileSync(join(workdir, "wrangler.jsonc"), JSON.stringify({ dev: { inspector_port: 9240 }, name: "app" }), "utf8");
+
+            expect(resolveInspectorPort({ inspectorPort: 9235, logger: silentLogger() }, workdir)).toBe(9235);
+        });
+
+        it("resolves nothing when neither the flag nor the config names a port", () => {
+            expect.assertions(2);
+
+            writeFileSync(join(workdir, "wrangler.jsonc"), JSON.stringify({ dev: { port: 8788 }, name: "app" }), "utf8");
+
+            // `undefined`, never a default: the argv must stay exactly as it was
+            // so wrangler keeps its own upward probe.
+            expect(resolveInspectorPort({ logger: silentLogger() }, workdir)).toBeUndefined();
+            expect(resolveInspectorPort({ logger: silentLogger() }, join(workdir, "no-wrangler-here"))).toBeUndefined();
+        });
+    });
+
     describe("runDevCommand", () => {
         it("spawns the wrangler worker, starts studio + codegen, and tears them down on exit", async () => {
             expect.assertions(6);
@@ -565,6 +646,37 @@ describe("lunora dev", () => {
             expect(codegenClosed).toBe(true);
             expect(studioClosed).toBe(true);
             expect(result.plan.workerOrigin).toBe("http://localhost:8787");
+        });
+
+        it("carries `dev.inspector_port` from the wrangler config into the spawned wrangler argv", async () => {
+            expect.assertions(2);
+
+            // The resolution lives one level above `planDevCommand`, so a flag
+            // that resolves correctly and never reaches the spawn is the failure
+            // mode this covers end to end.
+            writeFileSync(join(workdir, "wrangler.jsonc"), JSON.stringify({ dev: { inspector_port: 9235 }, name: "app" }), "utf8");
+
+            let spawned: string | undefined;
+
+            const result = await runDevCommand({
+                cwd: workdir,
+                findFreePort: async () => 8787,
+                logger: silentLogger(),
+                startCodegen: () => {
+                    return { close: async () => {}, ready: Promise.resolve(), watchAvailable: true };
+                },
+                startStudio: async () => {
+                    return { close: async () => {}, url: "http://127.0.0.1:6173" };
+                },
+                startWorker: (descriptor) => {
+                    spawned = descriptor.args.join(" ");
+
+                    return { exited: Promise.resolve(0), kill: () => {} };
+                },
+            });
+
+            expect(result.code).toBe(0);
+            expect(spawned).toContain("--inspector-port 9235");
         });
 
         it("provisions the bindings the code implies before starting the wrangler worker", async () => {

--- a/packages/cli/__tests__/commands/option-parsing.test.ts
+++ b/packages/cli/__tests__/commands/option-parsing.test.ts
@@ -69,6 +69,15 @@ describe("command option parsing → handler key mapping", () => {
         expect(parsed.workerPort).toBe(9000);
     });
 
+    it("`dev --inspector-port 9235` camelCases to `inspectorPort`", async () => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions("dev", devCommand.options ?? [], ["dev", "--inspector-port", "9235"]);
+
+        // dev/handler.ts reads `options.inspectorPort`; dev/lifecycle.ts forwards it.
+        expect(parsed.inspectorPort).toBe(9235);
+    });
+
     it("`verify --no-typecheck` parses to the negated `typecheck` key the handler reads", async () => {
         expect.assertions(1);
 

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -35,6 +35,7 @@ lunora mcp uninstall [client…]          # remove them again
 lunora mcp serve [--allow-writes]       # the stdio MCP server your editor spawns
             [--no-docs] [--url u] [--token t]
 lunora dev [--port n] [--worker-port n] # wrangler worker + studio + codegen watch
+            [--inspector-port n]
             [--no-studio] [--no-codegen]
 lunora codegen [--api-spec <spec>]      # one-shot codegen
             [--format <pretty|json>]
@@ -294,10 +295,11 @@ In a project on `@lunora/vite` it spawns `vite dev` instead: the Vite plugin
 already runs the worker, studio, and codegen inside the Vite dev server.
 
 ```bash
-lunora dev                     # default ports: studio 6173, worker 8787
-lunora dev --port 7000         # custom studio port
-lunora dev --worker-port 8790  # custom wrangler dev port
-lunora dev --no-studio         # Worker + codegen only
+lunora dev                       # default ports: studio 6173, worker 8787
+lunora dev --port 7000           # custom studio port
+lunora dev --worker-port 8790    # custom wrangler dev port
+lunora dev --inspector-port 9235 # pin wrangler's devtools inspector port
+lunora dev --no-studio           # Worker + codegen only
 ```
 
 When 8787 is taken, the worker lands on the next free port so two projects can
@@ -305,6 +307,39 @@ run side by side. That silent move is refused when `.dev.vars` pins the worker
 origin to 8787 — an `AUTH_URL`/`BETTER_AUTH_URL` (or any other loopback origin
 on that port) would be left pointing at nothing. Free 8787, or pass
 `--worker-port` and update the pinned values to match.
+
+#### The two ports wrangler takes
+
+`wrangler dev` binds the worker **and** a devtools inspector, and both are
+configurable from `lunora dev`. Each resolves the same way — the flag first,
+then the project's `wrangler.jsonc`:
+
+| Port      | Flag               | `wrangler.jsonc` key | Neither                                      |
+| --------- | ------------------ | -------------------- | -------------------------------------------- |
+| Worker    | `--worker-port`    | `dev.port`           | the first free port at or above 8787         |
+| Inspector | `--inspector-port` | `dev.inspector_port` | wrangler's own default: 9229, probing upward |
+
+```jsonc
+// wrangler.jsonc — the project-level equivalent of the two flags
+{
+    "dev": {
+        "inspector_port": 9235,
+        "port": 8788,
+    },
+}
+```
+
+Pin the inspector in a repo that runs several Workers side by side. Left unset
+it starts at 9229 and climbs while ports are busy, so it eventually lands on a
+port a _sibling_ worker pinned — and the worker that dies is whichever bound
+second, which makes the failure non-deterministic and the port in the error
+message impossible to grep for.
+
+`--inspector-port` is `wrangler dev` only. On the Vite flavors the inspector
+belongs to `@cloudflare/vite-plugin`: pass it through the plugin instead —
+`lunora({ cloudflare: { inspectorPort: 9235 } })` — and for the SvelteKit /
+Nuxt worker sidecar pin `dev.inspector_port` in `wrangler.dev.jsonc`, the
+config that sidecar runs. `lunora dev` says so rather than dropping the flag.
 
 #### Background mode (AI agents)
 

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -126,6 +126,8 @@ interface DevCommandOptions {
     flavor?: DevFlavor;
     /** Injection seam for tests — defaults to the real IPv6-loopback probe ({@link hasIpv6Loopback}). */
     hasIpv6Loopback?: () => boolean;
+    /** `wrangler dev` devtools inspector port (`--inspector-port`). Wrangler flavor only — see {@link resolveInspectorPort}. */
+    inspectorPort?: number;
 
     /**
      * Logs are NDJSON on stdout (`--json`, or a detected AI agent). Forwarded to
@@ -403,6 +405,39 @@ const resolveWorkerPort = async (options: DevCommandOptions, cwd: string): Promi
 };
 
 /**
+ * Resolve the port `wrangler dev` exposes its devtools inspector on. Precedence
+ * mirrors {@link resolveWorkerPort} — an explicit choice always wins:
+ *
+ * 1. `--inspector-port` on the CLI (`options.inspectorPort`).
+ * 2. `dev.inspector_port` pinned in the project's wrangler config.
+ * 3. `undefined` — no `--inspector-port` reaches wrangler, which keeps its own default: 9229, probing upward while that is taken.
+ *
+ * Step 3 is deliberately NOT the free-port probe the worker port falls back to.
+ * Wrangler already walks upward on its own, and pinning a port from here would
+ * claim one nothing asked for. The walk is what makes this worth configuring at
+ * all: in a repo where other `wrangler dev` processes pin 9230+ in their own dev
+ * scripts, an unpinned inspector climbs into one of THEIR ports and kills a
+ * worker that named the port in its config — so the fix is to make pinning
+ * possible, not to start pinning by default.
+ */
+const resolveInspectorPort = (options: DevCommandOptions, cwd: string): number | undefined => {
+    if (options.inspectorPort !== undefined) {
+        return options.inspectorPort;
+    }
+
+    const wranglerPath = findWranglerFile(cwd);
+
+    if (wranglerPath === undefined) {
+        return undefined;
+    }
+
+    const { parsed } = readWranglerJsonc<{ dev?: { inspector_port?: unknown } }>(wranglerPath);
+    const pinned = parsed?.dev?.inspector_port;
+
+    return typeof pinned === "number" ? pinned : undefined;
+};
+
+/**
  * Plan `lunora dev`. Wrangler flavor: the worker runs via `wrangler dev` and
  * nothing else as a child process. Vite flavor (`@lunora/vite` declared): the
  * plugin already runs the worker inside the Vite dev server, so the one child
@@ -457,6 +492,17 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
             );
         }
 
+        // `--inspector-port` is a `wrangler dev` flag and this branch spawns no
+        // `wrangler dev` of its own, so say where the knob actually lives rather
+        // than accepting the flag and dropping it.
+        if (options.inspectorPort !== undefined) {
+            options.logger.warn(
+                flavor === "framework-worker"
+                    ? `--inspector-port does not apply to the ${flavor} flavor: pin \`dev.inspector_port\` in ${DEV_WRANGLER_CONFIG} — that is the config the worker sidecar runs.`
+                    : `--inspector-port does not apply to the ${flavor} flavor: Vite owns the worker. Pin it in vite.config — \`lunora({ cloudflare: { inspectorPort: ${String(options.inspectorPort)} } })\`.`,
+            );
+        }
+
         return {
             runsCodegenWatch: false,
             flavor,
@@ -505,7 +551,20 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
     // On a host without IPv6 loopback, prepend `--ip 127.0.0.1` so workerd doesn't
     // abort trying to bind its default `[::1]` (see resolveLoopbackArgs).
     const loopbackArgs = resolveLoopbackArgs(cwd, options.hasIpv6Loopback ?? hasIpv6Loopback);
-    const exec = execArgsFor(manager, "wrangler", ["dev", "--port", String(workerPort), ...loopbackArgs, "--var", "WORKER_ENV:development", ...remote.args]);
+    // Only when something actually asked for a port. Passing wrangler's own
+    // default here would pin 9229 for every project — including the ones relying
+    // on wrangler walking off it — which is the opposite of what #689 needs.
+    const inspectorArgs = options.inspectorPort === undefined ? [] : ["--inspector-port", String(options.inspectorPort)];
+    const exec = execArgsFor(manager, "wrangler", [
+        "dev",
+        "--port",
+        String(workerPort),
+        ...inspectorArgs,
+        ...loopbackArgs,
+        "--var",
+        "WORKER_ENV:development",
+        ...remote.args,
+    ]);
 
     return {
         runsCodegenWatch: codegenRequested(options),
@@ -968,8 +1027,12 @@ const buildDevPlan = async (options: DevCommandOptions): Promise<DevCommandPlan>
     // The vite flavor lets Vite resolve its own port; only the wrangler flavor
     // needs a pre-picked free port passed through as `--port`.
     const workerPort = flavor === "wrangler" ? await resolveWorkerPort(options, cwd) : options.workerPort;
+    // Same split for the inspector: the other flavors get the flag back as a
+    // warning (see `planDevCommand`), so the wrangler-config fallback is only
+    // read where a `wrangler dev` argv exists to carry it.
+    const inspectorPort = flavor === "wrangler" ? resolveInspectorPort(options, cwd) : options.inspectorPort;
 
-    return planDevCommand({ ...options, cwd, flavor, workerPort });
+    return planDevCommand({ ...options, cwd, flavor, inspectorPort, workerPort });
 };
 
 /**
@@ -1479,6 +1542,7 @@ const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ a
         apiSpec: parseApiSpec(options.apiSpec),
         cwd,
         emitBindings: options.emitBindings,
+        inspectorPort: options.inspectorPort,
         jsonLogs,
         logger,
         port: options.port,
@@ -1495,4 +1559,4 @@ export type { DevCommandOptions, DevCommandPlan, DevRemotePlan, WorkerProcess, W
 // planning surface (`planDevCommand` and friends) stays importable from one module.
 export type { DevFlavor } from "./lifecycle";
 export { detectDevFlavor } from "./lifecycle";
-export { defaultWorkerSpawner, negatableDevFlags, planDevCommand, resolveWorkerPort, runDevCommand };
+export { defaultWorkerSpawner, negatableDevFlags, planDevCommand, resolveInspectorPort, resolveWorkerPort, runDevCommand };

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -21,6 +21,7 @@ const devCommand: Command = {
         ["lunora dev --emit-bindings dev-manifest.json", "Write what this worker needs + where it serves, for a task runner"],
         ["lunora dev --no-studio", "Skip the embedded studio server"],
         ["lunora dev --worker-port 8080", "Use a custom wrangler dev port"],
+        ["lunora dev --inspector-port 9235", "Pin wrangler's devtools inspector port instead of letting it walk up from 9229"],
         ["lunora dev --remote", "Proxy D1/KV/R2 to the deployed worker (also LUNORA_REMOTE=1)"],
     ],
     group: "Develop",
@@ -37,6 +38,12 @@ const devCommand: Command = {
             description: "Write the binding manifest (plus the dev origin) to <file>, for a supervisor that owns the rest of the graph",
             name: "emit-bindings",
             type: String,
+        },
+        {
+            description:
+                "wrangler dev inspector port, for `wrangler dev` only (defaults to `dev.inspector_port` in wrangler.jsonc; unset, wrangler probes upward from 9229 and can take a sibling worker's pinned port)",
+            name: "inspector-port",
+            type: Number,
         },
         { description: "Studio server port (default 6173)", name: "port", type: Number },
         TARGET_OPTION,
@@ -79,6 +86,7 @@ export type DevOptions = CreateOptions<{
     // side — every reader treats that as "on" via `!== false`.
     codegen: boolean | undefined;
     "emit-bindings": string | undefined;
+    "inspector-port": number | undefined;
     json: boolean | undefined;
     lines: number | undefined;
     port: number | undefined;

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -485,6 +485,13 @@ const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
         args.push("--worker-port", String(options.workerPort));
     }
 
+    // The daemon is the process that spawns `wrangler dev`, so an unforwarded
+    // `--inspector-port` would leave the background run on wrangler's own
+    // upward walk — the exact failure the flag exists to stop.
+    if (options.inspectorPort !== undefined) {
+        args.push("--inspector-port", String(options.inspectorPort));
+    }
+
     // Forwarded, or a `--background` run would emit nothing: the daemon child is
     // the process that knows the resolved origin, and the supervisor asking for
     // the manifest is the same one that wanted the server detached.


### PR DESCRIPTION
## The problem

`lunora dev` surfaced `--worker-port` but nothing for the second port `wrangler dev` takes. Since
`lunora dev` spawns `wrangler dev`, the inspector fell back to wrangler's default 9229 and — finding
it busy — walked upward into the inspector ports sibling workers had pinned in their own dev
scripts. The resulting failure is expensive to read: the error names a port that appears in no
service's config, and *which* worker dies depends on which bound first.

The reporter's actual point is the asymmetry: one of the two ports wrangler takes was a flag and the
other was not, which reads as "not supported" rather than "configure it elsewhere".

## The fix

`--inspector-port`, threaded end to end exactly the way `--worker-port` is:

- flag definition + `--help` example and description (`packages/cli/src/commands/dev/index.ts`)
- `DevCommandOptions.inspectorPort` and a `resolveInspectorPort` next to `resolveWorkerPort`
- the resolved value into the spawned `wrangler dev` argv (`planDevCommand`)
- forwarded to the detached daemon on the `--background` re-spawn (`dev/lifecycle.ts`), which is the
  automatic path when an AI agent runs `lunora dev` — an unforwarded flag is silently dropped there

## Precedence (identical to `--worker-port`)

1. `--inspector-port` on the CLI — an explicit choice always wins.
2. `dev.inspector_port` in the project's `wrangler.jsonc`.
3. Neither → **nothing is passed**. The argv is byte-identical to today's and wrangler keeps its own
   9229-and-upward probe, so projects relying on that walk are unaffected. Deliberately *not* the
   free-port fallback the worker port has: pinning a default here would claim a port nothing asked
   for.

No mismatch warning, because `--worker-port` over `dev.port` has none — inventing one for only one
of the two ports would re-create the asymmetry this closes.

The flag is wrangler-flavor only (`lunora dev` spawns no `wrangler dev` of its own on the Vite
flavors). `--help` says so, and rather than accepting the flag and dropping it, the plan warns and
names the knob that does work there: `lunora({ cloudflare: { inspectorPort: N } })` in vite config,
or `dev.inspector_port` in `wrangler.dev.jsonc` for the SvelteKit/Nuxt worker sidecar.

Docs (issue's option 2, also done): `packages/cli/docs/index.mdx` gains a "The two ports wrangler
takes" section with the precedence table and the `wrangler.jsonc` `dev` block, and
`apps/docs/.../concepts/monorepos-and-iac.mdx` — the multi-worker page where this bites — gains a
"Pin the inspector port too" section.

## Tested

10 new tests (`packages/cli/__tests__/commands/`):

- `--inspector-port` → wrangler argv; `wrangler.jsonc` `dev.inspector_port` → wrangler argv
  (end to end through `runDevCommand`, asserting the descriptor the spawner is handed)
- flag beats config; neither → no `--inspector-port` anywhere in the argv
- `--background` daemon re-spawn forwards it, and omits it when unset
- the vite-flavor warning names the plugin option
- `--inspector-port 9235` camelCases to `inspectorPort` (the option-name → handler-key guard)

Gates run locally: `pnpm --filter "@lunora/cli..." run build`, `pnpm --filter "@lunora/cli" run test`
(1535 passed), `lint:types`, `lint:eslint` (clean), `pnpm run lint:prettier`, `pnpm run build:packages`,
and `pnpm run api:check` — the snapshot diff (one added optional field) is committed.

Fixes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `--inspector-port` option to `wrangler dev`.
  - Inspector ports can be configured through the CLI or project settings.
  - The option is preserved when running development servers in the background.
  - Vite and framework-worker projects provide guidance to configure the inspector through their respective tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->