### PR TITLE
fix(vue,svelte,solid,angular): key reactive args on content

### DIFF
--- a/packages/angular/__tests__/live-query.dom.test.ts
+++ b/packages/angular/__tests__/live-query.dom.test.ts
@@ -175,6 +175,40 @@ describe("liveQuery — reactive args (plan 340)", () => {
         expect(data()).toStrictEqual({ messages: ["fresh"] });
     });
 
+    it("does not re-subscribe when the args source re-emits equal content", () => {
+        // A dependency that feeds the args source without changing what it
+        // produces — `Math.min(limit, 10)` clamps 15 and 20 to the same 10.
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const injector = TestBed.inject(Injector);
+        const limit = signal(15);
+
+        const data = liveQuery(
+            listRef,
+            () => {
+                return { channelId: "general", limit: Math.min(limit(), 10) };
+            },
+            { client: fake.asClient, destroyRef: destroy.asDestroyRef, injector },
+        );
+
+        TestBed.tick();
+
+        expect(fake.subscriptions).toHaveLength(1);
+
+        fake.subscriptions[0]?.push({ messages: ["hi"] });
+
+        expect(data()).toStrictEqual({ messages: ["hi"] });
+
+        limit.set(20);
+        TestBed.tick();
+
+        // The produced args are byte-identical, so the live subscription must be
+        // left alone — no teardown, no re-open, and no blanking of the signal.
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+        expect(data()).toStrictEqual({ messages: ["hi"] });
+    });
+
     it("a static args value subscribes exactly once and never resubscribes, even as unrelated signals tick", () => {
         const fake = createFakeClient();
         const destroy = createFakeDestroyRef();

--- a/packages/angular/src/platform.ts
+++ b/packages/angular/src/platform.ts
@@ -1,5 +1,7 @@
 import type { DestroyRef, Injector } from "@angular/core";
-import { effect, inject, NgZone, PLATFORM_ID, untracked } from "@angular/core";
+import { computed, effect, inject, NgZone, PLATFORM_ID, untracked } from "@angular/core";
+
+import { stableWireKey } from "../../../shared/wire-key";
 
 /**
  * Whether a reactive primitive should open its live WebSocket subscription (and
@@ -71,11 +73,21 @@ export const runOutsideAngular = <T>(fromInjectionContext: boolean, register: ()
 
 /**
  * Wire the reactive-args form of a primitive: re-run `open` whenever the tracked
- * `args` thunk produces a new value, tearing the previous generation down first
- * (via the `onCleanup` handed to `open`), and stop the whole effect when the
- * owner is destroyed.
+ * `args` thunk produces args with new CONTENT, tearing the previous generation
+ * down first (via the `onCleanup` handed to `open`), and stop the whole effect
+ * when the owner is destroyed.
  *
- * `args` is read TRACKED — it is the only dependency the effect exists for.
+ * The effect tracks `stableWireKey(args())` rather than the args object: a thunk
+ * such as `() => ({ id: id(), limit: Math.min(limit(), 10) })` builds a fresh
+ * object whenever any signal it reads ticks, and tracking identity would tear the
+ * live subscription down and re-snapshot from the server — blanking the signal —
+ * for args that did not actually change. A `computed` memoises the key, so an
+ * equal-content tick never schedules the effect at all (the dedupe cannot live
+ * inside the effect body: by then Angular has already run the previous
+ * generation's `onCleanup`).
+ *
+ * `args` is read TRACKED through that key — it is the only dependency the effect
+ * exists for.
  * `open` runs UNTRACKED, which is load-bearing rather than an optimisation: a
  * primitive that reads its own signals while building a generation (the
  * paginated engine reads its page list) would otherwise take a dependency on
@@ -100,14 +112,15 @@ export const attachReactiveArgs = <A>(
     open: (resolved: A, onCleanup: (teardown: () => void) => void) => void,
 ): void => {
     let effectRef;
+    const argsKey = computed(() => stableWireKey(args()));
 
     try {
         effectRef = effect(
             (onCleanup) => {
-                const resolved = args();
+                argsKey();
 
                 untracked(() => {
-                    open(resolved, onCleanup);
+                    open(args(), onCleanup);
                 });
             },
             { injector: owner.injector, manualCleanup: true },

--- a/packages/react/__tests__/use-query.test.tsx
+++ b/packages/react/__tests__/use-query.test.tsx
@@ -15,6 +15,11 @@ const makeRef = (ref: string): FunctionReference => {
 
 const DEFAULT_ARGS: Record<string, unknown> = {};
 const SHARED_ARGS: Record<string, unknown> = { a: 1 };
+// Two DISTINCT objects with identical content — what a re-render produces when
+// the args are rebuilt from dependencies that changed without changing the args
+// (`Math.min(15, 10)` and `Math.min(20, 10)` are both 10).
+const EQUAL_ARGS_FIRST: Record<string, unknown> = { a: 1, limit: 10 };
+const EQUAL_ARGS_SECOND: Record<string, unknown> = { a: 1, limit: 10 };
 
 const Display = ({ args = DEFAULT_ARGS }: { args?: Record<string, unknown> | "skip" }): ReactElement => {
     const data = useQuery(makeRef("posts:list"), args);
@@ -122,6 +127,39 @@ describe("useQuery", () => {
 
         expect(mock.query).toHaveBeenCalledTimes(1);
         expect(mock.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-subscribe when a re-render produces an equal-but-new args object", async () => {
+        expect.hasAssertions();
+
+        // The contract every adapter in this repo shares: the live subscription
+        // is keyed on the args' CONTENT, not on object identity. A re-render
+        // that rebuilds the args object without changing what it contains must
+        // not tear the subscription down and re-snapshot from the server.
+        const mock = createMockClient(() => {
+            return { count: 3 };
+        });
+
+        const { rerender } = render(
+            <LunoraProvider client={mock.asClient}>
+                <Display args={EQUAL_ARGS_FIRST} />
+            </LunoraProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 3 }));
+        });
+
+        expect(mock.subscribe).toHaveBeenCalledTimes(1);
+
+        rerender(
+            <LunoraProvider client={mock.asClient}>
+                <Display args={EQUAL_ARGS_SECOND} />
+            </LunoraProvider>,
+        );
+
+        expect(mock.subscribe).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 3 }));
     });
 
     it("surfaces a server-pushed subscription error through onError", async () => {

--- a/packages/solid/__tests__/create-query.test.tsx
+++ b/packages/solid/__tests__/create-query.test.tsx
@@ -82,6 +82,38 @@ describe(createQuery, () => {
         expect(fake.subscriptions[1]?.unsubscribed).toBe(false);
     });
 
+    it("does not re-subscribe when the args accessor re-emits equal content", () => {
+        // A dependency that feeds the args accessor without changing what it
+        // produces — `Math.min(limit, 10)` clamps 15 and 20 to the same 10.
+        const fake = createFakeClient();
+        const [limit, setLimit] = createSignal(15);
+
+        const { container } = render(
+            () => {
+                const data = createQuery(listRef, () => {
+                    return { channelId: "channel:a", limit: Math.min(limit(), 10) };
+                });
+
+                return <pre>{data() === undefined ? "loading" : JSON.stringify(data())}</pre>;
+            },
+            { wrapper: (props) => <LunoraProvider client={fake.asClient}>{props.children}</LunoraProvider> },
+        );
+
+        expect(fake.subscriptions).toHaveLength(1);
+
+        fake.subscriptions[0]?.push(["from-a"]);
+
+        expect(container.textContent).toBe(JSON.stringify(["from-a"]));
+
+        setLimit(20);
+
+        // The produced args are byte-identical, so the live subscription must be
+        // left alone — no teardown, no re-open, and no blanking of the list.
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+        expect(container.textContent).toBe(JSON.stringify(["from-a"]));
+    });
+
     it("forwards onError so a server-pushed subscription error reaches the caller", () => {
         // Regression: `createQuerySubscription` accepts an `onError` sink but
         // `createQuery` never exposed one — an RLS denial or a query that starts

--- a/packages/solid/src/create-paginated-query.ts
+++ b/packages/solid/src/create-paginated-query.ts
@@ -6,6 +6,7 @@ import { createMemo, createSignal } from "solid-js";
 
 import { stableWireKey } from "../../../shared/wire-key";
 import { useLunora } from "./context";
+import { trackedArgsEffect } from "./reactive-args";
 import { trackedEffect } from "./solid-compat";
 
 /** The args a paginated query exposes minus the framework-supplied page cursor. */
@@ -319,8 +320,11 @@ const createPaginatedCore = <T>(
         pendingPageKeys.clear();
     };
 
-    // Re-subscribe whenever the base args (or skip) change.
-    trackedEffect(resolveArgs, (current) => {
+    // Re-subscribe whenever the base args (or skip) change. Keyed on the args'
+    // CONTENT, so an equal-but-new args object — e.g. an accessor recomputed
+    // from an unrelated signal — never tears down and collapses a multi-page
+    // loaded feed back to page one.
+    trackedArgsEffect(resolveArgs, (current) => {
         teardownAll();
         setPages(initialPages(initialNumItems));
         setPageResults([]);

--- a/packages/solid/src/create-query.ts
+++ b/packages/solid/src/create-query.ts
@@ -4,7 +4,7 @@ import type { Accessor } from "solid-js";
 import { createSignal } from "solid-js";
 
 import { useLunora } from "./context";
-import { trackedEffect } from "./solid-compat";
+import { trackedArgsEffect } from "./reactive-args";
 
 export interface CreateQueryOptions {
     /**
@@ -53,14 +53,15 @@ export const createQuery = <F extends FunctionReference>(
 
     const resolveArgs = (): ArgsOf<F> | "skip" => (typeof args === "function" ? (args as Accessor<ArgsOf<F> | "skip">)() : args);
 
-    // `trackedEffect(resolveArgs, …)` re-runs the body whenever the args
-    // accessor changes, tearing down the previous subscription (the returned
+    // `trackedArgsEffect(resolveArgs, …)` re-runs the body whenever the args'
+    // CONTENT changes, tearing down the previous subscription (the returned
     // disposer) before opening the next. A static (non-accessor) `args` resolves
-    // once and never re-runs. The skip-handling, subscribe, and cleanup are
-    // owned by the shared `@lunora/client/query` state machine; this binds it to
-    // a Solid signal. The `() => …` setter forms keep Solid from mistaking a
-    // function-valued server result for an updater.
-    trackedEffect(resolveArgs, (current) => {
+    // once and never re-runs, and an accessor that re-runs but produces equal
+    // args leaves the live subscription alone. The skip-handling, subscribe, and
+    // cleanup are owned by the shared `@lunora/client/query` state machine; this
+    // binds it to a Solid signal. The `() => …` setter forms keep Solid from
+    // mistaking a function-valued server result for an updater.
+    trackedArgsEffect(resolveArgs, (current) => {
         // The previous args' value must not render under the new args until the
         // new subscription's first frame lands.
         setValue(() => undefined as ReturnOf<F> | undefined);

--- a/packages/solid/src/create-subscription.ts
+++ b/packages/solid/src/create-subscription.ts
@@ -5,7 +5,7 @@ import type { Accessor } from "solid-js";
 import { createSignal } from "solid-js";
 
 import { useLunora } from "./context";
-import { trackedEffect } from "./solid-compat";
+import { trackedArgsEffect } from "./reactive-args";
 
 interface CreateSubscriptionResult<T> {
     data: Accessor<T | undefined>;
@@ -33,7 +33,7 @@ const createSubscription = <F extends FunctionReference>(
 
     const resolveArgs = typeof args === "function" ? (args as Accessor<ArgsOf<F> | "skip">) : () => args;
 
-    trackedEffect(resolveArgs, (currentArgs) => {
+    trackedArgsEffect(resolveArgs, (currentArgs) => {
         // Each args generation starts clean: the previous args' value must not
         // render under the new args until the new subscription's first frame.
         setData(() => undefined);

--- a/packages/solid/src/reactive-args.ts
+++ b/packages/solid/src/reactive-args.ts
@@ -1,0 +1,37 @@
+import type { Accessor } from "solid-js";
+import { createMemo } from "solid-js";
+
+import { stableWireKey } from "../../../shared/wire-key";
+import type { Disposer } from "./solid-compat";
+import { trackedEffect } from "./solid-compat";
+
+/**
+ * Bind a maybe-reactive args source to a live subscription, re-opening only when
+ * the args' **content** changes.
+ *
+ * The tracked source is a `createMemo` over `stableWireKey(resolveArgs())`, not
+ * the args object: an accessor such as
+ * `() => ({ id: id(), limit: Math.min(limit(), 10) })` produces a fresh object
+ * every time any dependency ticks, and keying on identity would tear the live
+ * subscription down and re-snapshot from the server — blanking the rendered
+ * value — for args that did not actually change.
+ *
+ * The memo is load-bearing, not a cache: `createEffect` re-runs whenever a
+ * tracked *signal* changes, not when the tracked *expression's value* changes,
+ * so a bare `() => stableWireKey(...)` source would still re-run the body on
+ * every tick. A memo only notifies its observers when the key itself differs.
+ * The dedupe also cannot live inside `apply`: by then the previous generation's
+ * disposer has already run.
+ *
+ * `apply` runs in the (untracked) apply phase, so re-reading `resolveArgs()`
+ * there registers no dependency; it returns the teardown for what it opened,
+ * exactly as {@link trackedEffect} expects. This is Solid's counterpart to
+ * `@lunora/svelte`'s `subscribeReactiveArgs` and `@lunora/angular`'s
+ * `attachReactiveArgs`.
+ */
+// eslint-disable-next-line import/prefer-default-export -- named export so it composes with the other named imports at its call sites; a default would not.
+export const trackedArgsEffect = <T>(resolveArgs: Accessor<T>, apply: (value: T) => Disposer): void => {
+    const argsKey = createMemo(() => stableWireKey(resolveArgs()));
+
+    trackedEffect(argsKey, () => apply(resolveArgs()));
+};

--- a/packages/svelte/__tests__/query.test.ts
+++ b/packages/svelte/__tests__/query.test.ts
@@ -205,6 +205,31 @@ describe("query store with reactive args", () => {
         expect([...live]).toStrictEqual([]);
     });
 
+    it("does not re-subscribe when the args store re-emits equal content", () => {
+        // A store fed by a derivation that clamps its input: two distinct
+        // upstream values produce byte-identical args, so the live subscription
+        // must survive untouched instead of tearing down and re-snapshotting.
+        const { client, emit, subscribe, unsubscribe } = createFakeClient();
+        const argsStore = writable<unknown>({ limit: 10, room: "general" });
+        const store = query(client, fnRef, argsStore);
+
+        const stop = store.subscribe(() => {});
+
+        expect(subscribe).toHaveBeenCalledTimes(1);
+
+        emit([{ id: 1 }]);
+
+        expect(get(store)).toStrictEqual([{ id: 1 }]);
+
+        argsStore.set({ limit: 10, room: "general" });
+
+        expect(unsubscribe).not.toHaveBeenCalled();
+        expect(subscribe).toHaveBeenCalledTimes(1);
+        expect(get(store)).toStrictEqual([{ id: 1 }]);
+
+        stop();
+    });
+
     it("tears down without re-opening and resets to undefined on a 'skip' emission", () => {
         const { client, emit, subscribe, unsubscribe } = createFakeClient();
         const argsStore = writable<unknown>({ room: "general" });

--- a/packages/svelte/src/subscribe-reactive-args.ts
+++ b/packages/svelte/src/subscribe-reactive-args.ts
@@ -1,5 +1,6 @@
 import type { Readable, Unsubscriber } from "svelte/store";
 
+import { stableWireKey } from "../../../shared/wire-key";
 import { isReadableStore } from "./is-readable-store";
 
 /**
@@ -8,11 +9,17 @@ import { isReadableStore } from "./is-readable-store";
  * `paginatedQuery`) all depend on.
  *
  * A static value opens exactly once. A `Readable` source opens on every
- * emission, tearing the previous subscription down **before** opening the
- * next — so an emission that resolves to nothing (the `"skip"` sentinel, whose
- * `open` returns a no-op teardown) cannot leak the subscription it replaced.
- * The returned stop function detaches the args source and tears down whatever
- * is currently open.
+ * emission whose args **content** differs from the open one, tearing the
+ * previous subscription down **before** opening the next — so an emission that
+ * resolves to nothing (the `"skip"` sentinel, whose `open` returns a no-op
+ * teardown) cannot leak the subscription it replaced. The returned stop
+ * function detaches the args source and tears down whatever is currently open.
+ *
+ * Emissions are compared by `stableWireKey`, not object identity: a store
+ * derived from several inputs (`derived([a, b], … => ({ id, limit: Math.min(b, 10) }))`)
+ * re-emits a fresh object whenever any input ticks, and re-opening on that
+ * would blank the rendered value and re-snapshot from the server for args that
+ * did not actually change. An equal-content emission is a no-op.
  *
  * `open` returns the teardown for the subscription it opened; anything a fresh
  * emission must reset (a stale error, pagination state) belongs in that
@@ -35,6 +42,10 @@ export const subscribeReactiveArgs = <T>(args: T | Readable<T>, open: (value: T)
     let opening = false;
     // A one-slot queue, not a value: `T` itself may legitimately be undefined.
     let queued: [T] | undefined;
+    // Content key of the currently-open args; `undefined` until the first open,
+    // and `stableWireKey` never returns `undefined`, so the first emission
+    // always opens.
+    let openKey: string | undefined;
 
     const unsubscribeArgs = args.subscribe((resolved) => {
         if (opening) {
@@ -53,8 +64,14 @@ export const subscribeReactiveArgs = <T>(args: T | Readable<T>, open: (value: T)
             let next: [T] | undefined = [resolved];
 
             while (next) {
-                teardown();
-                teardown = open(next[0]);
+                const nextKey = stableWireKey(next[0]);
+
+                if (nextKey !== openKey) {
+                    openKey = nextKey;
+                    teardown();
+                    teardown = open(next[0]);
+                }
+
                 next = queued;
                 queued = undefined;
             }

--- a/packages/vue/__tests__/use-query.test.ts
+++ b/packages/vue/__tests__/use-query.test.ts
@@ -1,0 +1,81 @@
+import type { FunctionReference } from "@lunora/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { effectScope, nextTick, ref } from "vue";
+
+import { useQuery } from "../src/use-query";
+import { createFakeClient } from "./fake-client";
+
+const listRef = { __lunoraRef: "messages:list" } as unknown as FunctionReference;
+
+describe(useQuery, () => {
+    // `useQuery` gates its live subscription on a browser `window` (SSR guard);
+    // the vitest env is `node`, so define one for these client-path tests.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
+    it("does not re-subscribe when a reactive args source re-emits equal content", async () => {
+        const fake = createFakeClient();
+        // A dependency that feeds the args getter without changing what it
+        // produces — `Math.min(limit, 10)` clamps 15 and 20 to the same 10.
+        const limit = ref(15);
+
+        const scope = effectScope();
+        const data = scope.run(() =>
+            fake.provide(() =>
+                useQuery(listRef, () => {
+                    return { channelId: "c1", limit: Math.min(limit.value, 10) };
+                }),
+            ),
+        )!;
+
+        expect(fake.subscribeCalls).toHaveLength(1);
+
+        fake.push("messages:list", { channelId: "c1", limit: 10 }, ["a"]);
+
+        expect(data.value).toStrictEqual(["a"]);
+
+        limit.value = 20;
+        await nextTick();
+
+        // The produced args are byte-identical, so the live subscription must be
+        // left alone — no teardown, no re-open, and no blanking of the list.
+        expect(fake.unsubscribeSpy).not.toHaveBeenCalled();
+        expect(fake.subscribeCalls).toHaveLength(1);
+        expect(data.value).toStrictEqual(["a"]);
+
+        scope.stop();
+    });
+
+    it("re-subscribes when the reactive args content actually changes", async () => {
+        const fake = createFakeClient();
+        const channelId = ref("c1");
+
+        const scope = effectScope();
+        const data = scope.run(() =>
+            fake.provide(() =>
+                useQuery(listRef, () => {
+                    return { channelId: channelId.value };
+                }),
+            ),
+        )!;
+
+        fake.push("messages:list", { channelId: "c1" }, ["a"]);
+
+        expect(data.value).toStrictEqual(["a"]);
+
+        channelId.value = "c2";
+        await nextTick();
+
+        expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(fake.subscribeCalls).toHaveLength(2);
+        expect(fake.subscribeCalls[1]?.args).toStrictEqual({ channelId: "c2" });
+        expect(data.value).toBeUndefined();
+
+        scope.stop();
+    });
+});

--- a/packages/vue/src/use-query.ts
+++ b/packages/vue/src/use-query.ts
@@ -4,6 +4,7 @@ import type { MaybeRefOrGetter, Ref } from "vue";
 import { shallowRef, toValue, watch } from "vue";
 
 import { isBrowser } from "../../../shared/is-browser";
+import { stableWireKey } from "../../../shared/wire-key";
 import { useLunora } from "./lunora-provider";
 import onScopeDisposeOrWarn from "./scope-dispose";
 import type { UseQueryOptions } from "./types";
@@ -95,9 +96,16 @@ export const useQuery = <F extends FunctionReference>(
     // `args` resolves once and the watcher never re-fires. The skip-handling,
     // subscribe, and cleanup are owned by the shared `@lunora/client/query` state
     // machine; this composable only binds it to a Vue `ref`.
+    //
+    // Key the watch on the args' CONTENT (`stableWireKey`), not on object
+    // identity: a getter such as `() => ({ id: props.id, limit: Math.min(n, 10) })`
+    // re-runs whenever any dependency ticks, and would otherwise tear the live
+    // subscription down and re-snapshot from the server — blanking the rendered
+    // value — for args that did not actually change. The live args are re-read
+    // inside the callback (matching `use-paginated-core`).
     watch(
-        () => toValue(args),
-        (current, _previous, onCleanup) => {
+        () => stableWireKey(toValue(args)),
+        (_key, _previousKey, onCleanup) => {
             // Client-only: an `immediate: true` watcher fires once during
             // `renderToString` with no unmount to run `onCleanup` (see
             // `use-presence.ts`'s guard rationale) — skip the subscription
@@ -113,7 +121,7 @@ export const useQuery = <F extends FunctionReference>(
             const unsubscribe = createQuerySubscription(
                 client,
                 function_,
-                current,
+                toValue(args),
                 {
                     onData: (value) => {
                         data.value = value;

--- a/packages/vue/src/use-subscription.ts
+++ b/packages/vue/src/use-subscription.ts
@@ -5,6 +5,7 @@ import type { MaybeRefOrGetter, Ref } from "vue";
 import { onScopeDispose, ref, toValue, watch } from "vue";
 
 import { isBrowser } from "../../../shared/is-browser";
+import { stableWireKey } from "../../../shared/wire-key";
 import { useLunora } from "./lunora-provider";
 import type { UseQueryOptions } from "./types";
 
@@ -32,9 +33,14 @@ const useSubscription = <F extends FunctionReference>(
     const data = ref<ReturnOf<F> | undefined>(undefined) as Ref<ReturnOf<F> | undefined>;
     const error = ref<Error | undefined>(undefined);
 
+    // Keyed on the args' CONTENT (`stableWireKey`), not object identity — a
+    // getter that re-runs and produces equal args must not tear the live
+    // subscription down and re-snapshot. See `use-query`.
     watch(
-        () => toValue(args),
-        (currentArgs, _previous, onCleanup) => {
+        () => stableWireKey(toValue(args)),
+        (_key, _previousKey, onCleanup) => {
+            const currentArgs = toValue(args);
+
             // Each args generation starts clean: the previous args' value must not
             // render under the new args until the new subscription's first frame.
             data.value = undefined;


### PR DESCRIPTION
## The defect

Vue, Svelte, Solid and Angular re-opened a live subscription on **every** emission
of a reactive args source, comparing object identity rather than what the args
contained.

A getter built from several dependencies —

```ts
useQuery(api.list, () => ({ id: props.id, limit: Math.min(props.limit, 10) }))
```

— produces a fresh object whenever any of them ticks. `props.limit` going 15 → 20
leaves the produced args byte-identical, but the adapter still tore the
subscription down, blanked the rendered value and re-snapshotted from the server.
`@lunora/react` was already immune: its effect keys on a serialized content hash.

Executed before the fix, all four reproduced (subscribe called twice, the old
subscription torn down, the value back to `undefined`).

## The fix

Each adapter now tracks `stableWireKey(args)` **at the source** of its reactive
binding, so an unchanged key means the effect never runs. The comparison cannot
live inside the effect body — by then the previous generation's teardown has
already fired.

| adapter | where |
| --- | --- |
| vue | `useQuery` / `useSubscription` watch the key — the shape `use-paginated-core` already used for this same defect |
| svelte | `subscribeReactiveArgs` skips an equal-content emission, covering `query`, `subscription` and `paginatedQuery` in one place |
| solid | new `trackedArgsEffect` memoises the key ahead of the effect (`createEffect` re-runs per tracked *signal*, not per changed *value*, so a bare key accessor deduped nothing) |
| angular | `attachReactiveArgs` tracks a `computed` over the key, covering `liveQuery`, `subscription` and `paginatedQuery` |

## Tests

Each test asserts the subscription was **not re-opened** — not merely that data
survived — and each was run against the unfixed code first and failed there. The
React suite gains the same assertion so the shared contract is pinned rather than
implied; sabotaging React's effect dep to the raw `queryKey` makes it fail, so it
cannot pass for the wrong reason.

## Gates

`build:packages`, the five adapters' suites (761 tests), `lint:types --no-cache`,
`api:check` (54 snapshots match), prettier, eslint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
