### PR TITLE
fix(runtime): cap admin JSON bodies at the reader

### DIFF
--- a/packages/runtime/__tests__/admin-export-import.test.ts
+++ b/packages/runtime/__tests__/admin-export-import.test.ts
@@ -10,6 +10,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutionContextLike, ShardingInfo } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
+import chunkedBody from "./helpers/chunked-body";
 
 const fakeContext: ExecutionContextLike = {
     passThroughOnException: () => undefined,
@@ -31,23 +32,7 @@ const ADMIN_TOKEN = "admin-bear";
  * A chunked request body that streams just over the 1 MiB `MAX_BODY_BYTES`
  * cap with no `Content-Length`, so only the byte-budgeted reader can reject it.
  */
-const oversizedStream = (): ReadableStream<Uint8Array> => {
-    const chunk = new Uint8Array(256 * 1024).fill(120); // 'x'
-    let sent = 0;
-
-    return new ReadableStream<Uint8Array>({
-        pull(controller) {
-            if (sent >= 5) {
-                controller.close();
-
-                return;
-            }
-
-            sent += 1;
-            controller.enqueue(chunk); // 5 × 256 KiB = 1.25 MiB > 1 MiB cap
-        },
-    });
-};
+const oversizedStream = (): ReadableStream<Uint8Array> => chunkedBody({ exceedBytes: 1_048_576 });
 
 describe("createWorker — admin export endpoint", () => {
     it("rejects without a configured admin token (403)", async () => {

--- a/packages/runtime/__tests__/helpers/chunked-body.ts
+++ b/packages/runtime/__tests__/helpers/chunked-body.ts
@@ -1,0 +1,44 @@
+/**
+ * A chunked request body for the body-budget tests: bytes arrive in pieces with
+ * NO `Content-Length`, so the entry-point header fast path cannot see the size
+ * and only the byte-budgeted reader can reject it. `Request` does not synthesize
+ * the header either, which is exactly the shape a chunked upload has on the wire.
+ */
+
+/**
+ * Streams `prefix`, then padding that strictly exceeds `exceedBytes`, then
+ * `suffix` — so a caller passes the cap it wants the body to be over and gets a
+ * body over it, with no rounding to reason about at the call site.
+ *
+ * `prefix`/`suffix` wrap the padding in JSON when the route must parse the body
+ * to reach the assertion; omit both when the reader rejects it unparsed.
+ */
+const chunkedBody = ({ exceedBytes, prefix = "", suffix = "" }: { exceedBytes: number; prefix?: string; suffix?: string }): ReadableStream<Uint8Array> => {
+    const chunk = new Uint8Array(256 * 1024).fill(120); // 'x'
+    const encoder = new TextEncoder();
+    const padChunks = Math.floor(exceedBytes / chunk.byteLength) + 1;
+    // Index-driven: chunk 0 is the prefix, the next `padChunks` are padding, and
+    // the one after that is the suffix and closes the stream — so what a reader
+    // has to follow is the enqueue order, not a counter shared between two roles.
+    let index = 0;
+
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            const current = index;
+
+            index += 1;
+
+            if (current === 0) {
+                controller.enqueue(encoder.encode(prefix));
+            } else if (current <= padChunks) {
+                controller.enqueue(chunk);
+            } else {
+                controller.enqueue(encoder.encode(suffix));
+                controller.close();
+            }
+        },
+    });
+};
+
+// Sole export, so `default` is the form the repo's lint rule requires here.
+export default chunkedBody;

--- a/packages/runtime/__tests__/tenant-fanout.test.ts
+++ b/packages/runtime/__tests__/tenant-fanout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { CronHandler, ExecutionContextLike, QueueForwardBatch, QueueForwardHandler } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
+import chunkedBody from "./helpers/chunked-body";
 
 /**
  * The two reserved fan-out endpoints a Workers-for-Platforms tenant depends on.
@@ -84,6 +85,21 @@ describe("createWorker — the tenant cron fan-out endpoint", () => {
         const response = await worker.fetch(post(SCHEDULED_PATH, {}), {}, fakeContext);
 
         expect(response.status).toBe(400);
+    });
+
+    it("refuses a JSON `null` root with the tick's own 400, not a 500", async () => {
+        expect.assertions(2);
+
+        const cron = vi.fn<CronHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, crons: { "*/5 * * * *": cron }, shardDO: shardNamespace() });
+
+        // `readLooseJsonBody` can only return `{}`, a parsed value, or throw —
+        // but `null` IS a parsed value, so a handler that reads a property off
+        // the result without guarding turns a malformed tick into a 500.
+        const response = await worker.fetch(post(SCHEDULED_PATH, null), {}, fakeContext);
+
+        expect(response.status).toBe(400);
+        expect(cron).not.toHaveBeenCalled();
     });
 
     it("refuses a GET (405), so the endpoint cannot be triggered by a link", async () => {
@@ -187,6 +203,65 @@ describe("createWorker — the tenant queue fan-out endpoint", () => {
 });
 
 /**
+ * A `{"retry": []}` answer tells the platform consumer every message in the
+ * batch was handled, so it deletes them. A body this endpoint could not read
+ * must therefore never reach that answer: a request that names no batch has to
+ * fail loudly, or a forwarder that writes no body — or a proxy that strips one —
+ * silently destroys every message it was carrying, with a 200 to say it went
+ * fine. Cloudflare Queues never delivers an empty batch, so an explicit
+ * `messages: []` stays a legal (if pointless) request.
+ */
+describe("createWorker — a queue dispatch that names no batch", () => {
+    const refusedBodies: [label: string, body: unknown][] = [
+        ["a JSON null root", null],
+        ["an array root", []],
+        ["a string root", "jobs"],
+        ["a number root", 123],
+        ["an object with no `messages`", { queue: "jobs" }],
+        ["a `messages` that is not an array", { messages: "m1", queue: "jobs" }],
+    ];
+
+    it.each(refusedBodies)("refuses %s (400) rather than acking a batch it never read", async (_label, body) => {
+        expect.assertions(2);
+
+        const queueHandler = vi.fn<QueueForwardHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, queueHandler, shardDO: shardNamespace() });
+
+        const response = await worker.fetch(post(QUEUE_PATH, body), {}, fakeContext);
+
+        expect(response.status).toBe(400);
+        expect(queueHandler).not.toHaveBeenCalled();
+    });
+
+    it("refuses a POST with no body at all (400)", async () => {
+        expect.assertions(2);
+
+        const queueHandler = vi.fn<QueueForwardHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, queueHandler, shardDO: shardNamespace() });
+
+        // The likeliest real trigger: a forwarder that fails to write a body, or
+        // a proxy that strips it. `readLooseJsonBody` maps an empty body to `{}`,
+        // so nothing upstream of the guard distinguishes it from a real batch.
+        const response = await worker.fetch(new Request(QUEUE_PATH, { headers: { authorization: `Bearer ${ADMIN_TOKEN}` }, method: "POST" }), {}, fakeContext);
+
+        expect(response.status).toBe(400);
+        expect(queueHandler).not.toHaveBeenCalled();
+    });
+
+    it("still accepts an explicit empty batch", async () => {
+        expect.assertions(2);
+
+        const queueHandler = vi.fn<QueueForwardHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, queueHandler, shardDO: shardNamespace() });
+
+        const response = await worker.fetch(post(QUEUE_PATH, { messages: [], queue: "jobs" }), {}, fakeContext);
+
+        expect(response.status).toBe(200);
+        expect(queueHandler).toHaveBeenCalledTimes(1);
+    });
+});
+
+/**
  * Both endpoints take an admin-supplied JSON body, so both need the byte budget
  * the rest of the reserved surface reads under. `Content-Length` is forgeable
  * and absent on a chunked body, so the entry-point header check is a fast path,
@@ -195,31 +270,6 @@ describe("createWorker — the tenant queue fan-out endpoint", () => {
  * batch is accepted or rejected depending on how the platform consumer framed it.
  */
 describe("createWorker — the fan-out endpoints' body budget", () => {
-    /** A chunked body streaming at least `bytes` of padding inside a valid JSON object, with no `Content-Length`. */
-    const chunkedJson = (prefix: string, bytes: number): ReadableStream<Uint8Array> => {
-        const chunk = new Uint8Array(256 * 1024).fill(120); // 'x'
-        const encoder = new TextEncoder();
-        const padChunks = Math.ceil(bytes / chunk.byteLength);
-        let sent = 0;
-
-        return new ReadableStream<Uint8Array>({
-            pull(controller) {
-                if (sent === 0) {
-                    controller.enqueue(encoder.encode(prefix));
-                } else if (sent > padChunks) {
-                    controller.enqueue(encoder.encode(`"}`));
-                    controller.close();
-
-                    return;
-                } else {
-                    controller.enqueue(chunk);
-                }
-
-                sent += 1;
-            },
-        });
-    };
-
     /** POST a chunked (length-less) body carrying the admin bearer. */
     const postChunked = (url: string, body: ReadableStream<Uint8Array>): Request =>
         new Request(url, {
@@ -236,7 +286,11 @@ describe("createWorker — the fan-out endpoints' body budget", () => {
         const cron = vi.fn<CronHandler>();
         const worker = createWorker({ adminToken: ADMIN_TOKEN, crons: { "*/5 * * * *": cron }, shardDO: shardNamespace() });
 
-        const response = await worker.fetch(postChunked(SCHEDULED_PATH, chunkedJson(String.raw`{"cron":"*/5 * * * *","pad":"`, 1_048_576)), {}, fakeContext);
+        const response = await worker.fetch(
+            postChunked(SCHEDULED_PATH, chunkedBody({ exceedBytes: 1_048_576, prefix: String.raw`{"cron":"*/5 * * * *","pad":"`, suffix: `"}` })),
+            {},
+            fakeContext,
+        );
 
         expect(response.status).toBe(413);
         // The tick must be refused before it fires, not after the oversized body
@@ -251,7 +305,7 @@ describe("createWorker — the fan-out endpoints' body budget", () => {
         const worker = createWorker({ adminToken: ADMIN_TOKEN, queueHandler, shardDO: shardNamespace() });
 
         const response = await worker.fetch(
-            postChunked(QUEUE_PATH, chunkedJson(String.raw`{"queue":"jobs","messages":[],"pad":"`, 16 * 1_048_576)),
+            postChunked(QUEUE_PATH, chunkedBody({ exceedBytes: 16 * 1_048_576, prefix: String.raw`{"queue":"jobs","messages":[],"pad":"`, suffix: `"}` })),
             {},
             fakeContext,
         );

--- a/packages/runtime/__tests__/tenant-fanout.test.ts
+++ b/packages/runtime/__tests__/tenant-fanout.test.ts
@@ -185,3 +185,120 @@ describe("createWorker — the tenant queue fan-out endpoint", () => {
         expect(response.status).toBe(400);
     });
 });
+
+/**
+ * Both endpoints take an admin-supplied JSON body, so both need the byte budget
+ * the rest of the reserved surface reads under. `Content-Length` is forgeable
+ * and absent on a chunked body, so the entry-point header check is a fast path,
+ * not the cap — only a reader counting bytes as they arrive is. And the cap the
+ * reader applies has to be the one the header check applies, or an identical
+ * batch is accepted or rejected depending on how the platform consumer framed it.
+ */
+describe("createWorker — the fan-out endpoints' body budget", () => {
+    /** A chunked body streaming at least `bytes` of padding inside a valid JSON object, with no `Content-Length`. */
+    const chunkedJson = (prefix: string, bytes: number): ReadableStream<Uint8Array> => {
+        const chunk = new Uint8Array(256 * 1024).fill(120); // 'x'
+        const encoder = new TextEncoder();
+        const padChunks = Math.ceil(bytes / chunk.byteLength);
+        let sent = 0;
+
+        return new ReadableStream<Uint8Array>({
+            pull(controller) {
+                if (sent === 0) {
+                    controller.enqueue(encoder.encode(prefix));
+                } else if (sent > padChunks) {
+                    controller.enqueue(encoder.encode(`"}`));
+                    controller.close();
+
+                    return;
+                } else {
+                    controller.enqueue(chunk);
+                }
+
+                sent += 1;
+            },
+        });
+    };
+
+    /** POST a chunked (length-less) body carrying the admin bearer. */
+    const postChunked = (url: string, body: ReadableStream<Uint8Array>): Request =>
+        new Request(url, {
+            body,
+            // @ts-expect-error -- duplex is required by the fetch spec for a streaming body but missing from the lib types here
+            duplex: "half",
+            headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+            method: "POST",
+        });
+
+    it("rejects an oversized chunked cron tick at the reader, not only at the Content-Length header (413)", async () => {
+        expect.assertions(2);
+
+        const cron = vi.fn<CronHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, crons: { "*/5 * * * *": cron }, shardDO: shardNamespace() });
+
+        const response = await worker.fetch(postChunked(SCHEDULED_PATH, chunkedJson(String.raw`{"cron":"*/5 * * * *","pad":"`, 1_048_576)), {}, fakeContext);
+
+        expect(response.status).toBe(413);
+        // The tick must be refused before it fires, not after the oversized body
+        // has been buffered in full and dispatched.
+        expect(cron).not.toHaveBeenCalled();
+    });
+
+    it("rejects a chunked queue batch over the route's own budget (413)", async () => {
+        expect.assertions(2);
+
+        const queueHandler = vi.fn<QueueForwardHandler>();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, queueHandler, shardDO: shardNamespace() });
+
+        const response = await worker.fetch(
+            postChunked(QUEUE_PATH, chunkedJson(String.raw`{"queue":"jobs","messages":[],"pad":"`, 16 * 1_048_576)),
+            {},
+            fakeContext,
+        );
+
+        expect(response.status).toBe(413);
+        expect(queueHandler).not.toHaveBeenCalled();
+    });
+
+    it("accepts a forwarded batch above the shared 1 MiB JSON cap", async () => {
+        expect.assertions(3);
+
+        const seen: QueueForwardBatch[] = [];
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            queueHandler: (batch) => {
+                seen.push(batch);
+            },
+            shardDO: shardNamespace(),
+        });
+
+        // 2 MiB of message bodies: a fraction of what a full 100 × 128 KiB batch
+        // weighs, and over the shared 1 MiB cap this endpoint used to inherit.
+        const messages = Array.from({ length: 16 }, (_, index) => {
+            return { body: "x".repeat(128 * 1024), id: `m${String(index)}` };
+        });
+        const body = JSON.stringify({ messages, queue: "jobs" });
+
+        // Declared explicitly: a real forwarded POST carries a `Content-Length`,
+        // and it is the entry-point header check — not the reader — that a batch
+        // over the shared cap used to die on. `Request` does not synthesize the
+        // header, so without it this asserts only half the path.
+        const response = await worker.fetch(
+            new Request(QUEUE_PATH, {
+                body,
+                headers: {
+                    authorization: `Bearer ${ADMIN_TOKEN}`,
+                    "content-length": String(new TextEncoder().encode(body).byteLength),
+                    "content-type": "application/json",
+                },
+                method: "POST",
+            }),
+            {},
+            fakeContext,
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ retry: [] });
+        expect(seen[0]?.messages).toHaveLength(16);
+    });
+});

--- a/packages/runtime/docs/index.mdx
+++ b/packages/runtime/docs/index.mdx
@@ -393,6 +393,14 @@ misconfigured tenant fails loudly instead of dropping every batch. Messages with
 no string `id` are dropped before the handler sees them — there would be nothing
 to ack or retry them by.
 
+A forwarded batch is capped at **16 MiB** and a larger one is refused with a
+`413` — chunked or not, since the cap is enforced as the bytes arrive rather than
+from `Content-Length`. That is sized for a full Cloudflare Queues batch (100
+messages × 128 KiB) plus the forwarding envelope, so a consumer that respects the
+queue's own limits never meets it. A body that names no `messages` array — an
+empty body included — is a `400` rather than an empty batch, because answering
+`{ "retry": [] }` would tell the consumer to ack messages this worker never read.
+
 Neither endpoint replaces the native triggers where a host has them. On an
 ordinary account-level Worker, `triggers.crons` and a real queue consumer are
 still the path; these are the seam a platform reaches for when the host removed

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -29,7 +29,7 @@ import type { AuthAuditReader } from "./auth-audit-rpc";
 import { buildGetAuthAuditLog, GET_AUTH_AUDIT_LOG_OP } from "./auth-audit-rpc";
 import { buildBackupAdminRoutes } from "./backup-admin-routes";
 import { groupBatchCallsByShard } from "./batch";
-import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit } from "./body-readers";
+import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit, readLooseJsonBody } from "./body-readers";
 import { buildDataMovementAdminRoutes } from "./data-movement-admin-routes";
 import type { FunctionArgumentDescriptor } from "./describe-args";
 import { LunoraError, toErrorResponse } from "./errors";
@@ -88,16 +88,6 @@ interface RpcEnvelope {
 }
 
 type Route = (request: Request, env: unknown, context: ExecutionContextLike) => Promise<Response> | Response;
-
-/**
- * Routes whose reader declares a body budget above the shared {@link MAX_BODY_BYTES}
- * JSON cap. The entry-point `Content-Length` fast-reject reads this table so the
- * header check agrees with the reader that actually enforces the limit.
- */
-const ROUTE_BODY_BUDGETS: Record<string, number> = {
-    [KV_VALUE_PATH]: KV_VALUE_MAX_BODY_BYTES,
-    [STORAGE_PATH]: STORAGE_UPLOAD_MAX_BODY_BYTES,
-};
 
 /**
  * Context handed to HTTP-action handlers. Built per request by the worker; its
@@ -1744,6 +1734,29 @@ const SCHEDULED_TICK_PATH = "/_lunora/scheduled";
 // WfP Workers can't be queue consumers, so a platform-owned consumer forwards
 // batches here, where the app's `queueHandler` runs.
 const QUEUE_DISPATCH_PATH = "/_lunora/queue";
+
+/**
+ * Body budget for a forwarded queue batch, declared by this route the way the KV
+ * value PUT declares `KV_VALUE_MAX_BODY_BYTES`. Derived from what Cloudflare
+ * Queues can hand a consumer: `max_batch_size` tops out at 100 messages and a
+ * message may carry 128 KiB, so a full batch is 12.5 MiB of message bodies
+ * before the forwarding envelope (`queue`, per-message `id`) and JSON string
+ * escaping. 16 MiB covers that with the same ~1.3× headroom the KV cap allows
+ * its 25 MiB value, and stays under the 32 MiB the KV and storage routes already
+ * buffer, so it is not a new memory ceiling for the isolate.
+ */
+const QUEUE_DISPATCH_MAX_BODY_BYTES: number = 16 * 1_048_576;
+
+/**
+ * Routes whose reader declares a body budget above the shared {@link MAX_BODY_BYTES}
+ * JSON cap. The entry-point `Content-Length` fast-reject reads this table so the
+ * header check agrees with the reader that actually enforces the limit.
+ */
+const ROUTE_BODY_BUDGETS: Record<string, number> = {
+    [KV_VALUE_PATH]: KV_VALUE_MAX_BODY_BYTES,
+    [QUEUE_DISPATCH_PATH]: QUEUE_DISPATCH_MAX_BODY_BYTES,
+    [STORAGE_PATH]: STORAGE_UPLOAD_MAX_BODY_BYTES,
+};
 
 /**
  * The reserved cross-shard relation reader's function-path prefix. Inlined as a
@@ -5139,7 +5152,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             throw new LunoraError("scheduled tick endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
         }
 
-        const body = (await request.json().catch(() => undefined)) as { cron?: unknown } | undefined;
+        const body = (await readLooseJsonBody(request, "Scheduled tick")) as { cron?: unknown } | undefined;
         const cron = typeof body?.cron === "string" ? body.cron : "";
 
         if (cron === "") {
@@ -5168,7 +5181,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             throw new LunoraError("no queueHandler configured", { code: "BAD_REQUEST", status: 400 });
         }
 
-        const body = (await request.json().catch(() => undefined)) as { messages?: unknown; queue?: unknown } | undefined;
+        const body = (await readLooseJsonBody(request, "Queue dispatch", QUEUE_DISPATCH_MAX_BODY_BYTES)) as { messages?: unknown; queue?: unknown } | undefined;
         const queue = typeof body?.queue === "string" ? body.queue : "";
         const rawMessages = Array.isArray(body?.messages) ? body.messages : [];
         const messages = rawMessages

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -29,7 +29,7 @@ import type { AuthAuditReader } from "./auth-audit-rpc";
 import { buildGetAuthAuditLog, GET_AUTH_AUDIT_LOG_OP } from "./auth-audit-rpc";
 import { buildBackupAdminRoutes } from "./backup-admin-routes";
 import { groupBatchCallsByShard } from "./batch";
-import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit, readLooseJsonBody } from "./body-readers";
+import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit } from "./body-readers";
 import { buildDataMovementAdminRoutes } from "./data-movement-admin-routes";
 import type { FunctionArgumentDescriptor } from "./describe-args";
 import { LunoraError, toErrorResponse } from "./errors";
@@ -62,6 +62,7 @@ import { runScheduledBackup } from "./scheduled-backup";
 import type { SecurityOptions } from "./security-headers";
 import { decorateResponse, enforceOrigin, enforceWebSocketOrigin, handleCorsPreflight, resolveSecurity } from "./security-headers";
 import { buildStorageAdminRoutes, STORAGE_PATH, STORAGE_UPLOAD_MAX_BODY_BYTES } from "./storage-admin-routes";
+import { buildTenantFanoutRoutes, QUEUE_DISPATCH_MAX_BODY_BYTES, QUEUE_DISPATCH_PATH } from "./tenant-fanout-routes";
 import type { TrustInboundTraceContext } from "./trace-trust";
 import { createDroppedTraceNotice, resolveTraceTrust } from "./trace-trust";
 import { trustedClientIp } from "./trusted-client-ip";
@@ -88,6 +89,17 @@ interface RpcEnvelope {
 }
 
 type Route = (request: Request, env: unknown, context: ExecutionContextLike) => Promise<Response> | Response;
+
+/**
+ * Routes whose reader declares a body budget above the shared {@link MAX_BODY_BYTES}
+ * JSON cap. The entry-point `Content-Length` fast-reject reads this table so the
+ * header check agrees with the reader that actually enforces the limit.
+ */
+const ROUTE_BODY_BUDGETS: Record<string, number> = {
+    [KV_VALUE_PATH]: KV_VALUE_MAX_BODY_BYTES,
+    [QUEUE_DISPATCH_PATH]: QUEUE_DISPATCH_MAX_BODY_BYTES,
+    [STORAGE_PATH]: STORAGE_UPLOAD_MAX_BODY_BYTES,
+};
 
 /**
  * Context handed to HTTP-action handlers. Built per request by the worker; its
@@ -1723,40 +1735,6 @@ const STATUS_PATH = "/_lunora/status";
 
 /** True for the admin routes the async `adminGate` may authorize — everything under `/_lunora/admin/` plus `/_lunora/migrate`. */
 const isAdminPath = (pathname: string): boolean => pathname.startsWith(ADMIN_PATH_PREFIX) || pathname === MIGRATE_PATH;
-
-// Admin-gated HTTP entrypoint that runs a cron expression's jobs exactly as the
-// native `scheduled()` trigger would. Cloudflare silently drops `triggers.crons`
-// for Workers uploaded into a Workers-for-Platforms dispatch namespace, so a
-// platform fans cron ticks out to its tenants by POSTing here.
-const SCHEDULED_TICK_PATH = "/_lunora/scheduled";
-
-// Admin-gated HTTP entrypoint that processes a forwarded queue batch. Namespaced
-// WfP Workers can't be queue consumers, so a platform-owned consumer forwards
-// batches here, where the app's `queueHandler` runs.
-const QUEUE_DISPATCH_PATH = "/_lunora/queue";
-
-/**
- * Body budget for a forwarded queue batch, declared by this route the way the KV
- * value PUT declares `KV_VALUE_MAX_BODY_BYTES`. Derived from what Cloudflare
- * Queues can hand a consumer: `max_batch_size` tops out at 100 messages and a
- * message may carry 128 KiB, so a full batch is 12.5 MiB of message bodies
- * before the forwarding envelope (`queue`, per-message `id`) and JSON string
- * escaping. 16 MiB covers that with the same ~1.3× headroom the KV cap allows
- * its 25 MiB value, and stays under the 32 MiB the KV and storage routes already
- * buffer, so it is not a new memory ceiling for the isolate.
- */
-const QUEUE_DISPATCH_MAX_BODY_BYTES: number = 16 * 1_048_576;
-
-/**
- * Routes whose reader declares a body budget above the shared {@link MAX_BODY_BYTES}
- * JSON cap. The entry-point `Content-Length` fast-reject reads this table so the
- * header check agrees with the reader that actually enforces the limit.
- */
-const ROUTE_BODY_BUDGETS: Record<string, number> = {
-    [KV_VALUE_PATH]: KV_VALUE_MAX_BODY_BYTES,
-    [QUEUE_DISPATCH_PATH]: QUEUE_DISPATCH_MAX_BODY_BYTES,
-    [STORAGE_PATH]: STORAGE_UPLOAD_MAX_BODY_BYTES,
-};
 
 /**
  * The reserved cross-shard relation reader's function-path prefix. Inlined as a
@@ -5137,66 +5115,16 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         }
     };
 
-    /**
-     * `POST /_lunora/scheduled` — run a cron expression's jobs over HTTP, the
-     * Workers-for-Platforms workaround for dropped `triggers.crons` (a platform
-     * fans ticks out to its namespaced tenants). Admin-gated; the body carries
-     * the cron expression to run as `{ "cron": "0 9 * * *" }`, and dispatch goes through the SAME
-     * `handleScheduled` path the native trigger uses (user crons + code crons +
-     * scheduled backup), so behaviour is identical to a real firing.
-     */
-    const handleScheduledTick = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<Response> => {
-        assertAdminAuthorized(request);
-
-        if (request.method !== "POST") {
-            throw new LunoraError("scheduled tick endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
-        }
-
-        const body = (await readLooseJsonBody(request, "Scheduled tick")) as { cron?: unknown } | undefined;
-        const cron = typeof body?.cron === "string" ? body.cron : "";
-
-        if (cron === "") {
-            throw new LunoraError("scheduled tick requires a `cron` expression", { code: "BAD_REQUEST", status: 400 });
-        }
-
-        await handleScheduled({ cron, noRetry: () => {}, scheduledTime: Date.now() }, env, context);
-
-        return Response.json({ cron, ok: true });
-    };
-
-    /**
-     * `POST /_lunora/queue` — process a forwarded queue batch (the WfP workaround
-     * for queue consumers). Admin-gated; the body is
-     * `{ "queue": "name", "messages": [{ "id": "...", "body": ... }] }`. Returns
-     * `{ "retry": [ids] }` so the platform consumer can retry only the failures.
-     */
-    const handleQueueDispatch = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<Response> => {
-        assertAdminAuthorized(request);
-
-        if (request.method !== "POST") {
-            throw new LunoraError("queue dispatch endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
-        }
-
-        if (!options.queueHandler) {
-            throw new LunoraError("no queueHandler configured", { code: "BAD_REQUEST", status: 400 });
-        }
-
-        const body = (await readLooseJsonBody(request, "Queue dispatch", QUEUE_DISPATCH_MAX_BODY_BYTES)) as { messages?: unknown; queue?: unknown } | undefined;
-        const queue = typeof body?.queue === "string" ? body.queue : "";
-        const rawMessages = Array.isArray(body?.messages) ? body.messages : [];
-        const messages = rawMessages
-            .filter(
-                (message): message is { body: unknown; id: string } =>
-                    typeof message === "object" && message !== null && typeof (message as { id?: unknown }).id === "string",
-            )
-            .map((message) => {
-                return { body: (message as { body?: unknown }).body, id: (message as { id: string }).id };
-            });
-
-        const result = await options.queueHandler({ messages, queue }, env, context);
-
-        return Response.json({ retry: result?.retry ?? [] });
-    };
+    // The reserved WfP fan-out entrypoints (`/_lunora/scheduled`,
+    // `/_lunora/queue`). Kept out of the internal route table below because both
+    // need the execution `context` — the cron tick for user-cron `waitUntil`,
+    // the queue batch to hand to the app's handler — which the table-shaped
+    // routes don't receive.
+    const tenantFanoutRoutes = buildTenantFanoutRoutes({
+        assertAdmin: assertAdminAuthorized,
+        dispatchScheduled: handleScheduled,
+        queueHandler: options.queueHandler,
+    });
 
     // Internal endpoint dispatch table. Keyed by pathname; each handler takes
     // the request (and, where needed, env/url) and returns the response.
@@ -5459,8 +5387,9 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         const contentLength = Number(request.headers.get("content-length") ?? "");
         // Routes that declare their own larger body budget (the KV value PUT,
-        // which reads under `KV_VALUE_MAX_BODY_BYTES` to allow a 25 MiB KV value,
-        // and the storage object upload, which moves real files) must not be
+        // which reads under `KV_VALUE_MAX_BODY_BYTES` to allow a 25 MiB KV value;
+        // the storage object upload, which moves real files; and the queue
+        // fan-out, which takes a full 100 × 128 KiB forwarded batch) must not be
         // pre-rejected by the shared 1 MiB cap — else the per-route cap is dead
         // code for any client that sends a `Content-Length`. Pick the route's cap
         // so the header check matches the reader's cap.
@@ -5506,15 +5435,13 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             }
         }
 
-        // The cron-tick entrypoint needs the execution `context` (for user-cron
-        // `waitUntil`), which the table-shaped routes don't receive — dispatch it
-        // here while `context` is in scope.
-        if (url.pathname === SCHEDULED_TICK_PATH) {
-            return handleScheduledTick(request, env, context);
-        }
+        // The WfP fan-out entrypoints need the execution `context`, which the
+        // table-shaped routes below don't receive — dispatch them here while
+        // `context` is in scope.
+        const fanoutRoute = tenantFanoutRoutes[url.pathname];
 
-        if (url.pathname === QUEUE_DISPATCH_PATH) {
-            return handleQueueDispatch(request, env, context);
+        if (fanoutRoute) {
+            return fanoutRoute(request, env, context);
         }
 
         // Internal `/_lunora/*` endpoints, keyed by pathname. Each entry adapts

--- a/packages/runtime/src/tenant-fanout-routes.ts
+++ b/packages/runtime/src/tenant-fanout-routes.ts
@@ -1,0 +1,156 @@
+/**
+ * The two reserved fan-out entrypoints a Workers-for-Platforms tenant depends
+ * on, extracted from `create-worker.ts` (mirrors `./scheduled-admin-routes`).
+ *
+ * A Worker uploaded into a WfP dispatch namespace gets neither `triggers.crons`
+ * nor a queue consumer of its own, so the platform drives both over HTTP
+ * instead: `POST /_lunora/scheduled` replays a cron firing and `POST
+ * /_lunora/queue` hands over a batch a platform-owned consumer drained. Both are
+ * admin-gated, and both are the only path by which a tenant's scheduled and
+ * queue work runs at all.
+ *
+ * Every handler is closure-free of the worker's internals — it reaches the
+ * admin gate, the shared `scheduled()` dispatch, and the app's queue handler
+ * through the injected {@link TenantFanoutRouteDeps}, so this module imports no
+ * runtime values from `create-worker`.
+ *
+ * Like `./kv-admin-routes` and `./storage-admin-routes`, this module owns both
+ * its paths and the body budget one of them declares, so the entry-point
+ * `Content-Length` fast path and the reader that actually enforces the cap read
+ * the same number from the same place.
+ */
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+import { readLooseJsonBody } from "./body-readers";
+import type { QueueForwardHandler, ScheduledControllerLike } from "./create-worker";
+import { LunoraError } from "./errors";
+
+// Admin-gated HTTP entrypoint that runs a cron expression's jobs exactly as the
+// native `scheduled()` trigger would. Cloudflare silently drops `triggers.crons`
+// for Workers uploaded into a Workers-for-Platforms dispatch namespace, so a
+// platform fans cron ticks out to its tenants by POSTing here.
+const SCHEDULED_TICK_PATH = "/_lunora/scheduled";
+
+// Admin-gated HTTP entrypoint that processes a forwarded queue batch. Namespaced
+// WfP Workers can't be queue consumers, so a platform-owned consumer forwards
+// batches here, where the app's `queueHandler` runs.
+const QUEUE_DISPATCH_PATH = "/_lunora/queue";
+
+/**
+ * Body budget for a forwarded queue batch, declared by this route the way the KV
+ * value PUT declares `KV_VALUE_MAX_BODY_BYTES`. Derived from what Cloudflare
+ * Queues can hand a consumer: `max_batch_size` tops out at 100 messages and a
+ * message may carry 128 KiB, so a full batch is 12.5 MiB of message bodies
+ * before the forwarding envelope (`queue`, per-message `id`) and JSON string
+ * escaping. 16 MiB covers that with the same ~1.3× headroom the KV cap allows
+ * its 25 MiB value, and stays under the 32 MiB the KV and storage routes already
+ * buffer, so it is not a new memory ceiling for the isolate.
+ */
+const QUEUE_DISPATCH_MAX_BODY_BYTES: number = 16 * 1_048_576;
+
+/** The worker internals the fan-out routes reach through injection rather than closure. */
+interface TenantFanoutRouteDeps {
+    /** Admin-gate the request (throws `ADMIN_FORBIDDEN` when unauthorized). */
+    assertAdmin: (request: Request) => void;
+
+    /**
+     * The worker's own `scheduled()` dispatch. The HTTP tick goes through the
+     * SAME path the native trigger uses (user crons + code crons + scheduled
+     * backup), so a replayed firing behaves identically to a real one.
+     */
+    dispatchScheduled: (controller: ScheduledControllerLike, env: unknown, context: ExecutionContextLike) => Promise<void>;
+
+    /** The app's forwarded-batch handler, off `WorkerOptions`. Absent when the app declares no queues. */
+    queueHandler?: QueueForwardHandler;
+}
+
+/** Build the reserved fan-out route map merged into the worker's internal route table. */
+const buildTenantFanoutRoutes = (
+    deps: TenantFanoutRouteDeps,
+): Record<string, (request: Request, env: unknown, context: ExecutionContextLike) => Promise<Response>> => {
+    const { assertAdmin, dispatchScheduled, queueHandler } = deps;
+
+    /**
+     * `POST /_lunora/scheduled` — run a cron expression's jobs over HTTP, the
+     * Workers-for-Platforms workaround for dropped `triggers.crons` (a platform
+     * fans ticks out to its namespaced tenants). Admin-gated; the body carries
+     * the cron expression to run as `{ "cron": "0 9 * * *" }`.
+     */
+    const handleScheduledTick = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<Response> => {
+        assertAdmin(request);
+
+        if (request.method !== "POST") {
+            throw new LunoraError("scheduled tick endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
+        }
+
+        // Read under the shared byte budget, like every sibling admin route: a
+        // bare `request.json()` drains whatever is sent, so a chunked body slips
+        // the cap the `Content-Length` fast path only loosely enforces.
+        // `| null`, not `| undefined`: the reader returns `{}` for an empty body,
+        // the parsed value, or throws — so it never resolves `undefined`, but
+        // `JSON.parse("null")` is a perfectly good parsed value, and reading a
+        // property off it would 500 a request that deserves the 400 below.
+        const body = (await readLooseJsonBody(request, "Scheduled tick")) as { cron?: unknown } | null;
+        const cron = typeof body?.cron === "string" ? body.cron : "";
+
+        if (cron === "") {
+            throw new LunoraError("scheduled tick requires a `cron` expression", { code: "BAD_REQUEST", status: 400 });
+        }
+
+        await dispatchScheduled({ cron, noRetry: () => {}, scheduledTime: Date.now() }, env, context);
+
+        return Response.json({ cron, ok: true });
+    };
+
+    /**
+     * `POST /_lunora/queue` — process a forwarded queue batch (the WfP workaround
+     * for queue consumers). Admin-gated; the body is
+     * `{ "queue": "name", "messages": [{ "id": "...", "body": ... }] }`. Returns
+     * `{ "retry": [ids] }` so the platform consumer can retry only the failures.
+     */
+    const handleQueueDispatch = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<Response> => {
+        assertAdmin(request);
+
+        if (request.method !== "POST") {
+            throw new LunoraError("queue dispatch endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
+        }
+
+        if (!queueHandler) {
+            throw new LunoraError("no queueHandler configured", { code: "BAD_REQUEST", status: 400 });
+        }
+
+        // `| null`, not `| undefined`: see the note in the cron tick above.
+        const body = (await readLooseJsonBody(request, "Queue dispatch", QUEUE_DISPATCH_MAX_BODY_BYTES)) as { messages?: unknown; queue?: unknown } | null;
+
+        // An answer of `{"retry": []}` tells the platform consumer to ACK the
+        // whole batch, so a body this route could not read must be a 400 rather
+        // than a run over an empty message list: no body at all, a JSON root that
+        // isn't an object, or a `messages` that isn't an array would otherwise
+        // acknowledge — and discard — messages nothing ever delivered. Queues
+        // never hands a consumer an empty batch, so an explicit `[]` stays legal.
+        if (!Array.isArray(body?.messages)) {
+            throw new LunoraError("queue dispatch requires a `messages` array", { code: "BAD_REQUEST", status: 400 });
+        }
+
+        const queue = typeof body.queue === "string" ? body.queue : "";
+        const messages = body.messages
+            .filter(
+                (message): message is { body: unknown; id: string } =>
+                    typeof message === "object" && message !== null && typeof (message as { id?: unknown }).id === "string",
+            )
+            .map((message) => {
+                return { body: (message as { body?: unknown }).body, id: (message as { id: string }).id };
+            });
+
+        const result = await queueHandler({ messages, queue }, env, context);
+
+        return Response.json({ retry: result?.retry ?? [] });
+    };
+
+    return {
+        [QUEUE_DISPATCH_PATH]: handleQueueDispatch,
+        [SCHEDULED_TICK_PATH]: handleScheduledTick,
+    };
+};
+
+export type { TenantFanoutRouteDeps };
+export { buildTenantFanoutRoutes, QUEUE_DISPATCH_MAX_BODY_BYTES, QUEUE_DISPATCH_PATH, SCHEDULED_TICK_PATH };

--- a/packages/runtime/src/workflows-admin-routes.ts
+++ b/packages/runtime/src/workflows-admin-routes.ts
@@ -22,6 +22,7 @@
  */
 import type { WorkflowInstanceStatus, WorkflowsRestClient } from "@lunora/workflow";
 
+import { readLooseJsonBody } from "./body-readers";
 import { LunoraError } from "./errors";
 import { assertMethod } from "./method-guard";
 
@@ -167,7 +168,7 @@ const buildWorkflowsAdminRoutes = (
             return throwNotConfigured();
         }
 
-        const body = (await request.json().catch(() => undefined)) as { action?: unknown; id?: unknown; name?: unknown } | undefined;
+        const body = (await readLooseJsonBody(request, "Workflows status")) as { action?: unknown; id?: unknown; name?: unknown } | undefined;
 
         if (typeof body?.name !== "string" || body.name === "" || typeof body.id !== "string" || body.id === "") {
             throw new LunoraError("Workflows status action requires string `name` and `id`", { code: "BAD_REQUEST", status: 400 });

--- a/packages/runtime/src/workflows-admin-routes.ts
+++ b/packages/runtime/src/workflows-admin-routes.ts
@@ -168,7 +168,14 @@ const buildWorkflowsAdminRoutes = (
             return throwNotConfigured();
         }
 
-        const body = (await readLooseJsonBody(request, "Workflows status")) as { action?: unknown; id?: unknown; name?: unknown } | undefined;
+        // Read under the shared byte budget, like every sibling admin route: a
+        // bare `request.json()` drains whatever is sent, so a chunked body slips
+        // the cap the `Content-Length` fast path only loosely enforces.
+        // `| null`, not `| undefined`: the reader returns `{}` for an empty body,
+        // the parsed value, or throws — so it never resolves `undefined`, but
+        // `JSON.parse("null")` is a perfectly good parsed value, and reading a
+        // property off it would 500 a request that deserves the 400 below.
+        const body = (await readLooseJsonBody(request, "Workflows status")) as { action?: unknown; id?: unknown; name?: unknown } | null;
 
         if (typeof body?.name !== "string" || body.name === "" || typeof body.id !== "string" || body.id === "") {
             throw new LunoraError("Workflows status action requires string `name` and `id`", { code: "BAD_REQUEST", status: 400 });


### PR DESCRIPTION
## The defect

Three admin JSON routes on the public HTTP edge read their request body with a raw `request.json()`
instead of the byte-budgeted readers every other body-reading route uses:

- `packages/runtime/src/create-worker.ts` — `handleScheduledTick`, `POST /_lunora/scheduled`
- `packages/runtime/src/create-worker.ts` — `handleQueueDispatch`, `POST /_lunora/queue`
- `packages/runtime/src/workflows-admin-routes.ts` — `handleStatus`, `POST /_lunora/admin/workflows/status`

**1. The authoritative cap was skipped.** `enforceDeclaredBodyLimit` documents itself as a
non-authoritative fast path — `Content-Length` is forgeable, absent on a chunked body, and `NaN` for
a non-numeric value, so a missing/unparseable length is deliberately let through — and says the real
enforcement happens in `readBodyTextWithLimit` / the streaming import reader. These three routes
never reached that enforcement, so a chunked oversized body was buffered in full before the handler
inspected it.

**2. `/_lunora/queue` had the wrong budget.** `ROUTE_BODY_BUDGETS` raised the cap only for the KV
value PUT and the storage upload, so the queue endpoint inherited the shared `MAX_BODY_BYTES`
(1 MiB). A forwarded batch declaring a `Content-Length` over 1 MiB was rejected 413, while the same
batch sent chunked sailed through — the header-check-vs-reader-cap mismatch the per-route budget
table exists to prevent.

Everything in the report checked out against the tree. Two notes on what the code actually does,
both covered by the change:

- `Request` in the Node test environment does **not** synthesize a `content-length` header for a
  string body, so the pre-existing `post()` helper never exercised the header fast path at all. The
  accept test therefore sets `content-length` explicitly; without it the test passes against the
  unfixed code and proves nothing.
- On `/_lunora/queue` a malformed body did not 400 at all: it became `undefined`, the handler ran
  with `queue: ""` and an empty message list, and answered `{"retry": []}` — telling the platform
  consumer to **ack every message** in a batch that was never parsed. Routing through the shared
  reader closes that too.

## The fix

All three handlers now read through `readLooseJsonBody` (chosen over `readJsonBodyWithLimit`: these
handlers tolerate a non-object root and produce their own 400 from the missing field, and
`readJsonBodyWithLimit`'s "Request body must be an object" would replace those messages). Each
handler's own 400 for a body that parses but names no `cron` / `name` / `id` is unchanged.

`/_lunora/queue` gains `QUEUE_DISPATCH_MAX_BODY_BYTES` in `ROUTE_BODY_BUDGETS`, so the entry-point
header check and the reader enforce the same number.

### Budget derivation (16 MiB)

Grounded in what Cloudflare Queues can actually hand a consumer, per the vendored limits table in
`.agents/skills/cloudflare/references/queues/gotchas.md` (mirrored in
`.agents/skills/cloudflare/references/queues/configuration.md`, `max_batch_size` "1-100, default 10",
and in `packages/config/src/cloudflare/wrangler-validator.ts`, which models `max_batch_size`):

| Input | Value |
| --- | --- |
| Consumer batch size (`max_batch_size`) | 100 messages max |
| Message size | 128 KiB max |
| Worst-case message bodies in one batch | 100 × 128 KiB = **12.5 MiB** |
| Forwarding envelope (`queue`, per-message `id`) + JSON string escaping | headroom |

16 MiB covers the full batch with ~1.3× headroom — the same ratio the KV route already allows
(`KV_VALUE_MAX_BODY_BYTES` is 32 MiB for a 25 MiB KV value) — and stays under the 32 MiB the KV and
storage routes already buffer, so it introduces no new memory ceiling for the isolate.

The platform-side consumer is not in this repo (it is platform-owned; `queueHandler`'s docs say so),
so the number comes from the vendor limits rather than from an observed payload.

## Behaviour change

On a pre-release branch, stated rather than shimmed: a body that is **not valid JSON** now answers
400 `"<route> body must be valid JSON"` instead of the handler's own message, and on
`/_lunora/queue` it is refused instead of silently acking an unread batch. No existing test asserted
the old malformed-body behaviour.

## Tests — each verified by breaking the code first

Three tests added to `packages/runtime/__tests__/tenant-fanout.test.ts` (which had 11 tests for these
endpoints and none for body limits). All three were run against the **unfixed** code first and
failed, each for the right reason:

| Test | Against unfixed code | After the fix |
| --- | --- | --- |
| oversized **chunked** cron tick (1.25 MiB, no `Content-Length`) | `expected 200 to be 413` — body buffered and the cron **fired** | 413, cron not called |
| **chunked** queue batch over the route budget (>16 MiB, no `Content-Length`) | `expected 200 to be 413` | 413, handler not called |
| legitimate 2 MiB queue batch with an explicit `Content-Length` | `expected 413 to be 200` — killed by the header check | 200, all 16 messages delivered |

Then re-run after the fix: 12 passed (12).

## Gates

| Gate | Result |
| --- | --- |
| `pnpm run build:packages` | pass (54 projects) |
| `pnpm --filter "@lunora/runtime" run test` | pass — 73 files, 1079 tests |
| `pnpm run test:affected` | pass — 139 files, 1776 tests across 35 projects |
| `pnpm run test:workerd` | pass — all 11 workerd suites |
| `vis run lint:types --no-cache` | pass — 121 tasks |
| `pnpm run api:check` | pass — matches all 54 committed snapshots (no public surface change) |
| `pnpm run lint:prettier` | pass (repo-wide, run **before** eslint) |
| `pnpm --filter "@lunora/runtime" run lint:eslint` | pass — `--max-warnings=0` |

`lint:package-json` not run — no manifest was touched.

## Deliberately left alone

The raw `request.json()` calls in `packages/do`, `packages/auth`, `packages/replica` and
`packages/scheduler` are DO-internal, reached only through the worker, which has already capped the
body.

---

# Round 2 — review follow-ups

## The silent ack was only half closed

The first round closed *unparseable* JSON. It did not close parseable-but-wrong-shape: the reader
maps an empty body to `{}` and `Array.isArray(body?.messages) ? … : []` swallowed every other root.
No body at all, `null`, `[]`, `"jobs"`, `123`, `{"queue":"jobs"}` and `{"messages":"m1"}` all
answered 200 `{"retry":[]}` and ran `queueHandler` with an empty batch — telling the platform
consumer to ack, and therefore delete, messages this worker never read. An absent body is the
likeliest real trigger (a forwarder that writes none, a proxy that strips it).

All of them are now a 400. Cloudflare Queues never delivers an empty batch, so an explicit
`messages: []` stays legal, and the three existing `messages: []` tests are unaffected — they gate
earlier, on auth or on the missing `queueHandler`.

## The dead-cast cleanup found a live 500

`readLooseJsonBody` returns `{}`, the parsed value, or throws, so `| undefined` was dead as
reviewed — but `JSON.parse("null")` **is** a parsed value, and dropping the `?.` along with it turns
a `null` JSON root into a `TypeError` → 500 on all three routes. The new `null`-root tests caught it
before it shipped: `expected 500 to be 400`.

So the casts now read `| null` and keep the optional chaining. That is what the reader's contract
actually allows, and it is narrower than what was there before (`| undefined` claimed a state that
cannot occur). Kept on `readLooseJsonBody` with per-route labels as directed.

## Extraction: taken

Both fan-out handlers now live in `packages/runtime/src/tenant-fanout-routes.ts`, closure-free over
an injected `TenantFanoutRouteDeps` (`assertAdmin`, `dispatchScheduled`, `queueHandler`), copying the
`scheduled-admin-routes.ts` shape. It owns and exports `SCHEDULED_TICK_PATH`,
`QUEUE_DISPATCH_PATH` and `QUEUE_DISPATCH_MAX_BODY_BYTES`, like `kv-admin-routes` and
`storage-admin-routes` own theirs.

`ROUTE_BODY_BUDGETS` is back at its original position — the TDZ error only existed because a
`create-worker`-local const joined a table declared 1,600 lines above it; an imported binding is
hoisted. `create-worker.ts` is ~75 lines shorter, and the two `if (url.pathname === …)` blocks
collapse into one table lookup. The stale comment enumerating only KV and storage is updated anyway,
since it now needs to mention the queue route.

## Docs — one file, not two

`apps/docs/src/content/docs/packages/runtime/index.mdx` does not exist in the tree and is not
hand-maintained: `apps/docs/scripts/copy-package-docs.js` generates the whole
`src/content/docs/packages` tree from `packages/<pkg>/docs/`, and `apps/docs/.gitignore:8` ignores
it. So `packages/runtime/docs/index.mdx` is the single source of truth and is the only file edited;
the site copy regenerates from it. The added paragraph states the 16 MiB ceiling, that it is
enforced as bytes arrive rather than from `Content-Length`, and that a body naming no `messages`
array is a 400.

## Test helper

`chunkedBody({ exceedBytes, prefix, suffix })` now lives in
`packages/runtime/__tests__/helpers/chunked-body.ts` and backs both suites;
`admin-export-import.test.ts`'s `oversizedStream()` is a one-line call to it. The close condition is
index-driven (chunk 0 = prefix, next N = padding, next = suffix + close), and the size contract is
"strictly exceeds `exceedBytes`" so callers pass the cap they want to be over with no rounding to
reason about. Sole export, so `default` per `import/prefer-default-export`.

## Round-2 tests, each verified by breaking the code first

| Test | Against reverted code | After |
| --- | --- | --- |
| 6 × wrong-shape roots (`null`, `[]`, `"jobs"`, `123`, no `messages`, non-array `messages`) | `expected 200 to be 400` ×6 | 400, handler not called |
| POST with no body at all | `expected 200 to be 400` | 400, handler not called |
| explicit `messages: []` still accepted | 200 (negative control, passes both ways) | 200 |
| cron tick with a `null` root | `expected 500 to be 400` | 400, cron not called |

The guard was reverted to the exact pre-fix expression to produce the left column, then restored.

## Round-2 gates

| Gate | Result |
| --- | --- |
| `pnpm run build:packages` | pass (54 projects) |
| `pnpm --filter "@lunora/runtime" run test` | pass — 73 files, **1088** tests |
| `pnpm run test:affected` | pass — 35 projects |
| `pnpm run test:workerd` | pass — all 11 suites |
| `vis run lint:types --no-cache` | pass — 121 tasks |
| `pnpm run api:check` | pass — **no `api:update` needed**: the new module is internal and not re-exported from `index.ts`, exactly like `kv-admin-routes`' own path/budget exports |
| `pnpm run lint:prettier` | pass (repo-wide, before eslint) |
| `pnpm --filter "@lunora/runtime" run lint:eslint` | pass — `--max-warnings=0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
