### PR TITLE
docs: correct stale symbol names in comments

### DIFF
--- a/packages/bindings/src/images/types.ts
+++ b/packages/bindings/src/images/types.ts
@@ -8,12 +8,11 @@
  * (`input(stream).transform(opts).output(opts)` + `info(stream)`), not the full
  * hosted-images CRUD surface.
  *
- * TODO(workers-types): the 2026-06-16 optimization features — the `aspect-crop`
- * / `scale-up` fit modes and the `upscale` param — are modeled here by hand
- * because `@cloudflare/workers-types` (through 4.20260616.1) does not type them
- * yet. Re-check on the next `@cloudflare/workers-types` bump: once `ImageTransform`
- * carries `fit: "aspect-crop" | "scale-up"` and `upscale`, drop our hand-rolled
- * additions and lean on the upstream type.
+ * TODO(workers-types): the `aspect-crop` fit mode is modeled here by hand because
+ * `@cloudflare/workers-types` still does not type it — checked at the pinned
+ * 5.20260811.1, whose `ImageTransform` now carries `fit: "scale-up"` and `upscale`.
+ * Re-check on the next bump: once `ImageTransform` also carries
+ * `fit: "aspect-crop"`, drop our hand-rolled addition and lean on the upstream type.
  */
 
 /**

--- a/packages/client/src/agent-chat-reconcile.ts
+++ b/packages/client/src/agent-chat-reconcile.ts
@@ -80,7 +80,7 @@ const maxSeq = (messages: ReadonlyArray<{ seq: number }>): number => {
  * persists only the user row (+1). Those non-(+2) turns are retired by the PRIMARY
  * seq-based content match below (which sees the user row land at a greater `seq`),
  * never by this count-based fallback. The fully robust fix is a server-echoed
- * correlation id on each persisted user row (deferred — see plan 188).
+ * correlation id on each persisted user row (deferred; no plan filed).
  *
  * KNOWN LIMITATION (inherent to a client-only heuristic): on an ownerless /
  * `instanceId`-less thread a FOREIGN writer that advances `seq` by >= 2 between this

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -7101,7 +7101,7 @@ class LunoraClient {
      * instead of the flush guard discarding them as a mismatch.
      *
      * That map alone was not enough: it is consumed and DELETED on the first
-     * flush attempt (`passesReplayIdentityGate`), while the queue entry and its
+     * flush attempt (`replayIdentityVerdict`), while the queue entry and its
      * persisted record keep the original stamp. So a reload, or a requeue after a
      * transient failure, fell back to the old token hash — and once the token had
      * been refreshed, `isSameCredentialUnderTokenHash` no longer recognised it
@@ -7182,11 +7182,11 @@ class LunoraClient {
      * (see `queuedOfflineShardKeys`). Used on a FOLLOWER tab when the
      * mirrored leader status transitions to `"connected"` — a follower has no
      * per-shard `ShardConnection` reconnect event to hang the usual
-     * single-shard `flushOfflineQueue(shardKey)` call off of (see the
-     * `handleConnect` call site), so this walks every shard that might have
-     * something queued instead. Flushing an already-empty shard is a cheap
-     * no-op (`flushOfflineQueue` returns immediately once `drain` yields
-     * nothing), so over-inclusion here is harmless.
+     * single-shard `flushOfflineQueue(shardKey)` call off of (see the `onOpen`
+     * callback that calls `flushOfflineQueue(shardKey)`), so this walks every
+     * shard that might have something queued instead. Flushing an already-empty
+     * shard is a cheap no-op (`flushOfflineQueue` returns immediately once
+     * `drain` yields nothing), so over-inclusion here is harmless.
      */
     private flushAllOfflineQueues(): void {
         for (const shardKey of this.queuedOfflineShardKeys) {
@@ -7623,7 +7623,7 @@ class LunoraClient {
                 const value = await this.rpc(item.functionPath, item.args, item.shardKey, {
                     captureBookmark: true,
                     // The id that queued the write, not the live session's — see the
-                    // `clientId` stamp in `enqueueOffline`.
+                    // `clientId` stamp in `enqueueOfflineMutation`.
                     clientId: item.clientId ?? this.clientId,
                     mutationId: item.id,
                     onCommitCursor: (cursor) => {

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -598,7 +598,7 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
     // more than one collection (see `getShardCheckpoints`). A `shape` carries its
     // own shard key; the `list` path uses the top-level one. The sync callbacks
     // re-resolve rather than close over the capture below, because
-    // {@link disposeShardCheckpoints} drops the whole per-client map: a
+    // {@link releaseShardCheckpoints} drops the whole per-client map: a
     // collection still mounted across that teardown must advance the registry a
     // later {@link getShardCheckpoints} mints, not the disposed one it was built
     // with (whose gates resolve to `Infinity`, so every overlay drops ungated).

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2505,7 +2505,7 @@ abstract class ShardDO {
      *
      * A no-op seam here; the generated subclass overrides it, because running a
      * reactor needs two things the base cannot build — a ctx (for `select` and the
-     * handler) and a read footprint around it. Mirrors `runSubscription`, which
+     * handler) and a read footprint around it. Mirrors `executeSubscription`, which
      * has the identical shape for the socket-terminated side of reactivity.
      * @returns the run's digest and read footprint, or `undefined` when the path
      * resolves to nothing (a manifest naming a function this build does not have).
@@ -7861,7 +7861,7 @@ abstract class ShardDO {
                     // is the signal that a reactor is watching more than it needs to.
                     result: outcome.ran ? "ran" : "suppressed",
                     // The sentinel is stripped for the same reason the delta frame
-                    // strips it (see `pushSubscriptionDelta`): `tables` is persisted
+                    // strips it (see `pushSubscriptionData`): `tables` is persisted
                     // in `__reactor_state` and rendered as the reactor's watched-table
                     // list in the Studio, so a reactor that read `ctx.kv` would show an
                     // internal marker to an operator. Inert either way —

--- a/packages/replica/src/define-events.ts
+++ b/packages/replica/src/define-events.ts
@@ -96,18 +96,7 @@ export type EventsDefinition<TDefinition extends Record<string, Record<string, u
 
 // ─── Implementation ──────────────────────────────────────────────────────
 
-/**
- * Declare typed event types for event sourcing.
- *
- * Each key under a namespace becomes a factory function that produces
- * an {@link InputEvent} — an optimistic / command event that the event
- * log will assign a sequence number to on append.
- * @param definition A nested object where the outer keys are namespaces
- * and the inner keys are event names mapped to their
- * payload schemas (or simple type-descriptor objects).
- * @returns An object with the same nesting structure, where each leaf is
- * a factory function plus a `.type` property.
- */
+/** Options accepted by {@link defineEvents}. */
 export interface DefineEventsOptions {
     /**
      * Optional version prefix for all event types.
@@ -122,7 +111,19 @@ export interface DefineEventsOptions {
 }
 
 /**
+ * Declare typed event types for event sourcing.
+ *
+ * Each key under a namespace becomes a factory function that produces
+ * an {@link InputEvent} — an optimistic / command event that the event
+ * log will assign a sequence number to on append.
+ *
  * `defineEvents` is part of the experimental `@lunora/replica` API and may change without a major version bump.
+ * @param definition A nested object where the outer keys are namespaces
+ * and the inner keys are event names mapped to their
+ * payload schemas (or simple type-descriptor objects).
+ * @param options Optional {@link DefineEventsOptions} — currently a `version` prefix.
+ * @returns An object with the same nesting structure, where each leaf is
+ * a factory function plus a `.type` property.
  * @experimental
  */
 export const defineEvents = <TDefinition extends Record<string, Record<string, unknown>>>(

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -3428,7 +3428,8 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // Cloudflare serialises as JSON into durable storage — so a decoded
             // `bigint` fails creation outright and a decoded `Date` silently arrives
             // as a string. The wire form IS JSON-safe, so it travels intact and
-            // `createRunContext` decodes it where the handler reads `params`.
+            // `@lunora/workflow`'s `createWorkflowRunContext` decodes it where the
+            // handler reads `params`.
             await startWorkflowInstance(candidate.workflow, args, env, "scheduled workflow", recordId);
 
             await releasePoolSlot(candidate);

--- a/packages/runtime/src/orchestration-admin-routes.ts
+++ b/packages/runtime/src/orchestration-admin-routes.ts
@@ -407,7 +407,7 @@ const buildOrchestrationAdminRoutes = (deps: OrchestrationAdminRouteDeps): Recor
     /**
      * `POST /_lunora/admin/pitr` — drive native Durable-Object point-in-time
      * recovery on a single shard. Admin-gated (its own bearer check), so it is
-     * NOT subject to the user-facing `authorizeShard`/`authorizeFunction`
+     * NOT subject to the user-facing `authorizeShard`/`authorizeFanOut`
      * callbacks the public RPC path enforces; the forwarded `Authorization`
      * header then satisfies the shard's own admin gate in `handleAdminRpc`.
      * Forwards `getPitrBookmark` (read the current / for-a-time bookmark) or

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -458,7 +458,7 @@ class SchedulerDO {
         return jsonResponse({ error: { code: "NOT_FOUND" } }, 404);
     }
 
-    /** Called by the Workers runtime when the alarm previously set by `_rescheduleAlarm()` fires. */
+    /** Called by the Workers runtime when the alarm previously set by `rescheduleAlarm()` fires. */
     public async alarm(): Promise<void> {
         // BEFORE the due slice is read, so a job recovered here fires in this
         // very pass rather than waiting for the next one.

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -285,7 +285,7 @@ const maskPage = <Context>(page: QueryPage, columns: MaskColumns<Context>, base:
  * `assertWhereAllowed` (below) closes on the `where` path, reached instead
  * through the index builder.
  *
- * Unlike `where` (a plain object walked by `collectWhereFields`), the
+ * Unlike `where` (a plain object walked by `assertWhereScope`), the
  * range/search is a builder CALLBACK (`q => q.eq("ssn", x)`), so the referenced
  * fields aren't statically inspectable. Run the callback once against a
  * recording proxy: its blanket `get` trap turns EVERY property access into a

--- a/packages/server/src/presence.ts
+++ b/packages/server/src/presence.ts
@@ -227,6 +227,10 @@ const presenceExtension = defineSchemaExtension(PRESENCE_KEY, {
     },
 }) as unknown as SchemaExtension<{ [PRESENCE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
 
+// The presence functions are built with the procedure builders (no generated
+// server here, so bind the base contexts via `initLunora.dataModel().create()`).
+const { mutation, query } = initLunora.dataModel().create();
+
 /**
  * Build a presence {@link Component} — schema extension + heartbeat / listPresent
  * / sweep functions — wired to a single TTL. Re-export `component.functions`
@@ -240,10 +244,6 @@ const presenceExtension = defineSchemaExtension(PRESENCE_KEY, {
  * @param options presence configuration (TTL).
  * @returns a component bundling the extension and the presence functions.
  */
-// The presence functions are built with the procedure builders (no generated
-// server here, so bind the base contexts via `initLunora.dataModel().create()`).
-const { mutation, query } = initLunora.dataModel().create();
-
 const definePresence = (options: DefinePresenceOptions = {}): PresenceComponent => {
     const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
     // A grace window longer than the TTL would never hide the row before the

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -1250,7 +1250,7 @@ const wrapDatabase = (base: RlsDatabase, raw: RlsDatabase, steps: ReadonlyArray<
             // bypass the secure-by-default guard and leak every row of a protected
             // table. Defer to the GUARDED `base.get` instead: a protected table
             // fails closed under `.rls("required")` and a `.public()` one returns
-            // the row. Mirrors the `route`/`readRoute` fail-closed parity.
+            // the row. Mirrors the `route`/`guardWriter` fail-closed parity.
             if (!restricts) {
                 return base.get(id, expectedTable);
             }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -2240,7 +2240,7 @@ interface SpanOptions {
  * @param name Span name, e.g. `"stripe.charge"`. Prefer a low-cardinality name
  * and put the varying part in `attributes` — a name built from an id makes every
  * span its own group in a collector.
- * @param fn The body to time, receiving a tracer bound to this span for any
+ * @param function_ The body to time, receiving a tracer bound to this span for any
  * nested spans and the enclosing span's {@link SpanHandle} for post-hoc
  * attributes. May be sync or async; the result is awaited.
  * @param attributes Either a plain attribute bag to stamp on the span at start

--- a/packages/shard-engine/src/ctx-db-commit-seq.ts
+++ b/packages/shard-engine/src/ctx-db-commit-seq.ts
@@ -119,7 +119,7 @@ const readCommitSeq = (sql: SqlExec): number => {
  * `durable-stream.ts`, which declines it for the same reason).
  *
  * Callers must memoize the result for the life of one mutation — see
- * `createShardCtxDb`'s `commitSeqForWrite`. Calling this per row would make
+ * `createShardCtxDb`'s `commitSeqFields`. Calling this per row would make
  * `_commitSeq` a row counter rather than a commit counter, and rows written by
  * one mutation would no longer compare equal.
  * @returns the freshly allocated sequence (always `>= 1`).

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -617,7 +617,7 @@ const searchViaFts = (
 /**
  * Portable fallback for engines without FTS5 (the `node:sqlite` test runner):
  * pull candidate rows (narrowed by `.eq()` filters in SQL), tokenize the indexed
- * field in JS, and rank with `scoreDoc`. Matches the FTS path's AND +
+ * field in JS, and rank with `scoreTokens`. Matches the FTS path's AND +
  * prefix-on-last-token semantics; relevance order is term-frequency, ties broken
  * by creation time (newest first).
  *
@@ -1221,7 +1221,7 @@ const compileOrderByText = (keys: OrderKey[]): string => {
     return parts.join(", ");
 };
 
-/** Drizzle ORDER BY for the DO: each key as `<jsonPath> ASC|DESC`, with an `id` tiebreak in the last key's direction (see `tiebreakDirectionFor`) unless an id field is already ordered. The drizzle twin of `compileOrderBy`. */
+/** Drizzle ORDER BY for the DO: each key as `<jsonPath> ASC|DESC`, with an `id` tiebreak in the last key's direction (see `tiebreakDirectionFor`) unless an id field is already ordered. The drizzle twin of {@link compileOrderByText}. */
 const compileOrderBySql = (keys: OrderKey[]): SQL => {
     const parts = keys.map((key) => dsql`${jsonPathSql(key.field)} ${dsql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -188,9 +188,10 @@ const nullsPlacement = (dialect: SqlDialect, key: { direction?: string; nullable
 };
 
 /**
- * Drizzle `ORDER BY` list — the SQL-object twin of `@lunora/do`'s string
- * `compileOrderBy`: each key as `<col> ASC|DESC`, with an `id` tiebreak appended
- * unless an id field is already ordered (keeps paging deterministic).
+ * Drizzle `ORDER BY` list — the SQL-object twin of `@lunora/shard-engine`'s
+ * string `compileOrderByText`: each key as `<col> ASC|DESC`, with an `id`
+ * tiebreak appended unless an id field is already ordered (keeps paging
+ * deterministic).
  *
  * The tiebreak follows the last key's direction, via the shared
  * `tiebreakDirectionFor`. Declared indexes here now carry the same


### PR DESCRIPTION
Nineteen stale comment/JSDoc defects in `packages/*/src`, across ten packages. Every one was
re-verified before editing: `grep -rnw <old>` over `packages/*/src` (plus `shared/`) had to return
the comment and nothing else, and the proposed replacement had to exist as a real declaration in
the package the comment points at. Each replacement was applied only after asserting the old text
occurs **exactly once** in that file, so no edit could silently no-op.

## Wrong-name references

| Comment said | Real referent | File:line (pre-edit) |
| --- | --- | --- |
| `{@link disposeShardCheckpoints}` | `releaseShardCheckpoints` (`:405`) | `packages/db/src/collection-options.ts:601` |
| `` `_rescheduleAlarm()` `` | `rescheduleAlarm()` (`:1514`) | `packages/scheduler/src/scheduler-do.ts:461` |
| Mirrors `` `runSubscription` `` | `executeSubscription` (`:4395`) | `packages/do/src/shard-do.ts:2508` |
| see `` `pushSubscriptionDelta` `` | `pushSubscriptionData` (`:11581`) | `packages/do/src/shard-do.ts:7864` |
| stamp in `` `enqueueOffline` `` | `enqueueOfflineMutation` (`:4512`) | `packages/client/src/lunora-client.ts:7626` |
| the `` `handleConnect` `` call site | the `onOpen` callback that calls `flushOfflineQueue(shardKey)` (`:5777`/`:5853`) | `packages/client/src/lunora-client.ts:7185-7186` |
| `` (`passesReplayIdentityGate`) `` | `replayIdentityVerdict` (`:1515`) | `packages/client/src/lunora-client.ts:7104` |
| `` `createRunContext` `` | `` `@lunora/workflow`'s `createWorkflowRunContext` `` (`workflow/src/run-context.ts:34`) | `packages/runtime/src/create-worker.ts:3431` |
| `` `authorizeShard`/`authorizeFunction` `` | `authorizeShard`/`authorizeFanOut` (`create-worker.ts:899`/`:926`) | `packages/runtime/src/orchestration-admin-routes.ts:410` |
| walked by `` `collectWhereFields` `` | `assertWhereScope` (`:691`) | `packages/server/src/mask/middleware.ts:288` |
| the `` `route`/`readRoute` `` parity | `route`/`guardWriter` (`:867`, and `:864` already names `guardWriter`) | `packages/server/src/rls/middleware.ts:1253` |
| `` `createShardCtxDb`'s `commitSeqForWrite` `` | `commitSeqFields` (`ctx-db.ts:2250`, inside `createShardCtxDb`) | `packages/shard-engine/src/ctx-db-commit-seq.ts:122` |
| rank with `` `scoreDoc` `` | `scoreTokens` (`@lunora/search-core`, called at `ctx-db.ts:675`) | `packages/shard-engine/src/ctx-db.ts:620` |
| drizzle twin of `` `compileOrderBy` `` | `{@link compileOrderByText}` (`:1214`) | `packages/shard-engine/src/ctx-db.ts:1224` |
| `` `@lunora/do`'s string `compileOrderBy` `` | `` `@lunora/shard-engine`'s string `compileOrderByText` `` — `@lunora/do` has no ORDER BY compiler at all | `packages/sql-store/src/ctx-db.ts:191-192` |

## Misplaced doc blocks (comment moved, code untouched)

- `packages/replica/src/define-events.ts` — the `@param definition` / `@returns` block sat on
  `export interface DefineEventsOptions`, which has no parameter and returns nothing, while the
  exported `defineEvents` carried only the `@experimental` stub. The block now documents
  `defineEvents` (merged with the `@experimental` note, plus a `@param options` entry the moved
  block needs to be complete on a two-parameter function); the interface gets a one-liner.
- `packages/server/src/presence.ts` — the `@param options` / `@returns` block for `definePresence`
  sat above the unrelated `const { mutation, query } = initLunora.dataModel().create();`, leaving
  the exported function undocumented. The block now sits directly on `definePresence`. Git renders
  this as the `const` moving up, but no statement changed position relative to another executable
  statement — see the proof below.

## Wrong `@param` name

- `packages/server/src/types.ts:2242` — `LunoraTracer`'s docblock said `@param fn`; the parameter
  is `function_` (`:2259`). Renamed the tag rather than the parameter, so no code changed.

## Dangling pointers

- `packages/client/src/agent-chat-reconcile.ts:83` — deferred a correlation id to "plan 188".
  There is no `plans/188-*`, and the only "188" in `plans/README.md` is at `:740`, inside the row
  for plan **149**, where it names the already-shipped extraction of `agent-chat-reconcile.ts`
  itself — not a correlation-id plan. Rewritten to `(deferred; no plan filed)` rather than
  inventing a number.
- `packages/bindings/src/images/types.ts:11-16` — the TODO claimed `@cloudflare/workers-types`
  types none of `aspect-crop` / `scale-up` / `upscale`, citing 4.20260616.1. The pin is
  `5.20260811.1` (`pnpm-workspace.yaml:367`), whose `ImageTransform` carries `"scale-up"` in the
  `fit` union (`index.d.ts:12942`) and `upscale?: "interpolate" | "generate"` (`:13069`);
  `aspect-crop` has no match. TODO narrowed to `aspect-crop` and re-dated to the pinned version
  rather than deleted — the hand-rolled `fit` union is still load-bearing for that one mode.

## Rejected findings

None. All 19 re-verified as accurate.

## Comment-only proof

No executable code changed. Two independent checks, both against the pre-edit (HEAD) copy of each
of the 16 touched files, using the repo's own TypeScript (6.0.3, `catalog:tsc`).

**1. `ts.transpileModule` with `removeComments: true`:**

```
typescript 6.0.3
comparing 16 files (HEAD vs working copy, comments stripped)

IDENTICAL  packages/bindings/src/images/types.ts  (11 bytes)
IDENTICAL  packages/client/src/agent-chat-reconcile.ts  (937 bytes)
IDENTICAL  packages/client/src/lunora-client.ts  (127306 bytes)
IDENTICAL  packages/db/src/collection-options.ts  (9988 bytes)
IDENTICAL  packages/do/src/shard-do.ts  (170450 bytes)
IDENTICAL  packages/replica/src/define-events.ts  (828 bytes)
IDENTICAL  packages/runtime/src/create-worker.ts  (84351 bytes)
IDENTICAL  packages/runtime/src/orchestration-admin-routes.ts  (10178 bytes)
IDENTICAL  packages/scheduler/src/scheduler-do.ts  (26319 bytes)
IDENTICAL  packages/server/src/mask/middleware.ts  (18255 bytes)
IDENTICAL  packages/server/src/presence.ts  (6330 bytes)
IDENTICAL  packages/server/src/rls/middleware.ts  (23723 bytes)
IDENTICAL  packages/server/src/types.ts  (114 bytes)
IDENTICAL  packages/shard-engine/src/ctx-db-commit-seq.ts  (991 bytes)
IDENTICAL  packages/shard-engine/src/ctx-db.ts  (96063 bytes)
IDENTICAL  packages/sql-store/src/ctx-db.ts  (84724 bytes)

PASS: 16/16 files byte-identical after comment stripping
```

Transpiling erases types, so for the two type-only files that proof is thin — `images/types.ts`
emits 11 bytes and `server/types.ts` 114. A second check reprints the **full AST** with
`ts.createPrinter({ removeComments: true })`, which keeps every type declaration:

**2. AST reprint, comments removed:**

```
typescript 6.0.3 — AST reprint, comments removed
comparing 16 files (HEAD vs working copy)

IDENTICAL  packages/bindings/src/images/types.ts  (2611 bytes)
IDENTICAL  packages/client/src/agent-chat-reconcile.ts  (1375 bytes)
IDENTICAL  packages/client/src/lunora-client.ts  (158010 bytes)
IDENTICAL  packages/db/src/collection-options.ts  (13223 bytes)
IDENTICAL  packages/do/src/shard-do.ts  (201556 bytes)
IDENTICAL  packages/replica/src/define-events.ts  (2489 bytes)
IDENTICAL  packages/runtime/src/create-worker.ts  (110951 bytes)
IDENTICAL  packages/runtime/src/orchestration-admin-routes.ts  (12511 bytes)
IDENTICAL  packages/scheduler/src/scheduler-do.ts  (30866 bytes)
IDENTICAL  packages/server/src/mask/middleware.ts  (25321 bytes)
IDENTICAL  packages/server/src/presence.ts  (8070 bytes)
IDENTICAL  packages/server/src/rls/middleware.ts  (33284 bytes)
IDENTICAL  packages/server/src/types.ts  (29698 bytes)
IDENTICAL  packages/shard-engine/src/ctx-db-commit-seq.ts  (1113 bytes)
IDENTICAL  packages/shard-engine/src/ctx-db.ts  (107342 bytes)
IDENTICAL  packages/sql-store/src/ctx-db.ts  (92805 bytes)

PASS: 16/16 files byte-identical after comment removal
```

This is what makes the `presence.ts` move safe: the 8070-byte reprint is unchanged, so the
`const { mutation, query }` binding did not move relative to any other statement.

## Gates

Run in order, after `pnpm run build:packages` (so `dist/` is fresh):

- `prettier --write` over all 16 files — all reported `(unchanged)`.
- `lint:eslint` (`eslint . --max-warnings=0`) across all ten touched packages — exit 0, no
  findings. (Run before the build it reported 3 `no-unsafe-*` errors in an untouched
  `replica/src/events-context.ts`; those were stale-`dist/` artifacts and are gone once built.)
- `pnpm run lint:types` (repo-wide, including `lint:types:registry`) — exit 0.
- `pnpm run api:check` — `✅ Public API surface matches all 54 committed snapshots.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API comments and references to match current callback, helper, and lifecycle names.
  - Clarified event-definition options, version-prefix behavior, and image fit-mode support.
  - Corrected tracing, ordering, authorization, scheduling, and data-processing documentation.
  - Removed outdated references and improved cross-links throughout the developer documentation.

- **Refactor**
  - Procedure builders are now initialized per presence-definition call rather than shared at module load, improving isolation between invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->