### PR TITLE
fix(notify): do not retry a partially delivered push

### DIFF
--- a/packages/notify/__tests__/notify.test.ts
+++ b/packages/notify/__tests__/notify.test.ts
@@ -1234,3 +1234,54 @@ describe("mixed-kind push routing", () => {
         expect(receipt.success).toBe(false);
     });
 });
+
+describe("mixed-kind push routing under the resilience middleware", () => {
+    // The router is ONE provider to the engine, so the retry middleware re-runs
+    // `send` with the WHOLE payload. These drive the real facade, the real router
+    // and the real `attachResilience` (through `mockEngine`) because the
+    // interaction between the three is the behaviour under test.
+    const origins = { allowedPushOrigins: ["https://push.example"] };
+    const sub = (path: string) => JSON.stringify({ endpoint: `https://push.example/${path}`, keys: { auth: "a", p256dh: "p" } });
+
+    const mixedSend = (to: ReadonlyArray<string>) => {
+        const webPush = mockPushProvider();
+        const fcm = mockPushProvider();
+        const engine = mockEngine({ push: routingPushProvider({ ...origins, fcm: fcm.provider, webPush: webPush.provider }) });
+        const { notify } = createNotify(baseDefinition(memorySubscriptionStore()), {}, { engine, silent: true });
+
+        return { fcm, send: async () => notify.send({ push: { body: "b", to: [...to] } }), webPush };
+    };
+
+    it("does not re-send to the group that already delivered when the other fails", async () => {
+        expect.hasAssertions();
+
+        // The web-push target is accepted; the FCM token answers a transient 503.
+        const { fcm, send, webPush } = mixedSend([sub("ok"), "fail-token"]);
+        const [receipt] = await send();
+
+        // One send each: retrying the router re-POSTs the accepted web-push
+        // target, delivering that notification to the device four times over.
+        expect(webPush.sends).toHaveLength(1);
+        expect(fcm.sends).toHaveLength(1);
+        expect(receipt?.successful).toBe(false);
+
+        // The caller is told the send was partial and which group still needs it
+        // — the same "re-send the narrower set" contract `runRetryIds` offers.
+        const errors = receipt?.successful === false ? receipt.errorMessages.join(" ") : "";
+
+        expect(errors).toContain("partially delivered");
+        expect(errors).toContain("the fcm group failed");
+    });
+
+    it("still retries when BOTH groups fail — there is no delivery to duplicate", async () => {
+        expect.hasAssertions();
+
+        const { fcm, send, webPush } = mixedSend([sub("fail"), "fail-token"]);
+
+        await send();
+
+        // The engine's budget: the initial attempt plus three retries.
+        expect(webPush.sends).toHaveLength(4);
+        expect(fcm.sends).toHaveLength(4);
+    });
+});

--- a/packages/notify/src/providers.ts
+++ b/packages/notify/src/providers.ts
@@ -1,4 +1,4 @@
-import { LunoraError } from "@lunora/errors";
+import { isLunoraError, LunoraError } from "@lunora/errors";
 import type { Middleware, Notification, NotificationProviders, NotificationResult, Provider, PushPayload, Result } from "@visulima/notification";
 import { createNotification } from "@visulima/notification";
 import { retryMiddleware } from "@visulima/notification/middleware";
@@ -136,29 +136,6 @@ const mergeSendResults = (first: NotificationResult, second: NotificationResult)
 };
 
 /**
- * Fold the two group outcomes of a mixed-kind push into the single `Result` the
- * caller gets back.
- *
- * Nothing may be dropped in the fold: two successes merge their delivery data
- * (or the receipt names only half the send), two failures keep both causes, and
- * a mixed outcome reports the failure — a partially delivered send is never
- * reported as a success.
- */
-const mergeGroupResults = (webPush: Result<NotificationResult>, fcm: Result<NotificationResult>): Result<NotificationResult> => {
-    if (!webPush.success || !fcm.success) {
-        if (webPush.success || fcm.success) {
-            return webPush.success ? fcm : webPush;
-        }
-
-        return { error: new AggregateError([webPush.error, fcm.error], "@lunora/notify: both push target groups failed"), success: false };
-    }
-
-    const data = webPush.data === undefined || fcm.data === undefined ? (webPush.data ?? fcm.data) : mergeSendResults(webPush.data, fcm.data);
-
-    return data === undefined ? { success: true } : { data, success: true };
-};
-
-/**
  * The failure text of a middleware `Result`, or `undefined` when there is none to
  * read. Providers answer with an `Error` (the engine wraps a provider's own
  * failure in a `NotificationError` whose message carries the provider text
@@ -171,6 +148,67 @@ const failureText = (error: unknown): string | undefined => {
     }
 
     return typeof error === "string" ? error : undefined;
+};
+
+/**
+ * The `code` of the error a mixed-kind push answers with when one transport
+ * group delivered and the other did not. Uncatalogued on purpose: it never
+ * reaches the wire — it lands in the `Result` the engine turns into a receipt.
+ */
+const PARTIAL_DELIVERY_CODE = "PUSH_PARTIALLY_DELIVERED";
+
+/**
+ * Whether a failure is the "one group delivered, the other did not" verdict
+ * {@link mergeGroupResults} returns — the one failure that must NOT be retried,
+ * because the retry re-sends the whole payload and the delivered group would get
+ * the notification again on every attempt.
+ */
+const isPartialDelivery = (error: unknown): boolean => isLunoraError(error) && error.code === PARTIAL_DELIVERY_CODE;
+
+/**
+ * Fold the two group outcomes of a mixed-kind push into the single `Result` the
+ * caller gets back.
+ *
+ * Nothing may be dropped in the fold: two successes merge their delivery data
+ * (or the receipt names only half the send), two failures keep both causes, and
+ * a mixed outcome reports the failure — a partially delivered send is never
+ * reported as a success.
+ *
+ * A mixed outcome reports it as a PARTIAL failure, distinct from the
+ * both-groups-failed one, because retrying the two is not the same operation.
+ * The router is one provider to the engine, so the retry middleware re-runs
+ * `send` with the whole payload: retrying a partial re-POSTs the group that
+ * already delivered, three extra notifications per device for a failure that was
+ * never theirs. Two failures carry no delivery to duplicate and stay retryable.
+ *
+ * This is the shape `runRetryIds` already keeps one layer up: a run that
+ * delivered to SOME recipients resolves and names the ones still outstanding, so
+ * the caller re-sends the strictly narrower set instead of the whole message.
+ * Targets are deliberately not named in the message — a web-push target is the
+ * stringified subscription, keys included, and this text is logged.
+ */
+const mergeGroupResults = (webPush: Result<NotificationResult>, fcm: Result<NotificationResult>): Result<NotificationResult> => {
+    if (!webPush.success || !fcm.success) {
+        if (webPush.success || fcm.success) {
+            const [delivered, failed] = webPush.success ? (["web-push", "fcm"] as const) : (["fcm", "web-push"] as const);
+            const cause = webPush.success ? fcm.error : webPush.error;
+
+            return {
+                error: new LunoraError(
+                    PARTIAL_DELIVERY_CODE,
+                    `@lunora/notify: push partially delivered — the ${delivered} group was accepted, the ${failed} group failed (${failureText(cause) ?? "unknown error"}). Not retried: a retry would re-send to the ${delivered} targets that already received it. Re-send to the ${failed} targets only.`,
+                    { cause },
+                ),
+                success: false,
+            };
+        }
+
+        return { error: new AggregateError([webPush.error, fcm.error], "@lunora/notify: both push target groups failed"), success: false };
+    }
+
+    const data = webPush.data === undefined || fcm.data === undefined ? (webPush.data ?? fcm.data) : mergeSendResults(webPush.data, fcm.data);
+
+    return data === undefined ? { success: true } : { data, success: true };
 };
 
 /**
@@ -423,7 +461,12 @@ export const attachResilience = (engine: Notification, options: ResilienceOption
         // budget — four POSTs and ~2.2 s of backoff each — against an endpoint the
         // very next line of the facade deletes, and those attempts were what fed
         // the breaker below.
-        .use(retryMiddleware({ baseDelay: options.retryBaseDelay, shouldRetry: (error) => !isPermanentFailure(error) }))
+        //
+        // It also refuses a PARTIAL delivery (see `mergeGroupResults`): the retry
+        // re-runs the provider with the whole payload, so retrying a send whose
+        // other transport group already delivered notifies those devices again on
+        // every attempt.
+        .use(retryMiddleware({ baseDelay: options.retryBaseDelay, shouldRetry: (error) => !isPermanentFailure(error) && !isPartialDelivery(error) }))
         .use(perProviderCircuitBreaker());
 
 /**


### PR DESCRIPTION
## The defect

`routingPushProvider` partitions a mixed-transport push into a web-push group and an FCM group,
sends both, and folds the two outcomes with `mergeGroupResults` — which reports a partial as
`success: false` (deliberately: a partly delivered send must never read as a success).

The router is **one** provider to the engine, so `retryMiddleware` re-runs `send` with the *whole*
payload whenever the result is not a success. One transport failing therefore re-POSTed the group
that had already delivered.

Driving the real `notify.send()`, the real `routingPushProvider` and the real `attachResilience`,
with the FCM leg answering a transient 503:

```
webPush.sends 4 fcm.sends 4     # before
webPush.sends 1 fcm.sends 1     # after
```

Three duplicate notifications to every web-push device, for a failure that was never theirs.

## The fix

A mixed outcome now answers with a `PUSH_PARTIALLY_DELIVERED` error that `shouldRetry` refuses,
and whose message names the group still outstanding (never the targets themselves — a web-push
target is the stringified subscription, keys included, and this text is logged). The caller
re-sends the strictly narrower set, which is the shape `runRetryIds` already keeps one layer up
for a partly recovered retry page.

Two failed groups carry no delivery to duplicate, so they keep the full retry budget.

## Tests

Two tests against the real facade + router + resilience middleware: one asserting a partial sends
each group exactly once and reports the partial, one asserting a both-groups-failed send still
burns all four attempts per group. Verified by breaking the code first — with the `shouldRetry`
guard removed the first fails with `expected […] to have a length of 1 but got 4`, and with the
branded error reverted it fails the same way; the both-fail control passes in both directions.

## Sibling paths checked

- `retryMiddleware` is used nowhere else in the repo; `@lunora/notify` is its only consumer.
- The upstream web-push and FCM providers aggregate a multi-recipient `to` with "any recipient
  sent ⇒ `success: true`", so a single-kind partial is never retried (it is reported as a success,
  with per-recipient status in `data.recipients`). The opposite bias, not this defect.
- The facade's own fan-out (`deliver` / `broadcastPage`) sends exactly one target per call, so it
  cannot produce a partial group at all.
- `@lunora/mail`'s queued send re-sends to every recipient on redelivery, but it never splits and
  merges groups and its at-least-once semantics are documented on `consumeQueuedSend`. Left alone.

One thing deliberately left: `perProviderCircuitBreaker` still counts a partial towards opening
the router's circuit, which sheds the healthy transport too. Out of scope here.

## Gates

`build:packages`, `--filter @lunora/notify test` (170 passed), `lint:types`, `api:check`
(54 snapshots match), prettier, eslint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
