### PR TITLE
docs(cli): give registry build the --from it requires

### DIFF
--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -882,7 +882,7 @@ Fetch and manage reusable Lunora components (queries, mutations, UI widgets):
 lunora registry list
 lunora registry view auth/session-token
 lunora registry add auth/session-token
-lunora registry build   # regenerate the local catalog index.json
+lunora registry build --from ./registry   # regenerate the local catalog index.json
 ```
 
 ### `lunora rules`

--- a/packages/cli/skills/lunora-create-package/SKILL.md
+++ b/packages/cli/skills/lunora-create-package/SKILL.md
@@ -73,8 +73,8 @@ A registry item is a directory under `registry/<name>/` with three files:
 Add an entry to `registry/index.json`, then rebuild and check the index:
 
 ```bash
-lunora registry build              # regenerate registry/index.json
-lunora registry build --check      # verify the index is up to date (CI)
+lunora registry build --from ./registry           # regenerate registry/index.json
+lunora registry build --from ./registry --check   # verify the index is up to date (CI)
 lunora registry view <name>        # preview what `add` would do
 lunora registry add <name>         # install into the current project
 ```
@@ -122,7 +122,8 @@ declaration the user must add so codegen wires the typed surface.
 - [ ] Chose the right shape (registry item, workspace package, or both).
 - [ ] Registry item: `registry.json` + `index.ts` + `README.md` authored;
       `bindings`/`envVars`/`requires`/`files` correct.
-- [ ] `lunora registry build` run; `lunora registry build --check` passes.
+- [ ] `lunora registry build --from ./registry` run; the same command with
+      `--check` passes.
 - [ ] Workspace package: scaffolded via `vis generate lunora-package`; no `.js`
       extensions, no mixed default+named exports, catalog versions used.
 - [ ] `lint:types` and `test` pass for the new package.


### PR DESCRIPTION
`lunora registry build` cannot succeed without `--from`. From
`packages/cli/src/commands/registry/commands.ts:358-363`:

```ts
const root = options.from;

if (root === undefined) {
    options.logger.error("registry build requires --from <registry root>");

    return { ...empty, code: 1 };
}
```

Four examples still printed the bare form:

| File | Line | Why it matters |
| --- | --- | --- |
| `packages/cli/skills/lunora-create-package/SKILL.md` | 76, 77 | a skill an agent follows step by step — the failure lands mid-workflow |
| `packages/cli/skills/lunora-create-package/SKILL.md` | 125 | the release checklist item, so the box can never honestly be ticked |
| `packages/cli/docs/index.mdx` | 885 | the CLI reference |

All four now pass `--from ./registry`, matching the path the error message asks for.

## The better fix, not taken here

The root cause is arguably the command, not the prose: `build` could default `from`
to `./registry` when that directory exists, which would make every one of these
examples correct without touching a word. I did not do that — it changes CLI
behaviour on an assumption about what a registry root is called in a consumer's
repo, and that is a judgement call for a maintainer rather than something to infer
from the examples. Worth considering separately.

## Scope

Only the four occurrences above. `apps/docs/src/content/docs/packages/cli/index.mdx`
is the generated mirror of the CLI docs page (gitignored, produced by
`apps/docs/scripts/copy-package-docs.js`) and regenerates on its own.
`apps/docs/src/content/docs/concepts/registry-items.mdx` carries the same defect and
is already corrected on another branch.

Prettier reports both files unchanged after formatting; docs-only, so no build,
type or API-surface impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
