### PR TITLE
fix(bindings): scope vector compensation to what was written

### DIFF
--- a/packages/bindings/__tests__/vectors/ctx.test.ts
+++ b/packages/bindings/__tests__/vectors/ctx.test.ts
@@ -577,6 +577,37 @@ describe("createVectorSyncHook", () => {
         expect(vectors.deletes).toContainEqual(["docs-fulltext", ["d1"]]);
     });
 
+    it("on a failed UPDATE compensates only the indexes the fan-out actually wrote", async () => {
+        expect.assertions(3);
+
+        const original = new Error("embedder boom");
+        const vectors = fakeVectorSearch();
+
+        vi.mocked(vectors.upsert).mockImplementation(async (indexName, input) => {
+            if (indexName === "docs-fulltext") {
+                throw original;
+            }
+
+            vectors.upserts.push([indexName, input]);
+        });
+
+        const schema: SchemaLike = {
+            tables: { docs: { vectorIndexes: [{ embed, field: "body", name: "docs-body" }] } },
+            vectorIndexes: { "docs-fulltext": { embed, select: (row) => String(row.body), table: "docs" } },
+        };
+        const hook = createVectorSyncHook({ allowSharedNamespace: true, schema, vectors });
+
+        await expect(hook({ doc: { body: "edited" }, id: "d1", op: "update", table: "docs" })).rejects.toBe(original);
+
+        // The hook runs inside the mutation's transaction, so this throw rolls the
+        // row back UNCHANGED. `docs-fulltext` was never written, so it still holds
+        // the prior row's vector — which the rollback makes correct again. Purging
+        // it would leave a live, unchanged row unsearchable in an index that never
+        // failed. `docs-body` did get the (now discarded) new vector and must go.
+        expect(vectors.deletes).toContainEqual(["docs-body", ["d1"]]);
+        expect(vectors.deletes).not.toContainEqual(["docs-fulltext", ["d1"]]);
+    });
+
     it("runs compensation only after every in-flight upsert has settled (no stale-vector race)", async () => {
         // Regression for the compensating-delete race: when one index's upsert
         // fails, a slow SIBLING upsert must fully settle before compensation

--- a/packages/bindings/src/vectors/context.ts
+++ b/packages/bindings/src/vectors/context.ts
@@ -403,9 +403,11 @@ const pickMetadata = (row: Record<string, unknown>, fields: ReadonlyArray<string
  * Vectorize diverged. We mitigate, not eliminate: upserts/deletes are
  * idempotent (keyed by row id), so a retry of the same write converges; and on
  * a fan-out failure we attempt a best-effort compensating delete of the row's
- * id from every affected index before re-throwing. A delete after a failed
- * upsert can itself fail — this is best-effort, the authoritative recovery is
- * re-running the (idempotent) write.
+ * id before re-throwing — from every index of the table on an insert, and on an
+ * update from the indexes this fan-out actually wrote, since the rollback leaves
+ * the untouched ones holding the prior row's still-correct vector. A delete
+ * after a failed upsert can itself fail — this is best-effort, the authoritative
+ * recovery is re-running the (idempotent) write.
  */
 const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespace?: string; schema: SchemaLike; vectors: VectorSearchLike }): WriteHook => {
     const { allowSharedNamespace, namespace, schema, vectors } = options;
@@ -470,6 +472,11 @@ const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespa
         // the fan-out with the same cap as `upsertMany`: a table with many
         // vector indexes (or a bulk apply reusing this hook) must not spawn an
         // unbounded number of concurrent embedder + Vectorize subrequests.
+        //
+        // Each upsert records its index only once it has RESOLVED, which is what
+        // scopes the compensation below to the indexes this fan-out actually
+        // wrote (see there).
+        const upsertedIndexNames: string[] = [];
         const operations: (() => Promise<void>)[] = [
             ...inlineToClear.map((entry) => async (): Promise<void> => {
                 await vectors.deleteByIds(entry.index.name, [event.id]);
@@ -486,6 +493,8 @@ const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespa
                     metadata: entry.index.metadata ? pickMetadata(row, entry.index.metadata) : undefined,
                     namespace,
                 });
+
+                upsertedIndexNames.push(entry.index.name);
             }),
             ...standaloneIndexes.map(([name, definition]) => async (): Promise<void> => {
                 if (!allowSharedNamespace && namespace === undefined) {
@@ -499,6 +508,8 @@ const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespa
                     metadata: definition.metadata?.(row),
                     namespace,
                 });
+
+                upsertedIndexNames.push(name);
             }),
         ];
 
@@ -506,10 +517,31 @@ const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespa
             await concurrentMap(operations, UPSERT_EMBED_CONCURRENCY, async (operation) => operation());
         } catch (error) {
             // Best-effort compensation: a partial fan-out leaves some indexes
-            // mutated. Purge this row's id from every affected index so the
-            // diverged state is at least empty rather than stale-but-present,
-            // then surface the original failure to the write path.
-            await Promise.allSettled(allIndexNames.map((name) => vectors.deleteByIds(name, [event.id])));
+            // mutated. Purge this row's id from them so the diverged state is at
+            // least empty rather than stale-but-present, then surface the
+            // original failure to the write path.
+            //
+            // WHICH indexes depends on the op, because the throw below rolls the
+            // mutation back (the hook runs inside the mutation's transaction) and
+            // what a rollback restores is not the same in the two cases:
+            //
+            // - insert: the row will not exist, and no vector for this id existed
+            // before the fan-out either, so purging every index on the table is
+            // free of collateral damage and also clears an upsert that landed
+            // remotely before failing on the response.
+            // - update: the row survives UNCHANGED, so an index this fan-out never
+            // wrote still holds the prior row's vector — which the rollback makes
+            // correct again. Deleting that unsearchables a live, unchanged row in
+            // an index that never failed. Only the indexes whose upsert RESOLVED
+            // hold a vector for a row version that is about to vanish.
+            //
+            // The residual case an update cannot resolve: an upsert that applied
+            // remotely and then failed keeps a stale-but-present vector. Live and
+            // slightly wrong beats absent, and re-running the (idempotent) write
+            // converges either way — the recovery this whole hook defers to.
+            const toCompensate = event.op === "insert" ? allIndexNames : upsertedIndexNames;
+
+            await Promise.allSettled(toCompensate.map((name) => vectors.deleteByIds(name, [event.id])));
 
             throw error;
         }


### PR DESCRIPTION
## The defect

`createVectorSyncHook` fans a row write out across every vector index sourced from the table and,
when one call fails, compensates by purging the row's id from `allIndexNames` — **every** index on
the table, not the ones the fan-out actually wrote.

## The rollback interaction, established

The reporter rated this MEDIUM with the rollback read from two call sites rather than run. It
holds. A mutation handler runs inside `ShardRunner.runInTransaction` → `ShardHost.transaction`,
which is `BEGIN` … `COMMIT`, or `ROLLBACK` when the closure throws (`node-shard-host.ts`
`runTransaction`; workerd's `state.storage.transaction` behaves the same). The hook is awaited as
`onWrite` inside `patch`, i.e. inside that closure, so its throw rolls the row back.

Driving the real hook through the real `createShardCtxDb` (`node:sqlite` harness), with two indexes
over one table and only the second index's upsert rejecting, inside the same `BEGIN`/`ROLLBACK` the
host issues:

```
threw: vectorize: docs_summary upsert rejected
upserts that applied: [ 'docs_body' ]
deletes issued by compensation: [ 'docs_body', 'docs_summary' ]     # before
row after rollback: { doc: '{"authorId":"ann",…,"text":"original body",…}' }
```

The row comes back out of the rollback **unchanged**. `docs_summary` was never written, so it still
held the vector for `original body` — exactly the row that survived — and compensation deleted it.
A live, unchanged row went unsearchable in an index that never failed. After the fix the same run
prints `deletes issued by compensation: [ 'docs_body' ]`.

Severity stands as reported. It is not silent-data-loss (re-running the idempotent write restores
the vector, and the write did fail, so an app that retries recovers) but nothing signals it, and an
app that gives up leaves the row unsearchable indefinitely.

## The fix

An **update** purges only the indexes whose upsert resolved. Those hold a vector for a row version
that is about to vanish; the rest hold the prior row's vector, which the rollback makes correct.

An **insert** keeps purging every index: no vector for that id existed beforehand, so the wider
sweep has nothing to destroy, and it still clears an upsert that landed remotely before failing on
the response.

The one case an update cannot resolve is that same landed-then-failed upsert: its index keeps a
stale-but-present vector. Live and slightly wrong beats absent, and re-running the idempotent write
converges either way — the recovery the hook's docblock already defers to.

## Tests

New: `on a failed UPDATE compensates only the indexes the fan-out actually wrote`. Verified by
breaking the code first — with the scope widened back to `allIndexNames` it fails with
`expected [ [ 'docs-body', …] , …(1) ] to not deep equally contain [ 'docs-fulltext', [ 'd1' ] ]`.
The existing insert-path compensation test is unchanged and still passes, which is the point of
splitting the two ops.

## Gates

`build:packages`, `--filter @lunora/bindings test` (292 passed), `--filter @lunora/shard-engine test`
(1453 passed — it composes the hook with the real ctx-db), `lint:types`, `api:check` (54 snapshots
match), prettier, eslint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
