### PR TITLE
feat(auth): check the schema before the first write

### DIFF
--- a/packages/auth/__tests__/migrate.test.ts
+++ b/packages/auth/__tests__/migrate.test.ts
@@ -1,5 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 
+import type { SchemaFinding } from "@better-auth/core/db/internal";
+import { createSchemaCheck, SchemaMismatchError } from "@better-auth/core/db/internal";
 import { LunoraError } from "@lunora/errors";
 import { getMigrations } from "better-auth/db/migration";
 import { describe, expect, it, vi } from "vitest";
@@ -274,6 +276,36 @@ describe("ensureMigrated", () => {
         const database = fakeD1();
 
         await expect(ensureMigrated({ options: { database } })).resolves.toBeUndefined();
+    });
+
+    it("invalidates a schema verdict cached for this database, so the migration's fix is seen", async () => {
+        // `lunoraD1Adapter` caches its verdict per database — a mismatch is kept and
+        // rethrown without asking the store again. `ensureMigrated` is the thing that
+        // can make that verdict wrong, so it bumps the revision better-auth keys the
+        // cache on. Both instances name the SAME raw binding (`lunoraD1Adapter(env.DB)`
+        // for requests, `createAuth({ database: env.DB })` for migrating), which is what
+        // makes one invalidate the other.
+        expect.assertions(3);
+
+        mockGetMigrations.mockReset();
+        mockGetMigrations.mockResolvedValue(makeMigrations() as never);
+
+        const database = fakeD1();
+        let findings: SchemaFinding[] = [{ kind: "missing-table", table: "apikey" }];
+        const find = vi.fn<() => Promise<SchemaFinding[]>>(async () => findings);
+        const check = createSchemaCheck(find, "database", database);
+
+        await expect(check()).rejects.toThrow(SchemaMismatchError);
+        // Cached: the store is not asked a second time.
+        await expect(check()).rejects.toThrow(SchemaMismatchError);
+
+        findings = [];
+
+        await ensureMigrated({ options: { database } });
+
+        await check();
+
+        expect(find).toHaveBeenCalledTimes(2);
     });
 
     it("leaves a non-D1 database alone, since the remedy there is to relax the constraint", async () => {

--- a/packages/auth/__tests__/schema-check.test.ts
+++ b/packages/auth/__tests__/schema-check.test.ts
@@ -1,0 +1,276 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { apiKey } from "@better-auth/api-key";
+import { schemaCheckFor, SchemaMismatchError } from "@better-auth/core/db/internal";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lunoraD1Adapter } from "../src/adapter";
+import type { LunoraAuthOptions } from "../src/create-auth";
+import { createAuth, resolveAuthOptions } from "../src/create-auth";
+import { authDoSchemaStatements } from "../src/do-schema";
+import { admin, organization } from "../src/plugins";
+import { d1TableInfo, doTableInfo, findSchemaProblems } from "../src/schema-check";
+import { executorFor, materialiseAuthSchema } from "./helpers/sqlite-auth-db";
+
+/**
+ * The drift gate for `lunoraD1Adapter` / `lunoraDoAdapter` (issue #690).
+ *
+ * Both of the drifts that motivated it are here as named cases: `account.accountId`
+ * transcribed under NextAuth's `providerAccountId` spelling, and an `apikey` table
+ * that was never created although `apiKey()` is in the plugin list — the second
+ * being the one nothing in a hand-written `schema.ts` could have revealed, because
+ * nothing in it was *wrong*, something was simply *absent*.
+ *
+ * The suite drives a real `node:sqlite` database rather than a statement recorder:
+ * the whole point of choosing live introspection over a walk of the declared tables
+ * is that the database answers, so a double that replays canned rows would be
+ * testing the wrong half.
+ */
+
+const SECRET = "lunora-schema-check-secret-lunora-schema-xx";
+
+let database: DatabaseSync;
+
+/** Statements the adapter issued, so a test can count introspection sweeps. */
+let statements: string[];
+
+/**
+ * A D1 binding over `node:sqlite`.
+ *
+ * It executes rather than records — `PRAGMA table_info("x")` has to really answer
+ * with zero rows for a missing table, which is the signal the whole missing-table
+ * finding rests on. `prepare` is lazy so a rejected statement throws at execution,
+ * as it does on D1.
+ */
+interface FakeStatement {
+    all: () => Promise<{ results?: Record<string, unknown>[] }>;
+    bind: (...values: unknown[]) => FakeStatement;
+    run: () => Promise<unknown>;
+}
+
+const fakeD1 = (): { prepare: (query: string) => FakeStatement } => {
+    const statement = (query: string, values: ReadonlyArray<unknown> = []): FakeStatement => {
+        return {
+            all: async (): Promise<{ results?: Record<string, unknown>[] }> => {
+                statements.push(query);
+
+                return { results: database.prepare(query).all(...(values as never[])) };
+            },
+            bind: (...bound: unknown[]) => statement(query, bound),
+            run: async (): Promise<void> => {
+                statements.push(query);
+                database.prepare(query).run(...(values as never[]));
+            },
+        };
+    };
+
+    return { prepare: (query: string) => statement(query) };
+};
+
+/** How many table-shape reads the adapter made. */
+const introspectionCount = (): number => statements.filter((query) => query.includes("table_info")).length;
+
+/**
+ * Add a genuinely `NOT NULL`, default-less column to an existing table.
+ *
+ * SQLite's `ADD COLUMN` refuses that combination (existing rows would breach it on
+ * the spot), and adding the column WITH a default would make `hasDefault` true and
+ * test nothing — so the table is rebuilt from its own column metadata, which is
+ * what a real migration does.
+ */
+const addRequiredColumn = (table: string, column: string, type: string): void => {
+    const existing = database.prepare(`SELECT name, type, "notnull", pk FROM pragma_table_info(?)`).all(table) as {
+        name: string;
+        notnull: number;
+        pk: number;
+        type: string;
+    }[];
+    const columns = existing.map(
+        (candidate) => `"${candidate.name}" ${candidate.type}${candidate.pk === 1 ? " PRIMARY KEY" : ""}${candidate.notnull === 1 ? " NOT NULL" : ""}`,
+    );
+
+    database.exec(`DROP TABLE "${table}"`);
+    database.exec(`CREATE TABLE "${table}" (${[...columns, `"${column}" ${type} NOT NULL`].join(", ")})`);
+};
+
+const baseOptions: LunoraAuthOptions = { baseURL: "http://localhost:3000", emailAndPassword: { enabled: true }, secret: SECRET };
+
+/** The findings for the live `node:sqlite` database, read through the D1 statement form. */
+const problemsFor = async (options: LunoraAuthOptions = baseOptions) => findSchemaProblems(resolveAuthOptions(options), executorFor(database), d1TableInfo);
+
+describe("auth schema drift check", () => {
+    beforeEach(() => {
+        database = new DatabaseSync(":memory:");
+        statements = [];
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        database.close();
+    });
+
+    describe("findSchemaProblems", () => {
+        it("reports nothing when the tables match the configuration", async () => {
+            expect.assertions(1);
+
+            materialiseAuthSchema(database, baseOptions);
+
+            await expect(problemsFor()).resolves.toStrictEqual([]);
+        });
+
+        it("names the column when `accountId` was transcribed as NextAuth's `providerAccountId`", async () => {
+            // The drift that killed every sign-up in #690: all four tables existed, all
+            // four sat at 0 rows, and the app merely looked "not signed in".
+            expect.assertions(2);
+
+            vi.spyOn(console, "error").mockImplementation(() => undefined);
+            materialiseAuthSchema(database, baseOptions);
+            database.exec(`ALTER TABLE "account" RENAME COLUMN "accountId" TO "providerAccountId"`);
+
+            const findings = await problemsFor();
+
+            expect(findings).toContainEqual({ column: "accountId", kind: "missing-column", table: "account" });
+            // The leftover column is nullable, so it is not *also* reported as required —
+            // the report names the one change that fixes it.
+            expect(findings).toHaveLength(1);
+        });
+
+        it("names the whole table when a plugin's table was never created", async () => {
+            // `apiKey()` is in the plugin list and `apikey` is not in the database.
+            // Invisible from a hand-written schema alone: nothing in it is wrong.
+            expect.assertions(2);
+
+            const reported = vi.spyOn(console, "error").mockImplementation(() => undefined);
+            const options: LunoraAuthOptions = { ...baseOptions, plugins: [apiKey()] };
+
+            materialiseAuthSchema(database, baseOptions);
+
+            const findings = await problemsFor(options);
+
+            expect(findings).toStrictEqual([{ kind: "missing-table", table: "apikey" }]);
+            expect(String(reported.mock.calls[0]?.[0])).toContain(`Table "apikey" is missing`);
+        });
+
+        it("flags an extra required column better-auth never writes", async () => {
+            // Every insert into the table would fail its NOT NULL, because better-auth
+            // builds the INSERT from its own field list and never supplies this one.
+            expect.assertions(1);
+
+            vi.spyOn(console, "error").mockImplementation(() => undefined);
+            materialiseAuthSchema(database, baseOptions);
+            addRequiredColumn("user", "tenantId", "TEXT");
+
+            await expect(problemsFor()).resolves.toStrictEqual([{ column: "tenantId", kind: "unexpected-required-column", table: "user" }]);
+        });
+
+        it("does not flag Lunora's `_creationTime`, which the store fills on every insert", async () => {
+            // `authTables(...)` + `lunora migrate` puts `_creationTime REAL NOT NULL` on
+            // every auth table. Read straight off the DDL that is an unexpected required
+            // column on ALL of them — which would fail every such app on its first
+            // request — but `createSqlAuthStore` supplies it, so an insert that omits it
+            // still succeeds and there is nothing to report.
+            expect.assertions(1);
+
+            materialiseAuthSchema(database, baseOptions);
+
+            for (const table of ["user", "session", "account", "verification", "rateLimit"]) {
+                addRequiredColumn(table, "_creationTime", "REAL");
+            }
+
+            await expect(problemsFor()).resolves.toStrictEqual([]);
+        });
+
+        it("reads the same answers through the Durable Object statement form", async () => {
+            // D1's authorizer refuses the table-valued `pragma_table_info(?)` the object's
+            // own SQLite accepts, so the two backends run different statements against one
+            // introspector. This pins that they agree on the answer.
+            expect.assertions(2);
+
+            vi.spyOn(console, "error").mockImplementation(() => undefined);
+            materialiseAuthSchema(database, baseOptions);
+
+            await expect(findSchemaProblems(resolveAuthOptions(baseOptions), executorFor(database), doTableInfo)).resolves.toStrictEqual([]);
+
+            database.exec(`ALTER TABLE "session" RENAME COLUMN "token" TO "sessionToken"`);
+
+            await expect(findSchemaProblems(resolveAuthOptions(baseOptions), executorFor(database), doTableInfo)).resolves.toContainEqual({
+                column: "token",
+                kind: "missing-column",
+                table: "session",
+            });
+        });
+
+        it("reports nothing for the schema `authDoSchemaStatements` materialises", async () => {
+            // The Durable Object creates its own tables (better-auth's migrator is
+            // kysely-only), so its materialiser and this check are two independent
+            // readings of the same better-auth field list. If they ever disagree, every
+            // DO-backed app fails its first request — so the agreement is asserted here
+            // rather than only in the workerd suite, which is opt-in.
+            expect.assertions(1);
+
+            const options: LunoraAuthOptions = { ...baseOptions, plugins: [admin(), organization()] };
+            const resolved = resolveAuthOptions(options);
+
+            for (const statement of authDoSchemaStatements(resolved)) {
+                database.exec(statement);
+            }
+
+            await expect(findSchemaProblems(resolved, executorFor(database), doTableInfo)).resolves.toStrictEqual([]);
+        });
+    });
+
+    describe("lunoraD1Adapter schema check", () => {
+        it("fails the request naming the table and column, instead of emitting SQL against it", async () => {
+            expect.assertions(3);
+
+            vi.spyOn(console, "error").mockImplementation(() => undefined);
+            materialiseAuthSchema(database, baseOptions);
+            database.exec(`ALTER TABLE "account" RENAME COLUMN "accountId" TO "providerAccountId"`);
+
+            const auth = createAuth({ ...baseOptions, database: lunoraD1Adapter(fakeD1()) });
+            const failure = await auth.api.getSession({ headers: new Headers() }).catch((error: unknown) => error);
+
+            expect(failure).toBeInstanceOf(SchemaMismatchError);
+            expect((failure as SchemaMismatchError).message).toContain("account.accountId");
+            // The point of the gate: no INSERT was attempted. better-auth's durable rate
+            // limiter writes before the handler runs, so without this the first failing
+            // write is the first request of a session.
+            expect(statements.some((query) => query.startsWith("INSERT"))).toBe(false);
+        });
+
+        it("introspects once and reuses the verdict for later requests", async () => {
+            expect.assertions(2);
+
+            materialiseAuthSchema(database, baseOptions);
+
+            const auth = createAuth({ ...baseOptions, database: lunoraD1Adapter(fakeD1()) });
+
+            await auth.api.getSession({ headers: new Headers() });
+
+            const afterFirst = introspectionCount();
+
+            await auth.api.getSession({ headers: new Headers() });
+
+            expect(afterFirst).toBeGreaterThan(0);
+            expect(introspectionCount()).toBe(afterFirst);
+        });
+
+        it("registers no check at all when `advanced.database.validateSchema` is false", async () => {
+            expect.assertions(2);
+
+            materialiseAuthSchema(database, baseOptions);
+            database.exec(`ALTER TABLE "account" RENAME COLUMN "accountId" TO "providerAccountId"`);
+
+            const adapterFactory = lunoraD1Adapter(fakeD1());
+            const auth = createAuth({ ...baseOptions, advanced: { database: { validateSchema: false } }, database: adapterFactory });
+
+            // Resolving the context is what would register (and run) the check.
+            await auth.api.getSession({ headers: new Headers() });
+
+            const context = await auth.$context;
+
+            expect(schemaCheckFor(context.adapter)).toBeUndefined();
+            expect(introspectionCount()).toBe(0);
+        });
+    });
+});

--- a/packages/auth/__tests__/workerd/schema-check.workerd.test.ts
+++ b/packages/auth/__tests__/workerd/schema-check.workerd.test.ts
@@ -1,0 +1,88 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { LunoraAuthOptions } from "../../src/create-auth";
+import { resolveAuthOptions } from "../../src/create-auth";
+import { authDoSchemaStatements } from "../../src/do-schema";
+import { doExecutor } from "../../src/do-store";
+import { doTableInfo, findSchemaProblems } from "../../src/schema-check";
+
+/**
+ * The schema check's introspection statement, against **real** workerd SQLite.
+ *
+ * The two backends behind one executor seam do not accept the same statement: D1's
+ * authorizer refuses every pragma table-valued function through the Worker binding
+ * (see `d1-index-introspection.ts`), while a Durable Object's own SQLite accepts
+ * `pragma_table_info(?)` and refuses nothing this needs. A `node:sqlite` suite
+ * answers both forms happily and so proves neither — it is a different build of
+ * SQLite behind a different authorizer, which is exactly how the `_creationTime`
+ * probe in `creation-time-probe.workerd.test.ts` came to be green in Node while
+ * every Durable Object insert failed.
+ *
+ * So this pins the DO half where it actually runs: the statement is accepted, an
+ * absent table answers with zero rows rather than an error, and the findings match
+ * what the Node suite asserts for the D1 form.
+ */
+
+const SECRET = "lunora-workerd-schema-check-secret-lunora-xx";
+
+const options: LunoraAuthOptions = { emailAndPassword: { enabled: true }, secret: SECRET };
+
+/** Each case gets its own Durable Object so one test's schema cannot answer another's introspection. */
+const withStorage = async (name: string, assertion: (storage: DurableObjectState["storage"]) => Promise<void>): Promise<void> => {
+    const stub = env.AUTH_DO.get(env.AUTH_DO.idFromName(`schema-check-${name}`));
+
+    await runInDurableObject(stub, async (_instance, state) => assertion(state.storage));
+};
+
+/** Materialise better-auth's tables the way `LunoraAuthDO` does on a cold start. */
+const materialise = (storage: DurableObjectState["storage"], skip?: string): void => {
+    for (const statement of authDoSchemaStatements(resolveAuthOptions(options))) {
+        if (skip !== undefined && statement.includes(`"${skip}"`)) {
+            continue;
+        }
+
+        [...storage.sql.exec(statement)];
+    }
+};
+
+describe("auth schema check on workerd SQLite", () => {
+    it("reports nothing for the schema the Durable Object materialises for itself", async () => {
+        expect.assertions(1);
+
+        await withStorage("clean", async (storage) => {
+            materialise(storage);
+
+            await expect(findSchemaProblems(resolveAuthOptions(options), doExecutor(storage), doTableInfo)).resolves.toStrictEqual([]);
+        });
+    });
+
+    it("names a table the object never created, rather than erroring on the read", async () => {
+        // `pragma_table_info` on an unknown table must answer with zero rows — an error
+        // instead would reject the whole check and it would report nothing at all.
+        expect.assertions(1);
+
+        await withStorage("missing-table", async (storage) => {
+            materialise(storage, "verification");
+
+            await expect(findSchemaProblems(resolveAuthOptions(options), doExecutor(storage), doTableInfo)).resolves.toStrictEqual([
+                { kind: "missing-table", table: "verification" },
+            ]);
+        });
+    });
+
+    it("names a column transcribed under another framework's spelling", async () => {
+        expect.assertions(1);
+
+        await withStorage("missing-column", async (storage) => {
+            materialise(storage);
+            [...storage.sql.exec(`ALTER TABLE "account" RENAME COLUMN "accountId" TO "providerAccountId"`)];
+
+            await expect(findSchemaProblems(resolveAuthOptions(options), doExecutor(storage), doTableInfo)).resolves.toContainEqual({
+                column: "accountId",
+                kind: "missing-column",
+                table: "account",
+            });
+        });
+    });
+});

--- a/packages/auth/docs/index.mdx
+++ b/packages/auth/docs/index.mdx
@@ -75,6 +75,47 @@ against a fresh database leave the loser with `table user already exists` — an
 since this sits ahead of the router, that 500s every route, not just
 `/api/auth/*`. `defineApp().auth(...)` handles it for you.
 
+## Schema drift fails by name, not by 500
+
+`lunoraD1Adapter` builds its SQL from better-auth's own field list, and the tables it
+writes into are created somewhere else — by `ensureMigrated` / `compileMigrationsSql`,
+or by `authTables(options)` in your `lunora/schema.ts` plus `lunora migrate`. When the
+two halves drift, the adapter used to emit SQL against columns that were not there.
+
+So both adapters compare them. Before the first write — better-auth awaits the check in
+its router **ahead of the rate limiter**, which is the first thing that writes on any
+request, `get-session` included — the tables your plugin list needs are read back out of
+the database and diffed against it. A mismatch throws better-auth's own
+`SchemaMismatchError`, naming what is wrong:
+
+```
+Database schema mismatch
+
+  Missing tables
+    apikey
+
+  Missing columns
+    account.accountId
+```
+
+Both of those are real: `apikey` is what an `apiKey()` in the plugin list needs and
+nothing declared, and `accountId` is better-auth's spelling of the column NextAuth calls
+`providerAccountId`. Neither is visible by reading `schema.ts` — the first because
+nothing in it is _wrong_, only absent.
+
+Practical notes:
+
+- **The database is the authority**, not your schema file. A table you declared but never
+  migrated is reported exactly like one you never declared.
+- **One sweep per isolate.** The check is lazy, cached, and shared across concurrent
+  requests; `ensureMigrated` invalidates it, so a migration's fix is picked up without a
+  redeploy.
+- **`_creationTime` is not drift.** Tables from `authTables(...)` carry Lunora's
+  framework column, which better-auth never writes and the store fills in for it.
+- **Opt out** with `advanced: { database: { validateSchema: false } }` — better-auth's own
+  switch. `lunoraAuthAdapter(store)` over a custom store registers no check either: an
+  `AuthStore` is opaque CRUD with nothing to introspect.
+
 ## Read `ctx.auth` in functions
 
 The runtime resolves the inbound session and populates `ctx.auth` on every

--- a/packages/auth/src/adapter.ts
+++ b/packages/auth/src/adapter.ts
@@ -3,6 +3,7 @@ import { createAdapterFactory } from "better-auth/adapters";
 
 import type { DoStorageLike } from "./do-store";
 import { doExecutor, doTransactionRunner } from "./do-store";
+import { d1TableInfo, doTableInfo, withAuthSchemaCheck } from "./schema-check";
 import { createSqlAuthStore, d1Executor } from "./sql-store";
 import type { AuthRow, AuthStore } from "./store";
 
@@ -77,6 +78,11 @@ const customAdapter = (store: AuthStore): CustomAdapter => {
  * Scope: the {@link AuthStore} interface is single-table CRUD. better-auth's
  * relational `join` reads (an advanced opt-in) are not handled — pair the
  * adapter with `disableJoins` or let better-auth fall back to per-table reads.
+ *
+ * No schema check either: an {@link AuthStore} is opaque CRUD with nothing to
+ * introspect, so better-auth logs that validation is unavailable for this adapter
+ * and proceeds. {@link lunoraD1Adapter} and {@link lunoraDoAdapter} know which
+ * SQLite backend they sit on and register one — see `schema-check.ts`.
  */
 const lunoraAuthAdapter = (store: AuthStore, runInTransaction?: TransactionRunner): ReturnType<typeof createAdapterFactory> => {
     type AdapterOptions = Parameters<ReturnType<typeof createAdapterFactory>>[0];
@@ -148,8 +154,21 @@ const lunoraAuthAdapter = (store: AuthStore, runInTransaction?: TransactionRunne
  * same. The migration instance is the one exception — it wants raw `env.DB` so
  * `ensureMigrated`'s Kysely migrator can create the tables (its `$context` is
  * never resolved, so the hang doesn't apply there).
+ *
+ * Carries a schema check: before the first write — better-auth awaits it in the
+ * router ahead of the rate limiter, which is the first thing that writes — the
+ * tables this configuration needs are compared against the ones D1 holds, and a
+ * mismatch fails with the table and column named instead of `no such table: …`
+ * inside an empty 500. See `schema-check.ts`.
  */
-const lunoraD1Adapter = (d1: Parameters<typeof d1Executor>[0]): ReturnType<typeof lunoraAuthAdapter> => lunoraAuthAdapter(createSqlAuthStore(d1Executor(d1)));
+const lunoraD1Adapter = (d1: Parameters<typeof d1Executor>[0]): ReturnType<typeof lunoraAuthAdapter> => {
+    // One executor for both: the check reads the schema through the same seam the
+    // store writes through, so it can never be introspecting a different database
+    // than the one the adapter is about to emit SQL against.
+    const executor = d1Executor(d1);
+
+    return withAuthSchemaCheck(lunoraAuthAdapter(createSqlAuthStore(executor)), { database: d1, executor, tableInfo: d1TableInfo });
+};
 
 /**
  * A better-auth `database` backed by a Durable Object's own SQLite —
@@ -158,9 +177,18 @@ const lunoraD1Adapter = (d1: Parameters<typeof d1Executor>[0]): ReturnType<typeo
  * Unlike `lunoraD1Adapter` this one exposes real transactions, so plugins that
  * demand them (`@better-auth/scim`) accept it. Read the trade-offs in `do-store.ts`
  * before reaching for it: the auth tables then live inside a single Durable Object.
+ *
+ * Schema-checked like {@link lunoraD1Adapter}, against the object's own SQLite.
  * @experimental
  */
-const lunoraDoAdapter = (storage: DoStorageLike): ReturnType<typeof lunoraAuthAdapter> =>
-    lunoraAuthAdapter(createSqlAuthStore(doExecutor(storage)), doTransactionRunner(storage));
+const lunoraDoAdapter = (storage: DoStorageLike): ReturnType<typeof lunoraAuthAdapter> => {
+    const executor = doExecutor(storage);
+
+    return withAuthSchemaCheck(lunoraAuthAdapter(createSqlAuthStore(executor), doTransactionRunner(storage)), {
+        database: storage,
+        executor,
+        tableInfo: doTableInfo,
+    });
+};
 
 export { lunoraAuthAdapter, lunoraD1Adapter, lunoraDoAdapter };

--- a/packages/auth/src/framework-columns.ts
+++ b/packages/auth/src/framework-columns.ts
@@ -1,0 +1,23 @@
+/**
+ * Columns Lunora's own table machinery puts on a table and better-auth knows
+ * nothing about.
+ *
+ * Its own module because two modules on different tiers need the same name and
+ * neither should own it: `sql-store.ts` fills the column on every insert, and
+ * `schema-check.ts` has to tell better-auth's schema diff that an insert omitting
+ * it still succeeds. Declaring it in `sql-store.ts` would either duplicate the
+ * literal or widen the public `@lunora/auth/sql-store` surface with an internal
+ * constant; declaring it in `schema-check.ts` would make the low-level store
+ * import from the check that sits above it.
+ *
+ * Deliberately NOT in the package's `exports` map: internal to `@lunora/auth`.
+ */
+
+/**
+ * The creation timestamp `defineTable` puts on every Lunora table — `REAL NOT
+ * NULL`, with no DDL default, on both the D1 auto-provisioner's output and
+ * `lunora migrate`'s.
+ */
+// Sole export, so it is the file's default (the repo forbids mixing a default with
+// named exports, and ESLint requires one on a single-export file).
+export default "_creationTime";

--- a/packages/auth/src/migrate.ts
+++ b/packages/auth/src/migrate.ts
@@ -1,4 +1,4 @@
-import { getAuthTablesWithResolvedIndexes } from "@better-auth/core/db/internal";
+import { getAuthTablesWithResolvedIndexes, invalidateSchemaChecks } from "@better-auth/core/db/internal";
 import { LunoraError } from "@lunora/errors";
 import { getMigrations } from "better-auth/db/migration";
 
@@ -145,6 +145,33 @@ const dropLegacyIssuerColumn = async (options: LunoraAuthOptions): Promise<void>
 };
 
 /**
+ * Bump this database's schema revision, so a schema verdict `lunoraD1Adapter`'s
+ * check cached before the migration is re-taken rather than replayed.
+ *
+ * better-auth keys the revision on the database **object**, and the two instances
+ * agree on it by construction: the request instance registers its check against
+ * the binding handed to `lunoraD1Adapter(env.DB)`, and this migration instance
+ * holds that same `env.DB` as its `database` (the migrator needs the raw binding —
+ * see {@link assertMigratableDatabase}). Without this, a mismatch observed before
+ * the migration ran would be rethrown for the life of the isolate even though the
+ * migration has just fixed it.
+ *
+ * Reads `options.database`, not the proxy {@link withD1MigrationSupport} builds:
+ * that is a different object and would invalidate nothing. Widened to `unknown`
+ * for the same reason {@link assertMigratableDatabase} does it — better-auth's
+ * `database` union has an adapter arm the linter reads as an error type. The type
+ * guard is narrowing, not doubt: `assertMigratableDatabase` has already rejected a
+ * falsy or function `database` by the time this runs.
+ */
+const invalidateAuthSchemaChecks = (options: LunoraAuthOptions): void => {
+    const { database } = options as { database?: unknown };
+
+    if (typeof database === "object" && database !== null) {
+        invalidateSchemaChecks(database);
+    }
+};
+
+/**
  * Single-flight cache of in-flight (and completed) migration runs, keyed by the
  * `options` reference. Storing the *promise* — rather than a post-completion
  * flag — closes a TOCTOU race: concurrent callers that arrive before the first
@@ -192,6 +219,7 @@ export const ensureMigrated = async (auth: LunoraAuth | { options: LunoraAuthOpt
 
         await runMigrations();
         await dropLegacyIssuerColumn(options);
+        invalidateAuthSchemaChecks(options);
     })();
 
     // Record the promise synchronously (before the first await above resolves)

--- a/packages/auth/src/schema-check.ts
+++ b/packages/auth/src/schema-check.ts
@@ -1,0 +1,236 @@
+/**
+ * Drift detection between the tables better-auth writes and the tables the
+ * database actually holds.
+ *
+ * ## The failure this replaces
+ *
+ * `lunoraD1Adapter` builds its SQL from better-auth's own field list, and the
+ * tables it writes into are created somewhere else entirely — by `ensureMigrated`
+ * / `compileMigrationsSql`, or by `authTables(options)` in the app's own
+ * `lunora/schema.ts` + `lunora migrate`. Nothing compared the two halves, so a
+ * plugin added to `options.plugins` without the matching table, or a column
+ * transcribed under another framework's name (`account.providerAccountId` is
+ * NextAuth's spelling of better-auth's `accountId`), surfaced only as `no such
+ * table: apikey` / `no column named accountId` inside a 500 with an empty body.
+ *
+ * The timing is what made it expensive: better-auth's durable rate limiter writes
+ * a row **before** the handler runs, so the first failing write is the first
+ * request of a session — `get-session` included — and the app merely looks "not
+ * signed in" while all four auth tables sit at 0 rows.
+ *
+ * ## Why the live database is the authority
+ *
+ * The "expected" side is `getExpectedSchema(options)`: better-auth derives it from
+ * the plugin list, so a table nobody declared anywhere is still expected. The
+ * "actual" side could come from two places — the `defineTable` definitions the app
+ * declared, or the database itself — and only the database answers the question
+ * the adapter is actually asking. A `defineTable` walk proves the app *declared*
+ * `apikey`; it cannot prove the migration that creates it ever ran, and it needs
+ * the schema plumbed into the adapter, which `lunoraD1Adapter(env.DB)` is not
+ * given. Introspection covers both drifts with no extra plumbing, and it is the
+ * same authority (`SchemaSource` `"database"`) better-auth's own adapters report
+ * against.
+ *
+ * ## Why this hangs off better-auth's hook rather than throwing at init
+ *
+ * better-auth 1.7 exposes {@link registerSchemaCheck} for "adapters Better Auth
+ * does not own", and then awaits the registered check itself: once eagerly at
+ * `betterAuth()` (logging the mismatch), and again in the router's `onRequest`
+ * **before** the rate limiter writes — exactly where the empty 500 came from.
+ * {@link createSchemaCheck} supplies the caching, the shared promise across
+ * concurrent callers, and the invalidation after a migration, so nothing here has
+ * to. A round trip on a `D1Database` also cannot happen at module-eval time in
+ * workerd; deferring it to the first check is not an optimisation, it is the only
+ * way it can run at all.
+ *
+ * The check is therefore **lazy, cached, and single-flighted**: one `PRAGMA
+ * table_info` per expected table, once per adapter instance, and never again
+ * unless `ensureMigrated` invalidates it.
+ */
+import type { IntrospectedColumn, IntrospectedTable, SchemaFinding } from "@better-auth/core/db/internal";
+import { checksSchema, createSchemaCheck, diffSchema, formatSchemaFinding, getExpectedSchema, registerSchemaCheck } from "@better-auth/core/db/internal";
+import type { createAdapterFactory } from "better-auth/adapters";
+
+import { quoteIdentifier } from "../../../shared/quote-identifier";
+import CREATION_TIME_COLUMN from "./framework-columns";
+import type { SqlExecutor } from "./sql-store";
+
+/** better-auth's adapter factory shape — `(options) => Adapter`, the thing `database:` is given. */
+type AdapterFactory = ReturnType<typeof createAdapterFactory>;
+
+/** The options better-auth hands the factory: its own resolved `BetterAuthOptions`. */
+type AdapterOptions = Parameters<AdapterFactory>[0];
+
+/**
+ * The statement that reads one table's column metadata. Two SQLite backends sit
+ * behind {@link SqlExecutor} and they do **not** accept the same one, so the
+ * caller that knows which backend it is supplies the right form.
+ */
+type TableInfoQuery = (table: string) => { parameters: ReadonlyArray<unknown>; sql: string };
+
+/**
+ * D1: the `PRAGMA` **statement** form, with the table name inlined as a quoted
+ * identifier.
+ *
+ * Not `SELECT … FROM pragma_table_info(?)`. D1's authorizer refuses every pragma
+ * table-valued function through the Worker binding — with a bound parameter or an
+ * inline literal — which is the whole reason `d1-index-introspection.ts` exists.
+ * The plain statement is a different authorizer action and is on D1's documented
+ * supported-pragma list. A parameter cannot carry the name either: SQLite does not
+ * bind inside a pragma argument, hence {@link quoteIdentifier} rather than `?`.
+ */
+const d1TableInfo: TableInfoQuery = (table) => {
+    return { parameters: [], sql: `PRAGMA table_info(${quoteIdentifier(table)})` };
+};
+
+/**
+ * Durable Object storage: the table-valued **function** form, which SQLite-in-DO
+ * allows (`auth-do.ts` already reads its column names this way) and which takes
+ * the table name as a real binding.
+ */
+const doTableInfo: TableInfoQuery = (table) => {
+    return { parameters: [table], sql: "SELECT * FROM pragma_table_info(?)" };
+};
+
+/**
+ * One `pragma_table_info` row as better-auth compares it.
+ *
+ * `hasDefault` is documented as "the store fills the column when an insert omits
+ * it" — which is broader than a DDL `DEFAULT`, and the difference is load-bearing
+ * here. A table generated by `authTables(...)` and created by `lunora migrate`
+ * carries Lunora's own `_creationTime REAL NOT NULL`, a column better-auth never
+ * writes and cannot know about; read literally off the DDL it is an
+ * `unexpected-required-column` on **every** auth table, which would fail every
+ * such app on its first request. `createSqlAuthStore` fills that column on insert
+ * (see its `_creationTime` probe), so the honest answer to "does an insert that
+ * omits it succeed" is yes.
+ */
+const introspectedColumn = (row: Record<string, unknown>): IntrospectedColumn => {
+    const name = String(row["name"]);
+    const columnDefault = row["dflt_value"];
+
+    return {
+        hasDefault: (columnDefault !== null && columnDefault !== undefined) || name === CREATION_TIME_COLUMN,
+        name,
+        // SQLite reports `notnull` as 0/1; anything unreadable is treated as nullable,
+        // which can only ever suppress a finding rather than invent one.
+        nullable: Number(row["notnull"] ?? 0) === 0,
+    };
+};
+
+/**
+ * The live shape of `name`, or `undefined` when the table does not exist —
+ * `pragma_table_info` answers an unknown table with zero rows rather than an
+ * error, which is exactly the "missing table" signal `diffSchema` needs.
+ */
+const introspectTable = async (executor: SqlExecutor, tableInfo: TableInfoQuery, name: string): Promise<IntrospectedTable | undefined> => {
+    const { parameters, sql } = tableInfo(name);
+    const rows = await executor.all(sql, parameters);
+
+    if (rows.length === 0) {
+        return undefined;
+    }
+
+    return { columns: rows.map((row) => introspectedColumn(row)), name };
+};
+
+/**
+ * What the app has to change, in Lunora's terms.
+ *
+ * better-auth's own hint for a `"database"` finding is "Run `npx auth migrate`",
+ * which is the one remedy a Lunora app does not have — so the findings are
+ * restated here with the two places its auth tables actually come from. Logged
+ * once per verdict (the check caches a mismatch and rethrows it without asking the
+ * store again), not once per request.
+ */
+const reportFindings = (findings: ReadonlyArray<SchemaFinding>): void => {
+    const lines = [
+        "@lunora/auth: the auth tables do not match the better-auth options this app runs.",
+        ...findings.map((finding) => `  - ${formatSchemaFinding(finding, "database")}`),
+        "Fix the schema, not the adapter. better-auth's own tables are created by `ensureMigrated(...)` or by",
+        "`compileMigrationsSql(...)` at deploy time; tables you declared yourself come from `authTables(options)`",
+        "in `lunora/schema.ts` plus `lunora migrate`. `npx auth migrate` does not apply to a Lunora app.",
+    ];
+
+    // eslint-disable-next-line no-console -- no injected logger at this layer (workerd/Node both capture console)
+    console.error(lines.join("\n"));
+};
+
+/**
+ * Compare the tables this configuration writes with the tables the database
+ * holds.
+ *
+ * Only the tables better-auth would migrate are introspected: `diffSchema` skips a
+ * `disableMigrations` table anyway (the app manages its storage itself), so asking
+ * about it would be a round trip that can only be ignored.
+ */
+const findSchemaProblems = async (options: AdapterOptions, executor: SqlExecutor, tableInfo: TableInfoQuery): Promise<SchemaFinding[]> => {
+    const expected = getExpectedSchema(options);
+    const names = Object.entries(expected)
+        .filter(([, table]) => !table.disableMigrations)
+        .map(([name]) => name);
+
+    // Concurrent, not sequential: these are independent single-statement reads, and
+    // on D1 each is its own round trip. The whole sweep runs once per adapter
+    // instance, so the cost is a cold-start one and not a per-request one.
+    const introspected = await Promise.all(names.map(async (name) => introspectTable(executor, tableInfo, name)));
+    const findings = diffSchema(
+        expected,
+        introspected.filter((table): table is IntrospectedTable => table !== undefined),
+    );
+
+    if (findings.length > 0) {
+        reportFindings(findings);
+    }
+
+    return findings;
+};
+
+/** Everything the check needs to read the live schema of one backend. */
+interface AuthSchemaIntrospection {
+    /**
+     * The object identity better-auth keys this database's schema revision on. Pass
+     * the D1 binding / DO storage rather than the adapter, so `ensureMigrated`'s
+     * `invalidateSchemaChecks(options.database)` — which only ever sees the raw
+     * binding — invalidates the verdict this check cached.
+     */
+    database: object;
+
+    /** The seam the introspection statements run on; the same one the store uses. */
+    executor: SqlExecutor;
+
+    /** How this backend answers "what columns does this table have?". */
+    tableInfo: TableInfoQuery;
+}
+
+/**
+ * Wrap an adapter factory so every instance it builds carries a schema check.
+ *
+ * `checksSchema(options)` is better-auth's documented opt-out
+ * (`advanced.database.validateSchema: false`); honouring it here means an app that
+ * has turned validation off gets no check registered at all, and better-auth's own
+ * "schema validation is not available for adapter …" path takes over.
+ */
+const withAuthSchemaCheck =
+    (factory: AdapterFactory, introspection: AuthSchemaIntrospection): AdapterFactory =>
+    (options) => {
+        // The instance better-auth stores as `ctx.adapter` — `getBaseAdapter` uses the
+        // object this returns verbatim, and `schemaCheckFor` looks the check up by that
+        // identity. Registering on anything else (a nested transaction adapter, the
+        // factory) would attach a check nothing ever awaits.
+        const instance = factory(options);
+
+        if (checksSchema(options)) {
+            const { database, executor, tableInfo } = introspection;
+
+            registerSchemaCheck(
+                instance,
+                createSchemaCheck(async () => findSchemaProblems(options, executor, tableInfo), "database", database),
+            );
+        }
+
+        return instance;
+    };
+
+export type { AuthSchemaIntrospection, TableInfoQuery };
+export { d1TableInfo, doTableInfo, findSchemaProblems, withAuthSchemaCheck };

--- a/packages/auth/src/sql-store.ts
+++ b/packages/auth/src/sql-store.ts
@@ -1,3 +1,4 @@
+import CREATION_TIME_COLUMN from "./framework-columns";
 import type { AuthRow, AuthStore, AuthWhereClause } from "./store";
 
 /** Double-quote a table/column identifier, escaping embedded quotes. */
@@ -7,9 +8,6 @@ interface SqlFragment {
     params: unknown[];
     sql: string;
 }
-
-/** The framework column `defineTable` puts on every Lunora table, and better-auth knows nothing about. */
-const CREATION_TIME_COLUMN = "_creationTime";
 
 /**
  * "This table has no such column", in the wording of every engine a


### PR DESCRIPTION
## The failure

`lunoraD1Adapter` builds its SQL from better-auth's own field list, and the tables it writes into are created somewhere else — by `ensureMigrated` / `compileMigrationsSql`, or by `authTables(options)` in the app's `lunora/schema.ts` plus `lunora migrate`. Nothing compared the two halves, so drift surfaced only as `no such table: apikey` / `no column named accountId` inside a 500 with an empty body.

The timing is what made it expensive. better-auth's durable rate limiter writes a row **before** the handler runs, so the first failing write is the first request of a session — `get-session` included — and the app merely looks "not signed in" while all four auth tables sit at 0 rows.

Both of #690's drifts are now named cases in the test suite:

1. `account.accountId` transcribed under NextAuth's `providerAccountId` spelling → `missing-column`.
2. an `apikey` table that was never created although `apiKey()` is in the plugin list → `missing-table`. This is the one nothing in a hand-written `schema.ts` could reveal, because nothing in it was *wrong*, something was simply *absent*.

## Which side is "actual", and why

**Live database introspection**, not a walk over the app's `defineTable` definitions.

- The database is the only authority on the shape the adapter's SQL will actually meet. A `defineTable` walk proves the app *declared* `apikey`; it cannot prove the migration that creates it ever ran — and "declared but never migrated" is the same empty 500.
- It needs no new plumbing. `lunoraD1Adapter(env.DB)` is handed a binding, not a schema; routing the schema through would mean changing codegen's generated wiring (`emit-app.ts`) and every hand-written `createAuth` call site. **Codegen is unchanged by this PR.**
- It is the authority better-auth's own adapters report against (`SchemaSource: "database"`), so the message an app sees is the one better-auth users already see.

The expected side is `getExpectedSchema(options)`, derived from the plugin list, so a table nobody declared anywhere is still expected — which is exactly how the `apikey` case falls out.

The two SQLite backends behind `SqlExecutor` do **not** accept the same statement, so the adapter that knows which backend it is supplies the right form:

| backend | statement | why not the other one |
| --- | --- | --- |
| D1 | `PRAGMA table_info("<table>")` | D1's authorizer refuses every pragma **table-valued function** through the Worker binding — the reason `d1-index-introspection.ts` exists. The plain statement is a different authorizer action and is on [D1's documented supported-pragma list](https://developers.cloudflare.com/d1/sql-api/sql-statements/). SQLite does not bind inside a pragma argument, hence `quoteIdentifier` rather than `?`. |
| Durable Object | `SELECT * FROM pragma_table_info(?)` | the table-valued form SQLite-in-DO allows — `auth-do.ts` already reads its column names this way. |

An unknown table answers with zero rows rather than an error, which is the `missing-table` signal.

## `registerSchemaCheck`, not an init-time throw

better-auth 1.7 exposes `registerSchemaCheck` for "adapters Better Auth does not own", and then awaits the registered check itself — verified against 1.7.3's source:

- `createAuthContext` sets `ctx.checkSchema = schemaCheckFor(ctx.adapter)`;
- `createBetterAuth` fires it once at init and **logs** the mismatch;
- the router's `onRequest` awaits it **before** `onRequestRateLimit` — precisely where the empty 500 came from;
- `toAuthEndpoints` awaits it on every `auth.api.*` call, and `runWithTransaction` awaits it too.

So wiring into the hook is strictly better than a hand-rolled throw: `createSchemaCheck` gives the caching, the promise shared across concurrent callers, the "a failure to reach the store is not kept, so the next call asks again" retry, the post-migration invalidation, and better-auth's own `SchemaMismatchError` surface — and it lands the check ahead of the first write rather than at construction. It also keeps the D1 round trip off the module-eval path, where workerd forbids I/O.

`checksSchema(options)` is honoured, so better-auth's documented `advanced.database.validateSchema: false` opt-out still turns it off. `lunoraAuthAdapter(store)` over an opaque `AuthStore` registers nothing — there is nothing to introspect — and better-auth's own "schema validation is not available for adapter …" path takes over.

## The `_creationTime` landmine

`diffSchema` reports any column better-auth does not write that is `NOT NULL` with no default as `unexpected-required-column`. A table generated by `authTables(...)` and created by `lunora migrate` / the D1 auto-provisioner carries Lunora's `"_creationTime" REAL NOT NULL` — no DDL default. Read literally off the DDL that is a finding on **every** auth table, which would have failed every such app on its first request.

`createSqlAuthStore` fills that column on insert (its existing `_creationTime` probe), and `IntrospectedColumn.hasDefault` is documented as "the store fills the column when an insert omits it" — so it is reported as defaulted. That is the honest answer under better-auth's own definition, not a suppression. Pinned by a test.

## Also

`ensureMigrated` now calls `invalidateSchemaChecks(options.database)` after `runMigrations()`. better-auth keys the revision on the database **object**, and the two instances agree on it by construction: the request instance registers against the binding handed to `lunoraD1Adapter(env.DB)`, and the migration instance holds that same `env.DB` (the migrator needs the raw binding). Without it, a mismatch observed before the migration would be rethrown for the life of the isolate even though the migration had just fixed it.

No `@lunora/errors` catalog entry: the thrown value is better-auth's `SchemaMismatchError`, constructed by `createSchemaCheck` from the findings we return, so no Lunora error is raised on this path. What better-auth's hint cannot give is the Lunora remedy — its `"database"` hint is "Run `npx auth migrate`", which a Lunora app does not have — so the findings are also logged once per verdict through `formatSchemaFinding` with the two places its auth tables actually come from.

## What was tested

`packages/auth/__tests__/schema-check.test.ts` (10 cases), over a real `node:sqlite` database rather than a statement recorder — the whole point of choosing introspection is that the database answers:

- clean schema → no findings;
- `account.providerAccountId` → `missing-column: account.accountId`, and nothing else;
- `apiKey()` with no `apikey` table → `missing-table: apikey`, and the logged report names it;
- an extra `NOT NULL` column with no default → `unexpected-required-column`;
- `_creationTime NOT NULL` on every table → **no** findings;
- the DO statement form agrees with the D1 one on both answers;
- the schema `authDoSchemaStatements` materialises (with `admin()` + `organization()`) → no findings, so the DO materialiser and the check cannot drift apart;
- end to end through `lunoraD1Adapter` + `createAuth`: `auth.api.getSession` rejects with `SchemaMismatchError` mentioning `account.accountId`, and **no `INSERT` was attempted**;
- a clean schema introspects once and reuses the verdict on the second call;
- `advanced.database.validateSchema: false` registers no check at all (`schemaCheckFor(ctx.adapter)` is `undefined`) and issues zero introspection statements.

`packages/auth/__tests__/migrate.test.ts` gains one case: a verdict cached for a database is re-taken after `ensureMigrated` runs against it.

`packages/auth/__tests__/workerd/schema-check.workerd.test.ts` pins the DO half where it actually runs (statement accepted, absent table answers with zero rows, findings match the Node suite).

### Gates

| gate | result |
| --- | --- |
| `pnpm --filter "@lunora/auth..." run build` | pass |
| `pnpm --filter "@lunora/auth" run test` | pass — 37 files, 493 tests |
| `pnpm --filter "@lunora/auth" run test:coverage` | pass — 91.67 % statements / 83.44 % branches, over the 80/70 floor |
| `pnpm run lint:affected:types` | pass — 9 projects |
| `pnpm run lint:affected:eslint` | pass — 4 projects |
| `pnpm --filter "@lunora/auth" run lint:prettier` | pass |
| `pnpm --filter "@lunora/auth" run build` (isolated-declarations emit) | pass |
| `pnpm run api:check` | pass — all 54 snapshots match, **no public API change** |
| `pnpm run dist:check` | fails only on pre-existing `packages/studio` dev-build artifacts (182 `jsxDEV` files) because the tree was built with `build:packages`, not `build:packages:prod`. `packages/auth` is not implicated. |
| `pnpm run lint:package-json` | not run — no `package.json` was edited |
| `pnpm run lint:registry:sync` | not run — nothing under `registry/auth-*` changed |
| **`pnpm run test:workerd`** | **could not run** — see below |

### workerd could not boot

Probed twice with one small pre-existing suite (`--no-coverage --project workerd __tests__/workerd/creation-time-probe.workerd.test.ts`). Both runs hung at startup and were killed; the second captured the cause:

```
Error: [vitest-pool]: Timeout starting cloudflare-pool runner.
Fallback service failed to fetch module; exception =
  kj/async-io-unix.c++:1535: overloaded: connect(): Connection timed out
```

This is the documented environment-dependent boot failure — the sandbox cannot open the localhost loopback workerd needs — and it reproduces on a suite this PR does not touch, so it is not caused by this change. **The workerd suites are unverified here and need a CI run (or a local run on a machine that can boot workerd).**

To de-risk the two existing DO workerd suites, which now run the new check, the Node suite asserts that the schema `authDoSchemaStatements` materialises produces zero findings — the only way those suites could newly fail.

No `_generated` / codegen change, no new dependency, no catalog change, no `PlatformCapabilities` entry (this adds no `ctx.*` surface or binding).

Fixes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema validation for supported SQLite adapters, checking required tables and columns before database writes.
  * Added backend-specific checks for D1 and Durable Object storage.
  * Added clearer diagnostics and remediation guidance when schema differences are detected.

* **Bug Fixes**
  * Schema validation results are refreshed after migrations, ensuring subsequent operations use the latest database structure.

* **Documentation**
  * Clarified that generic adapters do not provide schema introspection, while supported SQLite adapters validate database structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->