### PR TITLE
ci: re-take the stale worker size baseline

### DIFF
--- a/packages/cli/__tests__/commands/build.test.ts
+++ b/packages/cli/__tests__/commands/build.test.ts
@@ -6,12 +6,15 @@ import { gzipSync } from "node:zlib";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BuildCommandResult } from "../../src/commands/build/handler";
-import { runBuildCommand } from "../../src/commands/build/handler";
+import type { BuildCommandData, BuildCommandResult } from "../../src/commands/build/handler";
+import { execute, runBuildCommand } from "../../src/commands/build/handler";
+import type { BuildOptions } from "../../src/commands/build/index";
 import { EXIT_CODE } from "../../src/util/exit-code";
 import type { Logger } from "../../src/util/logger";
+import { setCommandLogger } from "../../src/util/logger";
 import type { Spawner } from "../../src/util/spawn";
 import { createRecordingSpawner } from "../../src/util/spawn";
+import { runExecute } from "../helpers/execute";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureRoot = join(here, "..", "..", "..", "codegen", "__tests__", "fixtures", "simple");
@@ -68,6 +71,15 @@ const bundlingSpawner =
 
         return { code: 0, descriptor, stderr: "", stdout: "" };
     };
+
+// `execute` builds its own spawner, so the document test below would otherwise
+// shell out to a real wrangler. Stubbing the default makes that leg write the
+// same out-dir `bundlingSpawner` does.
+vi.mock(import("../../src/util/spawn"), async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return { ...actual, defaultSpawner: async (descriptor) => bundlingSpawner("dist-worker")(descriptor) };
+});
 
 describe("lunora build", () => {
     beforeEach(() => {
@@ -208,6 +220,34 @@ describe("lunora build", () => {
         // the wrangler leg cannot splice its own output into it.
         expect(written).toHaveLength(0);
         expect(result.bundle?.gzipBytes).toBeGreaterThan(0);
+    });
+
+    /**
+     * Through `execute`, because the envelope is `defineHandler`'s: the command
+     * body writes nothing, so nothing below this line is covered by asserting on
+     * `runBuildCommand`'s in-process result — which is how the measurement could
+     * move under `data` while `scripts/check-worker-size.js`, the one consumer,
+     * still read it off the top level and saw "no bundle" on every healthy build.
+     */
+    it("carries the bundle measurement in the --format json envelope's data", async () => {
+        expect.assertions(4);
+
+        setCommandLogger({ error: () => {}, info: () => {}, success: () => {}, warn: () => {} });
+
+        try {
+            const { code, document } = await runExecute<BuildOptions, BuildCommandData>(execute, {
+                commandName: "build",
+                cwd: workdir,
+                options: { format: "json", outDir: "dist-worker" },
+            });
+
+            expect(code).toBe(0);
+            expect(document?.code).toBe(0);
+            expect(document?.data?.bundle?.files).toBe(1);
+            expect(document?.data?.bundle?.gzipBytes).toBe(gzipSync(Buffer.from(SCRIPT)).byteLength);
+        } finally {
+            setCommandLogger(undefined);
+        }
     });
 
     it("says so rather than reporting zero when there is nothing to weigh", async () => {

--- a/scripts/check-worker-size.js
+++ b/scripts/check-worker-size.js
@@ -124,15 +124,17 @@ const measure = (appDirectory) => {
         fail("check-worker-size: `lunora build` failed on the reference template (its output is above).");
     }
 
-    const result = JSON.parse(stdout);
+    // `--format json` puts every command's payload under `data` in the shared
+    // `{ code, data, error }` envelope, so the measurement is `data.bundle`.
+    const { bundle } = JSON.parse(stdout).data ?? {};
 
     // A measurement of zero must never pass as a healthy result: that is exactly
     // what a changed wrangler out-dir layout would look like.
-    if (!result.bundle || result.bundle.files < 1 || result.bundle.gzipBytes < 1) {
+    if (!bundle || bundle.files < 1 || bundle.gzipBytes < 1) {
         fail("check-worker-size: `lunora build` reported no bundle — the wrangler out-dir layout may have changed.");
     }
 
-    return result.bundle;
+    return bundle;
 };
 
 const baseline = JSON.parse(readFileSync(fixturePath, "utf8"));

--- a/worker-size.json
+++ b/worker-size.json
@@ -1,7 +1,7 @@
 {
     "$comment": "Committed size baseline for the Worker a `templates/standalone` app deploys, measured by scripts/check-worker-size.js against a production build. Cloudflare's Worker script limit is 3 MB gzipped on the Free plan and 10 MB on Paid, so this is a framework-weight regression signal, not a proximity alarm. `pnpm run worker-size:update` re-baselines an intentional increase.",
     "template": "standalone",
-    "gzipBytes": 422840,
-    "rawBytes": 1725313,
+    "gzipBytes": 290039,
+    "rawBytes": 1178155,
     "allowanceBytes": 51200
 }


### PR DESCRIPTION
**Stacked on #724 (`fix/r37-worker-size-json`), not `alpha`.** That branch repairs the gate's
reader — on `alpha` the gate cannot produce a measurement at all, so there is nothing to
re-baseline against. Merge #724 first; this then retargets to `alpha` cleanly.

## The problem

The reference Worker shrank by ~130 KiB at some point and the baseline was never re-taken:

```
worker size (standalone): 1150.5 KiB raw, 283.2 KiB gzipped — baseline 412.9 KiB, ceiling 462.9 KiB
```

The ceiling sat ~180 KiB above the real measurement, so the gate would have waved through a
regression that nearly **doubles** the bundle before going red. It ran, reported green, and was
not holding the line it exists to hold — the same failure shape as a test that cannot fail.

## Before / after

Measured locally after `pnpm run build:packages:prod`, then re-taken with
`pnpm run worker-size:update`:

| | before | after |
|---|---|---|
| `gzipBytes` | 422840 (412.9 KiB) | **290039 (283.2 KiB)** |
| `rawBytes` | 1725313 (1685.0 KiB) | **1178155 (1150.5 KiB)** |
| `allowanceBytes` | 51200 (50.0 KiB) | 51200 (50.0 KiB) — unchanged |
| ceiling | 462.9 KiB | **333.2 KiB** |

## Which headroom rule, and how I determined it

**Absolute (50 KiB), not proportional.** Two things in `scripts/check-worker-size.js` settle it:

1. The ceiling is a sum, not a ratio — `const ceiling = baseline.gzipBytes + baseline.allowanceBytes;`.
2. The script's own `--update` path spreads the existing fixture and overwrites only the two
   measurements — `{ ...baseline, gzipBytes: bundle.gzipBytes, rawBytes: bundle.rawBytes }`. The
   maintainer-authored re-baseline therefore carries `allowanceBytes` across untouched by design.
   This PR is exactly that command's output.

The old pair happens to work out at ~12% of its baseline, but nothing in the code derives it that
way. Preserving the proportion instead would have set a 33.2 KiB allowance, and at this scale the
difference is large enough that guessing would be a silent policy change.

## Proof the re-baselined gate still fails

Temporarily imported ~90 KiB of incompressible base64 ballast into `templates/standalone/src`
(reverted; not in this diff) and re-ran the gate:

```
worker size (standalone): 1270.6 KiB raw, 374.4 KiB gzipped — baseline 283.2 KiB, ceiling 333.2 KiB
The reference Worker (templates/standalone) grew past its ceiling.
  now:      374.4 KiB gzipped (1270.6 KiB raw)
  baseline: 283.2 KiB gzipped, + 50.0 KiB allowance = 333.2 KiB
  delta:    +91.1 KiB against the baseline
Every Lunora app carries this. Find what arrived (`lunora analyze` prints the heaviest modules),
and if the growth is intended, accept it with `pnpm run worker-size:update` so the increase is
visible in review rather than buried.
```

Exit code 1, message names the delta and the fix. That same +91 KiB regression measures **green**
under the old baseline (374.4 < 462.9) — which is the slack this PR removes. Template restored and
the gate re-run clean afterwards.

## Gates

| gate | result |
|---|---|
| `pnpm run build:packages:prod` | pass (54 projects) |
| `pnpm run worker-size:check` | pass — 283.2 KiB gzipped vs 333.2 KiB ceiling |
| `pnpm run lint:types` | pass (54 projects) |
| `npx prettier --check worker-size.json` | pass |
| `pnpm run lint:eslint` | pass (58 projects) |
| `pnpm run lint:package-json` | pass — unaffected, all 89 sorted |
| fixture parses as JSON | pass |
| `pnpm run lint:batch-cap` | pass |

## Other budget fixtures

Checked the cheap ones; nothing else has drifted the same way.

- `check-batch-cap-drift.js` — **not a baseline.** It reconciles two live constants against their
  hand-written mirrors in the 8 non-JS SDKs and `protocol/README.md`; there is no committed
  measurement that can go stale, only agreement that can break. Green: both caps agree across 10
  mirrors each.
- `worker-size.json` is the **only** committed measured baseline in the repo. Root-level JSON is
  otherwise just `package.json`, `skills-lock.json` and the two tsconfigs, and no
  `size-limit`/`bundlesize`-style budget config exists anywhere in the tree.
- CodSpeed keeps its baselines service-side — there is no local file to drift, and it is out of
  scope here as noted.

## One recommendation, not applied

A fixed 50 KiB allowance was ~12% of the old baseline and is ~18% of the new one, so this faithful
re-take also loosens the gate in relative terms. If the intent was ever "about 10% of headroom",
`allowanceBytes` wants to come down to ~30000 in a follow-up. That is a maintainer's call about how
much room the project wants, not something to change silently while re-taking a measurement, so this
PR restores the relationship the existing numbers encode and leaves the number alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
