### PR TITLE
security(do): re-pin caller claims across the replay gate

### DIFF
--- a/packages/do/__tests__/shard-do.request-scope-identity.test.ts
+++ b/packages/do/__tests__/shard-do.request-scope-identity.test.ts
@@ -1,0 +1,247 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { readRequestLog } from "@lunora/observability";
+import { runShardMigrations } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import messagesSchema from "./_helpers/messages-schema";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The caller-CLAIMS half of the per-request scope, over the real dispatch path.
+ *
+ * `userId` alone does not describe a caller: RLS grants roles from the claims
+ * object (`readIdentityRoles` in `@lunora/server`), and `ctx.auth.getIdentity()`
+ * returns it. A mutation queued at the replay gate is admitted long after a
+ * sibling `fetch()`'s prologue has overwritten the shared `currentRequest*`
+ * fields, so anything the gate does not re-pin is the sibling's — which for the
+ * claims means the queued mutation evaluates RLS as whoever ran while it waited.
+ */
+
+/** One caller's identity headers, kept next to the claims they encode. */
+interface Caller {
+    claims: Record<string, unknown>;
+    userId: string;
+}
+
+const ADMIN: Caller = { claims: { role: "admin", tenant: "acme" }, userId: "userAdmin" };
+const MEMBER: Caller = { claims: { role: "member", tenant: "widgets" }, userId: "userMember" };
+const VIEWER: Caller = { claims: { role: "viewer", tenant: "zinc" }, userId: "userViewer" };
+
+/** What the handler saw on `this` at the moment it ran. */
+interface Observation {
+    functionPath: string;
+    identity: Record<string, unknown> | undefined;
+    userId: string | undefined;
+}
+
+/**
+ * A shard whose handler records the caller context the generated `buildCtx`
+ * reads (`getCurrentUserId` / `getCurrentIdentity`), and which can park a named
+ * function until the test releases it.
+ *
+ * `messages:send` and `messages:update` are mutations — the kind that takes the
+ * `runSerialized` replay gate; `messages:poll` is an action, which does not.
+ */
+class ScopeObservingShard extends ShardDO {
+    public readonly observed: Observation[] = [];
+
+    public readonly parks = new Map<string, Promise<void>>();
+
+    public override async handleRpc(functionPath: string): Promise<unknown> {
+        const park = this.parks.get(functionPath);
+
+        if (park !== undefined) {
+            await park;
+        }
+
+        this.observed.push({ functionPath, identity: this.getCurrentIdentity(), userId: this.getCurrentUserId() });
+
+        if (functionPath.endsWith(":boom")) {
+            throw new Error("boom");
+        }
+
+        return { ran: functionPath };
+    }
+
+    /** Park `functionPath` inside the handler until the returned callback runs. */
+    public park(functionPath: string): () => void {
+        let release: () => void = () => {};
+
+        this.parks.set(
+            functionPath,
+            new Promise<void>((resolve) => {
+                release = resolve;
+            }),
+        );
+
+        return release;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- pure predicate over the path, mirroring the codegen override
+    protected override isMutationFunction(functionPath: string): boolean {
+        return functionPath === "messages:send" || functionPath === "messages:update";
+    }
+}
+
+const makeState = (database: ReturnType<typeof createSqliteExec>): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets() {
+            return [];
+        },
+        storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+    };
+};
+
+/**
+ * A `blockConcurrencyWhile` double that actually serializes, so the second
+ * mutation really queues instead of interleaving. `AsyncLocalStorage` marks the
+ * callback's own await chain so a NESTED `runSerialized` (what
+ * `runInTransaction` does) runs in place rather than deadlocking on the gate its
+ * own caller holds — workerd's behaviour. Mirrors the double in
+ * `shard-do.idempotency.test.ts`.
+ */
+const makeSerializedState = (database: ReturnType<typeof createSqliteExec>): ShardDOState => {
+    let queue: Promise<void> = Promise.resolve();
+    const insideGate = new AsyncLocalStorage<true>();
+
+    return {
+        ...makeState(database),
+        blockConcurrencyWhile: async <T>(callback: () => Promise<T>): Promise<T> => {
+            if (insideGate.getStore() === true) {
+                return callback();
+            }
+
+            const previous = queue;
+            let release: () => void = () => {};
+
+            queue = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+
+            await previous;
+
+            try {
+                return await insideGate.run(true, callback);
+            } finally {
+                release();
+            }
+        },
+    };
+};
+
+const rpcRequest = (functionPath: string, mutationId: string, caller: Caller): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: {
+            "content-type": "application/json",
+            "x-lunora-identity": JSON.stringify(caller.claims),
+            "x-lunora-mutation-id": mutationId,
+            "x-lunora-userid": caller.userId,
+        },
+        method: "POST",
+    });
+
+/** Let every already-queued microtask and timer turn run. */
+const tick = async (): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+describe("shardDO per-request scope (caller claims)", () => {
+    it("runs a gate-queued mutation under ITS OWN claims, not those of whoever ran while it waited", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema);
+
+            const shard = new ScopeObservingShard(makeSerializedState(database), {});
+
+            // The admin's mutation takes the gate and parks inside it.
+            const releaseAdmin = shard.park("messages:send");
+            const adminMutation = shard.fetch(rpcRequest("messages:send", "m-admin", ADMIN));
+
+            await tick();
+
+            // The member's mutation runs its prologue (stamping its own claims)
+            // and then queues behind the gate.
+            const memberMutation = shard.fetch(rpcRequest("messages:update", "m-member", MEMBER));
+
+            await tick();
+
+            // A viewer's ACTION does not take the gate. Its prologue overwrites
+            // the shared fields with the viewer's claims and it parks there, so
+            // the claims sitting on `this` when the gate finally admits the
+            // member's queued mutation are the viewer's.
+            const releaseViewer = shard.park("messages:poll");
+            const viewerAction = shard.fetch(rpcRequest("messages:poll", "m-viewer", VIEWER));
+
+            await tick();
+
+            releaseAdmin();
+            await adminMutation;
+            await memberMutation;
+
+            releaseViewer();
+            await viewerAction;
+
+            const member = shard.observed.find((entry) => entry.functionPath === "messages:update");
+
+            expect(member?.userId).toBe(MEMBER.userId);
+            // Before the fix: the viewer's claims carried under the member's
+            // userId — so RLS grants the member whatever role the viewer holds.
+            expect(member?.identity).toStrictEqual(MEMBER.claims);
+        } finally {
+            database.close();
+        }
+    });
+
+    it("files a FAILED dispatch's request-log row under the caller that made it", async () => {
+        expect.assertions(3);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema);
+
+            const shard = new ScopeObservingShard(makeState(database), {});
+
+            // The admin's action parks, then throws.
+            const releaseAdmin = shard.park("messages:boom");
+            const failing = shard.fetch(rpcRequest("messages:boom", "m-boom", ADMIN));
+
+            await tick();
+
+            // The viewer's dispatch runs its prologue — overwriting the shared
+            // fields — and parks there, so the failure below resolves while the
+            // viewer owns them.
+            const releaseViewer = shard.park("messages:poll");
+            const viewerAction = shard.fetch(rpcRequest("messages:poll", "m-viewer", VIEWER));
+
+            await tick();
+
+            releaseAdmin();
+
+            const response = await failing;
+
+            expect(response.status).toBe(500);
+
+            releaseViewer();
+            await viewerAction;
+
+            const row = readRequestLog(database.sql).find((entry) => entry.functionPath === "messages:boom");
+
+            expect(row?.outcome).toBe("error");
+            // Before the fix: the viewer — a principal that never made this call,
+            // in a durable row that also ships to Logpush/SIEM.
+            expect(row?.userId).toBe(ADMIN.userId);
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/packages/do/__tests__/shard-do.request-scope-identity.test.ts
+++ b/packages/do/__tests__/shard-do.request-scope-identity.test.ts
@@ -66,6 +66,19 @@ class ScopeObservingShard extends ShardDO {
         return { ran: functionPath };
     }
 
+    /**
+     * The reserved cross-shard relation read, served BEFORE the ordinary
+     * dispatch path. The generated override is `async` and awaits a whole
+     * schema-aware child-table read, so a throw from it lands in the dispatch's
+     * `catch` having crossed an await — with the shared caller fields possibly
+     * belonging to a sibling by then.
+     */
+    public override async runRelationFanoutRead(functionPath: string): Promise<unknown> {
+        await this.parks.get(functionPath);
+
+        throw new Error("relation fan-out exploded");
+    }
+
     /** Park `functionPath` inside the handler until the returned callback runs. */
     public park(functionPath: string): () => void {
         let release: () => void = () => {};
@@ -239,6 +252,48 @@ describe("shardDO per-request scope (caller claims)", () => {
             expect(row?.outcome).toBe("error");
             // Before the fix: the viewer — a principal that never made this call,
             // in a durable row that also ships to Logpush/SIEM.
+            expect(row?.userId).toBe(ADMIN.userId);
+        } finally {
+            database.close();
+        }
+    });
+
+    it("files a FAILED relation fan-out read under the caller that made it", async () => {
+        expect.assertions(3);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema);
+
+            const shard = new ScopeObservingShard(makeState(database), {});
+
+            // The reserved relation prefix is served ahead of the ordinary
+            // dispatch path — before the mutator classification, and so before
+            // the capture the rest of the dispatch re-pins from. It awaits the
+            // child-table read first, which is the window.
+            const releaseAdmin = shard.park("__lunora_relation__:read");
+            const failing = shard.fetch(rpcRequest("__lunora_relation__:read", "m-relation", ADMIN));
+
+            await tick();
+
+            const releaseViewer = shard.park("messages:poll");
+            const viewerAction = shard.fetch(rpcRequest("messages:poll", "m-viewer", VIEWER));
+
+            await tick();
+
+            releaseAdmin();
+
+            const response = await failing;
+
+            expect(response.status).toBe(500);
+
+            releaseViewer();
+            await viewerAction;
+
+            const row = readRequestLog(database.sql).find((entry) => entry.functionPath === "__lunora_relation__:read");
+
+            expect(row?.outcome).toBe("error");
             expect(row?.userId).toBe(ADMIN.userId);
         } finally {
             database.close();

--- a/packages/do/__tests__/workerd/shard-do-request-scope.workerd.test.ts
+++ b/packages/do/__tests__/workerd/shard-do-request-scope.workerd.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Real-workerd verification that a dispatch re-pins its own caller CLAIMS after
+ * a sibling has run.
+ *
+ * The interleave is the one a Durable Object actually serves: an action parked
+ * on outbound I/O — no single-writer gate, so delivery of other events is not
+ * blocked — while a second `/rpc` arrives, runs end to end, and both stamps and
+ * then clears the shared `currentRequest*` fields. When the parked action
+ * resumes it re-pins its own request scope before filing its durable
+ * `__lunora_reqlog__` row; anything that scope does not carry is the sibling's
+ * leftovers. The claims object is the one RLS grants roles from
+ * (`readIdentityRoles`) and what `ctx.auth.getIdentity()` returns, so before it
+ * joined the scope the row — and the Logpush/SIEM event built from it — named a
+ * principal that never made the call.
+ *
+ * `packages/do/__tests__/shard-do.request-scope-identity.test.ts` pins the same
+ * property against a hand-rolled `blockConcurrencyWhile` double. A double
+ * encodes the very scheduling assumption under test — whether a sibling really
+ * gets to run while another dispatch waits is decided by the runtime, not by us
+ * — so this file re-runs it against real `workerd`, which also settles that the
+ * interleave is reachable in production and not an artifact of the double.
+ *
+ * Like every file in this directory, this suite only runs with
+ * `LUNORA_WORKERD_TESTS=1` (see `packages/do/vitest.config.ts`). Run explicitly:
+ * `LUNORA_WORKERD_TESTS=1 pnpm --filter "@lunora/do" run test`.
+ */
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { TestCounterDO } from "./test-worker";
+
+const PARKED = { claims: { role: "viewer", tenant: "zinc" }, userId: "userParked" };
+const SIBLING = { claims: { role: "admin", tenant: "acme" }, userId: "userSibling" };
+
+const rpcRequest = (functionPath: string, mutationId: string, caller: typeof PARKED): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: {
+            "content-type": "application/json",
+            "x-lunora-identity": JSON.stringify(caller.claims),
+            "x-lunora-mutation-id": mutationId,
+            "x-lunora-userid": caller.userId,
+        },
+        method: "POST",
+    });
+
+interface LoggedRow {
+    functionPath: string;
+    identity?: Record<string, unknown>;
+    userId?: string;
+}
+
+describe("shardDO per-request scope under real workerd", () => {
+    it("files a parked dispatch's request-log row under its own caller, claims included", async () => {
+        expect.assertions(3);
+
+        // A fresh shard and fresh mutation ids per run: Miniflare persists the
+        // DO's SQLite between runs, and a replayed id is served from the
+        // idempotency row — which would pass this test without dispatching.
+        const run = crypto.randomUUID();
+        const id = env.COUNTER.idFromName(`scope-parked-${run}`);
+        const stub: DurableObjectStub<TestCounterDO> = env.COUNTER.get(id);
+
+        const parked = stub.fetch(rpcRequest("counter:park", `m-park-${run}`, PARKED));
+
+        // Delivered and served while `counter:park` is still in flight — which
+        // is itself the property this file exists to settle. Its prologue
+        // overwrites the shared caller fields and its epilogue then clears them.
+        const sibling = await stub.fetch(rpcRequest("counter:release", `m-release-${run}`, SIBLING));
+
+        await expect(sibling.json()).resolves.toEqual({ result: { released: true } });
+
+        await parked;
+
+        const logResponse = await stub.fetch(rpcRequest("counter:reqlog", `m-log-${run}`, SIBLING));
+        const { result } = await logResponse.json<{ result: LoggedRow[] }>();
+        const row = result.find((entry) => entry.functionPath === "counter:park");
+
+        expect(row?.userId).toBe(PARKED.userId);
+        expect(row?.identity).toEqual(PARKED.claims);
+    }, 10_000);
+});

--- a/packages/do/__tests__/workerd/test-worker.ts
+++ b/packages/do/__tests__/workerd/test-worker.ts
@@ -12,6 +12,7 @@
  * runtime API directly the adapter is gone and `DurableObjectState` is
  * passed straight through — structurally compatible with `ShardDOState`.
  */
+import { readRequestLog } from "@lunora/observability";
 import type { DatabaseWriterLike, MutationDelta } from "@lunora/shard-engine";
 import { createShardCtxDb, runShardMigrations } from "@lunora/shard-engine";
 import { DurableObject } from "cloudflare:workers";
@@ -103,8 +104,37 @@ class ConcreteCountingShard extends ShardDO {
 
     private migrated = false;
 
-    public override async handleRpc(): Promise<unknown> {
+    /** Resolver for the in-flight `counter:park` dispatch, fired by `counter:release`. */
+    private releasePark: (() => void) | undefined;
+
+    public override async handleRpc(functionPath: string): Promise<unknown> {
         this.ensureMigrated();
+
+        // `counter:park` and `counter:release` are ACTIONS (see
+        // `isMutationFunction`), so neither takes the single-writer gate and a
+        // parked one really is interleavable with a sibling dispatch — the
+        // window `restoreRequestScope` exists for.
+        if (functionPath === "counter:park") {
+            await new Promise<void>((resolve) => {
+                this.releasePark = resolve;
+            });
+
+            return { parked: true };
+        }
+
+        if (functionPath === "counter:release") {
+            this.releasePark?.();
+            this.releasePark = undefined;
+
+            return { released: true };
+        }
+
+        // The durable request log, as the studio and Logpush see it. Read
+        // through the shard's own sql handle so the rows are the ones this DO
+        // actually wrote.
+        if (functionPath === "counter:reqlog") {
+            return readRequestLog(this.sql as Parameters<typeof readRequestLog>[0]);
+        }
 
         return this.runInTransaction(() => {
             this.runs += 1;
@@ -124,6 +154,11 @@ class ConcreteCountingShard extends ShardDO {
 
         runShardMigrations(this.sql as Parameters<typeof runShardMigrations>[0], messagesSchema);
         this.migrated = true;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- pure predicate over the path, mirroring the codegen override
+    protected override isMutationFunction(functionPath: string): boolean {
+        return functionPath !== "counter:park" && functionPath !== "counter:release" && functionPath !== "counter:reqlog";
     }
 }
 

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6023,11 +6023,22 @@ abstract class ShardDO {
         // error path files a durable `__lunora_reqlog__` row (and a Logpush/SIEM
         // event with it) that reads the caller off `this`, after every await this
         // dispatch took — so without a re-pin a failed request is attributed to
-        // whichever sibling's prologue ran last. `undefined` until the capture
-        // below, which is deliberately NOT hoisted with it: the capture has to
-        // run after `currentMutatorClass` is stamped, or the gate would re-pin a
-        // blank mutator classification over the real one.
-        let dispatchScope: RequestScope | undefined;
+        // whichever sibling's prologue ran last.
+        //
+        // Captured TWICE, deliberately, and this first one has to be here rather
+        // than at the second site: the relation fan-out branch below awaits a
+        // whole schema-aware child-table read before that site is reached, and a
+        // throw from inside it would otherwise find nothing to restore. Taken
+        // straight after `beginDispatch`, so it is exactly the prologue's own
+        // values (`mutatorClass` included — still `undefined` here, which is the
+        // truthful answer for a dispatch that has not been classified yet).
+        //
+        // The second capture, after the classification is stamped, is the one the
+        // replay gate and the tail re-pin: it is the only one that carries a real
+        // `currentMutatorClass`, so hoisting it in place of this would re-pin a
+        // blank classification over the real one and break the in-transaction
+        // watermark handshake.
+        let dispatchScope: RequestScope = this.captureRequestScope();
 
         try {
             // Reserved cross-shard relation read/count (reverse cross-backend
@@ -6052,7 +6063,13 @@ abstract class ShardDO {
             if (payload.functionPath.startsWith(RELATION_FUNCTION_PREFIX)) {
                 const value = await this.runRelationFanoutRead(payload.functionPath, payload.args ?? {});
 
-                return jsonResponse(encodeWire(value), 200, bookmarkHeaders(this.currentResponseBookmark));
+                // THIS dispatch's own by-value sink, never the shared field: a
+                // fan-out read performs no `.global()` write, so the sink is
+                // `undefined` and no bookmark is echoed — which is the honest
+                // answer. Read off `this` instead, the header could only ever
+                // carry a bookmark a sibling wrote during the await above, i.e. a
+                // stranger's D1 write position reported as this caller's.
+                return jsonResponse(encodeWire(value), 200, bookmarkHeaders(dispatchBookmark.value));
             }
 
             // Custom-mutator ordering: a watermarked push (`clientId` +
@@ -6265,13 +6282,8 @@ abstract class ShardDO {
             // `this`, and the throw can come from any await in the dispatch — by
             // which point a sibling `fetch()`'s prologue may own those fields. The
             // row it writes is durable and ships to Logpush/SIEM, so a mis-pinned
-            // one blames a principal that never made the call. `undefined` only
-            // when the throw beat the capture (a relation fan-out read, a
-            // watermark short-circuit), where the prologue's values are still this
-            // dispatch's own and there is nothing to restore.
-            if (dispatchScope !== undefined) {
-                this.restoreRequestScope(dispatchScope);
-            }
+            // one blames a principal that never made the call.
+            this.restoreRequestScope(dispatchScope);
 
             this.metrics.errors += 1;
             dispatchError = { thrown: error };

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -778,28 +778,59 @@ type ClientMutationClass = { expected: number; kind: "already" | "gap" | "next" 
  * `currentRequest*` fields while this dispatch waits its turn. Kept as one named
  * shape so the capture list lives in exactly one place instead of being an
  * unenforced "remember to add the next field here too" invariant.
+ *
+ * It stays a hand-written LIST rather than "snapshot every `currentRequest*`
+ * field", because membership is a judgement, not a category: `currentRequestTrace`
+ * is threaded by value as `dispatchTrace` and has its own claim/release
+ * lifecycle, `currentResponseBookmark` is PRODUCED by the dispatch (the restore
+ * clears it on purpose), and `mutationBookkeeping` is written DURING the handler
+ * — re-pinning the captured `undefined` at the tail would wipe the handshake the
+ * post-dispatch bookkeeping reads next. A mechanism that cannot forget a field
+ * would still have to be told which of those three answers each new field wants,
+ * so it would relocate the judgement rather than remove it. What the shape does
+ * buy is that adding a field here is a compile error in
+ * {@link ShardDO.captureRequestScope}'s object literal until it is captured —
+ * the answer stays a judgement, but a half-made one cannot compile.
  */
 interface RequestScope {
     /**
-     * The inbound `x-d1-bookmark`. In the scope for the same reason the identity
-     * fields are: a queued mutation admitted after a sibling's prologue would
-     * otherwise have `getInboundBookmark()` hand its `.global()` reads ANOTHER
-     * request's D1 session pin, which is read-your-writes reading someone else's.
+     * The inbound `x-d1-bookmark`. In the scope for the same reason `userId` is:
+     * a queued mutation admitted after a sibling's prologue would otherwise have
+     * `getInboundBookmark()` hand its `.global()` reads ANOTHER request's D1
+     * session pin, which is read-your-writes reading someone else's.
      */
     bookmark: string | undefined;
     clientId: string | undefined;
     clientSeq: number | undefined;
 
     /**
-     * The caller's IP. In the scope for the same reason `userId` is, and it is
-     * the field with the most recent proof: a nested call that re-pins the
-     * identity fields but not this one leaves `ctx.ip` reading whatever the
-     * guest left behind.
+     * The caller's CLAIMS — active org, role, tenant. Distinct from `userId` and
+     * far more load-bearing than the pairing suggests: RLS grants roles from this
+     * object (`readIdentityRoles`), and it is what `ctx.auth.getIdentity()`
+     * returns. Left out of the scope, a mutation admitted at the gate ran under
+     * its own `userId` and the SIBLING's role and tenant — an admin sibling
+     * handed it admin RLS; a finished one handed it no claims at all.
+     */
+    identity: Record<string, unknown> | undefined;
+
+    /**
+     * The caller's IP. In the scope for the same reason `userId` is: a nested
+     * call that re-pins the identity fields but not this one leaves `ctx.ip`
+     * reading whatever the guest left behind.
      */
     ip: string | undefined;
     mutationId: string | undefined;
     mutatorClass: ClientMutationClass | undefined;
     system: boolean;
+
+    /**
+     * The inbound W3C `traceparent`, which `buildCtx` hands to
+     * `createContainerContext` so an outbound container fetch joins the caller's
+     * trace. Telemetry rather than authorization, but the same shared field with
+     * the same interleaving — a guest dispatch that did not re-pin it filed its
+     * container spans under a parked request's trace.
+     */
+    traceparent: string | undefined;
     userId: string | undefined;
 }
 
@@ -5988,6 +6019,16 @@ abstract class ShardDO {
         // hand the thrown value straight through to the span's error classifier.
         let dispatchError: { thrown: unknown } | undefined;
 
+        // Hoisted for the `catch` in the same way and for the same reason: the
+        // error path files a durable `__lunora_reqlog__` row (and a Logpush/SIEM
+        // event with it) that reads the caller off `this`, after every await this
+        // dispatch took — so without a re-pin a failed request is attributed to
+        // whichever sibling's prologue ran last. `undefined` until the capture
+        // below, which is deliberately NOT hoisted with it: the capture has to
+        // run after `currentMutatorClass` is stamped, or the gate would re-pin a
+        // blank mutator classification over the real one.
+        let dispatchScope: RequestScope | undefined;
+
         try {
             // Reserved cross-shard relation read/count (reverse cross-backend
             // relations). Served BEFORE user dispatch and returned BARE (row
@@ -6075,6 +6116,8 @@ abstract class ShardDO {
             // one field over. (`dispatchTrace`/`dispatchHeadroom` above capture
             // the same way, for the same reason, on the other side of `handleRpc`.)
             const requestScope = this.captureRequestScope();
+
+            dispatchScope = requestScope;
 
             // Decode the wire codec (`bytes`/`bigint`/typed-array/±Infinity
             // leaves) ONLY for the handler, so `validateArgs` sees real
@@ -6216,6 +6259,20 @@ abstract class ShardDO {
 
             return response;
         } catch (error: unknown) {
+            // Re-pin before anything below attributes the failure, exactly as the
+            // ok path does before ITS `recordRequestLog`. `recordRequestLog` reads
+            // `currentRequestIdentity` and `getCurrentUserId()` straight off
+            // `this`, and the throw can come from any await in the dispatch — by
+            // which point a sibling `fetch()`'s prologue may own those fields. The
+            // row it writes is durable and ships to Logpush/SIEM, so a mis-pinned
+            // one blames a principal that never made the call. `undefined` only
+            // when the throw beat the capture (a relation fan-out read, a
+            // watermark short-circuit), where the prologue's values are still this
+            // dispatch's own and there is nothing to restore.
+            if (dispatchScope !== undefined) {
+                this.restoreRequestScope(dispatchScope);
+            }
+
             this.metrics.errors += 1;
             dispatchError = { thrown: error };
             const durationMs = Date.now() - dispatchStartedAt;
@@ -6423,10 +6480,12 @@ abstract class ShardDO {
             bookmark: this.currentRequestBookmark,
             clientId: this.currentRequestClientId,
             clientSeq: this.currentRequestClientSeq,
+            identity: this.currentRequestIdentity,
             ip: this.currentRequestIp,
             mutationId: this.currentRequestMutationId,
             mutatorClass: this.currentMutatorClass,
             system: this.currentRequestSystem,
+            traceparent: this.currentRequestTraceparent,
             userId: this.currentRequestUserId,
         };
     }
@@ -6444,10 +6503,12 @@ abstract class ShardDO {
         this.currentResponseBookmark = undefined;
         this.currentRequestClientId = scope.clientId;
         this.currentRequestClientSeq = scope.clientSeq;
+        this.currentRequestIdentity = scope.identity;
         this.currentRequestIp = scope.ip;
         this.currentRequestMutationId = scope.mutationId;
         this.currentMutatorClass = scope.mutatorClass;
         this.currentRequestSystem = scope.system;
+        this.currentRequestTraceparent = scope.traceparent;
         this.currentRequestUserId = scope.userId;
     }
 
@@ -8094,11 +8155,16 @@ abstract class ShardDO {
      * mutation dispatched through `runAs` could commit a dedup row and advance a
      * client watermark under the parked request's identity.
      *
-     * `currentRequestIp` is the third, and is cleared rather than carried: the
-     * admin plane genuinely has no caller IP to offer (nothing on this branch
-     * ever reads the header), so leaving the field alone would let a `runAs`
-     * dispatch run — and log, and rate-limit — under a parked `/rpc`'s address.
-     * `undefined` is the honest answer.
+     * `currentRequestIdentity` is the third, and the sharpest: it is the claims
+     * object RLS grants roles from, so a `runAs` dispatch that inherited a parked
+     * `/rpc`'s claims would evaluate row policies as that caller's role and tenant.
+     *
+     * `currentRequestIp` and `currentRequestTraceparent` are the remainder, and
+     * are cleared rather than carried for the same reason: the admin plane
+     * genuinely has neither to offer (nothing on this branch reads either header),
+     * so leaving them alone would let a `runAs` dispatch run — and log, and
+     * rate-limit — under a parked `/rpc`'s address, and file its container spans
+     * under that request's trace. `undefined` is the honest answer for both.
      *
      * Restoring rather than clearing on exit is deliberate: an admin call is a
      * guest on a thread another dispatch may own, and clearing would take that
@@ -8111,7 +8177,6 @@ abstract class ShardDO {
      */
     private async withAdminRequestScope<R>(run: () => Promise<R>): Promise<R> {
         const previousScope = this.captureRequestScope();
-        const previousIdentity = this.currentRequestIdentity;
         const previousBookkeeping = this.mutationBookkeeping;
 
         this.currentRequestBookmark = undefined;
@@ -8125,12 +8190,12 @@ abstract class ShardDO {
         this.currentMutatorClass = undefined;
         this.mutationBookkeeping = undefined;
         this.currentRequestSystem = false;
+        this.currentRequestTraceparent = undefined;
 
         try {
             return await run();
         } finally {
             this.restoreRequestScope(previousScope);
-            this.currentRequestIdentity = previousIdentity;
             this.mutationBookkeeping = previousBookkeeping;
         }
     }
@@ -8167,8 +8232,9 @@ abstract class ShardDO {
      * threading the whole caller context into `handleRpc` so the hook's ctx never
      * touches the shared fields at all, which is a signature change across
      * codegen and moves all three fields at once. The `/rpc` tail re-pins its own
-     * scope (`ip` included, since {@link RequestScope} now carries it) after every
-     * await, so the exposure is bounded by that window and does not survive it.
+     * scope (`ip` and the claims included, since {@link RequestScope} carries
+     * both) after every await, so the exposure is bounded by that window and does
+     * not survive it.
      *
      * Subscriptions deliberately do NOT use this primitive at all: they thread an
      * explicit {@link SubscriptionIdentity} into `executeSubscription` by value,


### PR DESCRIPTION
## Base

Targets **`fix/r37-do-ws-client-ip`** (#702), not `alpha`. That branch reworked the same
`RequestScope` / `restoreRequestScope` pair to close the `ip` half of this bug; branching off
`alpha` would conflict on every hunk and silently revert its fix. `.coderabbit.yaml` already
lists `fix/r[0-9]+-.*` as a review base, so the stack is covered.

## The defect

`RequestScope` exists so a mutation queued at the mutation-replay gate — admitted only after a
sibling `fetch()`'s prologue has overwritten the shared `currentRequest*` fields — is restored
to its own caller context before it runs. It carried `userId` but **not the caller's claims
object**: active org, role, tenant. That is what RLS grants roles from (`readIdentityRoles` in
`@lunora/server`) and what `ctx.auth.getIdentity()` returns; the emitted `buildCtx` reads it via
`getCurrentIdentity()`.

So a queued mutation ran with its own `userId` and the sibling's role and tenant. An admin
sibling handed it admin RLS. A sibling that had already finished handed it no claims at all — a
silent downgrade. The same omission put the wrong principal on a parked or failed dispatch's
durable `__lunora_reqlog__` row and on the Logpush/SIEM event built from it.

The type's own docblock said `ip` was in the scope "for the same reason the identity fields
are", which reads as though the claims were covered. Only `userId` was. That wording is fixed
here too — it is how the gap stayed invisible.

## Reproduction

Both proofs were run against the **base branch, unfixed**, and re-run green after the change.

Node, over the real `ShardDO` dispatch path with a serializing `blockConcurrencyWhile` double:

```
AssertionError: expected { role: 'viewer', tenant: 'zinc' } to strictly equal { role: 'member', tenant: 'widgets' }

- Expected
+ Received

  {
-   "role": "member",
-   "tenant": "widgets",
+   "role": "viewer",
+   "tenant": "zinc",
  }
```

The member's `userId` was correct; the claims were the viewer's.

Real **workerd**, with only `identity` removed from the restore — a parked action's durable
request-log row picking up an interleaved sibling's claims:

```
AssertionError: expected { role: 'admin', tenant: 'acme' } to deeply equal { role: 'viewer', tenant: 'zinc' }

- Expected
+ Received

  {
-   "role": "viewer",
-   "tenant": "zinc",
+   "role": "admin",
+   "tenant": "acme",
  }
```

And the error path, where the whole emitted event is visible:

```
{"durationMs":2,"error":"boom","function":"messages:boom","identity":{"role":"viewer","tenant":"zinc"},
 "outcome":"error","source":"lunora","traceId":"6f92…","type":"request","userId":"userViewer"}
```

That is the admin's failed call, filed under the viewer.

## `currentRequest*` audit

| Field | Status | Why |
| --- | --- | --- |
| `currentRequestIdentity` | **added here** | The claims RLS reads. The defect. |
| `currentRequestTraceparent` | **added here** | `buildCtx` → `createContainerContext`; an admin `runAs` inherited a parked request's trace. Telemetry, not authorization. Also now cleared on admin entry. |
| `currentRequestBookmark` | in scope | D1 session pin; read-your-writes would read someone else's. |
| `currentRequestUserId` | in scope | The dedup namespace and `ctx.auth.userId`. |
| `currentRequestIp` | in scope | Closed by #702. |
| `currentRequestMutationId` | in scope | Replay dedup key. |
| `currentRequestClientId` / `ClientSeq` | in scope | Custom-mutator watermark identity. |
| `currentMutatorClass` | in scope | In-transaction watermark handshake. |
| `currentRequestSystem` | in scope | The `internal`-visibility gate. |
| `currentResponseBookmark` | omitted, deliberately | PRODUCED by the dispatch, not inherited — the restore clears it on purpose and the tail re-pins its own from the by-value sink. |
| `currentRequestTrace` | omitted, safe | Threaded by value as `dispatchTrace` everywhere it is read after an await, and it has its own claim/release lifecycle that a blind re-pin would fight. |
| `mutationBookkeeping` | omitted, **must stay out** | Written DURING the handler, after the capture. Re-pinning the captured `undefined` at the tail would wipe the handshake `recordPostDispatchBookkeeping` reads next. `withAdminRequestScope` keeps its own save/restore for it. |
| relation fan-out branch (`__lunora_relation__:`) | **covered (review follow-up)** | Served ahead of the ordinary path, so it awaited the child-table read before any capture existed; a throw logged the failure under a sibling. An initial scope is now captured straight after `beginDispatch`, and the later recapture is kept. |
| `currentScannedTables` / `currentIndexHits` / `currentStmtSamples` | omitted, **reported not fixed** | Per-dispatch accumulators read at the tail by `recordFunctionCall` / `flushStmtSamples`. Same interleaving class, but a sibling's prologue swaps the container object, so the writes went somewhere else — re-pinning the captured `Set` would restore the reference, not the lost stamps. Telemetry-only, and a separate change. |

## Fix shape

Added the two fields to `RequestScope` rather than replacing it with a mechanism that cannot
forget one. This is the third field found missing (bookmark, ip, now identity), so the
question was taken seriously — the argument for keeping the list is in the type's docblock:
membership is a judgement, not a category. Three per-request fields need a *different* answer
from re-pin (produced-and-cleared, threaded-by-value, written-during-the-handler), so "snapshot
everything" is actively wrong for them and any automatic mechanism would have to be told which
answer each new field wants. That relocates the judgement rather than removing it. What the
shape already buys is real: adding a field to the interface is a compile error in
`captureRequestScope`'s object literal until it is captured, so a half-made decision cannot
compile.

Two things fell out and are fixed here:

- `withAdminRequestScope` had a hand-rolled `previousIdentity` side-save precisely *because*
  the scope did not carry it; that is now redundant and gone. It also clears the inbound
  `traceparent` on entry, closing the flagged gap.
- The error path re-pins before it attributes the failure, exactly as the ok path already does
  before its own `recordRequestLog`. The capture is hoisted into a `let` the `catch` can see,
  and deliberately stays at its current statement so it still runs after `currentMutatorClass`
  is stamped — hoisting the capture itself would re-pin a blank mutator classification over
  the real one.

Not fixed, reported: the lazy `userId: () => this.getCurrentUserId()` thunks in `makeTracer` /
`instrumentDb` / `makeFetch` and `emitLog` are the same shape. They resolve at emit time, after
the handler's awaits, so they can name a sibling. Closing them means threading the caller by
value into those factories rather than extending the scope — telemetry attribution only, and a
different change.

## What the tests prove, and what they do not

- `__tests__/workerd/shard-do-request-scope.workerd.test.ts` — real workerd. An action parks on
  outbound I/O (no single-writer gate, so delivery is not blocked), a sibling `/rpc` arrives and
  runs end to end, then the parked dispatch resumes and files its request-log row. **Proves the
  interleave is reachable in production** and that the restore is what fixes it. Verified to fail
  against the unfixed restore.
- `__tests__/shard-do.request-scope-identity.test.ts` — two node-level tests against the real
  `ShardDO` over `node:sqlite`: a mutation admitted at the replay gate observing its own claims,
  and a failed dispatch's request-log row naming its own caller. The first needs a hand-rolled
  serializing `blockConcurrencyWhile`, so it settles the *code* path, not the runtime's
  scheduling.
- What none of them prove: that two concurrent `/rpc` **mutations** alone can reach the gate-queue
  window on real workerd. They cannot — while a dispatch holds `blockConcurrencyWhile`, workerd
  delivers no other events, so a second mutation's prologue never runs while the first is inside.
  A version of the workerd test built that way passed against the unfixed code and was discarded
  rather than shipped green. The gate-queue re-pin is therefore defensive for hosts whose
  `runSerialized` queues without blocking delivery (the `ShardHost` contract permits it); the
  interleave that is demonstrably live on Cloudflare today is the parked-dispatch one above.

## Review follow-up: relation fan-out (CWE-362)

A review finding said the relation fan-out branch awaits before `dispatchScope` is assigned, so a
throw from it skips the restore. **Verified and it holds.** The generated override
(`emitRelationFanout`) is `async` and awaits a whole schema-aware child-table read through
`serveRelationFanout`; the branch sits ahead of the mutator classification and so ahead of the
capture; and its throw lands in the same `catch` that calls `recordRequestLog`. Reproduced
against the previous commit — this is the emitted event for an admin's failed relation read:

```
{"durationMs":3,"error":"relation fan-out exploded","function":"__lunora_relation__:read",
 "identity":{"role":"viewer","tenant":"zinc"},"outcome":"error","source":"lunora",
 "traceId":"0e8b58c7…","type":"request","userId":"userViewer"}

AssertionError: expected 'userViewer' to be 'userAdmin'
```

Fixed as suggested: an initial `RequestScope` captured immediately after `beginDispatch`, with
the later recapture kept — the later one is the only one carrying a real `currentMutatorClass`,
so replacing it would re-pin a blank classification and break the in-transaction watermark
handshake. The `catch` guard is now unconditional.

One thing fell out on the same branch: the fan-out's **success** path echoed
`bookmarkHeaders(this.currentResponseBookmark)`, read off the shared field after the same await.
Nothing on that path ever writes that field, so the header could only ever carry a bookmark a
sibling wrote — a stranger's D1 write position reported as this caller's. It now reports the
dispatch's own by-value sink, which for a read is empty.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm run build:packages` | pass (54 projects) |
| `pnpm --filter "@lunora/do" run test` | pass — 63 files, 719 tests |
| `pnpm run test:workerd` | pass — all 11 workerd suites |
| `pnpm run lint:types` | pass (75 projects; `@lunora/do` re-run uncached) |
| `pnpm run api:check` | pass — 54 snapshots unchanged, no public surface change |
| prettier, then eslint | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
