### PR TITLE
ci: record how vis maps non-project paths

### DIFF
--- a/vis.config.ts
+++ b/vis.config.ts
@@ -21,6 +21,32 @@ export default defineConfig({
             "!{workspaceRoot}/.storybook/**/*",
             "!{workspaceRoot}/**/*.stories.@(js|jsx|ts|tsx|mdx)",
         ],
+        // Do NOT add `shared/`, `protocol/`, `registry/`, `tools/` or `.vis/` here.
+        // They look like the gap they are not: none of them sits in a project root,
+        // `default` never matches them, and `.github/file-filters.yml` goes to some
+        // length to keep `shared/**` and `protocol/**` in the `packages` filter — so
+        // the obvious reading is that the filter starts the job and `vis affected`
+        // then selects nothing.
+        //
+        // It does not. A CHANGED PATH OUTSIDE EVERY PROJECT ROOT MARKS EVERY PROJECT
+        // AFFECTED. Measured on this tree, one committed one-line edit each, against
+        // `origin/alpha` with `--no-uncommitted` (the mode CI runs in): shared/,
+        // protocol/, registry/, tools/, .vis/ — 75 of 75 projects affected, for
+        // `test`, `lint:eslint` and `lint:types` alike. So do the controls: a
+        // top-level README, `plans/`, `marketing/` — 75 as well; one package source
+        // file — 73, the graph narrowing as intended.
+        //
+        // Listing them here would therefore change nothing except to widen
+        // `sharedGlobals`, whose whole job is to be the narrow set that invalidates
+        // the world.
+        //
+        // The one case that DOES select nothing is a tracked but UNCOMMITTED edit to
+        // such a path: `--uncommitted` (on locally, off in CI) drops non-project
+        // paths deliberately, so an untracked scratch file cannot invalidate all 75.
+        // `pnpm run test:affected` over a dirty `shared/` therefore prints "No files
+        // changed. Nothing to run." and exits 0 — a local-only artefact of that
+        // guard, not a hole in CI, which diffs committed refs. Commit first, or pass
+        // `--base origin/alpha`, before concluding a gate is missing.
         sharedGlobals: ["{workspaceRoot}/.nvmrc", "{workspaceRoot}/package.json", "{workspaceRoot}/tsconfig.json", "{workspaceRoot}/tsconfig.base.json"],
     },
     tasks: {


### PR DESCRIPTION
## Read this first: there is no gate to fix here

This started as "`shared/`, `protocol/`, `registry/` and `tools/` changes run no tests at
all". Reproducing it inverted the conclusion, so what lands is the measurement, as a comment
next to the config that looks like it has the hole.

### Why the gap looks real

`test.yml` gates the `test` job on `packages == 'true'`, and `file-filters.yml` goes to
genuine length to keep `shared/**` and `protocol/**` in that filter. But those paths sit in
no project root and in no `sharedGlobals` entry, so `vis`'s `default` input never matches
them — and the obvious reading is that the filter starts the job and `vis affected` then
selects nothing.

### What actually happens

**A changed path outside every project root marks every project affected.** Measured here,
one committed one-line edit each, `--no-uncommitted --base origin/alpha`, the mode CI runs in:

| committed edit | affected projects |
| --- | --- |
| `shared/stable-key.ts` | 75 / 75 |
| `protocol/fixtures/rpc.json` | 75 / 75 |
| `registry/TYPECHECK.md` | 75 / 75 |
| `tools/get-bench-config.ts` | 75 / 75 |
| `.vis/hooks/config.json` | 75 / 75 |
| `plans/README.md` (control) | 75 / 75 |
| `marketing/README.md` (control) | 75 / 75 |
| `README.md` (control) | 75 / 75 |
| `packages/errors/src/index.ts` (control) | 73 / 75 |

Same 75 for `lint:eslint` and `lint:types` with a committed `shared/` edit, so
`lint:affected:eslint` and `lint:affected:types` are not skipping either.

Adding these paths to `sharedGlobals` would therefore change no selection at all, and would
only widen the one set whose job is to stay narrow.

### Where the original reading came from

A tracked but **uncommitted** edit does select nothing:

```
$ printf '\n// r37 probe\n' >> shared/stable-key.ts
$ pnpm run test:affected
▸ Resolved affected refs from local (git merge-base HEAD origin/alpha=34bcaea3…)
▸ ignoring 1 uncommitted path(s) outside any project (untracked scratch would
  otherwise mark every project affected)
No files changed. Nothing to run.
$ echo $?
0
```

`--uncommitted` is on locally and off in CI, and it drops non-project paths deliberately so
an untracked scratch file cannot invalidate all 75. Commit the same edit and the run selects
every project. CI diffs committed refs, so it never takes this path.

### What this PR does

Records the table and that last paragraph as a comment above `sharedGlobals`, so the next
reader does not re-derive it from a local dirty tree. No behaviour change.

### Not done, deliberately

- **No `sharedGlobals` entries.** They would be a no-op, as measured above.
- **No "filter matched but nothing was selected" guard.** I could not construct a reachable
  state for it — every probe including markdown-only edits inside a package selects something
  — so it would be dead code that can only misfire.

### Verified / not verified

Verified locally: the ten selection measurements above (`vis affected … --dry-run`), for
three targets; `vis.config.ts` still parses and `vis affected` still runs against it;
prettier clean.

Not verified locally: nothing. No workflow file changed, so there was no CI wiring to
validate — `file-filters.yml`, `test.yml` and `lint.yml` are untouched and the
`files-changed` outputs allowlist needs no new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
