### PR TITLE
fix(ci): read the worker-size measurement from the json envelope

### DIFF
--- a/packages/cli/__tests__/commands/build.test.ts
+++ b/packages/cli/__tests__/commands/build.test.ts
@@ -6,12 +6,15 @@ import { gzipSync } from "node:zlib";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BuildCommandResult } from "../../src/commands/build/handler";
-import { runBuildCommand } from "../../src/commands/build/handler";
+import type { BuildCommandData, BuildCommandResult } from "../../src/commands/build/handler";
+import { execute, runBuildCommand } from "../../src/commands/build/handler";
+import type { BuildOptions } from "../../src/commands/build/index";
 import { EXIT_CODE } from "../../src/util/exit-code";
 import type { Logger } from "../../src/util/logger";
+import { setCommandLogger } from "../../src/util/logger";
 import type { Spawner } from "../../src/util/spawn";
 import { createRecordingSpawner } from "../../src/util/spawn";
+import { runExecute } from "../helpers/execute";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureRoot = join(here, "..", "..", "..", "codegen", "__tests__", "fixtures", "simple");
@@ -68,6 +71,15 @@ const bundlingSpawner =
 
         return { code: 0, descriptor, stderr: "", stdout: "" };
     };
+
+// `execute` builds its own spawner, so the document test below would otherwise
+// shell out to a real wrangler. Stubbing the default makes that leg write the
+// same out-dir `bundlingSpawner` does.
+vi.mock(import("../../src/util/spawn"), async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return { ...actual, defaultSpawner: async (descriptor) => bundlingSpawner("dist-worker")(descriptor) };
+});
 
 describe("lunora build", () => {
     beforeEach(() => {
@@ -208,6 +220,34 @@ describe("lunora build", () => {
         // the wrangler leg cannot splice its own output into it.
         expect(written).toHaveLength(0);
         expect(result.bundle?.gzipBytes).toBeGreaterThan(0);
+    });
+
+    /**
+     * Through `execute`, because the envelope is `defineHandler`'s: the command
+     * body writes nothing, so nothing below this line is covered by asserting on
+     * `runBuildCommand`'s in-process result — which is how the measurement could
+     * move under `data` while `scripts/check-worker-size.js`, the one consumer,
+     * still read it off the top level and saw "no bundle" on every healthy build.
+     */
+    it("carries the bundle measurement in the --format json envelope's data", async () => {
+        expect.assertions(4);
+
+        setCommandLogger({ error: () => {}, info: () => {}, success: () => {}, warn: () => {} });
+
+        try {
+            const { code, document } = await runExecute<BuildOptions, BuildCommandData>(execute, {
+                commandName: "build",
+                cwd: workdir,
+                options: { format: "json", outDir: "dist-worker" },
+            });
+
+            expect(code).toBe(0);
+            expect(document?.code).toBe(0);
+            expect(document?.data?.bundle?.files).toBe(1);
+            expect(document?.data?.bundle?.gzipBytes).toBe(gzipSync(Buffer.from(SCRIPT)).byteLength);
+        } finally {
+            setCommandLogger(undefined);
+        }
     });
 
     it("says so rather than reporting zero when there is nothing to weigh", async () => {

--- a/scripts/check-worker-size.js
+++ b/scripts/check-worker-size.js
@@ -124,15 +124,17 @@ const measure = (appDirectory) => {
         fail("check-worker-size: `lunora build` failed on the reference template (its output is above).");
     }
 
-    const result = JSON.parse(stdout);
+    // `--format json` puts every command's payload under `data` in the shared
+    // `{ code, data, error }` envelope, so the measurement is `data.bundle`.
+    const { bundle } = JSON.parse(stdout).data ?? {};
 
     // A measurement of zero must never pass as a healthy result: that is exactly
     // what a changed wrangler out-dir layout would look like.
-    if (!result.bundle || result.bundle.files < 1 || result.bundle.gzipBytes < 1) {
+    if (!bundle || bundle.files < 1 || bundle.gzipBytes < 1) {
         fail("check-worker-size: `lunora build` reported no bundle — the wrangler out-dir layout may have changed.");
     }
 
-    return result.bundle;
+    return bundle;
 };
 
 const baseline = JSON.parse(readFileSync(fixturePath, "utf8"));


### PR DESCRIPTION
## Symptom

The **Worker size budget** job fails on `alpha` (and **Check Test Run** with it, as its aggregate) on a build that succeeds:

```
ok    build complete — bundle written to out
info  bundle: 1150.5 KiB raw, 283.2 KiB gzipped across 1 file(s) — …
check-worker-size: `lunora build` reported no bundle — the wrangler out-dir layout may have changed.
```

Not a size violation, not a broken build, not environmental — reproduced locally after `pnpm run build:packages:prod`.

## The stdout `lunora build --format json` actually produces

Captured by instrumenting `measure()` to dump `stdout` before parsing:

```json
{
  "code": 0,
  "data": {
    "bundle": {
      "files": 1,
      "gzipBytes": 290045,
      "rawBytes": 1178155
    },
    "deployment": {
      "deployedAt": "2026-09-12T07:50:58.130Z",
      "dryRun": true,
      "preview": false,
      "workerName": "lunora-worker-size-reference"
    },
    "outDir": "out",
    "validation": {
      "problems": [],
      "report": { "errors": [], "valid": true, "warnings": [] },
      "wranglerPath": "/…/app/wrangler.jsonc"
    }
  }
}
```

The measurement is there and correct. It is just no longer at the top level.

## Root cause

`c03e7238` (#694) made `--format json` a single envelope for every command — `{ code, data, error }`, serialized once by `defineHandler`, with each command's payload under `data`. `packages/cli/docs/index.mdx` documents it (`… | jq '.data.findings[]'`), and the wave added `runExecute` document tests for `codegen`, `containers`, `add` and others.

`build`'s payload moved with it: `bundle` went from the document root to `data.bundle`. `scripts/check-worker-size.js` reads `JSON.parse(stdout).bundle`, got `undefined`, and its deliberate fail-closed guard fired — correctly, on a measurement it could no longer find.

The timing matches: the envelope landed at 06:59 UTC, every failing run is from 07:09 UTC onward, and the runs before it pass. It is not any one PR's content; it is every PR that ran after that commit was on `alpha`.

## Which side is fixed, and why

**The gate.** The envelope is not a regression — it is a deliberate, documented, repo-wide contract (23 commands, one shape, so a consumer parses one document and never has to know which command produced it). `bundle` was not dropped or renamed away; it was relocated into the payload slot every other command's data now occupies. The stale reader is the gate.

The assertion itself is untouched: zero files or zero gzipped bytes still fails closed, and the message still names the out-dir layout, because that is still what a silent zero would mean.

Nothing else consumes `lunora build --format json` — `scripts/check-worker-size.js` is the only caller in the repo (docs, CI workflows and scripts all checked). No other consumer would have broken the same way.

## Why it was not caught

`packages/cli/__tests__/commands/build.test.ts` had a `--format json` case, but it asserted on `runBuildCommand`'s **in-process** result — which still carries `bundle` at the top level and still does — and on stdout being empty (the body writes nothing; `defineHandler` does). So the one shape the gate depends on was never asserted anywhere.

This PR adds that assertion, driving `execute` through the `runExecute` helper the same wave introduced:

```
expect(document?.data?.bundle?.files).toBe(1);
expect(document?.data?.bundle?.gzipBytes).toBe(gzipSync(Buffer.from(SCRIPT)).byteLength);
```

**Verified by breaking the code first** — dropping `bundle` from the handler's `data`:

```
 FAIL  __tests__/commands/build.test.ts > lunora build > carries the bundle measurement in the --format json envelope's data
AssertionError: expected undefined to be 1 // Object.is equality
- Expected: 1
+ Received: undefined
 ❯ __tests__/commands/build.test.ts:246:51
      Tests  1 failed | 8 passed (9)
```

## Gates

| Gate | Result |
| --- | --- |
| `pnpm run build:packages:prod` | pass — 54 tasks |
| `pnpm --filter "@lunora/cli" run test` | pass — 108 files, 1583 tests |
| `pnpm --filter "@lunora/cli" run lint:types` | pass |
| `pnpm run api:check` | pass — 54 snapshots match |
| `node scripts/check-worker-size.js` | **pass** — `worker size (standalone): 1150.5 KiB raw, 283.2 KiB gzipped — baseline 412.9 KiB, ceiling 462.9 KiB`, exit 0 |
| prettier (before eslint) | pass — both files unchanged |
| `pnpm --filter "@lunora/cli" run lint:eslint` | pass — 0 errors, 0 warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle size measurement by correctly reading results from the command-line response format.
  * Preserved existing validation and return behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->