### PR TITLE
docs(cli,runtime): name the commands these comments describe

### DIFF
--- a/packages/cli/src/commands/build/bundle-size.ts
+++ b/packages/cli/src/commands/build/bundle-size.ts
@@ -24,7 +24,7 @@ interface BundleSize {
  *
  * The out-dir also carries artifacts Cloudflare never sees: sourcemaps (which
  * are larger than the script itself — counting them would roughly triple the
- * number), the esbuild metafile `lunora deploy --outdir` writes alongside the
+ * number), the esbuild metafile `lunora build --out-dir` writes alongside the
  * bundle, and the README wrangler drops in to explain the directory.
  */
 const isUploaded = (name: string): boolean => !name.endsWith(".map") && name !== "bundle-meta.json" && name !== "README.md";

--- a/packages/cli/src/commands/info/handler.ts
+++ b/packages/cli/src/commands/info/handler.ts
@@ -34,7 +34,7 @@ interface WranglerSummary {
     /**
      * Every binding the config declares, as `type:name`.
      *
-     * Derived by the same function `lunora bindings` and `--emit-bindings` use.
+     * Derived by the same function `lunora info --bindings` and `--emit-bindings` use.
      * This used to hand-roll its own read of three sections — d1, durable
      * objects, vectorize — so a project with R2, KV, queues, AI or any of the
      * other nine types was told it had none of them. A summary that silently

--- a/packages/cli/src/util/admin-url.ts
+++ b/packages/cli/src/util/admin-url.ts
@@ -18,7 +18,7 @@ const WRANGLER_DEV_URL = "http://localhost:8787";
  * every Vite-based project: those listen on 5173 and *bump to the next free
  * port* when it is taken, so the right port is not knowable in advance. The
  * running dev server already records its resolved URL in `.lunora/dev.json`
- * (the same record `lunora status`/`stop` and the MCP server read, and the same
+ * (the same record `lunora dev status`/`lunora dev stop` and the MCP server read, and the same
  * one that makes a second `lunora dev` idempotent), so read it instead of
  * guessing — a live record beats a hardcoded port every time.
  *

--- a/packages/cli/src/util/binding-manifest-file.ts
+++ b/packages/cli/src/util/binding-manifest-file.ts
@@ -2,7 +2,7 @@
  * The declarative description of what this Worker needs, for whoever is going to
  * provide it.
  *
- * Three entry points, one derivation. `lunora bindings` answers the question
+ * Three entry points, one derivation. `lunora info --bindings` answers the question
  * without running anything, for a supervisor planning its graph before it starts
  * a single process. `lunora build --emit-bindings` hands a deployer — Terraform,
  * Pulumi, Alchemy — the requirements it must provision. `lunora dev` writes the

--- a/packages/cli/src/util/text-diff.ts
+++ b/packages/cli/src/util/text-diff.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal line-level diff for `lunora add --diff` previews. Not a full LCS —
+ * Minimal line-level diff for `lunora registry add --diff` previews. Not a full LCS —
  * it trims the common prefix/suffix and marks the differing middle as removed
  * (`-`) / added (`+`), with a few lines of surrounding context. That's enough
  * to preview what an install or upgrade would change before any file is written.

--- a/packages/runtime/src/data-movement-admin-routes.ts
+++ b/packages/runtime/src/data-movement-admin-routes.ts
@@ -311,7 +311,8 @@ const buildDataMovementAdminRoutes = (deps: DataMovementAdminRouteDeps): Record<
     };
 
     /**
-     * Replay endpoint behind `lunora backup restore --to <time>`. Accepts
+     * Replay endpoint (`POST /_lunora/admin/apply`) for a connector replaying a
+     * `/sync` page; no `lunora` subcommand drives it today. Accepts
      * per-shard pre-bucketed batches (the shape `/sync` emits, so the caller
      * just forwards each shard's changes back to the same shard — no
      * re-bucketing, which also sidesteps deletes carrying no shard-key field)


### PR DESCRIPTION
Six source comments name a CLI surface that does not exist. Each was checked against the
command's own option table, not against other prose.

| Comment | Said | Actually |
| --- | --- | --- |
| `util/text-diff.ts:2` | `lunora add --diff` | `add/index.ts` declares no `diff` option; it is on `registry/command.ts:24` |
| `commands/build/bundle-size.ts:27` | `lunora deploy --outdir` | `deploy/index.ts` has no `outdir`; `build/index.ts:40` has `out-dir`, which drives wrangler's `--outdir` |
| `util/admin-url.ts:21` | `lunora status` / `stop` | no top-level `status` or `stop` command; both are `lunora dev` subcommands |
| `util/binding-manifest-file.ts:5` | `lunora bindings` | no such command; `info/index.ts:19` declares `--bindings` |
| `commands/info/handler.ts:37` | `lunora bindings` | same |
| `runtime/src/data-movement-admin-routes.ts:314` | replay sits "behind `lunora backup restore --to <time>`" | `backup/index.ts` declares no `--to`, and nothing in the CLI calls the endpoint |

The last one was the most misleading: it pointed a reader at a flag that has never existed, for an
endpoint no `lunora` subcommand drives. It now names the route (`POST /_lunora/admin/apply`) and
says plainly that it is reached by an external connector replaying a `/sync` page.

## Verification

Each replacement asserted exactly one occurrence in its file before writing, so none half-landed.
The full diff was read line by line: every changed line is inside a JSDoc block, nothing else
moved. Prettier reported all six files unchanged after formatting. No behaviour, no public API,
no test touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
