### PR TITLE
fix(values): accept a buffer view in v.bytes()

### DIFF
--- a/packages/values/__tests__/v.test.ts
+++ b/packages/values/__tests__/v.test.ts
@@ -53,13 +53,36 @@ describe("primitives", () => {
         expect(() => v.null().parse(undefined)).toThrow(ValidationError);
     });
 
-    it("bytes accepts ArrayBuffer only", () => {
+    it("bytes passes an ArrayBuffer through and rejects a non-buffer", () => {
         expect.assertions(2);
 
         const buffer = new ArrayBuffer(4);
 
         expect(v.bytes().parse(buffer)).toBe(buffer);
-        expect(() => v.bytes().parse(new Uint8Array(4))).toThrow(ValidationError);
+        expect(() => v.bytes().parse("nope")).toThrow(ValidationError);
+    });
+
+    it("bytes normalises a view to an ArrayBuffer", () => {
+        expect.assertions(3);
+
+        const parsed = v.bytes().parse(new Uint8Array([1, 2, 3]));
+
+        expect(parsed).toBeInstanceOf(ArrayBuffer);
+        expect(parsed.byteLength).toBe(3);
+        expect([...new Uint8Array(parsed)]).toStrictEqual([1, 2, 3]);
+    });
+
+    it("bytes copies only a view's own window, not its parent buffer", () => {
+        expect.assertions(2);
+
+        // A subarray views a slice of a larger buffer. Returning `view.buffer`
+        // would hand the column every byte of the parent — the neighbouring
+        // records' bytes included.
+        const parent = new Uint8Array([9, 9, 1, 2, 3, 9, 9]);
+        const parsed = v.bytes().parse(parent.subarray(2, 5));
+
+        expect(parsed.byteLength).toBe(3);
+        expect([...new Uint8Array(parsed)]).toStrictEqual([1, 2, 3]);
     });
 
     it("literal", () => {

--- a/packages/values/docs/index.mdx
+++ b/packages/values/docs/index.mdx
@@ -45,7 +45,7 @@ Lunora validator directly.
 | `v.boolean()`          | `boolean`                     | `true` / `false`                                       |
 | `v.null()`             | `null`                        | Only `null`                                            |
 | `v.bigint()`           | `bigint`                      | Stored as INTEGER (int64) in D1                        |
-| `v.bytes()`            | `ArrayBuffer`                 | Binary; stored as BLOB. A `Uint8Array` is rejected     |
+| `v.bytes()`            | `ArrayBuffer` or any view     | Binary; stored as BLOB. A view copies to its own bytes |
 | `v.any()`              | anything                      | Escape hatch; no runtime check — see below             |
 | `v.id(table)`          | `Id<table>`                   | Branded id string for the given table                  |
 | `v.literal(value)`     | exact `value`                 | `string` / `number` / `boolean` / `bigint` / `null`    |

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -784,6 +784,17 @@ const nullValidator = (): ColumnValidator<null, null> =>
 const bytes = (): ColumnValidator<ArrayBuffer, ArrayBuffer> =>
     asColumn(
         createValidator<ArrayBuffer>("bytes", (value, context) => {
+            // A view (`Uint8Array`, `DataView`, …) normalises to its OWN bytes.
+            // The wire codec round-trips a view as a view, so one reaches a
+            // `v.bytes()` argument or column whenever a caller passes one; the
+            // SQL layer binds either form as a BLOB. Copying through
+            // `byteOffset`/`byteLength` is the load-bearing half: a subarray
+            // views a window of a larger buffer, and handing back `value.buffer`
+            // would store bytes the caller never passed.
+            if (ArrayBuffer.isView(value)) {
+                return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+            }
+
             if (!(value instanceof ArrayBuffer)) {
                 fail(context, "ArrayBuffer", value);
             }


### PR DESCRIPTION
## The defect

`v.bytes()` accepted only an `ArrayBuffer`, but the wire codec deliberately
carries a buffer *view*: `encodeWire` tags a `Uint8Array` as `bytes` and
`decodeWire` rebuilds the same view type. A value a caller passes for a
`v.bytes()` argument therefore reaches the shard as a `Uint8Array`, and
`validateArgs` then rejected it — even though the transport preserved it exactly
and the SQL layer (`sqliteEncode`) binds either form as a BLOB.

Invisible to types: the declared input is `ArrayBuffer`, so this only ever
surfaced at runtime, on the payload path.

Confirmed end to end before changing anything — encoding a `Uint8Array`,
`JSON.stringify`/`parse`, decoding, then parsing: the decoded value is a
`Uint8Array` and `v.bytes().parse` throws `Expected ArrayBuffer at <root>,
received object Uint8Array`.

## The fix

`v.bytes()` accepts any `ArrayBufferView` and normalises it to an `ArrayBuffer`,
copying through `byteOffset`/`byteLength`. That last part is load-bearing: a
subarray views a window of a larger buffer, so returning `value.buffer` would
store every byte of the parent — data the caller never passed. A non-buffer
value still fails with the same error shape, and the inferred TypeScript type
stays `ArrayBuffer`, so no schema or generated code changes.

## Tests

Three cases in `packages/values/__tests__/v.test.ts`, each verified by breaking
the implementation first:

| Case | Sabotage | Real failure |
| --- | --- | --- |
| view normalises to an `ArrayBuffer` | disable the view branch | `ValidationError: Expected ArrayBuffer at <root>, received object Uint8Array` |
| subarray copies only its own window | return `value.buffer` | `AssertionError: expected 7 to be 3` |
| `ArrayBuffer` passes, non-buffer rejects | (unchanged behaviour, pre-existing) | — |

## Docs

`packages/values/docs/index.mdx` said "A `Uint8Array` is rejected"; corrected.
`apps/docs/.../concepts/validation.mdx` already documented
`ArrayBuffer / Uint8Array`, so the code was the outlier of the two.

## Gates

`build:packages`, `@lunora/values` tests (192 passed), `lint:types`,
`api:check` (54 snapshots match — no public surface change), prettier, eslint.

## Behaviour break

`v.bytes()` no longer throws on a view. Noted in the commit body so
semantic-release records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
