### PR TITLE
fix(do): key the reactive cache on the whole caller

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -83,6 +83,7 @@ Re-exported from `@lunora/shard-engine` — signature tracked at its source.
 ```ts
 interface QueryReadScope {
     footprint: ReadFootprint;
+    markIpRead: () => void;
     tracker: DependencyTracker;
 }
 ```
@@ -315,6 +316,7 @@ abstract class ShardDO {
     protected state: ShardDOState;
     protected env: unknown;
     protected readonly reactiveCache: ReactiveCache | undefined;
+    protected readonly ipKeyedFunctionPaths: Set<string>;
     protected shapeProbe: ShapeProbeCounters;
     protected globalPoll: GlobalPollCounters;
     constructor(state: ShardDOState, env: unknown, options?: ShardDOOptions);
@@ -447,7 +449,7 @@ abstract class ShardDO {
         maxRelationKeys?: number;
         relationExistsPushDown?: "always" | "auto" | "never";
     };
-    protected isQueryFunction(_functionPath: string): boolean;
+    protected isCacheableQuery(_functionPath: string): boolean;
     protected transactionLimits(): Partial<TransactionLimits>;
     protected transactionHeadroom(): TransactionHeadroomTracker;
     protected subscriptionHeadroom(): TransactionHeadroomTracker;

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -401,8 +401,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1137,7 +1143,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -723,8 +723,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1481,7 +1487,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -1189,8 +1189,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1928,7 +1934,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -394,8 +394,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1130,7 +1136,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -867,8 +867,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1618,7 +1624,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -432,8 +432,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1168,7 +1174,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -477,8 +477,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1215,7 +1221,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -389,8 +389,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1125,7 +1131,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -938,8 +938,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1682,7 +1688,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -494,8 +494,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1230,7 +1236,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -371,8 +371,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1107,7 +1113,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -912,8 +912,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1671,7 +1677,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -475,8 +475,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1211,7 +1217,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/packages/codegen/__tests__/emit-shard-reactive-cache.test.ts
+++ b/packages/codegen/__tests__/emit-shard-reactive-cache.test.ts
@@ -42,17 +42,20 @@ describe("emitShard — reactive cache wiring", () => {
         expect(emitted).toContain("...(config.relationExistsPushDown === undefined ? {} : { relationExistsPushDown: config.relationExistsPushDown }),");
     });
 
-    it("overrides isQueryFunction against the generated registry", () => {
-        expect.assertions(1);
+    it("overrides isCacheableQuery against the generated registry, excluding internal functions", () => {
+        expect.assertions(2);
 
         // The single point where the whole feature goes silently inert: the base
-        // class has no function registry, so its `isQueryFunction` answers `false`
+        // class has no function registry, so its `isCacheableQuery` answers `false`
         // and `runCachedQuery` returns early on every call — a wired cache that
         // memoizes nothing.
-        expect(emitShard({ schema: { tables: [], vectorIndexes: [] } })).toContain(
-            // eslint-disable-next-line no-secrets/no-secrets -- false positive: generated-code text asserted verbatim, not a credential
-            'protected override isQueryFunction(functionPath: string): boolean {\n            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";',
-        );
+        const emitted = emitShard({ schema: { tables: [], vectorIndexes: [] } });
+
+        expect(emitted).toContain("protected override isCacheableQuery(functionPath: string): boolean {");
+        // And the half that is a security boundary, not a performance knob: a hit
+        // skips `handleRpc` and with it the `internal` refusal, so an internal
+        // function must never reach the cache in the first place.
+        expect(emitted).toContain('return registered?.kind === "query" && registered.visibility !== "internal";');
     });
 
     it("overrides isPaidFunction against the generated registry", () => {
@@ -139,6 +142,26 @@ describe("emitApp — reactive cache wiring", () => {
 
         expect(output).toContain("public reactiveCache(config: boolean | { maxBytes?: number; maxEntries?: number } = true): this {");
         expect(output).toContain("reactiveCache: this.reactiveCacheConfig,");
+    });
+});
+
+/**
+ * The other half of the address-keyed memo. `@lunora/do` widens a cached query's
+ * key with the caller's IP only for function paths it has SEEN read `ctx.ip`,
+ * and the only thing that reports such a read is this getter. Emitted as a plain
+ * field — which is what it was — the mark never fires, the key never widens, and
+ * two anonymous callers share one entry with one of their addresses in it.
+ */
+describe("emitShard — ctx.ip marks the reactive-cache read scope", () => {
+    it("emits `ip` as a getter that marks the dispatch's read scope", () => {
+        expect.assertions(2);
+
+        const emitted = emitShard({ schema: { tables: [], vectorIndexes: [] } });
+
+        expect(emitted).toContain("get ip() {\n                    options.scope?.markIpRead();");
+        // The plain field is what the mark replaced; leaving one behind would
+        // hand handlers an unmarked route to the same value.
+        expect(emitted).not.toContain("\n                ip,\n");
     });
 });
 

--- a/packages/codegen/__tests__/emit-shard-stream-identity.test.ts
+++ b/packages/codegen/__tests__/emit-shard-stream-identity.test.ts
@@ -60,8 +60,10 @@ describe("emitted executeStream identity", () => {
         // `getCurrentIp()` reads the per-request field a CONCURRENT dispatch owns.
         // A subscription refresh runs inside the writing dispatch's flush, before
         // its `endDispatch`, so reading it here would hand every subscriber the
-        // mutating caller's IP. The ctx takes the already-resolved value.
-        expect(literal).toContain("\n                ip,\n");
+        // mutating caller's IP. The ctx takes the already-resolved value — the
+        // getter (which marks the reactive-cache read scope) returns that local
+        // and nothing else.
+        expect(literal).toContain("\n                    return ip;\n                },\n");
         expect(literal.slice(0, literal.indexOf("\n            };"))).not.toContain("getCurrentIp");
         // One expression on one discriminant, resolving all three members
         // together — parallel per-field ternaries are how `ip` was forgotten.

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -338,8 +338,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             });
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1201,7 +1207,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -475,8 +475,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             }
         }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT `kind === "query"` alone. A cache hit answers without running
+            // `handleRpc`, so the `internal` refusal at the top of it is skipped —
+            // and an `internalQuery` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -1236,7 +1242,19 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. `ctx.ip` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; `runCachedQuery`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -5304,7 +5304,7 @@ ${hasMemoryTables ? "            clearMemoryTables(this.sql as SqlExec, schema a
     // configured. The alarm bootstraps ride the same constructor rather than
     // minting a second one.
     //
-    // `isQueryFunction` rides with it, and is equally load-bearing: the base
+    // `isCacheableQuery` rides with it, and is equally load-bearing: the base
     // class has no function registry, so its answer is a conservative `false`
     // and `runCachedQuery` returns early on EVERY call — a wired cache that
     // memoizes nothing. This override is the single point where that goes
@@ -5330,8 +5330,14 @@ ${hasMemoryTables ? "            clearMemoryTables(this.sql as SqlExec, schema a
             });
 ${sourceBootstrap}${ttlBootstrap}        }
 
-        protected override isQueryFunction(functionPath: string): boolean {
-            return LUNORA_FUNCTIONS[functionPath]?.kind === "query";
+        protected override isCacheableQuery(functionPath: string): boolean {
+            // NOT \`kind === "query"\` alone. A cache hit answers without running
+            // \`handleRpc\`, so the \`internal\` refusal at the top of it is skipped —
+            // and an \`internalQuery\` primed by a trusted system dispatch was then
+            // served to an anonymous client that the refusal would have 404'd.
+            const registered = LUNORA_FUNCTIONS[functionPath];
+
+            return registered?.kind === "query" && registered.visibility !== "internal";
         }
 
         protected override isPaidFunction(functionPath: string): boolean {
@@ -6209,7 +6215,19 @@ ${notifyBuild}
                 // is visible and its spans join this trace. Degrades to the bare
                 // global when no sink is configured.
                 fetch: this.makeFetch(logFunctionPath, traceAnchor, observability),
-                ip,
+                // A GETTER, not a plain field, so the reactive cache can tell a
+                // handler that reads the caller's address from the majority that
+                // never do. \`ctx.ip\` is per-request state the memo must be keyed
+                // by — otherwise two anonymous callers share one entry and the
+                // second is served the first's address — but keying every entry
+                // by address would shard the cache per client for every query.
+                // Reading it here marks the dispatch's scope; \`runCachedQuery\`
+                // folds the address into the key for this function from then on.
+                get ip() {
+                    options.scope?.markIpRead();
+
+                    return ip;
+                },
                 log,
                 metrics,
                 now,${ormContextField}

--- a/packages/do/__tests__/reactive-cache.integration.test.ts
+++ b/packages/do/__tests__/reactive-cache.integration.test.ts
@@ -926,7 +926,7 @@ describe("shardDO + reactiveCache: base dispatch wiring", () => {
         }
 
         // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
-        protected override isQueryFunction(functionPath: string): boolean {
+        protected override isCacheableQuery(functionPath: string): boolean {
             return REGISTRY[functionPath] === "query";
         }
     }

--- a/packages/do/__tests__/shard-do.reactive-cache-ip-key.test.ts
+++ b/packages/do/__tests__/shard-do.reactive-cache-ip-key.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `ctx.ip` and the reactive cache key.
+ *
+ * `runCachedQuery` scopes each entry to the caller's full identity — userId plus
+ * the `getIdentity()` claims — precisely so that ambient per-request state one
+ * caller's rows were computed under is never handed to another. `ctx.ip` is
+ * ambient per-request state of exactly the same kind, and it was left out: two
+ * anonymous callers both collapse to the `null` identity bucket, so under
+ * `.reactiveCache(true)` the second is served the first's answer — including
+ * the first caller's address.
+ *
+ * Every registered `query` reaching `POST /rpc` routes through `runCachedQuery`,
+ * so this is not confined to one socket's refresh.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryReadScope, ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+const CALLER_A_IP = "203.0.113.5";
+const CALLER_B_IP = "198.51.100.1";
+
+const createFakeState = (): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets: () => [],
+        storage: { sql: { exec: vi.fn<(query: string) => unknown>() } },
+    };
+};
+
+/**
+ * Mirrors what the emitter produces: a plain `handleRpc` with no cache wrap of
+ * its own, whose handler reaches the caller's address through the ctx the
+ * generated `buildCtx` builds — where `ip` is a getter that marks the dispatch's
+ * read scope. `emit-shard-reactive-cache.test.ts` holds the emitter to that
+ * shape; this file asserts what the base class does with the mark.
+ *
+ * `whoami` reads the address, `feed` never does — the pair that shows the key is
+ * widened for the former and left alone for the latter.
+ */
+class IpReadingShard extends ShardDO {
+    public execCount = new Map<string, number>();
+
+    public override handleRpc(functionPath: string, _args: Record<string, unknown>, _headroom?: unknown, scope?: QueryReadScope): Promise<unknown> {
+        this.execCount.set(functionPath, (this.execCount.get(functionPath) ?? 0) + 1);
+
+        const readIp = (): string | undefined => {
+            scope?.markIpRead();
+
+            return this.getCurrentIp();
+        };
+        const ctx = {
+            get ip(): string | undefined {
+                return readIp();
+            },
+        };
+
+        // Only `whoami` touches `ctx.ip`; `feed` is the ordinary query that must
+        // keep sharing one entry across callers.
+        return Promise.resolve({ ip: functionPath === "session:whoami" ? (ctx.ip ?? null) : null });
+    }
+
+    /** Test-only: expose the protected `reactiveCache` field for assertions. */
+    public cacheRef(): typeof this.reactiveCache {
+        return this.reactiveCache;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub: every path in this harness is a query.
+    protected override isCacheableQuery(): boolean {
+        return true;
+    }
+}
+
+const rpc = async (shard: IpReadingShard, functionPath: string, ip: string): Promise<{ ip: null | string }> => {
+    const response = await shard.fetch(
+        new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath }),
+            headers: { "content-type": "application/json", "x-lunora-client-ip": ip },
+            method: "POST",
+        }),
+    );
+
+    const body: { result: { ip: null | string } } = await response.json();
+
+    return body.result;
+};
+
+describe("reactive cache + ctx.ip", () => {
+    it("never serves one anonymous caller a result computed under another caller's ip", async () => {
+        expect.hasAssertions();
+
+        const shard = new IpReadingShard(createFakeState(), {}, { reactiveCache: {} });
+
+        const a = await rpc(shard, "session:whoami", CALLER_A_IP);
+        const b = await rpc(shard, "session:whoami", CALLER_B_IP);
+
+        expect(a.ip).toBe(CALLER_A_IP);
+        expect(b.ip).toBe(CALLER_B_IP);
+    });
+
+    it("re-serves the memo to a repeat caller from the same address", async () => {
+        expect.hasAssertions();
+
+        const shard = new IpReadingShard(createFakeState(), {}, { reactiveCache: {} });
+
+        // The first dispatch is what DISCOVERS the read, so its entry sits under
+        // the address-less key; the second widens the key and re-runs. From the
+        // third on the same caller hits.
+        await rpc(shard, "session:whoami", CALLER_A_IP);
+        await rpc(shard, "session:whoami", CALLER_A_IP);
+        const third = await rpc(shard, "session:whoami", CALLER_A_IP);
+
+        expect(third.ip).toBe(CALLER_A_IP);
+        expect(shard.execCount.get("session:whoami")).toBe(2);
+    });
+
+    it("leaves a query that never reads ctx.ip sharing one entry across callers", async () => {
+        expect.hasAssertions();
+
+        const shard = new IpReadingShard(createFakeState(), {}, { reactiveCache: {} });
+
+        await rpc(shard, "posts:feed", CALLER_A_IP);
+        await rpc(shard, "posts:feed", CALLER_B_IP);
+
+        // Unconditional address-keying would make this 2 — the hit-rate
+        // regression the mark exists to avoid.
+        expect(shard.execCount.get("posts:feed")).toBe(1);
+        expect(shard.cacheRef()?.stats().hits).toBe(1);
+    });
+});

--- a/packages/do/__tests__/shard-do.reactive-cache-visibility.test.ts
+++ b/packages/do/__tests__/shard-do.reactive-cache-visibility.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The reactive cache and the `internal` visibility gate.
+ *
+ * That gate lives INSIDE the emitted `handleRpc` — the callback a cache hit
+ * exists to skip. Classifying cacheability on `kind` alone let an `internalQuery`
+ * route through `runCachedQuery` like any other query, and on a hit
+ * `ReactiveCache` returns the stored result without invoking the callback, so the
+ * gate never ran. Nothing about the trusted-dispatch flag reached the key either.
+ *
+ * A server-side dispatch (cron, an `httpRouter` route, `createShardClient`, the
+ * mail inbound dispatcher) arrives with `x-lunora-system: 1`, primes the entry,
+ * and an anonymous client POSTing the same path and args was handed it.
+ *
+ * Two independent defences now, tested separately because either alone closes it
+ * and neither should be allowed to rot behind the other. First, an internal
+ * function is not cacheable at all (`isCacheableQuery`). Second, the
+ * trusted-dispatch flag is part of the caller context the key is built from, so a
+ * client could not read a system dispatch's entry even if it were.
+ */
+import { LunoraError } from "@lunora/errors";
+import { describe, expect, it, vi } from "vitest";
+
+import type { QueryReadScope, ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+const REGISTRY: Readonly<Record<string, { kind: "query"; visibility: "internal" | "public" }>> = {
+    "posts:list": { kind: "query", visibility: "public" },
+    "secrets:listAll": { kind: "query", visibility: "internal" },
+};
+
+const createFakeState = (): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets: () => [],
+        storage: { sql: { exec: vi.fn<(query: string) => unknown>() } },
+    };
+};
+
+/** Mirrors the emitted subclass: the gate inside `handleRpc`, the registry lookup in `isCacheableQuery`. */
+class VisibilityShard extends ShardDO {
+    public handlerRuns = 0;
+
+    public override handleRpc(functionPath: string, _args: Record<string, unknown>, _headroom?: unknown, _scope?: QueryReadScope): Promise<unknown> {
+        const registered = REGISTRY[functionPath];
+
+        if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
+            throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
+        }
+
+        this.handlerRuns += 1;
+
+        return Promise.resolve({ rows: ["internal-only-row"] });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- mirrors the emitted override verbatim.
+    protected override isCacheableQuery(functionPath: string): boolean {
+        const registered = REGISTRY[functionPath];
+
+        return registered?.kind === "query" && registered.visibility !== "internal";
+    }
+}
+
+/**
+ * The same shard with the OLD, kind-only classification restored, so an internal
+ * function reaches the cache again. What must still refuse the client here is the
+ * key: the trusted-dispatch flag is part of the caller context it is built from.
+ */
+class KindOnlyVisibilityShard extends VisibilityShard {
+    // eslint-disable-next-line class-methods-use-this -- deliberately the pre-fix classification; the key is what is under test.
+    protected override isCacheableQuery(functionPath: string): boolean {
+        return REGISTRY[functionPath]?.kind === "query";
+    }
+}
+
+const rpc = async (shard: VisibilityShard, functionPath: string, system: boolean): Promise<{ body: unknown; status: number }> => {
+    const response = await shard.fetch(
+        new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath }),
+            headers: system ? { "content-type": "application/json", "x-lunora-system": "1" } : { "content-type": "application/json" },
+            method: "POST",
+        }),
+    );
+
+    return { body: await response.json(), status: response.status };
+};
+
+describe("reactive cache + internal visibility", () => {
+    it("refuses an anonymous client an internal query a system dispatch just ran", async () => {
+        expect.hasAssertions();
+
+        const shard = new VisibilityShard(createFakeState(), {}, { reactiveCache: {} });
+
+        // A trusted server-side dispatch runs the internal query.
+        const system = await rpc(shard, "secrets:listAll", true);
+
+        expect(system.status).toBe(200);
+
+        // The anonymous client must still be refused — a hit must not answer for
+        // a gate that never ran.
+        const client = await rpc(shard, "secrets:listAll", false);
+
+        expect(client.status).toBe(404);
+        expect(shard.handlerRuns).toBe(1);
+    });
+
+    it("refuses it through the key alone, even when an internal function does reach the cache", async () => {
+        expect.hasAssertions();
+
+        const shard = new KindOnlyVisibilityShard(createFakeState(), {}, { reactiveCache: {} });
+
+        await rpc(shard, "secrets:listAll", true);
+        const client = await rpc(shard, "secrets:listAll", false);
+
+        expect(client.status).toBe(404);
+        expect(shard.handlerRuns).toBe(1);
+    });
+
+    it("still memoizes a public query across two anonymous callers", async () => {
+        expect.hasAssertions();
+
+        const shard = new VisibilityShard(createFakeState(), {}, { reactiveCache: {} });
+
+        await rpc(shard, "posts:list", false);
+        const second = await rpc(shard, "posts:list", false);
+
+        expect(second.status).toBe(200);
+        expect(shard.handlerRuns).toBe(1);
+    });
+});

--- a/packages/do/__tests__/shard-do.request-attribution.test.ts
+++ b/packages/do/__tests__/shard-do.request-attribution.test.ts
@@ -48,7 +48,7 @@ class AttributionShard extends ShardDO {
         return { ok: true };
     }
 
-    protected override isQueryFunction(): boolean {
+    protected override isCacheableQuery(): boolean {
         return this.reactiveCache !== undefined;
     }
 

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -845,6 +845,21 @@ interface QueryAttribution {
 interface QueryReadScope {
     /** Range footprint for this dispatch — the `onReadRange` channel. */
     footprint: ReadFootprint;
+
+    /**
+     * Record that this dispatch's handler read `ctx.ip` — the ambient-read
+     * channel, and the reason the generated `buildCtx` exposes `ip` as a getter
+     * rather than a plain field.
+     *
+     * `ctx.ip` is per-request state of exactly the kind the cache's identity
+     * discriminator exists to separate, but unlike userId/claims it cannot be
+     * folded in blind: keying every entry by caller address would shard the
+     * cache per client for the overwhelming majority of queries that never read
+     * it. So {@link ShardDO.runCachedQuery} keys on it only for a `functionPath`
+     * some dispatch has been observed reading it through — this mark is that
+     * observation.
+     */
+    markIpRead: () => void;
     /** Dependency tracker for this dispatch — the `onRead` channel. */
     tracker: DependencyTracker;
 }
@@ -996,6 +1011,20 @@ const IDEMPOTENCY_RETENTION_MS = 86_400_000;
  * dispatch rather than a timer.
  */
 const IDEMPOTENCY_GC_INTERVAL_MS = 3_600_000;
+
+/**
+ * The encoded caller context of a plain anonymous request: no userId, no identity
+ * claims, no address in the key, and not a trusted system dispatch. The one
+ * context {@link ShardDO.runCachedQuery} maps onto `reactiveCacheKey`'s documented
+ * `null` bucket.
+ *
+ * Written as the encoding of a whole caller object rather than as a conjunction
+ * of field tests, so that a member added to the caller context and not mirrored
+ * here fails by no longer matching — every caller then gets its own bucket,
+ * which costs hit rate and leaks nothing.
+ */
+// eslint-disable-next-line unicorn/no-null -- mirrors the caller object `runCachedQuery` encodes, where absent fields serialize as null
+const ANONYMOUS_CALLER = stableStringify({ claims: null, ip: null, system: false, userId: null });
 
 /**
  * The refusal a paid (`.x402`) procedure gets on a socket. The paywall lives at
@@ -1395,6 +1424,21 @@ abstract class ShardDO {
      * on the first call.
      */
     protected readonly reactiveCache: ReactiveCache | undefined;
+
+    /**
+     * Function paths a dispatch has been observed reading `ctx.ip` through, and
+     * whose reactive-cache entries are therefore keyed by the caller's address
+     * as well as by identity — see the discriminator {@link ShardDO.runCachedQuery}
+     * builds.
+     *
+     * Learned at runtime rather than declared, because the honest signal is the
+     * property read itself: a handler may reach `ctx.ip` through a helper, and a
+     * source scan that missed one would leave the cache serving one caller's
+     * address to another. Marking is monotone and per-path, so it can only ever
+     * over-key. Its lifetime is the instance's, the same as the cache it guards,
+     * so a restart clears both together.
+     */
+    protected readonly ipKeyedFunctionPaths: Set<string> = new Set<string>();
 
     /**
      * Running read tallies for the shape-poke path, surfaced next to
@@ -2923,12 +2967,13 @@ abstract class ShardDO {
      * MUTATING caller's IP and hand it to every subscriber. Those paths take the
      * socket's own IP by value instead, via {@link SubscriptionIdentity.ip}.
      *
-     * Owning the FIELD is not the same as owning the value: `runCachedQuery`'s
-     * reactive-cache key folds userId + claims and not `ip`, so under
-     * `.reactiveCache(true)` an anonymous query reading `ctx.ip` can still be
-     * served one caller's answer for another. Pre-existing and tracked
-     * separately — noted so the next reader does not conclude this accessor is
-     * now safe everywhere.
+     * Under `.reactiveCache(true)` the memo is keyed by the caller's address as
+     * well as by identity, but only for function paths a dispatch has been seen
+     * reading `ctx.ip` through. That observation is the generated `buildCtx`'s
+     * `ip` GETTER calling {@link QueryReadScope.markIpRead} — so a subclass that
+     * surfaces this value to handlers by some other route, bypassing that
+     * getter, gets no mark and no address in the key, and two anonymous callers
+     * would share one entry again.
      */
     protected getCurrentIp(): string | undefined {
         return this.currentRequestIp;
@@ -4771,7 +4816,7 @@ abstract class ShardDO {
 
     /**
      * Wrap a query handler in the reactive cache. The `/rpc` dispatch path calls
-     * this for every path {@link ShardDO.isQueryFunction} recognises, so a
+     * this for every path {@link ShardDO.isCacheableQuery} admits, so a
      * subclass does NOT wrap its own `handleRpc` — see the re-entry guard below
      * for why doing both would be worse than doing neither. When the cache is
      * configured we key by `(identity, functionPath, stable-stringified args)`,
@@ -4839,7 +4884,14 @@ abstract class ShardDO {
 
         const tracker = createDependencyTracker();
         const footprint = createReadFootprint();
-        const scope: QueryReadScope = { footprint, tracker };
+        let ipRead = false;
+        const scope: QueryReadScope = {
+            footprint,
+            markIpRead: () => {
+                ipRead = true;
+            },
+            tracker,
+        };
 
         // Detect a cache hit cheaply by diffing the cache's lifetime hit
         // counter across the `run` call — a hit means the callback (and thus
@@ -4849,21 +4901,62 @@ abstract class ShardDO {
         // whether the cache is even enabled.
         const hitsBefore = this.reactiveCache.stats().hits;
 
-        // Scope the cache entry to the caller's FULL identity — userId AND the
-        // identity claims (active-org/role/tenant) that RLS can key on — so a
-        // per-request claim that varies while userId stays constant never
-        // memoizes one context's rows for another caller sharing the same DO.
-        // An anonymous request (no userId, no claims) collapses to the `null`
-        // bucket. `stableStringify` canonicalizes key order, so equal identities
-        // yield equal discriminators (same guarantee the args encoding relies on).
-        const userId = this.getCurrentUserId();
-        const claims = this.getCurrentIdentity();
+        // Scope the cache entry to the caller's FULL context, resolved as ONE
+        // object on one pass over the per-request state. Everything a cache HIT
+        // would skip has to be in here, because a hit returns the stored result
+        // without ever running the callback: not just what the handler reads
+        // (userId, the RLS-keyable claims, the address) but what the GATES
+        // around it branch on. The emitted `handleRpc` refuses an `internal`
+        // function to a caller without the trusted-dispatch flag — and that
+        // check lives inside the callback, so leaving the flag out of the key
+        // let a cron-primed `internalQuery` entry be handed to an anonymous
+        // client verbatim.
+        //
+        // One object rather than a field-per-expression for the same reason the
+        // emitted `buildCtx` resolves its caller on a single discriminant:
+        // parallel per-field expressions are how a field comes to be forgotten.
+        // A fifth field belongs here and nowhere else.
+        //
+        // `ip` is the one member NOT read unconditionally. Folding the address
+        // in always would key every entry by caller, collapsing the hit rate for
+        // the overwhelming majority of queries that never touch `ctx.ip`: on the
+        // default single-`__root__`-DO topology one public list read by N
+        // anonymous visitors would become N entries instead of one. So it joins
+        // only for a `functionPath` some dispatch has been OBSERVED reading
+        // `ctx.ip` through — the generated `buildCtx` exposes `ip` as a getter
+        // that calls `scope.markIpRead`, recorded below once the handler ran.
+        //
+        // The dispatch that DISCOVERS the read is the one case the mark cannot
+        // precede: its own key was already computed without the address. It is
+        // still safe, because the mark lands before its entry is stored (the
+        // range fallback below runs inside `ReactiveCache.run`'s callback, and
+        // the store happens after that resolves), while every later dispatch
+        // computes its key and probes the cache in one synchronous stretch. A
+        // dispatch that can see the discovering entry therefore keyed on the
+        // address and cannot be looking under the key that entry sits at: the
+        // orphan is unreachable and simply ages out.
+        const caller = {
+            // eslint-disable-next-line unicorn/no-null -- absent fields serialize as null so the encoded shape stays canonical
+            claims: this.getCurrentIdentity() ?? null,
+            // eslint-disable-next-line unicorn/no-null -- as above
+            ip: (this.ipKeyedFunctionPaths.has(functionPath) ? this.getCurrentIp() : undefined) ?? null,
+            system: this.isSystemDispatch(),
+            // eslint-disable-next-line unicorn/no-null -- as above
+            userId: this.getCurrentUserId() ?? null,
+        };
+        // `stableStringify` canonicalizes key order, so equal contexts yield
+        // equal discriminators (the same guarantee the args encoding relies on).
+        // The plain anonymous caller keeps `reactiveCacheKey`'s documented `null`
+        // bucket — matched on the ENCODED string rather than field by field, so a
+        // member added above that nobody mirrors in `ANONYMOUS_CALLER` simply
+        // stops matching and every caller gets its own bucket: a hit-rate
+        // regression the tests catch, never a shared entry.
+        const encoded = stableStringify(caller);
         const identity =
-            userId === undefined && claims === undefined
+            encoded === ANONYMOUS_CALLER
                 ? // eslint-disable-next-line unicorn/no-null -- reactiveCacheKey's identity arg is `null | string`; null is the documented "anonymous caller" discriminator
                   null
-                : // eslint-disable-next-line unicorn/no-null -- fold userId/claims into the discriminator; missing fields serialize as null so the shape stays canonical
-                  stableStringify({ claims: claims ?? null, userId: userId ?? null });
+                : encoded;
 
         // Wraps `run` so that, once the handler has actually executed and the
         // footprint is final, every table it touched that `footprint.ranges()`
@@ -4893,6 +4986,16 @@ abstract class ShardDO {
         // handler resolved but before either later step — lands in time.
         const runWithRangeFallback = async (): Promise<R> => {
             const result = await run(scope);
+
+            // Before the entry is stored, so the key every LATER dispatch of
+            // this path computes already carries the caller's address. See the
+            // discriminator comment above for why that ordering is what makes
+            // the discovering dispatch's own ip-less entry unreachable rather
+            // than servable.
+            if (ipRead) {
+                this.ipKeyedFunctionPaths.add(functionPath);
+            }
+
             const narrowed = footprint.ranges();
 
             for (const table of footprint.tables) {
@@ -5041,8 +5144,16 @@ abstract class ShardDO {
     }
 
     /**
-     * Whether `functionPath` names a registered `query` — the only kind whose
-     * result may be memoized by the reactive cache.
+     * Whether `functionPath` may have its result memoized by the reactive cache.
+     *
+     * Named for the decision rather than for the `kind` lookup that mostly
+     * answers it, because the `kind` is not the whole test. A cache HIT returns
+     * the stored result without running the dispatch callback, so every gate
+     * inside that callback is skipped — including the emitted `handleRpc`'s
+     * refusal of an `internal` function to an untrusted caller. An
+     * `internalQuery` is a registered `query`, and classifying on kind alone let
+     * a cron-primed entry be served to an anonymous client. So a function the
+     * gate can refuse is not cacheable, whatever its kind.
      *
      * The base class has no function registry, so the default is `false`: the
      * conservative answer, since caching an `action` would skip its outbound
@@ -5051,7 +5162,7 @@ abstract class ShardDO {
      * lookup, which is what production dispatch uses.
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this to consult `LUNORA_FUNCTIONS`
-    protected isQueryFunction(_functionPath: string): boolean {
+    protected isCacheableQuery(_functionPath: string): boolean {
         return false;
     }
 
@@ -6089,9 +6200,9 @@ abstract class ShardDO {
                 // decoded args are what get keyed (`stableWireKey` handles the
                 // `bigint`/bytes leaves), so two calls that differ only in wire
                 // encoding still share an entry. `runCachedQuery` is a pass-through
-                // when `reactiveCache` is undefined, but the kind lookup is skipped
-                // in that case so a cache-less shard pays nothing.
-                return this.reactiveCache !== undefined && this.isQueryFunction(payload.functionPath)
+                // when `reactiveCache` is undefined, but the cacheability lookup is
+                // skipped in that case so a cache-less shard pays nothing.
+                return this.reactiveCache !== undefined && this.isCacheableQuery(payload.functionPath)
                     ? this.runCachedQuery(
                           payload.functionPath,
                           handlerArgs,


### PR DESCRIPTION
## Targets `fix/r37-do-ws-client-ip`, not `alpha`

This is stacked on PR #702. That branch reworks the same regions of
`packages/do/src/shard-do.ts` and the emitted `buildCtx` — including the
`getCurrentIp` JSDoc this PR rewrites and the `ip` ctx field this PR turns into a
getter — and is not yet merged, so branching off `alpha` would conflict on every
hunk. `.coderabbit.yaml` already covers the base through its `fix/r[0-9]+-.*`
pattern, so review is not skipped.

## Two defects, one root cause

A cache **hit** returns the stored entry without running the dispatch callback, so
everything the callback would have done is skipped — the handler and the gates
around it alike. The entry's key therefore has to carry every piece of per-request
context those gates and that handler can observe. It carried userId and the
identity claims, and nothing else.

Both defects require `.reactiveCache(true)`. It is off by default
(`reactiveCacheConfig = false`, and the base only routes through `runCachedQuery`
when `this.reactiveCache !== undefined`), so **an app that has not enabled the
reactive cache is exposed to neither**.

### 1. `ctx.ip` was not in the key

Two anonymous callers both collapse to the same bucket, so a handler reading
`ctx.ip` could be served an answer computed under a different caller's address.
Every registered `query` reaching `POST /rpc` routes through `runCachedQuery`
(`shard-do.ts` docstrings at the `/rpc` query path), so this was not confined to
one socket's refresh.

### 2. The trusted-dispatch flag was not in the key — and that one crosses a privilege boundary

The emitted `handleRpc` refuses an `internal` function to a caller without
`isSystemDispatch()`, and that refusal lives **inside** the skipped callback.
`isQueryFunction` classified on `kind` alone, and an `internalQuery` is a
registered `query`. So a server-side dispatch — a cron via `dispatchToShard`, an
`httpRouter` route's `ctx.runQuery(internal.x)`, `createShardClient().call(...)`,
the mail inbound dispatcher — primed the entry, and an anonymous client POSTing
the same path and args got it back with a 200.

## Failing tests first

Both were written and run against the unfixed code before anything was changed.

**1 — `ctx.ip`.** Caller B at `198.51.100.1` is handed caller A's address:

```
 FAIL  __tests__/shard-do.reactive-cache-ip-key.test.ts > reactive cache + ctx.ip >
       never serves one anonymous caller a result computed under another caller's ip
AssertionError: expected '203.0.113.5' to be '198.51.100.1' // Object.is equality

Expected: "198.51.100.1"
Received: "203.0.113.5"

 ❯ __tests__/shard-do.reactive-cache-ip-key.test.ts:73:22
     72|         expect(a.ip).toBe(CALLER_A_IP);
     73|         expect(b.ip).toBe(CALLER_B_IP);
```

The raw wire response, captured while reproducing, with caller B's request
carrying `x-lunora-client-ip: 198.51.100.1`:

```
STATUS 200 BODY {"result":{"ip":"203.0.113.5"}}
STATUS 200 BODY {"result":{"ip":"203.0.113.5"}}
```

**2 — internal visibility.** Reproduced independently against the real `ShardDO`,
with a subclass mirroring the emitted `handleRpc` gate and the emitted
kind-only `isQueryFunction`:

```
 FAIL  __tests__/shard-do.reactive-cache-visibility.test.ts >
       reactive cache + internal visibility >
       refuses an anonymous client an internal query already primed by a system dispatch
AssertionError: expected 200 to be 404 // Object.is equality

- Expected
+ Received

- 404
+ 200

 ❯ __tests__/shard-do.reactive-cache-visibility.test.ts:82:31
     80|         const client = await rpc(shard, "secrets:listAll", false);
     82|         expect(client.status).toBe(404);
```

`handlerRuns` stayed at 1 across both calls: one execution, two callers, and the
second was one the gate would have refused.

Every new test was also verified by breaking the fixed code — see *Verified by
sabotage* below.

## The fix

**One caller context, one place.** The discriminator is now built from a single
resolved object — `{claims, ip, system, userId}` — rather than a field per
expression. Parallel per-field expressions on one discriminant are exactly how
`ip` came to be forgotten a layer down in `buildCtx`; a fifth field now belongs in
one place and is in the key by construction.

The plain anonymous caller still maps onto `reactiveCacheKey`'s documented `null`
bucket, but that is matched on the **encoded string** against a module constant
rather than on a conjunction of field tests. A member added to the caller object
and not mirrored in the constant stops matching, so every caller gets its own
bucket — a hit-rate regression the tests catch, never a shared entry.

**The address joins the key only where it is read.** Folding `ip` in
unconditionally would key every entry by client: on the default
single-`__root__`-DO topology one public list read by N anonymous visitors becomes
N entries instead of one, and `.reactiveCache()` is an app-wide switch, so that
cost lands on every query in the app. Instead the generated `buildCtx` exposes
`ip` as a **getter** that marks the dispatch's read scope
(`QueryReadScope.markIpRead`), and `runCachedQuery` folds the address in for
function paths a dispatch has been observed reading it through. A runtime property
read rather than a source scan, because a handler can reach `ctx.ip` through a
helper and a missed detection would be a silent leak. Queries that never touch
`ctx.ip` keep sharing one entry exactly as before — pinned by a test.

The dispatch that *discovers* the read is the one whose key was already computed
without the address. It is still safe: the mark lands before its entry is stored
(inside `ReactiveCache.run`'s callback, which resolves before the store), while
every later dispatch computes its key and probes the cache in one synchronous
stretch — so a dispatch that could see that entry already keyed on the address and
is not looking under the key the entry sits at. The orphan is unreachable and ages
out. Cost: the first call of an ip-reading path runs twice.

**Second, independent defence for the privilege half.** An internal function must
not reach the cache at all. `isQueryFunction` is renamed to `isCacheableQuery` —
the old name is what invited classifying on `kind` alone — and the generated
override now also excludes `internal`.

Either defence alone closes defect 2; both are tested separately so neither can
rot behind the other.

## Hit-rate consequence

| | before | after |
|---|---|---|
| query that never reads `ctx.ip` | 1 entry | 1 entry (unchanged) |
| query that reads `ctx.ip` | 1 entry, **wrong across callers** | 1 entry per address; first call runs twice |
| query dispatched both by cron and by clients | 1 entry | 2 entries |
| `internalQuery` | 1 entry, **served to anyone** | not cached |

## Audit: what else a skipped callback hides

The emitted `handleRpc` for a query contains, in order: the registry lookup +
visibility gate, `ensureMigrated()`, `buildCtx(...)`, the handler, and
`deferPastResponse(flushDeferredDeletes(ctx))`. A hit skips all five.

- **Visibility gate** — the defect above. Fixed twice over.
- **`ensureMigrated()`** — safe, but only because of a coupling worth naming: the
  emitted subclass's `migrated` flag and the base's `reactiveCache` are both
  per-instance and die together on restart or eviction, so a hit implies a prior
  miss *on this instance* already ran it. Not changed.
- **`buildCtx`** — no side effect that matters when the handler does not run. The
  paywall (`isPaidFunction`) and the rate-limit/watermark checks sit in the base
  `fetch` **before** `runHandler`, so they are not skipped.
- **Middleware inside the handler** — `.use(rateLimit(...))` does not run on a hit.
  That is arguably the point of a cache (no work is done), but it does mean a
  cached query can be hammered without consuming limiter budget. Reported, not
  changed.
- **Deferred deletes** — skipped consistently with the handler that would have
  queued them.
- **`resolveReactiveOutcomeDeduped`** (the sibling asked about) — **cannot** serve
  across IPs. It shares only when `isIdentityIndependent(functionPath)`, which is
  `startsWith(ADMIN_FUNCTION_PREFIX)`, and those route to
  `executeAdminSubscription`, whose signature is `(functionPath, args)` — it never
  receives the `SubscriptionIdentity` at all and builds no user ctx. Its dedup map
  is also a fresh `Map` per flush, unrelated to `ReactiveCache`. Separately, the
  generated `executeSubscription` does **not** go through `runCachedQuery`, so the
  subscription path never touches this cache; the new `ip` getter is a no-op there
  (`options.scope` is undefined).

## Verified by sabotage

Each new assertion was confirmed to fail for the right reason:

- `ip` unconditional in the key → the hit-rate test and the discovery test fail (2 failed, 1 passed).
- `ip` never in the key → the cross-caller test and the discovery test fail (2 failed, 1 passed).
- `system: false` hard-coded in the caller object → *"refuses it through the key alone"* fails, `expected 200 to be 404`; the routing test still passes.
- `system: false` **and** the kind-only classification restored → both visibility tests fail, `expected 200 to be 404`.

## Gates

| gate | result |
|---|---|
| `pnpm run build:packages` | pass |
| `@lunora/do` tests | 722 passed (64 files) |
| `@lunora/codegen` tests | 1778 passed (139 files) |
| `pnpm run test` (full) | 117 tasks, pass |
| `pnpm run test:workerd` | all 11 suites; `@lunora/do` 67 passed / 15 skipped |
| `pnpm exec vis run lint:types --no-cache` | 121 tasks, pass |
| `pnpm run api:check` | pass after `api:update` (below) |
| `pnpm run lint:prettier` | pass |
| `pnpm exec vis run lint:eslint --no-cache` | 104 tasks, pass |
| `pnpm run dist:check` | pass (after `build:packages:prod`) |
| `pnpm run lint:package-json` | pass |

## API surface

`api-snapshots/do.api.md` updated for three intended changes:

```diff
 interface QueryReadScope {
     footprint: ReadFootprint;
+    markIpRead: () => void;
     tracker: DependencyTracker;
 }

     protected readonly reactiveCache: ReactiveCache | undefined;
+    protected readonly ipKeyedFunctionPaths: Set<string>;

-    protected isQueryFunction(_functionPath: string): boolean;
+    protected isCacheableQuery(_functionPath: string): boolean;
```

Breaking, and noted in the commit body for semantic-release. This targets a
pre-release channel, so the old names are removed rather than aliased.

## Generated output

The emitter changed, so the two golden fixtures and all 13 `examples/*`
`_generated/shard.ts` are regenerated in the same commit. They were all in sync
with the emitter beforehand, so the diff across every one of them is exactly the
two intended hunks (the `ip` getter and the `isCacheableQuery` override) and no
unrelated drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
