### PR TITLE
fix(notify): key the push circuit per transport

### DIFF
--- a/packages/notify/__tests__/notify.test.ts
+++ b/packages/notify/__tests__/notify.test.ts
@@ -1285,3 +1285,120 @@ describe("mixed-kind push routing under the resilience middleware", () => {
         expect(fcm.sends).toHaveLength(4);
     });
 });
+
+describe("push circuit-breaker scope", () => {
+    // The router is ONE provider to the engine, so every push send — web-push,
+    // FCM, or mixed — arrives at the breaker under the same provider id. These
+    // drive the real facade, router and `attachResilience` because the breaker's
+    // key is only observable through all three.
+    const origins = { allowedPushOrigins: ["https://push.example"] };
+    const sub = (path: string) => JSON.stringify({ endpoint: `https://push.example/${path}`, keys: { auth: "a", p256dh: "p" } });
+
+    /** `CIRCUIT_THRESHOLD` in `providers.ts` — consecutive failures that open a circuit. */
+    const THRESHOLD = 5;
+
+    const harness = () => {
+        const webPush = mockPushProvider();
+        const fcm = mockPushProvider();
+        const engine = mockEngine({ push: routingPushProvider({ ...origins, fcm: fcm.provider, webPush: webPush.provider }) });
+        const { notify } = createNotify(baseDefinition(memorySubscriptionStore()), {}, { engine, silent: true });
+
+        return { fcm, notify, webPush };
+    };
+
+    it("keeps sending to web-push after enough partials have opened FCM's circuit", async () => {
+        expect.hasAssertions();
+
+        const { notify, webPush } = harness();
+
+        // Each mixed send delivers to web-push and 503s on FCM — a partial, which
+        // the sibling fix refuses to retry, so this is exactly THRESHOLD
+        // consecutive failures and no more.
+        for (let attempt = 0; attempt < THRESHOLD; attempt += 1) {
+            // eslint-disable-next-line no-await-in-loop -- the breaker counts CONSECUTIVE failures; concurrent sends would not be
+            await notify.send({ push: { body: "b", to: [sub("ok"), "fail-token"] } });
+        }
+
+        const delivered = webPush.sends.length;
+        const [receipt] = await notify.send({ push: { body: "b", to: sub("ok") } });
+
+        // FCM is down; web-push has accepted every single send. Shedding it here
+        // stops healthy browsers receiving anything at all.
+        expect(receipt?.successful).toBe(true);
+        expect(webPush.sends).toHaveLength(delivered + 1);
+    });
+
+    it("charges a partial to FCM exactly once — the circuit opens on the THRESHOLD'th partial, not before", async () => {
+        expect.hasAssertions();
+
+        /** Drive `partials` mixed sends, then report whether an FCM-only send still reaches the provider. */
+        const fcmStillReachedAfter = async (partials: number): Promise<boolean> => {
+            const { fcm, notify } = harness();
+
+            for (let attempt = 0; attempt < partials; attempt += 1) {
+                // eslint-disable-next-line no-await-in-loop -- the breaker counts CONSECUTIVE failures; concurrent sends would not be
+                await notify.send({ push: { body: "b", to: [sub("ok"), "fail-token"] } });
+            }
+
+            const attempted = fcm.sends.length;
+
+            await notify.send({ push: { body: "b", to: "fail-token" } });
+
+            return fcm.sends.length > attempted;
+        };
+
+        // The boundary pins the count from both sides: charging a partial to no
+        // transport would never open FCM's circuit, and charging it twice would
+        // have opened it on the third partial.
+        await expect(fcmStillReachedAfter(THRESHOLD - 1)).resolves.toBe(true);
+        await expect(fcmStillReachedAfter(THRESHOLD)).resolves.toBe(false);
+    });
+
+    /** Two FCM-only sends: each is retried, so the breaker sees four failures per send. */
+    const openFcmCircuit = async (notify: { send: (message: { push: { body: string; to: string } }) => Promise<unknown> }) => {
+        for (const attempt of [1, 2]) {
+            // eslint-disable-next-line no-await-in-loop -- the breaker counts CONSECUTIVE failures; concurrent sends would not be
+            await notify.send({ push: { body: `b${attempt.toString()}`, to: "fail-token" } });
+        }
+    };
+
+    it("still sheds FCM once FCM is the transport that is down", async () => {
+        expect.hasAssertions();
+
+        const { fcm, notify, webPush } = harness();
+
+        await openFcmCircuit(notify);
+
+        const attempted = fcm.sends.length;
+        const [shed] = await notify.send({ push: { body: "b", to: "fail-token" } });
+        const [browser] = await notify.send({ push: { body: "b", to: sub("ok") } });
+
+        // Shedding is the breaker's job and it still does it: the FCM leg never
+        // reaches the provider again. The browser leg was never measured against
+        // FCM's circuit and still delivers.
+        expect(shed?.successful).toBe(false);
+        expect(fcm.sends).toHaveLength(attempted);
+        expect(browser?.successful).toBe(true);
+        expect(webPush.sends).toHaveLength(1);
+    });
+
+    it("delivers a mixed send's web-push leg while FCM's circuit is open", async () => {
+        expect.hasAssertions();
+
+        const { notify, webPush } = harness();
+
+        await openFcmCircuit(notify);
+
+        const [receipt] = await notify.send({ push: { body: "b", to: [sub("ok"), "fail-token"] } });
+
+        // A send with one healthy transport is never shed — it has a delivery to
+        // make. The open transport's leg is still attempted and still fails, so
+        // the fold reports a partial rather than a total failure.
+        expect(webPush.sends).toHaveLength(1);
+        expect(receipt?.successful).toBe(false);
+
+        const errors = receipt?.successful === false ? receipt.errorMessages.join(" ") : "";
+
+        expect(errors).toContain("partially delivered");
+    });
+});

--- a/packages/notify/src/providers.ts
+++ b/packages/notify/src/providers.ts
@@ -1,5 +1,5 @@
 import { isLunoraError, LunoraError } from "@lunora/errors";
-import type { Middleware, Notification, NotificationProviders, NotificationResult, Provider, PushPayload, Result } from "@visulima/notification";
+import type { Middleware, Notification, NotificationProviders, NotificationResult, Provider, PushPayload, Result, SendContext } from "@visulima/notification";
 import { createNotification } from "@visulima/notification";
 import { retryMiddleware } from "@visulima/notification/middleware";
 import type { FcmConfig } from "@visulima/notification/providers/fcm";
@@ -42,6 +42,22 @@ const webPushEndpoint = (target: unknown): string | undefined => {
 
     return typeof endpoint === "string" ? endpoint : undefined;
 };
+
+/**
+ * Which transport a routed push target belongs to. The endpoint IS the decision —
+ * the same one {@link routingPushProvider} partitions `to` on.
+ */
+type PushTransport = "fcm" | "web-push";
+
+/** @see PushTransport */
+const pushTransportOf = (target: unknown): PushTransport => (webPushEndpoint(target) === undefined ? "fcm" : "web-push");
+
+/**
+ * The router's provider id. The engine reports it to the middleware chain as
+ * `SendContext.provider` for EVERY push send, whichever transport ends up
+ * handling it — which is why {@link breakerKeys} exists.
+ */
+const PUSH_ROUTER_ID = "lunora-push-router";
 
 /**
  * Per-isolate memo of the send-time rebinding verdict, keyed by hostname. A
@@ -166,6 +182,24 @@ const PARTIAL_DELIVERY_CODE = "PUSH_PARTIALLY_DELIVERED";
 const isPartialDelivery = (error: unknown): boolean => isLunoraError(error) && error.code === PARTIAL_DELIVERY_CODE;
 
 /**
+ * The transport whose group failed in a partial delivery, or `undefined` when the
+ * failure is not one.
+ *
+ * {@link mergeGroupResults} records it on the error's `data` as well as in its
+ * prose because {@link perTransportCircuitBreaker} has to charge the failure to the
+ * transport that produced it, and the prose is a message, not a contract.
+ */
+const partialFailedTransport = (error: unknown): PushTransport | undefined => {
+    if (!isPartialDelivery(error)) {
+        return undefined;
+    }
+
+    const { data } = error as LunoraError;
+
+    return data === "fcm" || data === "web-push" ? data : undefined;
+};
+
+/**
  * Fold the two group outcomes of a mixed-kind push into the single `Result` the
  * caller gets back.
  *
@@ -197,7 +231,9 @@ const mergeGroupResults = (webPush: Result<NotificationResult>, fcm: Result<Noti
                 error: new LunoraError(
                     PARTIAL_DELIVERY_CODE,
                     `@lunora/notify: push partially delivered — the ${delivered} group was accepted, the ${failed} group failed (${failureText(cause) ?? "unknown error"}). Not retried: a retry would re-send to the ${delivered} targets that already received it. Re-send to the ${failed} targets only.`,
-                    { cause },
+                    // `data` carries the failed transport verbatim for the breaker
+                    // — see `partialFailedTransport`. It never reaches the wire.
+                    { cause, data: failed },
                 ),
                 success: false,
             };
@@ -235,14 +271,79 @@ const mergeGroupResults = (webPush: Result<NotificationResult>, fcm: Result<Noti
  */
 const isPermanentFailure = (error: unknown): boolean => isGoneError(failureText(error));
 
-/** Consecutive non-permanent failures on one provider before its circuit opens. */
+/** Consecutive non-permanent failures on one transport before its circuit opens. */
 const CIRCUIT_THRESHOLD = 5;
 
-/** How long a provider's circuit stays open before a single trial send. */
+/** How long a transport's circuit stays open before a single trial send. */
 const CIRCUIT_RESET_MS = 30_000;
 
 /**
- * A circuit breaker keyed PER PROVIDER that does not count a permanently-gone
+ * The circuit keys a send counts against — one per transport it actually needs.
+ *
+ * For every provider but the push router that is the provider id, which is what a
+ * breaker is for: one key per service that can be down. The router is the
+ * exception because it is ONE provider hiding TWO: the engine reports
+ * `provider: "lunora-push-router"` to the middleware chain whether the targets are
+ * browser subscriptions or FCM tokens, so a single key charges an FCM outage to
+ * web push. Five failing FCM sends then shed every browser subscriber — the
+ * transport that had not failed once.
+ *
+ * The split is derived from `to` rather than from the result, because it has to be
+ * known BEFORE the send to decide whether to shed it, and `to` is the same input
+ * the router itself partitions on. A send naming no transport (an empty `to`,
+ * which the router rejects on its own terms) keeps the provider key so the refusal
+ * it gets is the router's, not a circuit it was never measured against.
+ */
+const breakerKeys = (context: SendContext): string[] => {
+    if (context.provider !== PUSH_ROUTER_ID) {
+        return [context.provider];
+    }
+
+    const { to } = context.payload as PushPayload;
+    const targets = Array.isArray(to) ? to : [to];
+    const transports = new Set(targets.map((target) => pushTransportOf(target)));
+
+    return transports.size === 0 ? [context.provider] : [...transports].map((transport) => `${context.provider}:${transport}`);
+};
+
+/** One circuit's consecutive-failure count and the moment it last opened. */
+interface CircuitState {
+    failures: number;
+    openedAt: number;
+}
+
+/** Whether `state`'s circuit is open and still inside its reset window at `now`. */
+const isCircuitOpen = (state: CircuitState, now: number): boolean => state.failures >= CIRCUIT_THRESHOLD && now - state.openedAt < CIRCUIT_RESET_MS;
+
+/**
+ * Apply one failed send's evidence to the circuits it is actually about.
+ *
+ * A partial names the transport whose group failed (see
+ * {@link partialFailedTransport}): charge that one, and CLEAR the other — it just
+ * delivered, which is the same evidence about ITS health that an outright success
+ * is. Charging both is how an FCM outage used to shed web push. Any other failure
+ * is charged to every transport the send needed, since nothing distinguishes them.
+ */
+const chargeFailure = (error: unknown, keys: ReadonlyArray<string>, entries: ReadonlyArray<CircuitState>): void => {
+    const failed = partialFailedTransport(error);
+    const failedKey = failed === undefined ? undefined : `${PUSH_ROUTER_ID}:${failed}`;
+    const attributable = failedKey !== undefined && keys.includes(failedKey);
+
+    for (const [index, state] of entries.entries()) {
+        if (attributable && keys[index] !== failedKey) {
+            state.failures = 0;
+        } else {
+            state.failures += 1;
+
+            if (state.failures >= CIRCUIT_THRESHOLD) {
+                state.openedAt = Date.now();
+            }
+        }
+    }
+};
+
+/**
+ * A circuit breaker keyed PER TRANSPORT that does not count a permanently-gone
  * recipient as evidence the service is down.
  *
  * Both halves replace real behaviour of the engine's own `circuitBreakerMiddleware`,
@@ -255,48 +356,71 @@ const CIRCUIT_RESET_MS = 30_000;
  * was never pruned and came back on the next broadcast to do it again. A retry job
  * over known-failing ids reproduced it every redelivery.
  *
- * A breaker is for a provider that is DOWN. An unsubscribed browser is not that.
+ * A breaker is for a service that is DOWN. An unsubscribed browser is not that,
+ * and neither is the sibling transport of one that is.
  */
-const perProviderCircuitBreaker = (): Middleware => {
-    const states = new Map<string, { failures: number; openedAt: number }>();
+const perTransportCircuitBreaker = (): Middleware => {
+    const states = new Map<string, CircuitState>();
+
+    const stateOf = (key: string): CircuitState => {
+        const existing = states.get(key);
+
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const fresh: CircuitState = { failures: 0, openedAt: 0 };
+
+        states.set(key, fresh);
+
+        return fresh;
+    };
 
     return async (context, next) => {
-        const state = states.get(context.provider) ?? { failures: 0, openedAt: 0 };
+        const keys = breakerKeys(context);
+        const entries = keys.map((key) => stateOf(key));
+        const now = Date.now();
 
-        states.set(context.provider, state);
+        // Shed only when EVERY transport this send needs is open. A mixed send
+        // with one healthy transport still has a delivery to make, and refusing
+        // it is exactly what a router-wide key got wrong; the open transport's
+        // leg fails fast at the provider and the fold reports the partial.
+        if (entries.every((state) => isCircuitOpen(state, now))) {
+            return {
+                error: new LunoraError(
+                    "SERVICE_UNAVAILABLE",
+                    `@lunora/notify: circuit open for "${keys.join('", "')}" after ${CIRCUIT_THRESHOLD.toString()} consecutive failures`,
+                ),
+                success: false,
+            };
+        }
 
-        if (state.failures >= CIRCUIT_THRESHOLD) {
-            if (Date.now() - state.openedAt < CIRCUIT_RESET_MS) {
-                return {
-                    error: new LunoraError(
-                        "SERVICE_UNAVAILABLE",
-                        `@lunora/notify: circuit open for provider "${context.provider}" after ${CIRCUIT_THRESHOLD.toString()} consecutive failures`,
-                    ),
-                    success: false,
-                };
+        // Half-open: drop back under the threshold so the next send is
+        // tried. It either clears the counter or puts it straight back over.
+        // Not "exactly one": the counter only rises again once a trial
+        // SETTLES, so sends that start while one is in flight pass too — a
+        // broadcast's concurrent batch probes a recovering provider with as
+        // many sends as it has in flight. Bounded and self-correcting (the
+        // first failure to land re-opens), and a shared in-flight gate would
+        // serialise every send through this middleware to get it.
+        //
+        // Applied to every over-threshold circuit this send touches, the still-open
+        // one included: the send is going out either way, so that circuit IS being
+        // probed and pretending otherwise would only hide the trial's verdict.
+        for (const state of entries) {
+            if (state.failures >= CIRCUIT_THRESHOLD) {
+                state.failures = CIRCUIT_THRESHOLD - 1;
             }
-
-            // Half-open: drop back under the threshold so the next send is
-            // tried. It either clears the counter or puts it straight back over.
-            // Not "exactly one": the counter only rises again once a trial
-            // SETTLES, so sends that start while one is in flight pass too — a
-            // broadcast's concurrent batch probes a recovering provider with as
-            // many sends as it has in flight. Bounded and self-correcting (the
-            // first failure to land re-opens), and a shared in-flight gate would
-            // serialise every send through this middleware to get it.
-            state.failures = CIRCUIT_THRESHOLD - 1;
         }
 
         const result = await next(context);
 
         if (result.success) {
-            state.failures = 0;
-        } else if (!isPermanentFailure(result.error)) {
-            state.failures += 1;
-
-            if (state.failures >= CIRCUIT_THRESHOLD) {
-                state.openedAt = Date.now();
+            for (const state of entries) {
+                state.failures = 0;
             }
+        } else if (!isPermanentFailure(result.error)) {
+            chargeFailure(result.error, keys, entries);
         }
 
         return result;
@@ -338,7 +462,7 @@ export const routingPushProvider = (options: RoutingPushOptions): Provider<unkno
 
     return {
         channel: "push",
-        id: "lunora-push-router",
+        id: PUSH_ROUTER_ID,
         initialize: async () => {
             await options.webPush?.initialize();
             await options.fcm?.initialize();
@@ -446,7 +570,7 @@ export interface ResilienceOptions {
 
 /**
  * Attach the engine's resilience middleware — retry with backoff, then a circuit
- * breaker to shed load when a push service is down.
+ * breaker to shed load off the transport that is down, and only that one.
  *
  * Exported so a TEST engine is wired by this function rather than by a copy of
  * it. `buildEngine` is the only production caller; a double that assembles a bare
@@ -467,7 +591,7 @@ export const attachResilience = (engine: Notification, options: ResilienceOption
         // other transport group already delivered notifies those devices again on
         // every attempt.
         .use(retryMiddleware({ baseDelay: options.retryBaseDelay, shouldRetry: (error) => !isPermanentFailure(error) && !isPartialDelivery(error) }))
-        .use(perProviderCircuitBreaker());
+        .use(perTransportCircuitBreaker());
 
 /**
  * Assemble the `@visulima/notification` engine from resolved channel configs and


### PR DESCRIPTION
## Targets `fix/r37-notify-partial-retry`, not `alpha`

PR #715 is unmerged and changes the same resilience chain in the same file — it introduces the
branded `PUSH_PARTIALLY_DELIVERED` error that this PR's breaker now reads. Basing on `alpha` would
conflict in `providers.ts` and, worse, would hide the interaction: the partial error is precisely
what makes this defect reachable at one failure per send. `.coderabbit.yaml` already lists
`fix/r[0-9]+-.*` in `reviews.auto_review.base_branches`, so the stack base is covered.

## The defect

`routingPushProvider` is ONE provider to the engine. `Notification.sendToChannel` builds the
middleware context as `{ channel, payload, provider: e.id }` where `e` is the registered provider
for the channel — so **every** push send reaches the middleware chain as
`provider: "lunora-push-router"`, whether its targets are browser subscriptions or FCM registration
tokens. The circuit breaker keyed on that string alone, which means it could not tell the two
transports apart: an FCM outage was counted against web push.

A partial is the sharpest way in. With #715 a mixed send answers once with `PUSH_PARTIALLY_DELIVERED`
and is not retried, so each one is exactly one failure on the router's single counter — five of them
open it, and the healthy transport is shed with the sick one.

### Reproduction

Five mixed sends whose FCM leg 503s (web-push accepted every time), then one web-push-only send,
driving the real facade, the real router and the real `attachResilience`:

```
stdout | __tests__/probe.test.ts > probe > prints the shed receipt
webPush sends before: 5 after: 5
receipt: {
  "channel": "push",
  "errorMessages": [
    "@lunora/notify: circuit open for provider \"lunora-push-router\" after 5 consecutive failures"
  ],
  "provider": "lunora-push-router",
  "successful": false
}
```

`webPush.sends` does not move: the browser send never reached the provider. Web-push subscribers
stop receiving anything because FCM is down.

The committed regression test fails the same way on the unfixed code:

```
 FAIL  __tests__/notify.test.ts > push circuit-breaker scope > keeps sending to web-push after enough partials have opened FCM's circuit
AssertionError: expected false to be true // Object.is equality
 ❯ __tests__/notify.test.ts:1327:37
    1327|         expect(receipt?.successful).toBe(true);
```

## Keying decision

This is a change to the resilience contract, so, explicitly:

**The key becomes `provider` for every provider except the push router, and
`lunora-push-router:web-push` / `lunora-push-router:fcm` for it.** A breaker exists to shed load off
one service that is down; the router hides two services behind one id, so one key per service means
one key per transport there. Non-routed providers (`chat`, `webhook`, `inApp`, and a bare push
provider wired in a test) are untouched — they really are one service per id.

The split is derived from `context.payload.to` using the same `webPushEndpoint` predicate the router
itself partitions on, not from the result. It has to be, because the decision to shed happens
*before* the send; and `to` is the only place inside the chain where the two transports are
distinguishable. A send naming no transport (an empty `to`, which the router rejects on its own
terms) keeps the provider key, so it still gets the router's `BAD_REQUEST` rather than a refusal
from a circuit it was never measured against.

**A send spanning two transports where one breaker is open goes through.** Shedding requires *every*
transport the send needs to be open. The alternative — refusing when *any* is — is the bug restated:
a mixed send with a healthy leg has a delivery to make, and the browser device did nothing wrong.
The open transport's leg is still attempted and still fails fast at the provider, and the existing
fold reports the partial. That residual POST to a down service is the deliberate cost: skipping the
open leg would require the router to read breaker state, a new coupling across the
provider/middleware boundary for a path (`notify.send()` with a mixed `to`) that the fan-out never
takes — `deliver` sends one target per call, so broadcasts are single-transport and fully shed.

**A partial counts once, against the transport that failed — and CLEARS the other.** Not "against
nothing": the failing transport is genuinely failing and should eventually open. Not against both:
that is the defect. And the delivering transport just proved itself, which is the same evidence
about *its* health as an outright success, so its consecutive-failure count resets. Attribution
comes from the failed transport recorded on the mixed-outcome error's `data`, added here on top of
#715's error — a field rather than the message prose, which is a message and not a contract.

Half-opening after the reset window now applies to every over-threshold circuit the send touches,
the still-open one included: if the send is going out anyway, that circuit *is* being probed, and
pretending otherwise would only discard the trial's verdict.

The middleware is renamed `perTransportCircuitBreaker` to match what it now keys on.

## Combined behaviour with #715

The breaker does see #715's error — it is the inner middleware (retry is registered first and so
wraps it), so every `Result` the retry layer inspects has already passed through the breaker.

| outcome | #715 (retry) | this PR (breaker) |
| --- | --- | --- |
| mixed, one leg 503s | `shouldRetry` refuses → one attempt, no duplicate delivery | one failure, charged to the failing transport only; the delivering transport's count resets |
| mixed, both legs fail | retried on the full budget (no delivery to duplicate) | each attempt charges both transports — both are failing |
| single-transport failure | retried | charges that transport |
| permanently-gone recipient | not retried | not counted (unchanged) |

So a partial is **counted exactly once, against the right transport, and never retried**. The two
changes compose without either weakening the other: #715 stops the duplicate delivery, this stops
the mis-attributed shedding, and together a mixed send whose FCM leg is down delivers to web push
once per send for as long as the caller keeps sending, while FCM's own circuit opens and sheds FCM.

## Sibling path: `@lunora/mail`

Confirmed it cannot produce a partial and has no breaker to mis-scope. `createMailer` resolves
exactly one transport (`transport` / `cloudflareSend` / `apiKey`) and `send()` is a single
`transport.send(payload)`; `consumeQueuedSend` validates the queue body and forwards to that same
one. There is no group split, no merge, no `@visulima/notification` engine and no resilience
middleware anywhere in the package. Nothing to change.

## Tests, each verified by breaking the code

Three cases in `push circuit-breaker scope`, all driving the real facade + router + `attachResilience`:

1. **keeps sending to web-push after enough partials have opened FCM's circuit** — the reproduction.
2. **still sheds FCM once FCM is the transport that is down** — the breaker must keep doing its job.
3. **delivers a mixed send's web-push leg while FCM's circuit is open** — the `every`-not-`some` rule.

Each was pinned by sabotaging a distinct part of the fix:

**Sabotage A — collapse `breakerKeys` back to `[context.provider]`:**
```
 ❯ __tests__/notify.test.ts (68 tests | 3 failed | 65 skipped) 37ms
     × keeps sending to web-push after enough partials have opened FCM's circuit 8ms
     × still sheds FCM once FCM is the transport that is down 16ms
     × delivers a mixed send's web-push leg while FCM's circuit is open 12ms
```

**Sabotage B — shed when `some` circuit is open instead of `every`:**
```
     ✓ keeps sending to web-push after enough partials have opened FCM's circuit 2ms
     ✓ still sheds FCM once FCM is the transport that is down 13ms
     × delivers a mixed send's web-push leg while FCM's circuit is open 15ms

AssertionError: expected [] to have a length of 1 but got +0
 ❯ __tests__/notify.test.ts:1372:31
    1372|         expect(webPush.sends).toHaveLength(1);
```

**Sabotage C — charge every key on a partial (`const charged = keys`):**
```
     × keeps sending to web-push after enough partials have opened FCM's circuit 9ms
     ✓ still sheds FCM once FCM is the transport that is down 13ms
     ✓ delivers a mixed send's web-push leg while FCM's circuit is open 8ms

AssertionError: expected false to be true // Object.is equality
 ❯ __tests__/notify.test.ts:1327:37
```

Sabotage C also covers the `data` plumbing: with the failed transport unreadable,
`partialFailedTransport` returns `undefined` and attribution falls back to charging every key.

## Gates

| gate | result |
| --- | --- |
| `pnpm run build:packages` | ✅ `Successfully ran target build for 54 projects` |
| `@lunora/notify` tests | ✅ `Test Files 7 passed (7) / Tests 173 passed (173)` |
| `pnpm run lint:types` | ✅ `Successfully ran target lint:types for 75 projects` (also run once with `--no-cache`, 121 tasks, 1m57s) |
| `pnpm run api:check` | ✅ `Public API surface matches all 54 committed snapshots.` (run after a fresh build) |
| `pnpm run lint:prettier` | ✅ `All matched files use Prettier code style!` |
| `@lunora/notify` `lint:eslint` | ✅ clean at `--max-warnings=0` |

Prettier was run before ESLint. `test:workerd` does not apply: `packages/notify/vitest.config.ts`
declares no workerd project (its comment says so explicitly — everything is tested in plain Node
against structural fakes), and this change touches no SQL, storage or Durable Object path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification delivery resilience by tracking circuit health separately for each delivery transport.
  * Partial delivery failures now affect only the transport that failed, while successful transports remain available.
  * Notifications are blocked only when all required delivery transports are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->