### PR TITLE
docs(hyperdrive): show the real ctx.sql wiring

### DIFF
--- a/packages/hyperdrive/src/create-hyperdrive.ts
+++ b/packages/hyperdrive/src/create-hyperdrive.ts
@@ -15,9 +15,14 @@ import type { HyperdriveConnection, HyperdriveLike, Mysql2Like, NodePgLike, Post
  * import { createHyperdrive, fromPostgresJs } from "@lunora/hyperdrive";
  * import postgres from "postgres";
  *
- * // inside an action (never a query/mutation):
- * const { connectionString } = createHyperdrive(env.HYPERDRIVE);
- * ctx.sql = fromPostgresJs(postgres(connectionString));
+ * // Wire the client once, on the app builder — called per shard construction,
+ * // not per request. `ctx.sql` is emitted `readonly`; it is never assigned.
+ * const app = defineApp<Env>()
+ *     .shard((env) => env.SHARD)
+ *     .hyperdrive((env) => fromPostgresJs(postgres(createHyperdrive(env.HYPERDRIVE).connectionString)))
+ *     .build();
+ *
+ * // Then, inside an action (never a query/mutation):
  * const rows = await ctx.sql.query("select id from users where org = $1", [orgId]);
  * ```
  * @remarks


### PR DESCRIPTION
The `@example` block on `createHyperdrive` showed the one form the generated context refuses.

```ts
// before
const { connectionString } = createHyperdrive(env.HYPERDRIVE);
ctx.sql = fromPostgresJs(postgres(connectionString));
```

`ctx.sql` is emitted `readonly` — `packages/codegen/src/capabilities.ts:156` emits
`readonly sql: import("@lunora/hyperdrive").SqlClient;` — and the client is supplied by the app
builder's `hyperdrive` thunk, not assigned inside a handler. So the sample never compiled, and
a reader following it lands on a type error with no hint where the wiring actually belongs.

The replacement is the builder form this package's own docs already document at
`packages/hyperdrive/docs/index.mdx:117`, keeping the action-scoped `ctx.sql.query` read that
followed it so the example still shows both halves.

## Verification

`packages/hyperdrive/docs/index.mdx` was already correct, so this only brings the JSDoc into
line with it — no doc change was needed. Prettier reports the file unchanged after formatting.
Comment-only: the diff touches nothing but the `@example` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
