### PR TITLE
fix(codegen,advisor): drop the OCC-retry claim from advisories

### DIFF
--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -1120,10 +1120,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -1464,10 +1464,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -1911,10 +1911,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -1113,10 +1113,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -1601,10 +1601,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -1151,10 +1151,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -1198,10 +1198,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -1108,10 +1108,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -1665,10 +1665,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -1213,10 +1213,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -1090,10 +1090,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -1654,10 +1654,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -1194,10 +1194,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/packages/advisor/__tests__/notify-send-outside-action.test.ts
+++ b/packages/advisor/__tests__/notify-send-outside-action.test.ts
@@ -46,6 +46,21 @@ describe("notify_send_outside_action", () => {
         expect(run(calls)).toHaveLength(1);
     });
 
+    it("names the hazard that actually applies to each kind, and claims no OCC retry", () => {
+        expect.assertions(4);
+
+        const [query] = run([{ callee: "ctx.notify.send", exportName: "listInbox", file: "inbox", kind: "query", line: 3 }]);
+        const [mutation] = run([{ callee: "ctx.push.broadcast", exportName: "announce", file: "announce", kind: "mutation", line: 9 }]);
+
+        // A query IS re-evaluated by a live subscription — that is the duplicate-send path.
+        expect(query?.detail).toContain("live subscription re-runs this query");
+        // A mutation is not re-run; the send just cannot be rolled back with the transaction.
+        expect(mutation?.detail).toContain("transaction that can roll back");
+        // There is no internal OCC retry loop on this runtime (see `nondeterministic_query_mutation`).
+        expect(query?.detail).not.toContain("retr");
+        expect(mutation?.detail).not.toContain("retried");
+    });
+
     it("is clean for an action (the feeder omits action handlers)", () => {
         expect.assertions(1);
 

--- a/packages/advisor/src/lints/static/hyperdrive-outside-action.ts
+++ b/packages/advisor/src/lints/static/hyperdrive-outside-action.ts
@@ -8,8 +8,8 @@ import type { Lint } from "../../types";
  * Hyperdrive (`@lunora/hyperdrive`) points at an **external** Postgres/MySQL
  * database Lunora does not own. A `ctx.sql` query is a network round-trip with a
  * mutable result — non-deterministic, exactly like `fetch` — so it breaks the
- * determinism the coordinator relies on when it re-runs a query on subscription
- * re-evaluation or a mutation on OCC retry. Worse, external writes are invisible
+ * determinism a `query` handler needs: a live subscription re-runs it whenever a
+ * table it reads changes. Worse, external writes are invisible
  * to the DO/SQLite change-feed, so a subscription will never re-fire on them.
  * `ctx.sql` is therefore wired onto `ActionCtx` **only** and belongs exclusively
  * in `action(...)` handlers; using it in a query/mutation is the same class of

--- a/packages/advisor/src/lints/static/notify-send-outside-action.ts
+++ b/packages/advisor/src/lints/static/notify-send-outside-action.ts
@@ -5,12 +5,27 @@ import type { Lint } from "../../types";
  * Flags a `@lunora/notify` send (`ctx.notify.*` / `ctx.push.*`) inside a
  * `query(...)` or `mutation(...)` handler body.
  *
- * A notification send is external I/O — a `fetch` to a Web Push service or FCM.
- * Like `fetch`/`ctx.sql`, it is non-deterministic, so it breaks the determinism
- * the coordinator relies on when it re-runs a query on subscription re-evaluation
- * or a mutation on OCC retry — a retried mutation would fire the notification
- * again (duplicate pushes). `ctx.notify` / `ctx.push` are therefore wired onto
- * `ActionCtx` only and belong exclusively in `action(...)` handlers.
+ * A notification send is external I/O — a `fetch` to a Web Push service or FCM —
+ * and it cannot be taken back once it leaves. Neither hazard below is an internal
+ * OCC retry: this runtime has none (a conflict throws back to the caller, and
+ * idempotency dedup answers a replayed call from cache rather than re-running the
+ * handler — see `nondeterministic_query_mutation`).
+ *
+ * A `query` handler genuinely IS re-run: every live subscription that reads it
+ * re-evaluates it whenever a table it depends on changes. A send there fires once
+ * per re-evaluation — duplicate pushes for one logical read.
+ *
+ * A `mutation` handler runs inside the shard's storage transaction, which can roll
+ * back on an OCC conflict, an RLS denial, a validator, or a failed row mid-batch.
+ * The push is already gone, so a user is notified about a write that never landed.
+ * This is the same irreversibility that makes `ctx.scheduler.runAfter` buffer until
+ * after commit and keeps `ctx.storage` read-only in a mutation. Duplicates follow
+ * from the retry: the client outbox re-dispatches a transiently failed write, and a
+ * replaying workflow step or queue consumer calls the mutation again — each a fresh
+ * dispatch that sends.
+ *
+ * `ctx.notify` / `ctx.push` are therefore wired onto `ActionCtx` only and belong
+ * exclusively in `action(...)` handlers.
  *
  * This lint runs when the codegen feeder has supplied send evidence
  * (`context.notifyCalls` present); a runtime caller with no evidence flags
@@ -20,7 +35,7 @@ import type { Lint } from "../../types";
 const notifySendOutsideAction: Lint = {
     categories: ["SCHEMA"],
     description:
-        "A `query`/`mutation` handler sends a notification via `ctx.notify`/`ctx.push`. A send is external I/O (a `fetch` to a push service / FCM): it is non-deterministic like `fetch`, and a mutation re-run on OCC retry would re-send it (duplicate pushes). These facades are available on `ActionCtx` only and must be confined to `action` handlers.",
+        "A `query`/`mutation` handler sends a notification via `ctx.notify`/`ctx.push`. A send is external I/O (a `fetch` to a push service / FCM) and cannot be undone: a `query` is re-run by every live subscription that reads it, so the send repeats per re-evaluation, and a `mutation` runs inside a transaction that can roll back, so the push goes out for a write that never landed. These facades are available on `ActionCtx` only and must be confined to `action` handlers.",
     facing: "EXTERNAL",
     level: "WARN",
     name: "notify_send_outside_action",
@@ -35,7 +50,10 @@ const notifySendOutsideAction: Lint = {
         return context.notifyCalls.map((call) =>
             emit(notifySendOutsideAction, {
                 cacheKey: `notify_send_outside_action:${call.file}:${call.line.toString()}:${call.callee}`,
-                detail: `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a ${call.kind} handler — a notification send is non-deterministic external I/O and a retried ${call.kind} would re-send it. Move it into an \`action\`, or enqueue/schedule the send.`,
+                detail:
+                    call.kind === "query"
+                        ? `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a query handler — a live subscription re-runs this query whenever a table it reads changes, so the send fires again on every re-evaluation. Move it into an \`action\`, or enqueue/schedule the send.`
+                        : `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a mutation handler — the mutation runs inside a transaction that can roll back (OCC conflict, RLS denial, validator, failed row mid-batch) but the send cannot, so the notification goes out for a write that never landed, and the caller's retry sends again. Move it into an \`action\`, or enqueue/schedule the send.`,
                 metadata: { callee: call.callee, exportName: call.exportName, file: call.file, kind: call.kind, line: call.line },
             }),
         );

--- a/packages/advisor/src/lints/static/r2sql-outside-action.ts
+++ b/packages/advisor/src/lints/static/r2sql-outside-action.ts
@@ -8,9 +8,9 @@ import type { Lint } from "../../types";
  * R2 SQL (`@lunora/bindings/r2sql`) queries Apache Iceberg tables over an **external**
  * REST endpoint Lunora does not own — there is no Workers binding, every query
  * is an HTTPS round-trip. A `ctx.r2sql` query is therefore non-deterministic
- * (exactly like `fetch`), which breaks the determinism the coordinator relies on
- * when it re-runs a query on subscription re-evaluation or a mutation on OCC
- * retry. And R2 SQL reads are invisible to the DO/SQLite change-feed, so a
+ * (exactly like `fetch`), which breaks the determinism a `query` handler needs:
+ * a live subscription re-runs it whenever a table it reads changes, so the result
+ * can differ between evaluations. And R2 SQL reads are invisible to the DO/SQLite change-feed, so a
  * subscription will never re-fire on them. `ctx.r2sql` is therefore wired onto
  * `ActionCtx` **only** and belongs exclusively in `action(...)` handlers; using
  * it in a query/mutation is the same class of bug as `fetch`/`Date.now`.

--- a/packages/advisor/src/notify-calls.ts
+++ b/packages/advisor/src/notify-calls.ts
@@ -6,10 +6,10 @@
  * (`ctx.notify.send`, `ctx.notify.chat/inApp/webhook`, `ctx.push.send`,
  * `ctx.push.broadcast`).
  *
- * A notification send is external I/O (a `fetch` to a push service / FCM): it is
- * non-deterministic like `fetch`, so it breaks the determinism the coordinator
- * relies on when re-running a query on subscription re-evaluation or a mutation on
- * OCC retry (a retried mutation would re-send). It therefore belongs **only** in
+ * A notification send is external I/O (a `fetch` to a push service / FCM) that
+ * cannot be taken back: a live subscription re-runs a `query` handler on every
+ * change to a table it reads, and a `mutation` handler runs inside a transaction
+ * that can roll back while the send cannot. It therefore belongs **only** in
  * `action(...)` handlers. Calls inside `action(...)` are intentionally **not**
  * recorded — actions are the escape hatch. Runtime callers don't supply this, so
  * the lint finds nothing there.

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -750,7 +750,7 @@ modules: `openapi` (the default) writes `openapi.json`, `openrpc` writes
 Reports per-function metrics from a **running** worker, ranked into three
 sections:
 
-- **Write-conflict hot-spots**: functions that lose OCC retries most often.
+- **Write-conflict hot-spots**: functions that lose the OCC race most often.
   These are your sharding candidates: a high conflict rate means many writers are
   contending on one Durable Object.
 - **Error hot-spots**: functions by error rate, with the most recent error

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -1184,10 +1184,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -1219,10 +1219,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
 
             // `ctx.now`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // `ctx.now` instead of `Date.now()` — the `nondeterministic_query_mutation`
-            // advisor flags the latter. Actions may still use ambient `Date.now()`.
+            // A `query` handler is re-run by every live subscription that reads it,
+            // so `Date.now()` there flickers between re-evaluations. A `mutation`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through `ctx.now` — the `nondeterministic_query_mutation`
+            // advisor flags `Date.now()`. Actions may still use ambient `Date.now()`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -6192,10 +6192,13 @@ ${facadeBlock}${paymentsBuild}
 ${notifyBuild}
             // \`ctx.now\`: the wall-clock instant (epoch ms) this function began,
             // captured ONCE so the whole handler body sees a single stable value.
-            // Query/mutation handlers must be deterministic (they may be re-run on
-            // OCC retry / subscription re-eval), so they must read time through
-            // \`ctx.now\` instead of \`Date.now()\` — the \`nondeterministic_query_mutation\`
-            // advisor flags the latter. Actions may still use ambient \`Date.now()\`.
+            // A \`query\` handler is re-run by every live subscription that reads it,
+            // so \`Date.now()\` there flickers between re-evaluations. A \`mutation\`
+            // handler does not replay under ordinary dispatch (an OCC conflict throws
+            // to the caller rather than retrying internally), but one called from a
+            // workflow step or queue consumer runs again when that step replays. Both
+            // read time through \`ctx.now\` — the \`nondeterministic_query_mutation\`
+            // advisor flags \`Date.now()\`. Actions may still use ambient \`Date.now()\`.
             const now = Date.now();
 
             const ctx: Record<string, unknown> = {


### PR DESCRIPTION
## Why this targets `fix/r37-do-ws-client-ip`

Stacked on **#702**, not on `alpha`. That branch heavily reworks `packages/codegen/src/emit.ts` and regenerates every `_generated/shard.ts` — exactly the files this PR touches. Branching off `alpha` would guarantee a conflict.

CodeRabbit picks this up: `.coderabbit.yaml` already carries `fix/r[0-9]+-.*` in `reviews.auto_review.base_branches`, which matches `fix/r37-do-ws-client-ip`. No config change was needed.

## The defect

The framework told users that `query`/`mutation` handlers "may be re-run on OCC retry". **There is no retry loop.** `packages/do/src/shard-do.ts` classifies an OCC conflict inside a `catch` and returns an error response to the caller, and idempotency dedup answers a replayed call from a cached result rather than re-running the handler. `packages/server/docs/index.mdx:161-163` already states the truth ("OCC surfaces as an error, not a retry"), and the `nondeterministic_query_mutation` advisory already draws the distinction carefully. The other advisories had not caught up.

The prose instances in `packages/server/README.md`, `packages/server/src/types.ts` and `packages/hyperdrive/README.md` are corrected by the sibling PR #706 and are deliberately untouched here. This PR fixes the claim where it ships as *behaviour*.

## Every instance found, and what it became

Found by grepping the concept (`re-run` / `rerun` / `retry` / `replay` near `OCC` / `conflict` / `optimistic`) across `packages/`, `shared/`, `apps/`, `examples/`, `registry/`, `templates/`, `sdks/` — not by one exact phrase.

| # | Location | Was | Now |
|---|---|---|---|
| 1 | `packages/advisor/src/lints/static/notify-send-outside-action.ts` — module docblock | "…re-runs a query on subscription re-evaluation or a mutation on OCC retry — a retried mutation would fire the notification again" | Names the two real hazards separately (see below) and states outright that this runtime has no internal OCC retry |
| 2 | same file — `description` (**printed to users**) | "a mutation re-run on OCC retry would re-send it (duplicate pushes)" | "a `query` is re-run by every live subscription that reads it, so the send repeats per re-evaluation, and a `mutation` runs inside a transaction that can roll back, so the push goes out for a write that never landed" |
| 3 | same file — `detail` (**printed to users**) | one string, "a retried ${kind} would re-send it" | split per procedure kind — the query branch cites subscription re-evaluation, the mutation branch cites transaction rollback plus the caller's retry |
| 4 | `packages/advisor/src/notify-calls.ts` — `AdvisorNotifyCall` docblock | "…or a mutation on OCC retry (a retried mutation would re-send)" | "a live subscription re-runs a `query` handler …, and a `mutation` handler runs inside a transaction that can roll back while the send cannot" |
| 5 | `packages/advisor/src/lints/static/r2sql-outside-action.ts` — module docblock | "…when it re-runs a query on subscription re-evaluation or a mutation on OCC retry" | Scoped to the determinism a `query` handler actually needs; the OCC-retry half dropped |
| 6 | `packages/advisor/src/lints/static/hyperdrive-outside-action.ts` — module docblock | same claim (**a 4th advisor source file, one more than the brief listed**) | same correction |
| 7 | `packages/codegen/src/emit.ts` (~:6155) — the `ctx.now` comment **emitted into generated code users read while debugging** | "Query/mutation handlers must be deterministic (they may be re-run on OCC retry / subscription re-eval)" | Separates the kinds: a `query` is re-run by live subscriptions; a `mutation` does not replay under ordinary dispatch (a conflict throws to the caller) but runs again when a calling workflow step or queue consumer replays |
| 8 | `packages/cli/docs/index.mdx:692` | "functions that lose OCC retries most often" | "functions that lose the OCC race most often" — same false implication, different wording, which is why the grep was by concept |
| 9–23 | **15** committed `_generated/shard.ts` files carrying #7's emitted text — the 2 codegen goldens (`fixtures/simple/expected`, `fixtures/delta-sync/lunora`) **and all 13 `examples/*`** | — | Regenerated, not hand-edited |

Note on 9–23: the brief expected two fixtures. The emitted comment also lives in all 13 `examples/*/lunora/_generated/shard.ts`, which `scripts/check-generated-files.mjs` holds to their generator. Goldens regenerated via `packages/codegen/__tests__/capture-expected.ts`; examples via each one's `pnpm run codegen`.

## What `notify_send_outside_action`'s rationale actually is

The lint is **correct and stays at WARN** — only its stated reason was wrong, so this does not weaken it. Two distinct hazards, neither an internal retry:

- **`query`:** a live subscription re-evaluates the handler whenever a table it reads changes. A send there fires once per re-evaluation — genuinely unbounded duplicate pushes for one logical read. This is the strongest case for the lint and the old message never made it.
- **`mutation`:** the handler runs inside the shard's storage transaction, which can roll back on an OCC conflict, an RLS denial, a validator, or a failed row mid-batch. The `fetch` to the push service cannot. The user is notified about a write that never landed — the inverse of a duplicate, and the *same* irreversibility argument the codebase already makes for `ctx.scheduler.runAfter` buffering until after commit (`packages/server/src/deferred-schedules.ts`) and `ctx.storage` being read-only in a mutation (`packages/server/src/deferred-deletes.ts`). The duplicate then arrives via the **caller's** retry, which is a fresh dispatch, not a handler re-run: the client's durable outbox re-dispatches a transiently failed write, and a replaying workflow step or queue consumer calls the mutation again.

This is the same shape `nondeterministic_query_mutation` already documents, so the advisories now agree with each other.

## Test

`packages/advisor/__tests__/notify-send-outside-action.test.ts` gained one case pinning each `detail` branch to its own hazard and asserting neither claims a retry. Verified by sabotage: swapping the ternary's condition fails it with `expected '…mutation handler — the mutation runs inside a transaction…' to contain 'live subscription re-runs this query'`, then restored and re-run green.

## Gates

| Gate | Result |
|---|---|
| `pnpm run build:packages` | ✅ 54 projects |
| `@lunora/codegen` tests | ✅ 139 files, 1777 tests |
| `@lunora/advisor` tests | ✅ 66 files, 546 tests (545 before, +1 new) |
| `pnpm run lint:types` | ✅ 75 projects; re-run uncached for `@lunora/advisor`, `@lunora/codegen`, `examples/chess` |
| `pnpm run api:check` (after build) | ✅ 54 snapshots match |
| `pnpm run lint:generated` | ✅ All 16 generators reproduce their committed output |
| `prettier --check` (advisor, codegen, examples, cli docs) | ✅ |
| `eslint --max-warnings=0` (advisor, codegen) | ✅ |

Prettier was run before ESLint. ESLint's `jsdoc/check-indentation` rejected an indented bullet list in the first draft of the `notify-send-outside-action` docblock; reflowed to flat paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidance for database, storage, notification, and time access in queries, mutations, and actions.
  - Improved lint messages explaining subscription re-evaluation, transaction rollbacks, retries, and irreversible external side effects.
  - Updated generated API documentation to explain when `ctx.now` should be used and when ambient time is appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->