### PR TITLE
fix(server): reject a table declaring two shard tiers

### DIFF
--- a/apps/docs/src/content/blog/introducing-lunora.mdx
+++ b/apps/docs/src/content/blog/introducing-lunora.mdx
@@ -107,11 +107,15 @@ cursors: defineTable({
     y: v.number(),
 })
     .shardBy("roomId") // one Durable Object per room or tenant
-    .global() // geo-replicated reads at the edge
     .index("by_room", ["roomId"]),
+
+// …or, for a read-mostly table nobody shards:
+regions: defineTable({ code: v.string(), name: v.string() })
+    .global(), // geo-replicated reads at the edge
 ```
 
-Same code, different topology.
+Same code, different topology. The two are alternatives — a table picks one
+tier, and declaring both throws.
 
 ## Where it's rough
 

--- a/packages/server/__tests__/schema.test.ts
+++ b/packages/server/__tests__/schema.test.ts
@@ -128,6 +128,17 @@ describe("defineTable", () => {
         expect(settings.shardMode).toEqual({ backend: "hyperdrive", kind: "global" });
     });
 
+    it("rejects chaining .shardBy() and .global() in either order", () => {
+        expect.assertions(2);
+
+        // Both write the one `shardMode`, so the later call used to discard the
+        // earlier silently: the table landed on a tier the author never chose.
+        // The chain is the only place the collision is observable — by the time
+        // `defineSchema` runs, one of the two modes is simply gone.
+        expect(() => defineTable({ roomId: v.string() }).shardBy("roomId").global()).toThrow(/cannot be both \.shardBy\(key\) and \.global\(\)/u);
+        expect(() => defineTable({ roomId: v.string() }).global().shardBy("roomId")).toThrow(/cannot be both \.shardBy\(key\) and \.global\(\)/u);
+    });
+
     it("table without .vectorize exposes an empty vectorIndexes array", () => {
         expect.assertions(1);
 

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -393,6 +393,32 @@ const defineTable = <Shape extends Record<string, Validator>>(inputShape: Shape)
     let ttl: TtlDefinition | undefined;
     let externalSource: ExternalSourceDefinition | undefined;
 
+    /**
+     * Write the table's shard tier, refusing a second, contradicting one.
+     * `.shardBy()` and `.global()` both own `shardMode`, so chaining them let
+     * the later call silently discard the earlier — the table landed on a tier
+     * the author never chose, losing either per-shard isolation or replicated
+     * edge reads, with nothing visible at build time or runtime.
+     *
+     * Unlike the `.source()` contradictions below, this one cannot be deferred
+     * to `defineSchema`: the whole-table validators see only the survivor, so
+     * by then the collision has left no trace. The chain is the only place it
+     * is still observable.
+     */
+    const setShardMode = (next: ShardMode): void => {
+        // Two non-root kinds exist, so "already set and different" is exactly
+        // the `.shardBy()`/`.global()` collision. Re-stating the same tier is
+        // redundant, not contradictory, and stays allowed.
+        if (shardMode.kind !== "root" && shardMode.kind !== next.kind) {
+            throw new LunoraError(
+                "INTERNAL",
+                "shardBy/global: a table cannot be both .shardBy(key) and .global() — pick one. .shardBy(key) puts the rows in one Durable Object per key (isolation, poke-live reactivity); .global() puts them in a single replicated backend read from the edge.",
+            );
+        }
+
+        shardMode = next;
+    };
+
     const builder: TableBuilder<Shape> = {
         aggregateIndex(name, options) {
             const op: AggregateOp = options?.op ?? "count";
@@ -443,7 +469,7 @@ const defineTable = <Shape extends Record<string, Validator>>(inputShape: Shape)
             return geoIndexes;
         },
         global(options?: { backend?: GlobalBackend }) {
-            shardMode = { backend: options?.backend ?? "d1", kind: "global" };
+            setShardMode({ backend: options?.backend ?? "d1", kind: "global" });
 
             return builder;
         },
@@ -553,7 +579,7 @@ const defineTable = <Shape extends Record<string, Validator>>(inputShape: Shape)
         },
         shape,
         shardBy(field) {
-            shardMode = { field, kind: "shardBy" };
+            setShardMode({ field, kind: "shardBy" });
 
             return builder;
         },


### PR DESCRIPTION
## The defect

`packages/server/src/schema.ts` — `.shardBy(key)` (was line 555) and `.global()`
(was line 445) both assigned the single `shardMode` variable (line 386) with no
guard, so chaining them was last-call-wins:

```ts
defineTable({ roomId: v.string(), x: v.number(), y: v.number() })
    .shardBy("roomId")
    .global(); // → { backend: "d1", kind: "global" }; the shard key is gone
```

The table silently lands on the wrong tier — losing per-shard isolation and
poke-live reactivity, or the replicated edge reads, depending on the order.
Nothing surfaces it: not the type checker, not codegen, not the runtime.

## Verification before changing anything

Confirmed there is no guard anywhere downstream:

- Codegen's AST discovery has the **same** last-wins clobber
  (`discover/schema/internal/table-builder.ts`, the `"global"` and `"shardBy"`
  cases overwrite one field).
- The IR carries one value only (`codegen/src/ir.ts:269`), and the advisor
  derives `shardKind` from the survivor (`codegen/src/advisor.ts:146`), so
  neither can ever see the collision.
- Every existing "cannot be both X and Y" guard pairs `.global()` with
  `.source()`, `.memory()` or `.commitOrdered()` — never with `.shardBy()`.
- The only statement of the rule is prose with no enforcement
  (`packages/cli/skills/lunora-performance-audit/SKILL.md:150`).

Callers chaining both: **none** in source. A balanced-paren scan of every
`defineTable(...)` chain across `examples/`, `templates/`, `registry/`, `apps/`,
`sdks/`, `tests/`, `packages/*/__tests__/` and all `lunora/_generated/` found
zero. One docs snippet showed the combination; corrected here.

## The fix

Both modifiers route through one `setShardMode` helper that throws a
`LunoraError("INTERNAL", …)` on the second, contradicting call, naming both
modes and saying what each buys.

The guard belongs in the chain, not in `defineSchema` alongside the sibling
`.source()` contradictions: those depend on the final table state, which is why
they are deferred — but this one *destroys* its own evidence. By the time the
whole-table validators run, the discarded mode is simply gone. Re-stating the
same tier is redundant rather than contradictory and stays allowed.

## Tests

`packages/server/__tests__/schema.test.ts` — both orders throw; the existing
single-modifier cases still pass. Verified by breaking the code first:

| Sabotage | Real failure |
| --- | --- |
| guard condition → `if (false)` | `AssertionError: expected [Function] to throw an error` at `.shardBy().global()` (line 138) |
| `shardBy` reverted to the raw assignment (one-sided guard) | same assertion, now at `.global().shardBy()` (line 139) — proves the second direction is really covered |

## A codegen advisory

`packages/codegen/src/advisor.ts` would be the natural place to *also* surface
this as a lint, but it cannot as things stand: discovery collapses the two calls
into one field before the advisor runs, so the advisory would need discovery to
record the collision first. Noted, not built.

## Gates

`build:packages`, repo-wide `pnpm run test` (139 files, 1776 tests),
`@lunora/server` tests (51 files, 837 tests), `lint:types`, `api:check` (54
snapshots match), prettier, eslint (`packages/server` and `apps/docs`).

## Behaviour break

Declaring both now throws at load time instead of silently keeping the last one.
Noted in the commit body so semantic-release records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
