### PR TITLE
docs(docs): correct drifted API and CLI claims

### DIFF
--- a/apps/docs/src/content/blog/introducing-lunora.mdx
+++ b/apps/docs/src/content/blog/introducing-lunora.mdx
@@ -107,7 +107,6 @@ cursors: defineTable({
     y: v.number(),
 })
     .shardBy("roomId") // one Durable Object per room or tenant
-    .global() // geo-replicated reads at the edge
     .index("by_room", ["roomId"]),
 ```
 

--- a/apps/docs/src/content/blog/keep-postgres-get-live-queries.mdx
+++ b/apps/docs/src/content/blog/keep-postgres-get-live-queries.mdx
@@ -48,16 +48,25 @@ the rows into a normal Lunora table in the same call, and subscribe to the table
 the change feed, so live queries over it behave like any other.
 
 ```ts
+// src/server.ts — wire the driver once, on the app builder.
+import type { HyperdriveLike } from "@lunora/hyperdrive";
 import { createHyperdrive, fromPostgresJs } from "@lunora/hyperdrive";
 import postgres from "postgres";
 
+import { defineApp } from "../lunora/_generated/app";
+
+const app = defineApp<Env>()
+    .shard((env) => env.SHARD)
+    .hyperdrive((env) => fromPostgresJs(postgres(createHyperdrive(env.HYPERDRIVE as HyperdriveLike).connectionString)))
+    .build();
+```
+
+```ts
 import { api } from "@/lunora/_generated/api";
 import { action, v } from "@/lunora/_generated/server";
 
 export const syncOrder = action.input({ id: v.string() }).action(async ({ ctx, args: { id } }) => {
-    const { connectionString } = createHyperdrive(ctx.env.HYPERDRIVE);
-    ctx.sql = fromPostgresJs(postgres(connectionString));
-
+    // `ctx.sql` is readonly — it is the client the `.hyperdrive()` thunk built.
     const [row] = await ctx.sql.query<{ id: string; total: number }>("select id, total from orders where id = $1", [id]);
 
     // This write is tracked. A `query` over `orders` re-runs for subscribers.
@@ -90,6 +99,11 @@ export default defineSchema({
             tenantBy: (shardKey) => [shardKey], // mandatory under .shardBy(), the tenant boundary
         }),
 });
+```
+
+```ts
+// lunora/shapes.ts
+import { defineShape } from "lunorash/server";
 
 export const channelMessages = defineShape({ table: "messages", where: () => ({}) });
 ```

--- a/apps/docs/src/content/docs/architecture.mdx
+++ b/apps/docs/src/content/docs/architecture.mdx
@@ -88,7 +88,7 @@ Three ideas carry the whole design:
 | **SchedulerDO**  | `@lunora/scheduler`         | Alarm-driven `runAfter` / `runAt` and Cron Triggers.                                                                                                                                                      |
 | **Container DO** | `@lunora/container`         | A Docker workload running as a Durable Object, for jobs that don't fit the Workers runtime (ffmpeg, headless Chrome, an ML model, a long-running process). Reached from actions via `ctx.containers`.     |
 | **D1**           | `@lunora/d1`                | Backs `.global()` tables. Wraps the Sessions API (`withSession(bookmark)`) for read-your-writes across regional replicas.                                                                                 |
-| **R2**           | `@lunora/storage`           | Typed buckets and signed URLs; the browser uploads/downloads directly, never proxied through the Worker.                                                                                                  |
+| **R2**           | `@lunora/storage`           | Typed buckets and signed URLs that point back at your Worker (it verifies the signature and streams the bytes, so storage rules apply); `getPresignedUrl` bypasses the Worker for direct R2 transfers.    |
 | **Queues**       | `@lunora/queue`             | Fire-and-forget background work via a typed `ctx.queues.<name>` producer and a generated `queue()` consumer.                                                                                              |
 | **Client**       | `@lunora/client` + adapters | Browser SDK: multiplexed WebSocket, optimistic writes, offline queue, reconnect-by-bookmark. Framework adapters expose `useQuery` / `useMutation` / `useSubscription`.                                    |
 | **Codegen**      | `@lunora/codegen`           | Reads `schema.ts` + your functions, emits `_generated/{api,server,dataModel}.ts` so the address of every shard and the type of every result is known at build time.                                       |
@@ -219,7 +219,7 @@ without a sticky-session router.
 
 ### Tier 3: Blob & async
 
-- **R2** (`@lunora/storage`): signed URLs; the browser transfers directly. Egress is free, so design around direct downloads.
+- **R2** (`@lunora/storage`): signed URLs served by your Worker; `getPresignedUrl` (needs R2 S3 credentials) transfers directly against R2. Egress is free, so design around direct downloads.
 - **Queues** (`@lunora/queue`): `ctx.queues.<name>.send(...)` from a mutation or action for fire-and-forget work. A generated `queue()` consumer drains it. Idempotency is on you.
 - **KV**: edge-cached config and feature flags via `@lunora/bindings/kv` (`ctx.kv`).
 
@@ -354,7 +354,7 @@ The theme is **fail closed and re-derive**, never silently diverge.
   Because containers reach data only through RPC, a crashed container can never
   leave storage half-written; the DO transaction is still the only writer.
 - **Hot shard (approaching the ceiling).** Not a crash but a capacity wall: the
-  runtime warns at 1 GB / sustained >700 req/s well before the hard limit, so a
+  runtime warns at 1 GiB of DO SQLite well before the hard limit, so a
   `.shardBy()` migration has runway. Moving the rows already in `__root__` needs
   a [write window](/docs/concepts/sharding#migrating-a-populated-table), which is
   the part to plan for. See [Limits](/docs/limits).

--- a/apps/docs/src/content/docs/concepts/actions.mdx
+++ b/apps/docs/src/content/docs/concepts/actions.mdx
@@ -13,14 +13,15 @@ An **action** runs outside Lunora's transaction. A `query` reads only and a
 `mutation` does transactional reads and writes, but an action can `fetch()` a
 third-party API, send an email, talk to a queue, or drive an AI model. Two
 things give way in return: actions are not reactive (clients don't auto-subscribe
-to them), and they have no transactional `db` for reading or writing your tables.
+to them), and their `ctx.db` writes are not wrapped in a transaction — each one
+commits on its own.
 
 ```ts
 import { action, v } from "@/lunora/_generated/server";
 import { api, internal } from "@/lunora/_generated/api";
 
 export const syncWithStripe = action.input({ customerId: v.string() }).action(async ({ ctx, args }) => {
-    // 1. Read current state via a query (no direct ctx.db).
+    // 1. Read current state via a query, so the read runs in a transaction.
     const customer = await ctx.runQuery(internal.customers.byStripeId, { stripeId: args.customerId });
 
     // 2. Talk to the outside world.
@@ -42,9 +43,9 @@ export const syncWithStripe = action.input({ customerId: v.string() }).action(as
 | Drive an AI model, browser, or BYO database                   | `action`   |
 
 A mutation runs inside the shard's transaction, so its `ctx.db` writes commit
-atomically and broadcast reactive deltas. An action runs in the worker (the
-action runtime), outside that transaction, so it can do unbounded I/O without
-holding the shard open. Reach for a mutation first, and promote to an action only
+atomically and broadcast reactive deltas. An action runs inside the shard's
+Durable Object too, but outside a storage transaction, so it can do unbounded I/O
+without holding one open. Reach for a mutation first, and promote to an action only
 when you need a side effect a mutation can't safely perform.
 
 ## `ActionCtx`
@@ -61,9 +62,10 @@ The handler receives `ctx: ActionCtx`. Its surface (from `@lunora/server`):
 - `ctx.log`: structured, function-attributed logger.
 - `ctx.ip`: the caller's IP (`undefined` for server-initiated dispatch).
 
-There is no transactional `ctx.db` reader/writer the way a mutation has one. An
-action reaches your data through `runQuery` and `runMutation`, each of which
-forwards to the owning shard and runs as its own transaction.
+An action does have a `ctx.db` writer, but it is **not** transactional: each write
+commits on its own and none of them roll back together. Use it for one-off writes,
+and route anything that must commit atomically through `runQuery` / `runMutation`,
+each of which forwards to the owning shard and runs as its own transaction.
 
 ## Calling queries and mutations from an action
 

--- a/apps/docs/src/content/docs/concepts/authentication.mdx
+++ b/apps/docs/src/content/docs/concepts/authentication.mdx
@@ -111,7 +111,8 @@ databaseHooks: {
         create: {
             after: async (user) => {
                 // Idempotent by construction: upsert on the user id, never insert.
-                await client.mutation(internal.profiles.ensureForUser, { userId: user.id });
+                // `shard` is a createShardClient(env.SHARD).forShard(user.id) handle.
+                await shard.call(internal.profiles.ensureForUser, { userId: user.id });
             },
         },
     },

--- a/apps/docs/src/content/docs/concepts/debugging.mdx
+++ b/apps/docs/src/content/docs/concepts/debugging.mdx
@@ -126,7 +126,7 @@ Auth failures are their own category because the identity is resolved before you
 function runs. Work through it in this order:
 
 1. **Is an identity present at all?** Log `ctx.auth.userId` at the top of the
-   function. `undefined` means the token never resolved, so the problem is in the
+   function. `null` means the token never resolved, so the problem is in the
    client or the auth wiring, not your handler.
 2. **Is the token reaching the worker?** Check the request carries the bearer
    token. `AUTH_HEADERS_MISSING` means auth is not wired up correctly.

--- a/apps/docs/src/content/docs/concepts/environment-variables.mdx
+++ b/apps/docs/src/content/docs/concepts/environment-variables.mdx
@@ -115,7 +115,7 @@ import { createAuth } from "@lunora/auth";
 const auth = createAuth({
     secret: env.AUTH_SECRET, // a secret from `wrangler secret put`
     baseURL: env.AUTH_URL, // a var from wrangler.jsonc
-    providers: [providers.github({ clientId: env.GH_CLIENT_ID, clientSecret: env.GH_CLIENT_SECRET })],
+    socialProviders: { github: { clientId: env.GH_CLIENT_ID, clientSecret: env.GH_CLIENT_SECRET } },
 });
 ```
 

--- a/apps/docs/src/content/docs/concepts/generated-code.mdx
+++ b/apps/docs/src/content/docs/concepts/generated-code.mdx
@@ -23,13 +23,19 @@ type safety: a query's argument and return types are inferred on the server and
 handed to the client through `api`, so a rename or a wrong arg is a compile
 error, not a runtime surprise.
 
-Three files are emitted from `schema.ts`:
+The three files you import from are:
 
 | File           | What it gives you                                                               |
 | -------------- | ------------------------------------------------------------------------------- |
 | `api.ts`       | the typed `api.*` (public) and `internal.*` (server-only) function registries   |
 | `server.ts`    | the project-typed server helpers: `query`/`mutation`/`action`, `v`, typed `ctx` |
 | `dataModel.ts` | the data-model types: `Id<"table">`, `Doc<"table">`, and insert/document shapes |
+
+Codegen emits more than those three. The rest is runtime wiring the worker entry
+consumes rather than code you import by hand: `app.ts`, `shard.ts`,
+`functions.ts`, `crons.ts`, `vectors.ts`, the Drizzle schemas
+(`drizzle.shard.ts` / `drizzle.global.ts`), and the OpenAPI document
+(`openapi.ts` / `openapi.json`).
 
 ## `api.ts`: function references
 

--- a/apps/docs/src/content/docs/concepts/offline-first.mdx
+++ b/apps/docs/src/content/docs/concepts/offline-first.mdx
@@ -53,7 +53,8 @@ const client = new LunoraClient({
 });
 ```
 
-Both adapters share a single `lunora` IndexedDB database, so there is nothing
+Each adapter opens its own IndexedDB database (`lunora-outbox`,
+`lunora-query-cache`; override either with `databaseName`), so there is nothing
 else to wire up. For tests or SSR you can swap in the in-memory variants
 (`createInMemoryPersistence()` / `createInMemoryQueryCache()`), which implement
 the same contract without touching IndexedDB.

--- a/apps/docs/src/content/docs/concepts/rest-api.mdx
+++ b/apps/docs/src/content/docs/concepts/rest-api.mdx
@@ -10,9 +10,9 @@ endpoint without rewriting it:
 
 ```ts
 export const list = query
-    .args({ limit: v.optional(v.number()) })
+    .input({ limit: v.optional(v.number()) })
     .expose({ rest: true }) // ← publishes GET /_lunora/rest/messages/list
-    .handler(async (ctx, { limit }) => ctx.db.query("messages").take(limit ?? 20));
+    .query(async ({ ctx, args }) => ctx.db.query("messages").take(args.limit ?? 20));
 ```
 
 The call is routed **through the procedure**, so everything that guards it over

--- a/apps/docs/src/content/docs/concepts/runtime.mdx
+++ b/apps/docs/src/content/docs/concepts/runtime.mdx
@@ -25,8 +25,8 @@ scaffolded config enables the compatibility flag:
 ```jsonc
 // wrangler.jsonc
 {
-    "compatibility_date": "2026-04-07",
-    "compatibility_flags": ["nodejs_compat", "web_socket_auto_reply_to_close"],
+    "compatibility_date": "2026-06-10",
+    "compatibility_flags": ["nodejs_compat"],
 }
 ```
 

--- a/apps/docs/src/content/docs/concepts/system-tables.mdx
+++ b/apps/docs/src/content/docs/concepts/system-tables.mdx
@@ -59,15 +59,16 @@ the job id for `_scheduled_functions`, and the object key for `_storage`.
 
 One row per pending invocation:
 
-| Field          | Type                      | Meaning                                           |
-| -------------- | ------------------------- | ------------------------------------------------- |
-| `id`           | `string`                  | The job id                                        |
-| `functionPath` | `string`                  | Fully-qualified function to invoke                |
-| `args`         | `Record<string, unknown>` | Arguments it will be dispatched with              |
-| `scheduledFor` | `number`                  | When it fires (epoch ms)                          |
-| `enqueuedAt`   | `number`                  | When it was enqueued (epoch ms)                   |
-| `attempts`     | `number \| undefined`     | Dispatch attempts so far; absent until a retry    |
-| `shardKey`     | `string \| undefined`     | Routing hint so dispatch lands on the right shard |
+| Field          | Type                      | Meaning                                                                          |
+| -------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| `id`           | `string`                  | The job id                                                                       |
+| `functionPath` | `string \| undefined`     | Fully-qualified function to invoke; absent when the row targets a workflow/agent |
+| `workflow`     | `string \| undefined`     | The `WORKFLOW_*` / `AGENT_*` binding started instead of `functionPath`           |
+| `args`         | `Record<string, unknown>` | Arguments it will be dispatched with                                             |
+| `scheduledFor` | `number`                  | When it fires (epoch ms)                                                         |
+| `enqueuedAt`   | `number`                  | When it was enqueued (epoch ms)                                                  |
+| `attempts`     | `number \| undefined`     | Dispatch attempts so far; absent until a retry                                   |
+| `shardKey`     | `string \| undefined`     | Routing hint so dispatch lands on the right shard                                |
 
 ## `_storage`
 

--- a/apps/docs/src/content/docs/concepts/validation.mdx
+++ b/apps/docs/src/content/docs/concepts/validation.mdx
@@ -156,22 +156,22 @@ second schema to keep in sync: the validator is the contract on both ends.
 
 ## Common validators
 
-| Validator              | Accepts                       | Notes                                    |
-| ---------------------- | ----------------------------- | ---------------------------------------- |
-| `v.string()`           | `string`                      | UTF-8 text                               |
-| `v.number()`           | `number`                      | Finite JS number; `NaN` throws           |
-| `v.boolean()`          | `boolean`                     | `true` / `false`                         |
-| `v.null()`             | `null`                        | Only `null`                              |
-| `v.bigint()`           | `bigint`                      | Stored lossless as INTEGER in D1         |
-| `v.bytes()`            | `ArrayBuffer` / `Uint8Array`  | Binary (BLOB in D1)                      |
-| `v.id(table)`          | `Id<table>`                   | Branded foreign-key id                   |
-| `v.literal(value)`     | exact `value`                 | String / number / boolean / null literal |
-| `v.array(inner)`       | `Array<Infer<inner>>`         | Homogeneous array                        |
-| `v.object(shape)`      | `{ ...shape }`                | Extra keys: stripped in, rejected out    |
-| `v.union(a, b, ...)`   | any member                    | Discriminated by `kind` when present     |
-| `v.record(key, value)` | `Record<key, value>`          | Map-style object                         |
-| `v.optional(inner)`    | `Infer<inner>` \| `undefined` | Makes a field optional                   |
-| `v.any()`              | anything                      | Escape hatch; disables runtime checks    |
+| Validator              | Accepts                       | Notes                                                                        |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------- |
+| `v.string()`           | `string`                      | UTF-8 text                                                                   |
+| `v.number()`           | `number`                      | Finite JS number; `NaN` throws                                               |
+| `v.boolean()`          | `boolean`                     | `true` / `false`                                                             |
+| `v.null()`             | `null`                        | Only `null`                                                                  |
+| `v.bigint()`           | `bigint`                      | Stored lossless as INTEGER in D1                                             |
+| `v.bytes()`            | `ArrayBuffer`                 | Binary (BLOB in D1); pass `u8.buffer` for a `Uint8Array`                     |
+| `v.id(table)`          | `Id<table>`                   | Branded foreign-key id                                                       |
+| `v.literal(value)`     | exact `value`                 | String / number / boolean / null literal                                     |
+| `v.array(inner)`       | `Array<Infer<inner>>`         | Homogeneous array                                                            |
+| `v.object(shape)`      | `{ ...shape }`                | Extra keys: stripped in, rejected out                                        |
+| `v.union(a, b, ...)`   | any member                    | First member that parses wins (declaration order); no discriminant fast-path |
+| `v.record(key, value)` | `Record<key, value>`          | Map-style object                                                             |
+| `v.optional(inner)`    | `Infer<inner>` \| `undefined` | Makes a field optional                                                       |
+| `v.any()`              | anything                      | Escape hatch; disables runtime checks                                        |
 
 Compose them freely for both columns and function contracts:
 `v.array(v.object({ ... }))`, `v.union(v.literal("a"),

--- a/apps/docs/src/content/docs/deployment.mdx
+++ b/apps/docs/src/content/docs/deployment.mdx
@@ -17,8 +17,8 @@ separate API service, no platform sign-up.
     "$schema": "node_modules/wrangler/config-schema.json",
     "name": "my-lunora-app",
     "main": "src/server/index.ts",
-    "compatibility_date": "2026-04-07",
-    "compatibility_flags": ["nodejs_compat", "web_socket_auto_reply_to_close"],
+    "compatibility_date": "2026-06-10",
+    "compatibility_flags": ["nodejs_compat"],
     "durable_objects": {
         "bindings": [
             { "name": "SHARD", "class_name": "ShardDO" },

--- a/apps/docs/src/content/docs/frameworks/angular.mdx
+++ b/apps/docs/src/content/docs/frameworks/angular.mdx
@@ -22,9 +22,10 @@ This page is the task-oriented guide; for the full reference see
 [`@lunora/angular`](/docs/packages/angular).
 
 <Callout type="warn">
-    **Deliberately small surface.** The Angular adapter ships the core four: DI wiring, `liveQuery`, `mutate`, `connectionStatus`. Parity extras the other
-    adapters have (paginated queries, bound optimistic-mutation handles, presence) aren't here yet. Reactive loaders are, via `@lunora/angular/server` +
-    `hydratePreloaded` (see below). For adapter maturity across frameworks see [Bring your framework](/docs/frameworks/bring-your-framework).
+    **Deliberately small surface.** The Angular adapter ships the core four — DI wiring, `liveQuery`, `mutate`, `connectionStatus` — alongside the parity extras
+    the other adapters have: `paginatedQuery` / `infiniteQuery`, the bound optimistic-mutation handle `mutator`, and `presence`. Reactive loaders are there too,
+    via `@lunora/angular/server` + `hydratePreloaded` (see below). For adapter maturity across frameworks see [Bring your
+    framework](/docs/frameworks/bring-your-framework).
 </Callout>
 
 ## Install
@@ -106,8 +107,9 @@ signal stays `undefined`.
 readonly profile = liveQuery(api.users.me, signedIn ? {} : "skip");
 ```
 
-Unlike the Vue/Solid adapters, `args` is a plain value here, not a reactive
-source, and changing it after the fact does not re-subscribe.
+Pass a plain object for static args (resolved once), or a function/`Signal` —
+`() => ({ channelId: channelId() })` — to re-subscribe when it changes, as in the
+Vue/Solid adapters.
 
 ## Mutations
 

--- a/apps/docs/src/content/docs/frameworks/astro.mdx
+++ b/apps/docs/src/content/docs/frameworks/astro.mdx
@@ -53,7 +53,7 @@ bun add @lunora/astro
 
 </Tabs>
 
-`astro` is an **optional** peer (`^6.0.0`); only the host Astro app pulls it in.
+`astro` is an **optional** peer (`>=6.0.0`); only the host Astro app pulls it in.
 `@lunora/astro`'s own public types are declared structurally, so the package
 type-checks even when `astro` is not installed.
 

--- a/apps/docs/src/content/docs/frameworks/bring-your-framework.mdx
+++ b/apps/docs/src/content/docs/frameworks/bring-your-framework.mdx
@@ -48,10 +48,11 @@ The worker resolves each request in this order:
 
 1. `/api/auth/*` → `@lunora/auth`
 2. explicit routes → webhooks / callbacks
-3. **`httpRouter.fetch`** → your meta-framework's SSR handler (everything else)
-4. `/_lunora/rpc` → query / mutation RPC
-5. `/_lunora/ws` → subscriptions / deltas
-6. `/_lunora/admin/*` → studio / observability
+3. `/_lunora/rpc` → query / mutation RPC
+4. `/_lunora/ws` → subscriptions / deltas
+5. `/_lunora/admin/*` → studio / observability (any other `/_lunora/*` path is a
+   404, never the app)
+6. **`httpRouter.fetch`** → your meta-framework's SSR handler (everything else)
 
 Lunora realtime is mounted under the reserved **`/_lunora/*`** namespace, so it
 never collides with your framework's routes. Pages and API go to your framework;
@@ -297,19 +298,19 @@ worth calling out for anyone who tracked the earlier previews:
 Scaffold a new project wired for your framework with `lunora init`:
 
 ```bash
-lunora init my-app -t tanstack-start   # class A — proven, with a live-loader route
+lunora init my-app -t tanstack-start-react   # class A — proven, with a live-loader route
 lunora init my-app --vite react        # React SPA (create-vite overlay) — the default
 lunora init my-app -t standalone       # worker-only, no frontend
 ```
 
-`lunora init -t tanstack-start` is fully wired: it mounts the framework SSR
+`lunora init -t tanstack-start-react` is fully wired: it mounts the framework SSR
 handler as the worker's `httpRouter`, ships a sample **live loader** route, and
 sets up the `@lunora/react` provider. `lunora init -t sveltekit` is proven
-end-to-end; its `src/server.ts`, `wrangler.jsonc`, and `lunora deploy` compose
+end-to-end; its `src/worker.ts`, `wrangler.jsonc`, and `lunora deploy` compose
 into a single worker (verified through `vite build` then `wrangler deploy --dry-run`,
 exporting `ShardDO` with the `SHARD` and `ASSETS` bindings). Templates for
-`react-router`, `solid-start`, `nuxt`, and `astro` exist alongside their
-adapters and are wired on the same composition seam. They are **preview**:
+`react-router`, `solid-v2`, `tanstack-start-solid`, `nuxt`, and `astro` exist
+alongside their adapters and are wired on the same composition seam. They are **preview**:
 scaffoldable, not yet each smoke-proven end-to-end.
 
 To add Lunora to an **existing** meta-framework app, the in-place patcher

--- a/apps/docs/src/content/docs/frameworks/deploy.mdx
+++ b/apps/docs/src/content/docs/frameworks/deploy.mdx
@@ -30,10 +30,11 @@ However your app is composed, the resulting Worker dispatches by path:
 
 1. `/api/auth/*` → `@lunora/auth`
 2. explicit routes → webhooks / callbacks
-3. **everything else** → your framework's SSR handler
-4. `/_lunora/rpc` → query / mutation RPC
-5. `/_lunora/ws` → subscriptions / deltas
-6. `/_lunora/admin/*` → studio / observability
+3. `/_lunora/rpc` → query / mutation RPC
+4. `/_lunora/ws` → subscriptions / deltas
+5. `/_lunora/admin/*` → studio / observability (any other `/_lunora/*` path is a
+   404, never the app)
+6. **everything else** → your framework's SSR handler
 
 Lunora realtime lives under the reserved `/_lunora/*` namespace, so it never
 collides with your framework's routes, and a 500 from SSR does not take down the
@@ -67,8 +68,8 @@ export { ShardDO };
 {
     "name": "my-app",
     "main": "src/server.ts",
-    "compatibility_date": "2026-04-07",
-    "compatibility_flags": ["nodejs_compat", "web_socket_auto_reply_to_close"],
+    "compatibility_date": "2026-06-10",
+    "compatibility_flags": ["nodejs_compat"],
     "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
 }
@@ -77,12 +78,12 @@ export { ShardDO };
 Deploy is the standard flow:
 
 ```bash
-pnpm lunora deploy   # codegen → D1 migrations → wrangler deploy
+pnpm lunora deploy   # codegen → config validation → wrangler deploy
 ```
 
 Because the SSR handler and Lunora run in the **same** Worker, an SSR loader can
 call Lunora over a same-process loopback (`/_lunora/rpc`) with near-zero latency.
-An in-process `serverQuery` fast-path that skips even the loopback is in progress.
+An in-process `serverQuery` fast-path skips even that loopback.
 See [Reactive loaders](/docs/frameworks/reactive-loaders).
 
 ## Class B: the framework owns the CF adapter
@@ -92,10 +93,11 @@ their own Worker, so Lunora does **not** take over the entry. Instead the Lunora
 worker composition is injected into the framework's server entry / hooks: Lunora
 realtime mounts under `/_lunora/*`, and the framework keeps everything else.
 
-- **SvelteKit**: `@sveltejs/adapter-cloudflare` builds the Worker; the Lunora
-  realtime handler is composed in via the server `handle` hook (the `@lunora/svelte`
-  adapter ships a `withLunora()`-style wrapper). `ShardDO` and the migrations are
-  declared in the adapter's `wrangler.jsonc`.
+- **SvelteKit**: `@sveltejs/adapter-cloudflare` builds the SSR handler;
+  `src/worker.ts` wraps it with the generated
+  `defineApp().buildFrameworkWorker(host)` (`@lunora/svelte` is client/loader
+  only). `ShardDO` and the migrations are declared in the adapter's
+  `wrangler.jsonc`.
 - **Nuxt**: Nitro's `cloudflare-module` preset builds the Worker; Lunora is
   composed into the Nitro server entry, with `ShardDO` exported from the same
   module.

--- a/apps/docs/src/content/docs/frameworks/reactive-loaders.mdx
+++ b/apps/docs/src/content/docs/frameworks/reactive-loaders.mdx
@@ -163,7 +163,7 @@ const preloaded = await preloadQuery(client, api.messages.list, { roomId }, { sh
 
 The reactive-loader contract is shipped for React today via `@lunora/react`
 (`createServerClient`, `preloadQuery`, `usePreloadedQuery`) and proven end-to-end
-on the TanStack Start template (`lunora init -t tanstack-start`).
+on the TanStack Start template (`lunora init -t tanstack-start-react`).
 
 A framework-neutral server entrypoint, `@lunora/client/ssr` (promoting
 `createServerClient` / `preloadQuery` plus a `getServerSession` cookie helper),

--- a/apps/docs/src/content/docs/frameworks/verify-live-loaders.mdx
+++ b/apps/docs/src/content/docs/frameworks/verify-live-loaders.mdx
@@ -40,7 +40,7 @@ path; the others are scaffoldable and in progress. See
 [Bring your framework](/docs/frameworks/bring-your-framework) for status.
 
 ```bash
-lunora init demo-app -t tanstack-start   # class A — proven end-to-end
+lunora init demo-app -t tanstack-start-react   # class A — proven end-to-end
 # or, for an existing app:
 #   cd my-existing-app && lunora init --here
 cd demo-app

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -115,8 +115,8 @@ my-app/
 │   ├── messages.ts        # query / mutation / action
 │   └── _generated/        # codegen output (don't edit)
 ├── src/
-│   ├── server/index.ts    # createWorker + ShardDO subclass
-│   └── client/main.tsx    # LunoraProvider + your React app
+│   ├── server.ts          # defineApp() worker entry + ShardDO export
+│   └── main.tsx           # LunoraProvider + your React app
 ├── wrangler.jsonc         # DO + D1 + R2 bindings
 └── vite.config.ts         # lunora() Vite plugin
 ```
@@ -160,8 +160,10 @@ bun run lunora deploy
 
 </Tabs>
 
-This calls `wrangler deploy`, runs pending D1 migrations, and publishes the
-Worker. Everything lives on your account, reachable through your own
+This runs codegen, validates `wrangler.jsonc`, and calls `wrangler deploy` to
+publish the Worker. Data migrations run only with `--migrate` (plus
+`--migrate-yes` in production); the D1 schema SQL `lunora migrate generate` emits
+is never applied for you. Everything lives on your account, reachable through your own
 `*.workers.dev` hostname or a custom domain.
 
 <Callout type="info">

--- a/apps/docs/src/content/docs/migrating/from-convex.mdx
+++ b/apps/docs/src/content/docs/migrating/from-convex.mdx
@@ -211,18 +211,19 @@ queue.
 ## File storage
 
 `ctx.storage.generateUploadUrl()` / `ctx.storage.getUrl(id)` mirror the
-Convex shape. Lunora backs them with **R2**: uploads go straight to R2 via
-a presigned URL, and downloads stream from the Worker.
+Convex shape. Lunora backs them with **R2**: uploads go through a Worker-signed
+`PUT` URL (so your storage rules still apply) and downloads use `getUrl` against
+your `publicBaseUrl`. `getPresignedUrl` is the direct-to-R2 escape hatch.
 
 <Callout type="warn">
-    **`ctx.storage` is read-only in queries AND mutations.** Convex allowed `ctx.storage.delete(id)` inside a mutation; Lunora types it as `ReadOnlyStorage`
-    there and puts `delete` / `store` / `generateUploadUrl` on actions only.
+    **`ctx.storage` has no immediate `delete` in a mutation.** Convex allowed `ctx.storage.delete(id)` inside a mutation; Lunora types it as `MutationStorage`
+    there — the read surface plus `deleteAfterCommit(key)` — and puts `delete` / `store` / `generateUploadUrl` on actions only. A query gets `ReadOnlyStorage`.
 
     This is deliberate. A mutation runs in a Durable Object transaction that can roll back, and an R2 delete cannot: a mutation that deleted an object and then
-    aborted would leave the row intact and the bytes gone. **Schedule the delete instead**, which is strictly better than the Convex original: the row deletion
-    commits transactionally and the object cleanup runs only if it did.
+    aborted would leave the row intact and the bytes gone. `deleteAfterCommit(key)` queues the object cleanup to run only if the transaction commits, so no
+    scheduling of your own is needed.
 
-    `Property 'delete' does not exist on type 'ReadOnlyStorage<"default">'` is the error to expect. Note the same rule makes `generateUploadUrl` an action, which
+    `Property 'delete' does not exist on type 'MutationStorage<"default">'` is the error to expect. Note the same rule makes `generateUploadUrl` an action, which
     changes the browser-facing contract: a client calling it as a mutation fails at runtime, not at compile time.
 
 </Callout>
@@ -330,10 +331,10 @@ so idle subscribers cost zero CPU. See [Real-time](/docs/concepts/realtime).
     </Callout>
 
 6. **Wire the React provider**: replace `<ConvexProvider client={…}>` with
-   `<LunoraProvider client={createLunoraClient({ url })}>`. URL is your
+   `<LunoraProvider client={new LunoraClient({ url })}>`. URL is your
    Worker's `*.workers.dev` hostname.
-7. **Deploy**: `lunora deploy` builds, runs migrations, calls
-   `wrangler deploy`. Your data plane is now in your own Cloudflare account.
+7. **Deploy**: `lunora deploy` builds and calls `wrangler deploy` (data
+   migrations are opt-in: `--migrate`, plus `--migrate-yes` in production). Your data plane is now in your own Cloudflare account.
 
 ## Caveats
 
@@ -376,9 +377,9 @@ export const linkConnector = defineWorkflow({
     handler: async (ctx) => {
         // Each step is checkpointed: a crash after step 1 resumes at step 2
         // rather than re-running step 1.
-        const definition = await ctx.step.do("read-definition", async () => ctx.runQuery(internal.connectors.getDefinition, { key: ctx.params.key }));
+        const definition = await ctx.step.do("read-definition", async () => ctx.run(internal.connectors.getDefinition, { key: ctx.params.key }));
 
-        await ctx.step.do("write-user-link", async () => ctx.runMutation(internal.connectors.linkForUser, { definition, userId: ctx.params.userId }));
+        await ctx.step.do("write-user-link", async () => ctx.run(internal.connectors.linkForUser, { definition, userId: ctx.params.userId }));
     },
 });
 ```

--- a/apps/docs/src/content/docs/migrating/from-firebase.mdx
+++ b/apps/docs/src/content/docs/migrating/from-firebase.mdx
@@ -220,8 +220,10 @@ for the Zero Trust path.
 
 ## File storage
 
-Cloud Storage maps to `ctx.storage`, backed by **R2**. Uploads go straight to
-R2 via a presigned URL and downloads stream from the Worker:
+Cloud Storage maps to `ctx.storage`, backed by **R2**. Uploads go through a
+Worker-signed `PUT` URL (so your storage rules still apply) and downloads use
+`getUrl` against your `publicBaseUrl`; `getPresignedUrl` is the direct-to-R2
+escape hatch:
 
 ```ts
 // Firebase: uploadBytes(ref(storage, path), file)
@@ -265,8 +267,8 @@ job for recurring work. Under the hood Lunora persists schedules in a
 8. **Wire the React provider.** Replace the Firebase app init with
    `<LunoraProvider client={new LunoraClient({ url })}>` (`url` is your Worker's
    `*.workers.dev` hostname).
-9. **Deploy.** `lunora deploy` builds, runs migrations, and calls
-   `wrangler deploy`. Your data plane now lives in your own Cloudflare account.
+9. **Deploy.** `lunora deploy` builds and calls `wrangler deploy` (data
+   migrations are opt-in: `--migrate`, plus `--migrate-yes` in production). Your data plane now lives in your own Cloudflare account.
 
 ## Importing your data
 

--- a/apps/docs/src/content/docs/migrating/from-supabase.mdx
+++ b/apps/docs/src/content/docs/migrating/from-supabase.mdx
@@ -213,11 +213,11 @@ const ownMessages = definePolicy({
 export const list = query.use(rls(definePolicies([ownMessages]))).query(async ({ ctx }) => ctx.db.query("messages").collect());
 ```
 
-Policies are pure functions bound to a `table` + operation (`on: "read"` /
-`"write"`) and applied per procedure via `.use(rls(...))`. A bare
-`query`/`mutation` sees an unguarded `ctx.db`, so RLS is opt-in exactly where
-you want it. Write authorization is an imperative `ctx.auth` check at the top of
-the mutation. There's no separate policy language to keep in sync with the app.
+Policies are pure functions bound to a `table` + operation (`on: "read"`,
+`"insert"`, `"update"`, or `"delete"`) and applied per procedure via
+`.use(rls(...))`. A bare `query`/`mutation` sees an unguarded `ctx.db`, so RLS is
+opt-in exactly where you want it — and it covers writes as well as reads. There's
+no separate policy language to keep in sync with the app.
 
 ## Edge Functions → actions
 
@@ -248,8 +248,10 @@ for the Zero Trust path.
 
 ## File storage
 
-Supabase Storage maps to `ctx.storage`, backed by **R2**. Uploads go straight
-to R2 via a presigned URL and downloads stream from the Worker:
+Supabase Storage maps to `ctx.storage`, backed by **R2**. Uploads go through a
+Worker-signed `PUT` URL (so your storage rules still apply) and downloads use
+`getUrl` against your `publicBaseUrl`; `getPresignedUrl` is the direct-to-R2
+escape hatch:
 
 ```ts
 // Supabase: supabase.storage.from(bucket).upload(path, file)
@@ -292,8 +294,8 @@ job for recurring work. Under the hood Lunora persists schedules in a
 8. **Wire the React provider.** Replace the `createClient(...)` init with
    `<LunoraProvider client={new LunoraClient({ url })}>` (`url` is your Worker's
    `*.workers.dev` hostname).
-9. **Deploy.** `lunora deploy` builds, runs migrations, and calls
-   `wrangler deploy`. Your data plane now lives in your own Cloudflare account.
+9. **Deploy.** `lunora deploy` builds and calls `wrangler deploy` (data
+   migrations are opt-in: `--migrate`, plus `--migrate-yes` in production). Your data plane now lives in your own Cloudflare account.
 
 ## Importing your data
 

--- a/apps/docs/src/content/docs/tutorial/realtime-chat.mdx
+++ b/apps/docs/src/content/docs/tutorial/realtime-chat.mdx
@@ -23,7 +23,8 @@ pnpm install
 ```
 
 The template gives you a `lunora/schema.ts`, a starter `lunora/messages.ts`,
-and a `src/server/index.ts` that boots `@lunora/runtime`'s `createWorker`.
+and a `src/server.ts` that builds the worker from the generated `defineApp()`
+(`lunora/_generated/app`).
 
 </Step>
 
@@ -126,7 +127,7 @@ client subscribed to `list` for that `channelId` re-renders.
 <Step>
 ## 6. Wire the React app
 
-`src/client/main.tsx` already wraps your tree in `LunoraProvider`. Build the
+`src/main.tsx` already wraps your tree in `LunoraProvider`. Build the
 chat panel:
 
 ```tsx


### PR DESCRIPTION
Documentation-only. Every claim below was re-read against the code before the edit; the changes touch the factual statement (or the code sample) and nothing else.

## What each page claimed vs what the code does

| Page | Claimed | Code |
| --- | --- | --- |
| `frameworks/reactive-loaders`, `verify-live-loaders`, `bring-your-framework` (×2) | `lunora init -t tanstack-start` | `init/handler.ts` offers `tanstack-start-react` / `tanstack-start-solid`; a bare `tanstack-start` exits 1 with "unknown --template" |
| `tutorial/realtime-chat`, `getting-started` | scaffold writes `src/server/index.ts` (booting `createWorker`) and `src/client/main.tsx` | `overlay/apply.ts` writes `src/server.ts` built from `defineApp()`; `overlay/adapters.ts` writes `src/main.tsx` |
| `concepts/rest-api` | `.args({...}).handler(async (ctx, { limit }))` | `builder/types.ts`: `input(...)` and `query(({ ctx, args }))`; no `.args` / `.handler` on the builder |
| `bring-your-framework`, `frameworks/deploy` | SSR handler matched 3rd, `/_lunora/*` after it | `create-worker.ts`: auth → explicit routes → internal `/_lunora/*` table → reserved-prefix 404 → `dispatchHttpRoute` ("lowest-priority matcher") |
| `frameworks/angular` | paginated queries, mutator handles and presence "aren't here yet" | `packages/angular/src/index.ts` exports `paginatedQuery`, `infiniteQuery`, `mutator`, `presence` |
| `frameworks/angular` | `liveQuery` args are a plain value that never re-subscribes | `live-query.ts:85` accepts `ArgsOf<F> \| "skip" \| (() => …)`; the function form goes through `attachReactiveArgs` |
| `frameworks/deploy` | SvelteKit composes via a server `handle` hook + `@lunora/svelte`'s `withLunora()` | `templates/sveltekit/src/worker.ts` calls `.buildFrameworkWorker(svelteKitWorker)`; no `withLunora` in `packages/svelte/src`, no `hooks.server.ts` |
| `bring-your-framework` | SvelteKit entry `src/server.ts`; template `solid-start` | `templates/sveltekit/src/worker.ts`; template ids are `solid-v2` / `tanstack-start-solid` |
| `frameworks/deploy` | in-process `serverQuery` fast-path "is in progress" | emitted into `_generated/app.ts` (`serverQuery: (request, rawEnv, …)`) |
| `concepts/runtime`, `deployment`, `frameworks/deploy` | scaffolded `compatibility_date` 2026-04-07 + `web_socket_auto_reply_to_close` | overlay and all 13 templates write `2026-06-10` / `["nodejs_compat"]`; `wrangler-validator.ts:1485` — the flag became the default on 2026-04-07 and workerd now warns when it is set |
| `concepts/system-tables` | `functionPath: string` (required) | `types.ts:822` `functionPath?: string` — absent when the row targets a workflow/agent (`workflow`) |
| `concepts/offline-first` | both adapters share one `lunora` IndexedDB database | `persistence.ts` → `lunora-outbox`; `query-cache.ts` → `lunora-query-cache` |
| `concepts/validation` | `v.bytes()` accepts `ArrayBuffer` / `Uint8Array` | `v.ts:783` throws unless `value instanceof ArrayBuffer`; `Uint8Array` appears nowhere in the file |
| `concepts/validation` | `v.union` "discriminated by `kind`" | `v.ts:1163` tries members in declaration order; `kind` is the validator's own tag, never read off the value |
| `frameworks/astro` | `astro` peer `^6.0.0` | `packages/astro/package.json:81` `">=6.0.0"` |
| `concepts/actions` | actions run in the worker with no `ctx.db` | `types.ts:2539` `readonly db: DatabaseWriter`; `:2530` an RPC action runs inside the DO; `shard-do.ts:2798` its writes commit independently |
| `concepts/debugging` | unauthenticated `ctx.auth.userId` is `undefined` | `types.ts:1303` `readonly userId: string \| null` |
| `concepts/environment-variables` | `providers: [providers.github(...)]` | `LunoraAuthOptions = BetterAuthOptions`; the key is `socialProviders` and no `providers` helper is exported |
| `concepts/authentication` | `client.mutation(internal.…)` "over the shard client" | `shard-client.ts` exposes only `call` |
| `concepts/generated-code` | "Three files are emitted" | twelve files in `_generated/`; three are the ones you import |
| `getting-started`, `migrating/from-{convex,supabase,firebase}`, `frameworks/deploy` | `lunora deploy` runs migrations / D1 migrations | `deploy/handler.ts:1381` `options.migrate ? runPostDeployMigrations(...) : 0`; no `d1 migrations apply` anywhere in the CLI |
| `architecture` (×2), `migrating/from-{supabase,firebase,convex}` | R2 transfers never proxied / uploads go straight to R2 | `generateUploadUrl` → `getSignedUrl(..., "PUT")`, a Worker-hosted URL; only the opt-in `getPresignedUrl` hits R2 directly |
| `architecture` | runtime warns at "sustained >700 req/s" | only `ROOT_DO_SIZE_WARN_BYTES` (1 GiB) exists; no req/s threshold in `do`/`runtime`/`advisor` |
| `migrating/from-convex` | mutation `ctx.storage` is `ReadOnlyStorage`; schedule the delete | `MutationCtx.storage: MutationStorage`, which adds `deleteAfterCommit(key)` |
| `migrating/from-convex` | `createLunoraClient({ url })` for the web client | that export is React-Native-only; the web client is `new LunoraClient({ url })` |
| `migrating/from-convex` | `ctx.runQuery` / `ctx.runMutation` inside a workflow | `WorkflowRunContext` has `run`, not `runQuery`/`runMutation` |
| `migrating/from-supabase` | RLS `on: "read" \| "write"`, writes checked imperatively | `PolicyOperation = "delete" \| "insert" \| "read" \| "update"`; write policies are enforced by RLS |
| `blog/keep-postgres-get-live-queries` | `defineShape` declared in `lunora/schema.ts` | `discover/shapes.ts`: shapes are only discovered in `lunora/shapes.ts` |
| `blog/keep-postgres-get-live-queries` | `ctx.sql = fromPostgresJs(...)` inside an action | `capabilities.ts:156` emits `readonly sql`; the client comes from the `.hyperdrive()` / `sql` config thunk |
| `blog/introducing-lunora` | `.shardBy("roomId").global()` | `schema.ts` keeps one `shardMode`; the later `.global()` overwrites the shard mode, so the table lands on D1 |

Three findings were fixed in more places than the report listed, because the same wrong string occurred elsewhere in `apps/docs`: the stale `compatibility_date` / redundant flag pair (also in `deployment.mdx` and `frameworks/deploy.mdx`) and the "deploy runs D1 migrations" claim (also in `frameworks/deploy.mdx`).

## Rejected findings

None. All 34 in-scope findings (C/D: F12–F33, I: F108–F119) reproduced exactly as reported when both sides were re-read in full.

## Recommendations on the three "doc may be right, code may be wrong" items

**F26 — `v.bytes()` vs `Uint8Array`: the code is the weaker side.** The doc row was false today and is corrected to `ArrayBuffer`, but the validator is the thing worth changing. `shared/wire-codec.ts` deliberately preserves a `Uint8Array` across the wire (`:378` emits the 2-element `bytes` tag for exactly that constructor, and `:626` decodes it back to `Uint8Array`), and the D1 dialect stores either as a `BLOB`. So a value the transport is designed to round-trip is rejected by the validator on arrival — a footgun that surfaces only at runtime, on the payload path. Suggested follow-up: have `bytes()` accept `ArrayBuffer | ArrayBufferView` and normalise a view to its `ArrayBuffer` (honouring `byteOffset`/`byteLength`), keeping the inferred type `ArrayBuffer`. That is a widening, so no existing schema breaks.

**F118 — `.shardBy(...).global()`: yes, the builder should throw.** The doc is fixed by dropping `.global()` from the sample. Separately, `defineTable` should reject the pair. `packages/server/src/schema.ts` keeps a single `shardMode` (`:386`) that both `global()` (`:446`) and `shardBy()` (`:556`) overwrite, with no guard — so the two calls silently produce the *opposite* of what the second-to-last one asked for, and the failure is invisible: the table simply lands on a different tier, losing per-shard isolation and poke-live reactivity. A throw in the second call ("a table is either `.shardBy(field)` or `.global()`") is a one-line, load-time error with no legitimate use case to break. This is a pre-release branch, so no deprecation cycle is needed.

**F119 — `ctx.sql = …`: the doc (and the JSDoc) are wrong, the code is right.** `capabilities.ts:156` emits `readonly sql`, and `emit.ts:3538` wires it from the optional `sql?: (env) => SqlClient` thunk, whose missing-thunk stub throws a message naming the correct wiring verbatim. The assignment form has not compiled since the field was emitted readonly. The blog sample is rewritten to wire `.hyperdrive((env) => …)` on the app builder and read `ctx.sql` in the action, matching `packages/hyperdrive/docs/index.mdx`. **No code change recommended** — but `packages/hyperdrive/src/create-hyperdrive.ts:20` carries the same stale JSDoc example and still needs the identical fix; it is outside this PR's scope (`apps/docs` only) and is left to the owner of that area.

## Verification

- Re-grepped 36 wrong strings across `apps/docs/src/content` — all zero. (The one broad pattern that still matched, `withLunora`, matches `@lunora/astro`'s real export, which the Astro pages document correctly; the false claim was specifically about `@lunora/svelte`, and `grep -rn withLunora packages/svelte/src` is empty.)
- `pnpm --filter @lunora/docs run build` — passes (after `pnpm run build:packages`, which the workspace deps need in a fresh worktree). Package docs under `src/content/docs/packages/` are generated by `scripts/copy-package-docs.js` during the build and were not edited.
- `prettier --check "apps/docs/src/content/**/*.mdx"` — clean (run before eslint).
- `eslint --max-warnings=0 src/content` in `apps/docs` — clean.

## Deliberately left alone

- `packages/astro/docs/index.mdx` also says `^6.0.0`, and `packages/hyperdrive/src/create-hyperdrive.ts` carries the stale `ctx.sql =` JSDoc. Both are the same defects as F28/F119 but live outside `apps/docs`, so they belong to the packages sweep.
- `src/server/index.ts` as a plain code-fence label in `deployment.mdx`, `local-first.mdx`, `authentication.mdx` and `environment-variables.mdx`: that path is real in the Expo template, and those lines make no claim about what the React overlay scaffolds.
- `monorepos-and-iac.mdx`'s `compatibilityDate: "2026-04-07"` in an emitted bindings manifest — that date is the validator's minimum, so the sample is valid.
- `templates/analog/README.md` and the other non-`apps/docs` findings the report lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
