### PR TITLE
fix(platform-node): serialize writes on one lock

### DIFF
--- a/packages/platform-node/__tests__/transaction-concurrency.test.ts
+++ b/packages/platform-node/__tests__/transaction-concurrency.test.ts
@@ -7,16 +7,69 @@ import { createNodeShardHost } from "../src/node-shard-host";
  * against a single shared connection. Two overlapping `transaction()` calls
  * used to race that connection directly — the second `BEGIN` while the first
  * was still open either threw `cannot start a transaction within a
- * transaction` or, worse, silently interleaved commits/rollbacks. This pins
- * the fix: a dedicated `transactionTail` serialization lane, distinct from
- * `runSerialized`'s own tail (routing through the same one would deadlock the
- * engine's `runSerialized(() => transaction(work))` composition).
+ * transaction` or, worse, silently interleaved commits/rollbacks.
+ *
+ * The first fix gave `transaction` a private serialization lane of its own,
+ * which closed the `transaction`-vs-`transaction` pair and left the **cross**
+ * pair — `runSerialized` against `transaction` — unsynchronized. That is what
+ * the second half of this file covers, plus the two compositions the engine
+ * actually issues, which a shared lane has to keep working. Every cross-pair
+ * test here fails on the two-lane host, one of them by deadlocking, so each
+ * carries an explicit timeout: a deadlock has to surface as a red test rather
+ * than a suite that never finishes.
  */
 describe("createNodeShardHost transaction concurrency", () => {
     const sleep = (ms: number): Promise<void> =>
         new Promise((resolve) => {
             setTimeout(resolve, ms);
         });
+
+    /**
+     * Record the transaction-control statements the host issues on the
+     * connection.
+     *
+     * `Object.defineProperty` rather than an assignment because
+     * better-sqlite3's `exec` lives on the prototype and the point is to shadow
+     * it for this one connection, without ESLint reading it as a mutated
+     * parameter.
+     */
+    const watchTransactionKeywords = (database: { exec: (source: string) => unknown }): string[] => {
+        const keywords: string[] = [];
+        const original = database.exec.bind(database);
+
+        Object.defineProperty(database, "exec", {
+            configurable: true,
+            value: (source: string) => {
+                if (source === "BEGIN" || source === "COMMIT" || source === "ROLLBACK") {
+                    keywords.push(source);
+                }
+
+                return original(source);
+            },
+            writable: true,
+        });
+
+        return keywords;
+    };
+
+    /** Whether a `BEGIN` was ever issued while another was still open. */
+    const nestsBegin = (keywords: ReadonlyArray<string>): boolean => {
+        let depth = 0;
+
+        for (const keyword of keywords) {
+            if (keyword === "BEGIN") {
+                depth += 1;
+
+                if (depth > 1) {
+                    return true;
+                }
+            } else {
+                depth -= 1;
+            }
+        }
+
+        return false;
+    };
 
     it("serializes two overlapping bare transaction() calls instead of corrupting each other's commits", async () => {
         expect.assertions(1);
@@ -77,4 +130,224 @@ describe("createNodeShardHost transaction concurrency", () => {
             dispose();
         }
     });
+
+    it("keeps a serialized boundary whole when a bare transaction() opens across its await", async () => {
+        expect.assertions(2);
+
+        const { dispose, host } = createNodeShardHost();
+
+        try {
+            host.sql.exec("CREATE TABLE rows_ (id TEXT PRIMARY KEY)");
+
+            // The shape a `blockConcurrencyWhile` span takes on this host: two
+            // writes with real work between them. On the two-lane host the
+            // second write lands after an unrelated `BEGIN` has opened on the
+            // other lane, so `assertOwnTurn` refuses it and the whole boundary
+            // rejects — with the FIRST write already committed. A caller that
+            // retries the rejection then re-applies it.
+            const serialized = host.runSerialized(async () => {
+                host.sql.exec("INSERT INTO rows_ (id) VALUES ('first')");
+
+                await sleep(30);
+
+                host.sql.exec("INSERT INTO rows_ (id) VALUES ('second')");
+
+                return "whole";
+            });
+
+            // Started WITHOUT awaiting the boundary, and holding its `BEGIN`
+            // open PAST the point where the boundary resumes — the overlap the
+            // second lane permitted.
+            await sleep(5);
+
+            const committed = host.transaction(async () => {
+                host.sql.exec("INSERT INTO rows_ (id) VALUES ('txn')");
+
+                await sleep(40);
+            });
+
+            await expect(serialized).resolves.toBe("whole");
+
+            await committed;
+
+            expect(
+                host.sql
+                    .exec<{ id: string }>("SELECT id FROM rows_ ORDER BY id")
+                    .toArray()
+                    .map((row) => row.id),
+            ).toStrictEqual(["first", "second", "txn"]);
+        } finally {
+            dispose();
+        }
+    }, 5000);
+
+    it("keeps a serialized boundary's write out of a concurrent transaction's rollback", async () => {
+        expect.assertions(3);
+
+        const { database, dispose, host } = createNodeShardHost();
+
+        try {
+            const keywords = watchTransactionKeywords(database);
+
+            host.sql.exec("CREATE TABLE rows_ (id TEXT PRIMARY KEY)");
+
+            let release = (): void => {};
+
+            const held = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+
+            // A bare `transaction()` holding its `BEGIN` open across an await —
+            // the shape an alarm or a `storage.transaction` bridge takes while
+            // a socket frame drives a boundary of its own, which nothing on a
+            // Node process serializes against it.
+            const outcome = host
+                .transaction(async () => {
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('A')");
+
+                    await held;
+
+                    throw new Error("boom");
+                })
+                .then(
+                    () => "committed",
+                    () => "rolled-back",
+                );
+
+            const serialized = host.runSerialized(async () => {
+                host.sql.exec("INSERT INTO rows_ (id) VALUES ('B')");
+            });
+
+            await sleep(20);
+
+            release();
+
+            await expect(outcome).resolves.toBe("rolled-back");
+
+            await serialized;
+
+            // On the two-lane host this row never existed: the write was
+            // refused inside the foreign `BEGIN` and the boundary rejected.
+            expect(
+                host.sql
+                    .exec<{ id: string }>("SELECT id FROM rows_ ORDER BY id")
+                    .toArray()
+                    .map((row) => row.id),
+            ).toStrictEqual(["B"]);
+            expect(nestsBegin(keywords)).toBe(false);
+        } finally {
+            dispose();
+        }
+    }, 5000);
+
+    it("runs the engine's runSerialized(() => transaction(work)) composition in place", async () => {
+        expect.assertions(2);
+
+        const { dispose, host } = createNodeShardHost();
+
+        try {
+            // `ShardRunner.runInTransaction` verbatim. A shared lane that was
+            // not re-entrant would deadlock here, which is the reason this host
+            // grew a second lane in the first place.
+            const result = await host.runSerialized(async () =>
+                host.transaction(async () => {
+                    host.sql.exec("CREATE TABLE rows_ (id TEXT PRIMARY KEY)");
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('A')");
+
+                    return "done";
+                }),
+            );
+
+            expect(result).toBe("done");
+            expect(
+                host.sql
+                    .exec<{ id: string }>("SELECT id FROM rows_")
+                    .toArray()
+                    .map((row) => row.id),
+            ).toStrictEqual(["A"]);
+        } finally {
+            dispose();
+        }
+    }, 5000);
+
+    it("runs ShardDO's nested runSerialized span in place instead of deadlocking", async () => {
+        expect.assertions(2);
+
+        const { dispose, host } = createNodeShardHost();
+
+        try {
+            // Both compositions the engine stacks on a mutation carrying an
+            // `x-lunora-mutation-id` header: `ShardDO.fetch` widens the dispatch
+            // into a `runSerialized` span, and `ShardRunner.runInTransaction`
+            // inside it is itself `runSerialized(() => transaction(work))`.
+            //
+            // The two-lane host hangs here forever — the inner `runSerialized`
+            // waits on a `tail` that only settles when the outer closure
+            // awaiting it resolves — and because nothing resets that `tail`, the
+            // wedge outlives the request.
+            const result = await host.runSerialized(async () =>
+                host.runSerialized(async () =>
+                    host.transaction(async () => {
+                        host.sql.exec("CREATE TABLE rows_ (id TEXT PRIMARY KEY)");
+                        host.sql.exec("INSERT INTO rows_ (id) VALUES ('A')");
+
+                        return "done";
+                    }),
+                ),
+            );
+
+            expect(result).toBe("done");
+
+            // The lock has to be released by the nesting too, or the next
+            // boundary on this shard never runs.
+            await expect(host.runSerialized(async () => "after")).resolves.toBe("after");
+        } finally {
+            dispose();
+        }
+    }, 5000);
+
+    it("never nests a raw BEGIN when a second top-level transaction overlaps the first", async () => {
+        expect.assertions(2);
+
+        const { database, dispose, host } = createNodeShardHost();
+
+        try {
+            const keywords = watchTransactionKeywords(database);
+
+            host.sql.exec("CREATE TABLE rows_ (id TEXT PRIMARY KEY)");
+
+            // A re-entrancy check that only asked whether the lock is HELD —
+            // a boolean rather than an `AsyncLocalStorage` store — would admit
+            // this second bare `transaction()` in place and nest its `BEGIN`.
+            // better-sqlite3 raises "cannot start a transaction within a
+            // transaction", and on the branch where it does not, the first
+            // call's `COMMIT` publishes the second's rows. A store scoped to a
+            // single call's own await chain is what tells the two cases apart.
+            await Promise.all([
+                host.transaction(async () => {
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('A')");
+
+                    await sleep(15);
+
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('B')");
+                }),
+                host.transaction(async () => {
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('C')");
+                }),
+                host.runSerialized(async () => {
+                    host.sql.exec("INSERT INTO rows_ (id) VALUES ('D')");
+                }),
+            ]);
+
+            expect(nestsBegin(keywords)).toBe(false);
+            expect(
+                host.sql
+                    .exec<{ id: string }>("SELECT id FROM rows_ ORDER BY id")
+                    .toArray()
+                    .map((row) => row.id),
+            ).toStrictEqual(["A", "B", "C", "D"]);
+        } finally {
+            dispose();
+        }
+    }, 5000);
 });

--- a/packages/platform-node/src/node-shard-host.ts
+++ b/packages/platform-node/src/node-shard-host.ts
@@ -387,25 +387,59 @@ interface NodeShardHostOptions {
 /**
  * Build a `ShardHost` over a real `better-sqlite3` database.
  *
- * `runSerialized` chains onto a single `tail` promise rather than the
- * reference host's explicit job-array-plus-drain-loop: every queued closure
- * runs once `tail` settles, and `tail` is reset to a version that always
- * resolves (never rejects) so one job's failure cannot wedge the queue for
- * every job after it — the same "no two closures interleave" guarantee,
- * fewer moving parts to get wrong.
+ * `runSerialized` and `transaction` share **one** boundary lock, because they
+ * write **one** `better-sqlite3` connection. `transaction` issues raw
+ * `BEGIN`/`COMMIT`/`ROLLBACK` — legal here (unlike inside a Cloudflare Durable
+ * Object, where the runtime forbids it and callers must use
+ * `storage.transaction`) because better-sqlite3 is a plain embedded database
+ * with no platform-level transaction primitive layered over it.
  *
- * `transaction` issues raw `BEGIN`/`COMMIT`/`ROLLBACK` — legal here (unlike
- * inside a Cloudflare Durable Object, where the runtime forbids it and
- * callers must use `storage.transaction`) because better-sqlite3 is a plain
- * embedded database with no platform-level transaction primitive layered over
- * it. It runs on its own private `transactionTail` chain, the same shape as
- * `runSerialized`'s but never shared with it: two bare, overlapping
- * `transaction()` calls on this host serialize against each other rather than
- * corrupting each other's commits (raw `BEGIN` on a connection already inside
- * a transaction throws, or worse, interleaves). Routing `transaction` through
- * `runSerialized` itself would deadlock, since the engine already composes
- * `runSerialized(() => transaction(work))` — the inner enqueue would then wait
- * on the outer closure awaiting it.
+ * ## Why one lane and not two
+ *
+ * This host shipped with two private tail chains, one per entry point, so each
+ * serialized against itself and neither against the other. `runSerialized`
+ * issues no `BEGIN` of its own, so one of its closures overlapping a bare
+ * `transaction()` wrote straight into that transaction's span. `assertOwnTurn`
+ * below catches the write — it is the only reason this host never silently lost
+ * one the way an unguarded connection would — but catching it is not the same
+ * as preventing it, and the refusal lands in the wrong place:
+ *
+ * 1. A `runSerialized` closure writes a row. Nothing is open, so it commits.
+ * 2. It awaits (a scheduler hop, an `onShardInit` read, any real I/O).
+ * 3. A bare `transaction()` runs `BEGIN` while it is parked. `transaction` is
+ * a public contract surface, and `./node-shard-state` re-exports it as the
+ * `storage.transaction` member `ShardDO` documents as "the platform
+ * primitive", so a subclass reaches one without going through the engine.
+ * 4. The closure resumes and its next write is refused with
+ * `SHARD_UNAVAILABLE`, so `runSerialized` **rejects** — with step 1 already
+ * durable.
+ *
+ * The boundary the contract promises is atomic-or-nothing to its caller tore in
+ * half: a rejection the caller will retry, on top of a write the retry now
+ * re-applies. That is `runSerialized`'s "no two closures interleave" guarantee
+ * broken by a `transaction` it was never serialized against.
+ *
+ * ## Why the lock is re-entrant, and why `AsyncLocalStorage` is what makes it so
+ *
+ * The engine composes the two, and stacks them: `ShardRunner.runInTransaction`
+ * is `runSerialized(() => transaction(work))` (`@lunora/shard-engine`), and
+ * `ShardDO.fetch` widens a mutation dispatch carrying `x-lunora-mutation-id`
+ * into a *further* `runSerialized` span around it (`@lunora/do`). Under two
+ * plain FIFO chains that outer span is already fatal on this host — the inner
+ * `runSerialized` waits on a `tail` that only settles when the outer closure it
+ * is running inside resolves, and because nothing ever resets that `tail`, the
+ * shard's write lane is wedged for the life of the process rather than for the
+ * life of the request.
+ *
+ * So the lock is skipped for a boundary opened from inside a boundary, and
+ * `AsyncLocalStorage` is the only thing that can tell that case from the one
+ * that must queue: its store follows a single call's own await chain without
+ * leaking into a sibling chain. A held boolean cannot — it reads `true` for an
+ * unrelated *second top-level* `transaction()` too, which would then nest a raw
+ * `BEGIN` on a connection already inside one. This is the same distinction
+ * workerd's `blockConcurrencyWhile` draws natively with "does not queue events
+ * initiated as part of the callback itself", which is what
+ * `@lunora/platform-cloudflare` leans on for the identical composition.
  *
  * The returned `dispose()` is this host's lifecycle owner: it clears the
  * pending alarm `setTimeout` (so it can never fire against a connection this
@@ -475,36 +509,68 @@ const createNodeShardHost = (
      */
     const background = new Set<Promise<unknown>>();
 
-    let tail: Promise<unknown> = Promise.resolve();
+    /**
+     * Set for the duration of a boundary's closure, and readable only from that
+     * closure's own await chain. See this module's `createNodeShardHost`
+     * docstring for why a plain boolean would be wrong here.
+     *
+     * Deliberately NOT `transactionScope`, which is a different question with a
+     * different answer. `transactionScope` means "my chain owns the open
+     * `BEGIN`", and two things read it: `assertOwnTurn`, to decide whether SQL
+     * is refused, and `createAlarms`' `inside`, to decide whether an alarm
+     * mutation is held until commit. Widening it to every `runSerialized`
+     * closure would re-open the hazard this fix closes from the other side — a
+     * plain serialized closure would be waved through `assertOwnTurn` while an
+     * unrelated transaction is open — and would strand every alarm it set in
+     * `pending`, since nothing commits a transaction that was never begun.
+     * `transactionScope` is a strict subset of this store, not a synonym for it.
+     */
+    const insideBoundary = new AsyncLocalStorage<true>();
 
-    const runSerialized: ShardHost["runSerialized"] = (function_) => {
-        const started = tail.then(function_, function_);
+    /**
+     * Tail of the one boundary queue. Only ever a `release` promise, so it
+     * cannot reject and one failed boundary cannot wedge every boundary behind
+     * it — the property the two `tail` chains this replaced got from resetting
+     * themselves to a never-rejecting version.
+     */
+    let boundaryTail: Promise<void> = Promise.resolve();
 
-        tail = started.then(
-            () => undefined,
-            () => undefined,
-        );
+    /**
+     * Hold the shard's single-writer lock for `function_`, or run it in place
+     * when the caller's own chain already holds it.
+     *
+     * The re-entrant branch takes no queue slot at all, so it cannot deadlock on
+     * the lock its own caller is holding. The queueing branch claims its slot
+     * synchronously — everything up to `await previous` runs on the calling tick
+     * — so boundaries are admitted in call order.
+     */
+    const withBoundary = async <T>(function_: () => Promise<T>): Promise<T> => {
+        if (insideBoundary.getStore() === true) {
+            return await function_();
+        }
 
-        return started;
+        const previous = boundaryTail;
+
+        let release: () => void = () => {};
+
+        boundaryTail = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+
+        await previous;
+
+        try {
+            // `return await`, not a bare `return`: the rejection has to reach
+            // the `finally`, or a boundary whose closure threw never releases
+            // the lock and the shard wedges for good. `await` re-throws by
+            // identity, which `ShardHost`'s error-identity requirement pins.
+            return await insideBoundary.run(true, function_);
+        } finally {
+            release();
+        }
     };
 
-    // A second, private tail chain of the exact same shape as `runSerialized`
-    // above, used ONLY by `transaction`. Raw BEGIN/COMMIT/ROLLBACK on a shared
-    // connection is not safe under overlap — a second `transaction()` call
-    // that starts before the first commits either throws "cannot start a
-    // transaction within a transaction" on the second BEGIN, or (worse) its
-    // COMMIT commits the first's uncommitted writes and the first's ROLLBACK
-    // then discards work that already reported success.
-    //
-    // Routing `transaction` through the SAME `runSerialized`/`tail` chain
-    // would deadlock: the engine composes them as
-    // `runSerialized(() => transaction(work))` (`shard-runner.ts`), so the
-    // inner enqueue would wait on the outer closure that is awaiting it. This
-    // dedicated lane serializes bare, overlapping `transaction()` calls
-    // against each other (the actual bug) while leaving `runInTransaction`'s
-    // composition free of self-deadlock (the outer gate is `runSerialized`,
-    // the inner lane is always empty when it runs).
-    let transactionTail: Promise<unknown> = Promise.resolve();
+    const runSerialized: ShardHost["runSerialized"] = <T>(function_: () => Promise<T>): Promise<T> => withBoundary(function_);
 
     const runTransaction = async <T>(function_: () => Promise<T>): Promise<T> => {
         database.exec("BEGIN");
@@ -536,19 +602,7 @@ const createNodeShardHost = (
         }
     };
 
-    const transaction: ShardHost["transaction"] = <T>(function_: () => Promise<T>): Promise<T> => {
-        const started = transactionTail.then(
-            () => runTransaction(function_),
-            () => runTransaction(function_),
-        );
-
-        transactionTail = started.then(
-            () => undefined,
-            () => undefined,
-        );
-
-        return started;
-    };
+    const transaction: ShardHost["transaction"] = <T>(function_: () => Promise<T>): Promise<T> => withBoundary(async () => runTransaction(function_));
 
     const host: ShardHost = {
         alarms,


### PR DESCRIPTION
`runSerialized` and `transaction` ran on two private tail chains in `node-shard-host.ts`, so each
serialized against itself and neither against the other. They write **one** `better-sqlite3`
connection.

## The hazard

`runSerialized` issues no `BEGIN` of its own, so one of its closures overlapping a bare
`transaction()` runs inside that transaction's span. Concretely:

1. A `runSerialized` closure writes a row. Nothing is open, so it **commits**.
2. It awaits — a scheduler hop, an `onShardInit` read, any real I/O.
3. A bare `transaction()` runs `BEGIN` while it is parked. `transaction` is a public contract
   surface, and `node-shard-state.ts` re-exports it as the `storage.transaction` member `ShardDO`
   documents as "the platform primitive", so a subclass reaches one without going through the
   engine.
4. The closure resumes and its next write is refused with `SHARD_UNAVAILABLE`, so `runSerialized`
   **rejects** — with step 1 already durable.

The boundary that is atomic-or-nothing to its caller tears in half: a rejection the caller will
retry, on top of a write the retry then re-applies.

### How this differs from the rivet symptom

`@lunora/platform-rivet` lost the write **silently** — its `flush()` skipped the snapshot for
`inTransaction`, `runSerialized` resolved, and the transaction's `ROLLBACK` destroyed a write
already reported durable. This host does **not** do that. `assertOwnTurn` (already present, and
absent from rivet) refuses the write instead, so the failure is loud. Same root cause, different
symptom: a torn boundary and a spurious retryable error rather than silent data loss. The fix is
the same shape; the wording is not.

There is also **no `flush`/`dirty`/snapshot step here** — `platform-node` writes straight to a
`better-sqlite3` file with no serialize-to-object-store round trip (confirmed: the only `snapshot`
hits in this package are workflow-run JSON in `node-workflow-store.ts`). So the second half of the
rivet fix, the `flushTail` in `rivet-shard-state.ts`, deliberately does **not** port.

### The nested deadlock — reachable, and no bare `transaction()` needed

`ShardDO.fetch` widens a mutation carrying `x-lunora-mutation-id` into a `runSerialized` span
(`shard-do.ts`), and `ShardRunner.runInTransaction` inside it is itself
`runSerialized(() => transaction(work))` (`shard-runner.ts:126`). That is `runSerialized` nested in
`runSerialized`, and on two FIFO chains the inner call waits on a `tail` that only settles when the
outer closure awaiting it resolves. Verified by probe: it hangs. Because nothing ever resets `tail`,
the shard's write lane stays wedged for the **life of the process**, not the life of the request.

## The design

One shared boundary lock over both entry points, re-entrant via `AsyncLocalStorage`.

**Why nesting cannot deadlock:** the re-entrant branch takes no queue slot at all — it never touches
`boundaryTail` — so it can never wait on a promise gated behind its own caller's release. The
queueing branch claims its slot synchronously (everything before `await previous` runs on the
calling tick), so boundaries are admitted in call order. `boundaryTail` is only ever a `release`
promise, so it cannot reject and one failed boundary cannot wedge those behind it.

**Why a separate store and not `transactionScope`:** the two answer different questions.
`transactionScope` means "my chain owns the open `BEGIN`", and both `assertOwnTurn` (refuse SQL?)
and `createAlarms`' `inside` (defer the alarm to commit?) read it. Widening it to every
`runSerialized` closure would wave a plain serialized closure through `assertOwnTurn` while an
unrelated transaction is open — re-opening this hazard from the other side — and would strand every
alarm such a closure set in `pending`, since nothing commits a transaction that was never begun.
`transactionScope` is a strict subset of the new store, not a synonym.

**Why not a held boolean:** it reads `true` for an unrelated *second top-level* `transaction()` too,
which would then run in place and nest a raw `BEGIN` on a connection already inside one. A test
pins this specifically.

The two-lane comment that argued the old design is rewritten rather than left contradicting the
code. Its `shard-runner.ts` composition claim was re-verified and still holds.

## Tests

Five added to the existing `__tests__/transaction-concurrency.test.ts`. **Four fail on unmodified
`alpha`**, one of them by deadlocking (each carries an explicit timeout so a deadlock is red, not a
hang):

| Test | Pre-fix |
| --- | --- |
| keeps a serialized boundary whole when a bare `transaction()` opens across its await | ❌ rejects `SHARD_UNAVAILABLE`, first write already durable |
| keeps a serialized boundary's write out of a concurrent transaction's rollback | ❌ rejects, row never exists |
| runs the engine's `runSerialized(() => transaction(work))` composition in place | ✅ regression guard |
| runs `ShardDO`'s nested `runSerialized` span in place instead of deadlocking | ❌ times out at 5s |
| never nests a raw `BEGIN` when a second top-level `transaction()` overlaps the first | ❌ (also trips the cross-pair hazard) |

Both pre-existing tests keep passing.

## Notes

- **No `PlatformCapabilities` change.** This is host-internal single-writer plumbing with no new
  `ctx.*` surface or binding. `NODE_CAPABILITIES.shardedState` already documents the refusal, and
  the fix makes that note *more* accurate — it narrows `SHARD_UNAVAILABLE` to the ungated query
  dispatch the note actually describes, instead of also hitting the shard's own write gate.
- **No existing mutex primitive to reuse.** Grepped `shared/` and every `@lunora/*` package; the
  only "semaphore" is the scheduler's durable job-concurrency pool, not an in-process async lock.
  Still true that ~20 lines is the right answer.
- **`test:workerd` is out of scope.** `platform-node` declares no `workerd` vitest project (it is
  not among the 11 the script discovers) and `better-sqlite3` cannot load in workerd. Nothing
  outside this package imports it, either.
- `@lunora/platform-rivet` has the same fix in flight on **PR #416**.

## Gates

`pnpm --filter "@lunora/platform-node..." run build` · `run build` (isolatedDeclarations) ·
`platform-node` tests 170/170 · `@lunora/platform` 51 · `@lunora/shard-engine` 1453 · `@lunora/do`
711 · `pnpm run lint:types` · `pnpm run lint:eslint` · `pnpm run api:check` (54 snapshots
unchanged) · `pnpm run build:packages:prod` + `pnpm run dist:check` · `pnpm run lint:package-json`
— all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
