### PR TITLE
docs(sdks,templates,registry): correct stale claims

### DIFF
--- a/apps/docs/src/content/docs/concepts/non-js-sdks.mdx
+++ b/apps/docs/src/content/docs/concepts/non-js-sdks.mdx
@@ -96,13 +96,17 @@ All eight also implement the two client-side write features, ported from
   so a write the server already committed is not applied twice. The queue is a
   bounded FIFO: overflow drops the OLDEST write, a stale precondition drops one
   before it replays, and a write queued under one identity never replays under
-  another. Give the client a persistence adapter to survive a process restart.
+  another. A flush of two or more writes coalesces into `/_lunora/rpc-batch`
+  round trips rather than one request per write. Give the client a persistence
+  adapter to survive a process restart.
 
-Two deliberate gaps everywhere:
+Two deliberate gaps:
 
 - **No multi-tab leader election.** A browser concern; there are no tabs here.
-- **No built-in HTTP or socket.** Both are injected, which is what lets you keep
-  your own stack — see below.
+- **No built-in HTTP or socket**, except in Python — its client defaults to a
+  `urllib` poster and can drive a live socket through the optional `websockets`
+  package. Everywhere else both are injected, and in Python both defaults are
+  overridable, which is what lets you keep your own stack — see below.
 
 How you reach the queued write path differs in one place, and it is worth knowing
 before you look for a method that is not there:
@@ -119,7 +123,7 @@ before you look for a method that is not there:
   `LunoraPersistence` adapter is asynchronous where the other seven's is
   synchronous.
 
-Two things only Dart gets, because a mobile client is disconnected routinely rather
+One thing only Dart gets, because a mobile client is disconnected routinely rather
 than exceptionally:
 
 - **A live query is a `Stream`.** `watchList(args)` (and `client.watch(path, args)`)
@@ -127,13 +131,6 @@ than exceptionally:
   on first listen and unsubscribes when the last listener cancels, so disposing the
   widget disposes the subscription. The callback-shaped `subscribeList(...)` every
   other language has is there too.
-- **Batched replay.** A reconnect flushing two or more writes coalesces them into
-  `/_lunora/rpc-batch` round trips instead of one request per write. The other seven
-  replay sequentially.
-
-One thing only Dart lacks: a **per-shard drain**. The other seven own a socket per
-shard, so one shard reconnecting flushes just its writes; Dart has a single
-connectivity signal, so one reconnect drains everything.
 
 In Dart, that rides the generated mutation:
 
@@ -182,9 +179,9 @@ Two things are worth knowing about the models everywhere:
   type is inferred by TypeScript and absent from the schema, so the SDK hands back
   its language's `any` rather than guessing a shape.
 
-HTTP and the socket are injected in every language rather than assumed, so you
-keep your own stack, timeouts, retries and socket library, and the conformance
-suites run with no network.
+HTTP and the socket are injected rather than assumed in every language but Python,
+whose defaults you can override, so you keep your own stack, timeouts, retries and
+socket library, and the conformance suites run with no network.
 
 ## Conformance
 

--- a/apps/docs/src/content/docs/concepts/registry-items.mdx
+++ b/apps/docs/src/content/docs/concepts/registry-items.mdx
@@ -35,7 +35,7 @@ same machinery.
 
 An item is a directory containing a `registry.json` plus the files it scaffolds:
 
-```json title="registry/ratelimit/registry.json"
+```json title="An example registry.json"
 {
     "$schema": "../schema/registry-item.schema.json",
     "name": "ratelimit",
@@ -143,11 +143,11 @@ A manifest that violates any of these is rejected rather than partially applied.
 ## Building the catalog
 
 `lunora registry build` regenerates the local catalog `index.json` that `list`
-and `view` read:
+and `view` read. `--from` names the registry root and is required:
 
 ```bash
-lunora registry build
-lunora registry build --check    # verify the index is current — a CI gate
+lunora registry build --from ./registry
+lunora registry build --from ./registry --check    # verify the index is current — a CI gate
 ```
 
 Run `--check` in CI so an item added without rebuilding the index fails the

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -80,7 +80,7 @@ type Template =
 interface InitCommandOptions {
     /**
      * Add features non-interactively after scaffolding (the `--add` flag): a
-     * comma-separated list of `ai | auth | backup | browser | cloudflare-access | crons | email | flags | hyperdrive | payment | presence | queue | storage | workflow`.
+     * comma-separated list of `ai | auth | auth-ui | backup | browser | cloudflare-access | crons | email | flags | hyperdrive | payment | presence | queue | storage | workflow`.
      * Bypasses the interactive multi-select and sub-prompts —
      * each named feature is applied with its shipped defaults.
      */

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -82,7 +82,7 @@ const initCommand: Command = {
         },
         {
             description:
-                "Add features non-interactively after scaffolding (comma-separated): ai | auth | backup | browser | cloudflare-access | crons | email | flags | hyperdrive | payment | presence | queue | storage | workflow",
+                "Add features non-interactively after scaffolding (comma-separated): ai | auth | auth-ui | backup | browser | cloudflare-access | crons | email | flags | hyperdrive | payment | presence | queue | storage | workflow",
             name: "add",
             type: String,
         },

--- a/packages/cli/src/commands/registry/command.ts
+++ b/packages/cli/src/commands/registry/command.ts
@@ -11,7 +11,7 @@ const registryCommand: Command = {
     examples: [
         ["lunora registry list", "List available registry items"],
         ["lunora registry add presence", "Scaffold a registry item into lunora/"],
-        ["lunora registry build --check", "Verify the committed catalog is current"],
+        ["lunora registry build --from ./registry --check", "Verify the committed catalog is current"],
     ],
     group: "Project",
     loader: () =>

--- a/registry/cloudflare-access/README.md
+++ b/registry/cloudflare-access/README.md
@@ -51,7 +51,7 @@ export const resolveIdentity = createAccessResolver({
 Wire it into your Worker entry:
 
 ```ts
-import { createWorker } from "#lunora/_generated/worker.js";
+import { createWorker } from "lunorash/runtime";
 import { resolveIdentity } from "./lunora/access/index.js";
 
 export default createWorker({

--- a/registry/index.json
+++ b/registry/index.json
@@ -127,7 +127,7 @@
             "title": "Storage"
         },
         {
-            "description": "Durable, long-running workflows for Lunora — declare a `defineWorkflow` export in lunora/workflows.ts with steps inspired by Temporal (step.do, step.sleep, fan-out via `branch()`). Codegen generates the WorkflowEntrypoint class and wires `ctx.workflows.<name>.start()` on mutation/action context.",
+            "description": "Durable, long-running workflows for Lunora — declare a `defineWorkflow` export in lunora/workflows.ts with steps inspired by Temporal (step.do, step.sleep, fan-out via `branch()`). Codegen generates the WorkflowEntrypoint class and wires a typed `ctx.workflows.get(\"<name>\")` handle (`create` / `createBatch`) on mutation/action context.",
             "name": "workflow",
             "title": "Workflows"
         }

--- a/registry/mail/README.md
+++ b/registry/mail/README.md
@@ -105,7 +105,7 @@ await createMailer({ apiKey: env.RESEND_API_KEY as string, from: env.MAIL_FROM a
     }
     ```
 
-2. Give the copied `mailer()` a queue binding. `createMailerFromEnv` takes no `queue`, so swap it for `createMailer` in `lunora/mail/mail.ts`:
+2. Give the copied `mailer()` a queue binding. `createMailerFromEnv` takes no `queue`, so swap it for `createMailer` in `lunora/mail/index.ts`:
 
     ```ts
     import { createMailer } from "@lunora/mail";

--- a/registry/workflow/registry.json
+++ b/registry/workflow/registry.json
@@ -2,7 +2,7 @@
     "$schema": "../schema/registry-item.schema.json",
     "name": "workflow",
     "title": "Workflows",
-    "description": "Durable, long-running workflows for Lunora — declare a `defineWorkflow` export in lunora/workflows.ts with steps inspired by Temporal (step.do, step.sleep, fan-out via `branch()`). Codegen generates the WorkflowEntrypoint class and wires `ctx.workflows.<name>.start()` on mutation/action context.",
+    "description": "Durable, long-running workflows for Lunora — declare a `defineWorkflow` export in lunora/workflows.ts with steps inspired by Temporal (step.do, step.sleep, fan-out via `branch()`). Codegen generates the WorkflowEntrypoint class and wires a typed `ctx.workflows.get(\"<name>\")` handle (`create` / `createBatch`) on mutation/action context.",
     "requires": [],
     "deps": {
         "@lunora/workflow": "workspace:*",

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -290,7 +290,7 @@ client is disconnected routinely rather than exceptionally, so a write it cannot
 send yet and a value it can show before the server confirms are the difference
 between a usable app and one that spins.
 
-Three things are Dart's alone, and each follows from this transport's own shape
+Two things are Dart's alone, and each follows from this transport's own shape
 rather than from taste:
 
 - **Connectivity is told, not observed.** The other seven flush on the socket
@@ -466,7 +466,7 @@ data race, and with no interior mutability, `static` or `unsafe` in the client
 that holds totally. Sharing is the caller's `Arc<Mutex<Client>>` — which required
 `Client: Send`, so the injected poster, sender and handlers carry a `+ Send`
 bound; without it one non-`Send` closure made the whole struct unshareable and no
-amount of wrapping helped. Note the difference that follows: the other five
+amount of wrapping helped. Note the difference that follows: the other six
 release their lock before invoking your callback and a caller's `Mutex` cannot,
 so a Rust handler must not re-lock the client it was called from.
 
@@ -527,7 +527,7 @@ Each of these is forced by what these SDKs are rather than chosen:
 | **A rate limit defers the next flush rather than dropping the write.** `FlushReport.retryAfterMs` carries the envelope's `data.retryAfterMs`, clamped to 60 s, and a flush inside that window is a no-op reporting the time remaining.                                                                                                                                 | "Not now" is not "no", and a queue that honours a limiter by discarding loses data for being punctual. The `Retry-After` HEADER is not read: the injected poster surfaces `(status, body)` only — see the capability matrix's note ⁵. The window is also **passive and global**: nothing schedules a re-flush when it elapses (the caller's next flush is what tries again), a refusal carrying no hint sets no window at all, and the one field gates every shard rather than the shard that met the limiter. |
 | **Every fold notifies.** The TypeScript engine suppresses a notification whose folded result is reference-identical to the value already displayed.                                                                                                                                                                                                                    | Reference identity has no portable meaning across eight languages. A consumer sees at most a few redundant callbacks carrying the same value, never a missing one.                                                                                                                                                                                                                                                                                                                                             |
 | **A persistence failure is SILENT unless you wire `on_persistence_error`.** The browser client falls back to `console.warn` when no handler is set.                                                                                                                                                                                                                    | There is no console in a Ruby worker or a JVM service, and writing to stderr from a library is its own bad default. The cost is real, so wire the handler: without it a durable store that has started failing looks exactly like one that is working.                                                                                                                                                                                                                                                         |
-| **An unencodable queued write settles with the coded verdict `OFFLINE_WRITE_UNENCODABLE`.** The reference settles the caller with the raw codec exception.                                                                                                                                                                                                             | Every other terminal drop in these ports carries a code, and a consumer classifying by exception type would need to know seven languages' codec error hierarchies to spot this one.                                                                                                                                                                                                                                                                                                                            |
+| **An unencodable queued write settles with the coded verdict `OFFLINE_WRITE_UNENCODABLE`.** The reference settles the caller with the raw codec exception.                                                                                                                                                                                                             | Every other terminal drop in these ports carries a code, and a consumer classifying by exception type would need to know eight languages' codec error hierarchies to spot this one.                                                                                                                                                                                                                                                                                                                            |
 
 **Multi-tab leader election** is the one browser-only half no port has — a Web
 Lock deciding which tab hydrates the shared durable queue, and there are no tabs
@@ -551,7 +551,7 @@ ways:
 | Go `sync.Mutex`, non-reentrant          | **Self-deadlock.** The second offline write past capacity hung the calling goroutine outright.                                                                     |
 | Ruby `Mutex`, non-reentrant             | **Silently swallowed.** It raised `ThreadError`, which the queue's own `rescue StandardError` then ate — so the evicted write never rolled back and never settled. |
 | Java / Kotlin `synchronized`, reentrant | No hang, but a consumer's callback ran inside the critical section guarding the subscription registry.                                                             |
-| Rust `&mut self`, Swift `NSLock`        | Never expressible — which is why those two were written this way first, and why the other five now match.                                                          |
+| Rust `&mut self`, Swift `NSLock`        | Never expressible — which is why those two were written this way first, and why the other six now match.                                                           |
 
 The Ruby failure is the instructive one: the mechanism that was supposed to stop
 an eviction dropping a durable write in silence was itself dropping it in silence.
@@ -564,7 +564,7 @@ its lock.** The optimistic transform is run against a snapshot and its result
 recorded; a queued write's `precondition` is evaluated on a snapshot too; the
 lock is then taken only to install what came back. Settle handlers, `on_settled`,
 and every subscription and error callback are likewise deferred and invoked after
-the lock is released. Four of the seven use a non-reentrant lock, so without this
+the lock is released. Four of the eight use a non-reentrant lock, so without this
 a callback reading `pending_mutation_count` would deadlock its own thread — a
 hazard the reference client cannot have, because it has no lock at all.
 
@@ -1084,8 +1084,8 @@ a generated call reaches the wire as
 every transport's tree because that is what they are — consumer code, importing
 `lunorasdk/lunoraapi` and `import LunoraApi`, which resolve only against generated
 output. `--from sdks` is passed for them, because the default fetch is the CLI's
-release tag and seven of the eight transports do not exist at any released tag
-yet.
+release tag, and CI has to exercise the transports in the checkout under test
+rather than whatever a published tag carries.
 
 The dart leg runs `dart analyze` in BOTH the generated package and the consumer,
 and the first is the one that matters: `dart analyze` only reports on the package

--- a/sdks/generated-check.sh
+++ b/sdks/generated-check.sh
@@ -21,10 +21,10 @@
 # frame — {"args":{"channelId":"chan_1"},"functionPath":"messages:list"} — which
 # the smoke programs under `sdks/smoke/<lang>/` do.
 #
-# --from, not a tag. The fetch defaults to the CLI's own release tag, and six of
-# the seven transports do not exist at any released tag yet. CI must not depend on
-# one, so this passes `--from sdks` and copies from the checkout. The remote path
-# is exercised by generating without it.
+# --from, not a tag. The fetch defaults to the CLI's own release tag, so without
+# this CI would exercise whatever transports that published tag carries rather than
+# the ones in the checkout under test. So this passes `--from sdks` and copies from
+# the checkout. The remote path is exercised by generating without it.
 set -uo pipefail
 
 cd "$(dirname "$0")/.."

--- a/sdks/java/src/dev/lunora/Optimistic.java
+++ b/sdks/java/src/dev/lunora/Optimistic.java
@@ -41,7 +41,7 @@ import java.util.function.UnaryOperator;
  *
  * <p><b>Divergence from {@code @lunora/client}.</b> The TypeScript engine suppresses a notification
  * whose folded result is reference-identical to the value already displayed. Reference identity has
- * no portable meaning across the seven ports, so they notify on every fold instead — a consumer
+ * no portable meaning across the eight ports, so they notify on every fold instead — a consumer
  * sees at most a few redundant callbacks carrying the same value, never a missing one.
  */
 public final class Optimistic {

--- a/sdks/java/test/dev/lunora/OptimisticOfflineTest.java
+++ b/sdks/java/test/dev/lunora/OptimisticOfflineTest.java
@@ -71,7 +71,7 @@ final class OptimisticOfflineTest {
      * — its monitor is REENTRANT, so a callback running inside the critical section neither hangs
      * nor deadlocks, which is why the violation was invisible for as long as it was. The re-entrant
      * call is the shape that hard-deadlocks the sibling ports whose lock is not reentrant, kept
-     * here so all seven suites drive the same scenario.
+     * here so all eight suites drive the same scenario.
      */
     private static void assertUnlocked(Client client, List<String> violations, String name) {
         if (Thread.holdsLock(client.lock)) {
@@ -85,7 +85,7 @@ final class OptimisticOfflineTest {
     /**
      * No callback a consumer supplies runs while the client holds its lock.
      *
-     * <p>{@code sdks/README.md} states this for all seven ports: not the optimistic update, not a
+     * <p>{@code sdks/README.md} states this for all eight ports: not the optimistic update, not a
      * queue entry's precondition, not {@code onSettled}, not a subscription handler. The transform
      * runs and the precondition is evaluated outside the critical section; the lock is taken only
      * to install the result — in ONE section with the offline decision and the enqueue, so the

--- a/sdks/kotlin/src/Optimistic.kt
+++ b/sdks/kotlin/src/Optimistic.kt
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * **Divergence from `@lunora/client`.** The TypeScript engine suppresses a
  * notification whose folded result is reference-identical to the value already
- * displayed. Reference identity has no portable meaning across the seven ports,
+ * displayed. Reference identity has no portable meaning across the eight ports,
  * so they notify on every fold instead — a consumer sees at most a few redundant
  * callbacks carrying the same value, never a missing one.
  */

--- a/sdks/lint-all.sh
+++ b/sdks/lint-all.sh
@@ -4,7 +4,7 @@
 # Same shape as `run-all.sh`: independent toolchains, per-language exit-status
 # files rather than output grepping, and only a failing language prints a log.
 #
-#   ./sdks/lint-all.sh            # all seven
+#   ./sdks/lint-all.sh            # all eight
 #   ./sdks/lint-all.sh go rust    # a subset
 #
 # WHAT IS CHECKED: the hand-written transports, their suites, and the consumer
@@ -28,8 +28,8 @@ set -uo pipefail
 
 REQUIRE_TOOLS="${SDK_LINT_REQUIRE_TOOLS:-0}"
 
-# The swift-format minor these Swift sources are formatted against. Six of the
-# seven linters are pinned by the workflow's install step; swift-format ships no
+# The swift-format minor these Swift sources are formatted against. Seven of the
+# eight linters are pinned by the workflow's install step; swift-format ships no
 # installable artifact, so its pin lives here — see the `swift)` leg.
 #
 # Overridable because the same release reports two different versions: the copy
@@ -213,7 +213,7 @@ lint_suite() {
             }
 
             # A different minor is a different rule set, which is exactly what
-            # the other six pins prevent. The runner image's default Xcode moves
+            # the other seven pins prevent. The runner image's default Xcode moves
             # on GitHub's schedule, so this drift is real and must be loud.
             local swift_format_drifted=0
             local swift_format_note="swift-format $swift_format_version"

--- a/sdks/python/lunora/optimistic.py
+++ b/sdks/python/lunora/optimistic.py
@@ -34,7 +34,7 @@ uses for server frames.
 
 **Divergence from ``@lunora/client``.** The TypeScript engine suppresses a
 notification whose folded result is reference-identical to the value already
-displayed. Reference identity has no portable meaning across these seven
+displayed. Reference identity has no portable meaning across these eight
 languages, and structural equality is not available for every value in all of
 them, so the ports notify on every fold instead: applying a layer, dropping one,
 and each server frame. A consumer therefore sees at most a few redundant

--- a/sdks/ruby/lib/lunora/optimistic.rb
+++ b/sdks/ruby/lib/lunora/optimistic.rb
@@ -35,7 +35,7 @@ module Lunora
   #
   # Divergence from @lunora/client: the TypeScript engine suppresses a
   # notification whose folded result is identical to the value already displayed.
-  # Reference identity has no portable meaning across the seven ports, so they
+  # Reference identity has no portable meaning across the eight ports, so they
   # notify on every fold instead — a consumer sees at most a few redundant
   # callbacks carrying the same value, never a missing one.
   module Optimistic

--- a/sdks/rust/src/offline.rs
+++ b/sdks/rust/src/offline.rs
@@ -600,7 +600,7 @@ impl OfflineQueue {
     /// its code, and every port evaluates it outside the queue so it can never run
     /// where the queue is mid-mutation. Rust needs no lock to make that safe —
     /// `&mut self` is the exclusion — but this surface is deliberately identical
-    /// across all seven ports, and a signature that means something different here
+    /// across all eight ports, and a signature that means something different here
     /// is exactly the drift that sameness exists to prevent.
     pub fn drain_conflict(&mut self, stale: &HashSet<String>) -> Vec<Discarded> {
         let conflicted = self.drain(|item| stale.contains(&item.id));

--- a/sdks/swift/Sources/Lunora/Optimistic.swift
+++ b/sdks/swift/Sources/Lunora/Optimistic.swift
@@ -36,7 +36,7 @@ import Foundation
 ///
 /// **Divergence from `@lunora/client`.** The TypeScript engine suppresses a
 /// notification whose folded result is reference-identical to the value already
-/// displayed. Reference identity has no portable meaning across the seven ports,
+/// displayed. Reference identity has no portable meaning across the eight ports,
 /// so they notify on every fold instead — a consumer sees at most a few redundant
 /// callbacks carrying the same value, never a missing one.
 public enum LunoraOptimistic {

--- a/templates/analog/README.md
+++ b/templates/analog/README.md
@@ -7,13 +7,13 @@ AnalogJS owns Angular routing + SSR; Lunora provides the real-time, type-safe
 backend on Cloudflare Workers + Durable Objects. Both run in a **single
 Cloudflare Worker** via Analog's Nitro `cloudflare-module` build.
 
-## The honest caveat: no Angular adapter
+## The honest caveat: this template predates `@lunora/angular`
 
-Lunora ships framework adapters for React, Vue, Solid, and Svelte
-(`@lunora/react|vue|solid|svelte`) — **but not Angular.** So this template does
-**not** use a `useQuery`-style adapter. Instead it uses the framework-neutral
-**vanilla client** `lunorash/client` (`new LunoraClient({ url })`) and a small
-hand-written Angular bridge:
+Lunora ships framework adapters for React, Vue, Solid, Svelte and Angular
+(`@lunora/react|vue|solid|svelte|angular`) — **but this template was written
+before the Angular one.** So it does **not** use a `useQuery`-style adapter.
+Instead it uses the framework-neutral **vanilla client** `lunorash/client`
+(`new LunoraClient({ url })`) and a small hand-written Angular bridge:
 
 - **`src/app/lunora.service.ts`** — an `@Injectable` `LunoraService` that owns
   one `LunoraClient` and exposes:
@@ -26,9 +26,9 @@ hand-written Angular bridge:
   `lunora.mutate(api.messages.send, …)`.
 
 This is the minimal "one component lists `messages` via a `LunoraClient`
-subscription into an Angular signal" demo. Swap `LunoraService` for a real
-`@lunora/angular` adapter once one ships — the component API (a `signal` + a
-`mutate` call) is deliberately small so the migration is mechanical.
+subscription into an Angular signal" demo. Swap `LunoraService` for the
+`@lunora/angular` adapter (see the note below) — the component API (a `signal` +
+a `mutate` call) is deliberately small so the migration is mechanical.
 
 > **`@lunora/angular` exists today** and covers `liveQuery` / `mutate` /
 > `connectionStatus`, plus a server half for SSR data loading:

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -2,10 +2,11 @@
 
 A Lunora app on **SvelteKit**, scaffolded by `lunora init`.
 
-Your route loaders are live: a `+page.ts` loader preloads Lunora data on the
-server (read-your-writes SSR), the HTML ships with it, and on the client the
-**same** data hydrates into a live subscription via `@lunora/svelte`'s
-`hydratePreloaded` — re-rendering on every server write with no loading flash.
+The scaffold ships a static welcome page plus the wiring behind it: a sharded
+schema, the typed API, and one Cloudflare Worker that serves SvelteKit SSR and
+the Lunora realtime plane together. `src/routes/+layout.svelte` already publishes
+the `LunoraClient`, so `query` / `mutation` / `hydratePreloaded` from
+`@lunora/svelte` resolve in any route you add.
 
 ## Develop
 
@@ -47,12 +48,21 @@ development"` / `"ShardDO…not exported"` warning. That's the adapter's own emp
   `ShardDO`.
 - `src/routes/+layout.svelte` — publishes the `LunoraClient` on Svelte context
   with `setLunoraClient` (the provider), pointed at the **same origin**.
-- `src/routes/+page.ts` — a universal `load` that calls `preloadQuery` through a
-  request-scoped `createServerClient`, forwarding SvelteKit's `fetch` for
-  same-origin session continuity. Because Lunora is mounted in the same worker,
-  it is a same-origin loopback.
-- `src/routes/+page.svelte` — uses `hydratePreloaded(data.preloaded)` for the
-  SSR-seed-to-live handoff and `mutation(api.messages.send)` for optimistic writes.
+- `src/routes/+page.svelte` — the static welcome page. It makes no Lunora call
+  yet; see below.
+
+## Making a loader live
+
+The scaffold does not load data yet. To go live:
+
+1. Add `src/routes/+page.ts` — a universal `load` that calls `preloadQuery`
+   through a request-scoped `createServerClient` (both from
+   `@lunora/svelte/server`), forwarding SvelteKit's `fetch` for same-origin
+   session continuity. Because Lunora is mounted in the same worker, it is a
+   same-origin loopback. It returns a serializable `Preloaded` token.
+2. In `src/routes/+page.svelte`, hand that token to
+   `hydratePreloaded(data.preloaded)` for the SSR-seed-to-live handoff, and use
+   `mutation(api.messages.send)` for optimistic writes.
 
 ## Stack
 
@@ -91,9 +101,12 @@ How it's wired here:
     export default app;
     ```
 
-- **`wrangler.jsonc`**'s `main` points at `src/worker.ts` (not at SvelteKit's
-  emitted `_worker.js`), and binds the `SHARD` Durable Object. One Worker bundles
-  both planes — no double-bundling the DO class.
+- **`wrangler.jsonc`**'s `main` is the adapter's own output
+  (`.svelte-kit/cloudflare/_worker.js`), because the adapter overwrites whatever
+  `main` names. `lunora deploy` passes `src/worker.ts` as the positional deploy
+  entry, which overrides `main`, so the composed worker is what ships.
+  `wrangler.jsonc` also binds the `SHARD` Durable Object. One Worker bundles both
+  planes — no double-bundling the DO class.
 
 The composed worker reserves `/_lunora/*` for Lunora realtime (`/_lunora/rpc`,
 `/_lunora/ws`, `/_lunora/admin/*`) and forwards **everything else** to

--- a/templates/tanstack-start-react/README.md
+++ b/templates/tanstack-start-react/README.md
@@ -16,8 +16,8 @@ Install dependencies and start the dev server with your package manager
 <pm> run dev
 ```
 
-The dev command runs the TanStack Start dev server alongside `wrangler dev` so
-your client and worker share the same origin.
+The dev command runs Vite with `@cloudflare/vite-plugin`, so the worker runs
+in-process in workerd and shares the dev server's origin with your client.
 
 ## Build
 

--- a/templates/tanstack-start-solid/README.md
+++ b/templates/tanstack-start-solid/README.md
@@ -18,8 +18,8 @@ Install dependencies and start the dev server with your package manager
 <pm> run dev
 ```
 
-The dev command runs the TanStack Start dev server alongside `wrangler dev` so
-your client and worker share the same origin.
+The dev command runs Vite with `@cloudflare/vite-plugin`, so the worker runs
+in-process in workerd and shares the dev server's origin with your client.
 
 ## Build
 


### PR DESCRIPTION
Documentation-only corrections across `sdks/`, `templates/*/README.md`, `registry/`, two docs
pages, and three CLI help strings. Every claim below was re-read against the code before editing;
the rejected one is listed at the bottom.

## Claimed vs actual

| Where | Claimed | Actual |
| --- | --- | --- |
| `sdks/lint-all.sh:7` | `# all seven` | `ALL=(python go ruby rust swift java kotlin dart)` — eight |
| `sdks/lint-all.sh:31`, `:216` | "Six of the seven linters are pinned" / "the other six pins" | seven of the eight are pinned by the workflow's install step (dart via `setup-dart`); swift-format is the only unpinned one |
| `sdks/generated-check.sh:24` | "six of the seven transports do not exist at any released tag yet" | `git ls-tree @lunora/cli@1.0.0-alpha.247 sdks/` lists all eight |
| `sdks/README.md:1086` | "seven of the eight transports do not exist at any released tag yet" | same — and it disagreed with the script's own count |
| `sdks/README.md:469` | "the other five release their lock" | six ports hold a lock (go, ruby, java, kotlin, swift, python — the README says so at `:426`) |
| `sdks/README.md:552` | "the other five now match" | rust + swift were first; the other six |
| `sdks/README.md:567` | "Four of the seven use a non-reentrant lock" | four (go `sync.Mutex`, ruby `Mutex`, swift `NSLock`, python `threading.Lock`) of eight |
| `sdks/README.md:530` | "seven languages' codec error hierarchies" | eight |
| `sdks/README.md:293` | "Three things are Dart's alone" | two bullets follow |
| `optimistic.*` headers (python, ruby, swift, java, kotlin), `OptimisticOfflineTest.java`, `rust/src/offline.rs` | "the seven ports" / "all seven suites" | eight — same claim the README carries |
| `non-js-sdks.mdx:130` | batched replay is Dart's alone, "the other seven replay sequentially" | `rpc-batch` is in all eight transports (`go/submit.go`, `python/submit.py`, `ruby/client.rb`, `rust/submit.rs`, `swift/Submit.swift`, `java/Submit.java`, `kotlin/Submit.kt`, `dart/replay.dart`) |
| `non-js-sdks.mdx:134` | "One thing only Dart lacks: a per-shard drain" | `client.dart:182` `setConnected(bool, {String? shardKey})`, `:206` `connectedTo(shardKey)`, `:625` `flushOfflineQueue(shardKey:)` |
| `non-js-sdks.mdx:104`, `:185` | "No built-in HTTP or socket" / "injected in every language" | `python/client.py:269` defaults `http_post` to a `urllib` poster; `connect_and_run` drives a socket via the optional `websockets` package |
| `registry/command.ts:14`, `registry-items.mdx:148` | `lunora registry build --check` | `commands.ts:358` errors and exits 1 when `options.from` is undefined |
| `init/index.ts:85`, `init/handler.ts:83` | `--add` list omits `auth-ui` | `offer-extras.ts:47` declares it and `parseFeatureList` accepts it |
| `templates/sveltekit/README.md:5`, `:50`, `:54` | a live `+page.ts` loader and a `+page.svelte` using `hydratePreloaded` / `mutation` | `src/routes/` holds only `+layout.svelte`, `+page.svelte` (static welcome page) and `welcome.css` |
| `templates/sveltekit/README.md:94` | wrangler `main` points at `src/worker.ts` | `wrangler.jsonc:15` `".svelte-kit/cloudflare/_worker.js"`; `lunora deploy` passes `src/worker.ts` positionally, overriding `main` |
| `templates/tanstack-start-{react,solid}/README.md:19` | dev runs "alongside `wrangler dev`" | `package.json` `"dev": "vite"` with `cloudflare()` in `vite.config.ts:61` |
| `templates/analog/README.md:12` | "**but not Angular.**" | `packages/angular` ships; the same page says so at `:33` |
| `registry/mail/README.md:108` | `lunora/mail/mail.ts` | manifest copies `mail.ts` → `lunora/mail/index.ts` (the README says so at `:18`) |
| `registry/cloudflare-access/README.md:54` | `import { createWorker } from "#lunora/_generated/worker.js"` | codegen emits no `_generated/worker`; `createWorker` comes from `lunorash/runtime` |
| `registry/workflow/registry.json` (+ generated `index.json`) | `ctx.workflows.<name>.start()` | `emit.ts:2171` emits `get(name)` returning a `WorkflowHandle` with `create`/`createBatch` (the item's own README uses it) |
| `registry-items.mdx:38` | block titled `registry/ratelimit/registry.json` | different title, no `envVars`, different deps and files |

Fixed: 13 of 13 findings in scope. Rejected: 0.

## CLI behaviour findings (not changed here)

**F35 — `lunora registry build` requires `--from`, and the behaviour is arguably the wrong side.**
`runBuildIndexCommand` (`packages/cli/src/commands/registry/commands.ts:358-363`) errors out with
exit 1 whenever `--from` is absent, so `lunora registry build --check` as printed by `--help` could
never succeed. This PR fixes the help text and the docs page only. The code recommendation, for a
separate change: default `options.from` to `./registry` in the `build` subcommand when that
directory exists, which makes the short form work for a registry repo laid out like this one and
keeps `--from` as the override. It is a behaviour change, so it does not belong in a docs PR.

**F36 — help text was the wrong side, not the parser.** `auth-ui` is a real `StackFeature`
(`offer-extras.ts:47`), offered interactively and accepted by `parseFeatureList`; only the two help
strings omitted it. Help text fixed; no behaviour change needed.

## Out of scope, left alone

- `packages/cli/docs/index.mdx:885` and `packages/cli/skills/lunora-create-package/SKILL.md:76-77,125`
  print `lunora registry build` without `--from` — the same defect as F35. `packages/*/docs` belongs
  to another slice of this sweep; flagged rather than edited to avoid a collision.
- `sdks/README.md:285` says "the six places every port departs from `@lunora/client`" where the table
  below it has nine rows. The intended denominator is ambiguous (two of the rows are qualified "in
  the seven non-Dart ports" / "in seven ports"), so the right number could be six, seven or nine;
  not guessed.
- `sdks/README.md:361` ("all seven survived") counts adversarial wire keys, not ports, and
  `sdks/go/lunora/conformance_test.go:75` ("the other seven suites") is correct for Go. Both kept.

## Verification

- Re-grepped every corrected claim across `sdks/`, `templates/`, `registry/` and `apps/docs/src`;
  the only surviving "seven" occurrences are the two correct ones listed above.
- `pnpm run lint:registry:sync` → `auth-ui registry is up to date.`
- `registry/index.json` re-checked field-by-field against all 26 manifests; the index carries only
  `name`/`title`/`description` per item and all three agree (the workflow description was updated in
  both, and both files still parse as JSON).
- Prettier (`--write`, then `--check`) over every touched file, then ESLint. The three touched
  `packages/cli` files: `init/index.ts` and `registry/command.ts` are clean; `init/handler.ts`
  reports pre-existing `no-unsafe-*` errors from line 584 onward, caused by unbuilt workspace
  `dist/` in this worktree and unrelated to the edit at line 83.
- The SDK edits are comment-only and length-preserving (`seven` → `eight`), but
  `bash sdks/lint-all.sh python ruby rust swift java kotlin` was run anyway: six PASS, no SKIP.
- `sdks/run-all.sh` was not run — no SDK behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
