### PR TITLE
security(do): stop cache hits skipping rate limits

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -1289,6 +1289,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `isPerDispatchMiddleware` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `isSafeHeaderValue` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -1338,6 +1342,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `storageRules` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `tagPerDispatchMiddleware` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -6107,6 +6115,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `isPerDispatchMiddleware` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `isSafeHeaderValue` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -6156,6 +6168,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `storageRules` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `tagPerDispatchMiddleware` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -3216,6 +3216,12 @@ const installPlugins: <T extends Record<string, TableDefinition>, const Plugins 
 const isDeny: (where: WhereInput) => boolean;
 ```
 
+### `isPerDispatchMiddleware` (const)
+
+```ts
+const isPerDispatchMiddleware: (middleware: unknown) => boolean;
+```
+
 ### `isSafeHeaderValue` (const)
 
 ```ts
@@ -3296,6 +3302,12 @@ const serveStorageObject: (context: ContextWithStorage, key: string, request: Re
 
 ```ts
 const storageRules: <Context extends StorageContextIn = StorageContextIn>(rules: ReadonlyArray<StorageRule<Context>>, options?: StorageRulesOptions) => Middleware<Context, Context>;
+```
+
+### `tagPerDispatchMiddleware` (const)
+
+```ts
+const tagPerDispatchMiddleware: <M extends object>(middleware: M) => M;
 ```
 
 ### `toWhereInput` (const)

--- a/examples/auth-playground/lunora/_generated/functions.ts
+++ b/examples/auth-playground/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -417,9 +417,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/blog/lunora/_generated/functions.ts
+++ b/examples/blog/lunora/_generated/functions.ts
@@ -38,6 +38,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -739,9 +739,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/chess/lunora/_generated/functions.ts
+++ b/examples/chess/lunora/_generated/functions.ts
@@ -38,6 +38,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -1205,9 +1205,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/expo/lunora/_generated/functions.ts
+++ b/examples/expo/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -410,9 +410,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/feedback-board/lunora/_generated/functions.ts
+++ b/examples/feedback-board/lunora/_generated/functions.ts
@@ -37,6 +37,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -883,9 +883,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/kanban-board/lunora/_generated/functions.ts
+++ b/examples/kanban-board/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -448,9 +448,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/notify-demo/lunora/_generated/functions.ts
+++ b/examples/notify-demo/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -493,9 +493,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/offline-rejections/lunora/_generated/functions.ts
+++ b/examples/offline-rejections/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -405,9 +405,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/payment-demo/lunora/_generated/functions.ts
+++ b/examples/payment-demo/lunora/_generated/functions.ts
@@ -35,6 +35,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -954,9 +954,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/realtime-cursors/lunora/_generated/functions.ts
+++ b/examples/realtime-cursors/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -510,9 +510,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/tanstack-start/lunora/_generated/functions.ts
+++ b/examples/tanstack-start/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -387,9 +387,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/team-chat/lunora/_generated/functions.ts
+++ b/examples/team-chat/lunora/_generated/functions.ts
@@ -39,6 +39,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -928,9 +928,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/examples/todo-app/lunora/_generated/functions.ts
+++ b/examples/todo-app/lunora/_generated/functions.ts
@@ -36,6 +36,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -491,9 +491,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/packages/auth/src/turnstile-middleware.ts
+++ b/packages/auth/src/turnstile-middleware.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 import type { Middleware } from "@lunora/server";
+import { tagPerDispatchMiddleware } from "@lunora/server";
 
 import type { FetchLike, TurnstileVerifyResult } from "./turnstile";
 import { verifyTurnstile } from "./turnstile";
@@ -85,8 +86,15 @@ interface VerifyTurnstileMiddlewareOptions<Context> {
  *
  * On a `success: false` verdict (or a missing token) it throws a structural
  * `LunoraError` (`{ name: "LunoraError", code: "FORBIDDEN", status: 403 }`) —
- * the runtime maps it to the matching RPC/HTTP status without any runtime
- * import of `@lunora/server` (the `Middleware` import is type-only).
+ * the runtime maps it to the matching RPC/HTTP status without any import of
+ * the error machinery from `@lunora/server`.
+ *
+ * The middleware is tagged PER-DISPATCH: a Turnstile token is single-use, so
+ * verifying one is an effect of the request that a memoized response cannot
+ * stand in for. The builder hoists the mark onto the registered function and
+ * the generated `isCacheableQuery` keeps such a query out of the reactive
+ * cache — a hit answers without running this chain, so one solved token would
+ * otherwise admit every request the memo served.
  *
  * **Failure policy:** if the siteverify call itself throws, the middleware
  * **fails closed by default** (logs and rejects with 403). Pass
@@ -98,9 +106,8 @@ interface VerifyTurnstileMiddlewareOptions<Context> {
  * `validate(result)` predicate) to assert the siteverify response's `hostname`
  * /`action` and reject mismatches with 403.
  */
-export const verifyTurnstileMiddleware =
-    <Context>(options: VerifyTurnstileMiddlewareOptions<Context>): Middleware<Context, Context> =>
-    async ({ ctx, next }) => {
+export const verifyTurnstileMiddleware = <Context>(options: VerifyTurnstileMiddlewareOptions<Context>): Middleware<Context, Context> =>
+    tagPerDispatchMiddleware(async ({ ctx, next }) => {
         const token = options.token(ctx);
 
         if (token === undefined || token === "") {
@@ -142,6 +149,6 @@ export const verifyTurnstileMiddleware =
         }
 
         return next();
-    };
+    });
 
 export type { VerifyTurnstileMiddlewareOptions };

--- a/packages/codegen/__tests__/emit-shard-reactive-cache.test.ts
+++ b/packages/codegen/__tests__/emit-shard-reactive-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { emitShard } from "../src/emit";
+import { emitFunctions, emitShard } from "../src/emit";
 import { emitApp } from "../src/emit-app";
 
 /**
@@ -42,6 +42,21 @@ describe("emitShard — reactive cache wiring", () => {
         expect(emitted).toContain("...(config.relationExistsPushDown === undefined ? {} : { relationExistsPushDown: config.relationExistsPushDown }),");
     });
 
+    it("keeps a procedure with a per-dispatch middleware out of the cache", () => {
+        expect.assertions(2);
+
+        // A `.use(rateLimit(...))` step runs as part of the registered function's
+        // handler, so it runs inside the dispatch callback — and a cache HIT never
+        // invokes that callback. The query was therefore charged once and served
+        // from the memo to every request after, each of which still reached the
+        // Durable Object. The builder hoists `perDispatch` onto such a function;
+        // this is the half that acts on it.
+        expect(emitFunctions({ functions: [] })).toContain("perDispatch?: boolean;");
+        expect(emitShard({ schema: { tables: [], vectorIndexes: [] } })).toContain(
+            'return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;',
+        );
+    });
+
     it("overrides isCacheableQuery against the generated registry, excluding internal functions", () => {
         expect.assertions(2);
 
@@ -55,7 +70,7 @@ describe("emitShard — reactive cache wiring", () => {
         // And the half that is a security boundary, not a performance knob: a hit
         // skips `handleRpc` and with it the `internal` refusal, so an internal
         // function must never reach the cache in the first place.
-        expect(emitted).toContain('return registered?.kind === "query" && registered.visibility !== "internal";');
+        expect(emitted).toContain('registered?.kind === "query" && registered.visibility !== "internal"');
     });
 
     it("overrides isPaidFunction against the generated registry", () => {

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/functions.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/functions.ts
@@ -37,6 +37,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -354,9 +354,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
@@ -37,6 +37,14 @@ export interface RegisteredLunoraFunction {
      * `reactor` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the `.use()` chain carries a step with a
+     * per-dispatch effect — `rateLimit(...)` consuming budget, a single-use
+     * captcha token being burned. Read by `isCacheableQuery`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -492,9 +492,18 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `handleRpc`, so the `internal` refusal at the top of it is skipped —
             // and an `internalQuery` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // `perDispatch` is the same argument one layer out: the procedure's
+            // own `.use()` chain runs INSIDE `handleRpc`, so a hit skips it too.
+            // A `.use(rateLimit(...))` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2687,6 +2687,14 @@ export interface RegisteredLunoraFunction {
      * \`reactor\` have no caller identity, so RLS has no user to scope to.
      */
     lifecycle?: "connect" | "disconnect" | "init" | "reactor";
+    /**
+     * Hoisted by the builder when the \`.use()\` chain carries a step with a
+     * per-dispatch effect — \`rateLimit(...)\` consuming budget, a single-use
+     * captcha token being burned. Read by \`isCacheableQuery\`: the chain runs
+     * inside the dispatch callback, and a reactive-cache HIT skips that
+     * callback, so such a query must never be memoized.
+     */
+    perDispatch?: boolean;
     /** \`"internal"\` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
     /**
@@ -5360,9 +5368,18 @@ ${sourceBootstrap}${ttlBootstrap}        }
             // \`handleRpc\`, so the \`internal\` refusal at the top of it is skipped —
             // and an \`internalQuery\` primed by a trusted system dispatch was then
             // served to an anonymous client that the refusal would have 404'd.
+            //
+            // \`perDispatch\` is the same argument one layer out: the procedure's
+            // own \`.use()\` chain runs INSIDE \`handleRpc\`, so a hit skips it too.
+            // A \`.use(rateLimit(...))\` query was therefore charged once and then
+            // served from the memo to every later request — each of which still
+            // reached this Durable Object and still cost it a dispatch, so only
+            // the accounting was skipped. Metering and memoizing are mutually
+            // exclusive; the author asking for the first is choosing against the
+            // second.
             const registered = LUNORA_FUNCTIONS[functionPath];
 
-            return registered?.kind === "query" && registered.visibility !== "internal";
+            return registered?.kind === "query" && registered.visibility !== "internal" && registered.perDispatch !== true;
         }
 
         protected override isPaidFunction(functionPath: string): boolean {

--- a/packages/do/__tests__/shard-do.reactive-cache-per-dispatch.test.ts
+++ b/packages/do/__tests__/shard-do.reactive-cache-per-dispatch.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-dispatch middleware and the reactive cache.
+ *
+ * A cache HIT returns the stored entry without invoking the dispatch callback,
+ * so nothing inside `handleRpc` runs — and a `.use(rateLimit(...))` step is
+ * inside it, because the middleware chain is part of the registered function's
+ * own handler. The gates in the base `fetch` (paywall, watermark, dedup) run
+ * before the callback and are unaffected; a limiter the AUTHOR attached to the
+ * procedure is not.
+ *
+ * The consequence is not a stale answer but an unmetered one: the requests still
+ * reach the Durable Object and still cost it a dispatch, and only the accounting
+ * is skipped. So a cached query can be hammered for free.
+ *
+ * `isCacheableQuery` is where this is settled — the same seam that already keeps
+ * `internal` functions out of the cache because a hit would skip their refusal.
+ * The emitted override now also refuses a function whose chain carries a
+ * per-dispatch middleware; this file pins the base class's half: what it does
+ * with each answer.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+const createFakeState = (): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets: () => [],
+        storage: { sql: { exec: vi.fn<(query: string) => unknown>() } },
+    };
+};
+
+/**
+ * Stands in for what the emitter produces for a procedure built as
+ * `query.use(rateLimit(limiter, "feed")).query(...)`: the limiter is consumed by
+ * the middleware chain, which `registered.handler` runs before the user handler
+ * — all of it inside `handleRpc`, i.e. inside the cache callback.
+ *
+ * `cacheable` mirrors the emitted `isCacheableQuery`: the paths it admits are
+ * memoized, the paths it refuses dispatch every time.
+ */
+class MeteredShard extends ShardDO {
+    /** Units the limiter has been charged, per function path. */
+    public charged = new Map<string, number>();
+
+    private readonly cacheable: (functionPath: string) => boolean;
+
+    public constructor(state: ShardDOState, cacheable: (functionPath: string) => boolean) {
+        super(state, {}, { reactiveCache: {} });
+        this.cacheable = cacheable;
+    }
+
+    public override handleRpc(functionPath: string): Promise<unknown> {
+        // `.use(rateLimit(...))` — runs as part of the handler, so it runs only
+        // when the handler runs.
+        this.charged.set(functionPath, (this.charged.get(functionPath) ?? 0) + 1);
+
+        return Promise.resolve({ ok: true });
+    }
+
+    protected override isCacheableQuery(functionPath: string): boolean {
+        return this.cacheable(functionPath);
+    }
+}
+
+const rpc = async (shard: MeteredShard, functionPath: string): Promise<void> => {
+    await shard.fetch(
+        new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+        }),
+    );
+};
+
+describe("reactive cache + per-dispatch middleware", () => {
+    it("consumes no limiter budget on a hit when the path is admitted to the cache", async () => {
+        expect.hasAssertions();
+
+        // The defect, pinned: admitted to the cache, the second and third
+        // dispatches are answered from the memo and the limiter never sees them.
+        const shard = new MeteredShard(createFakeState(), () => true);
+
+        await rpc(shard, "posts:feed");
+        await rpc(shard, "posts:feed");
+        await rpc(shard, "posts:feed");
+
+        expect(shard.charged.get("posts:feed")).toBe(1);
+    });
+
+    it("charges the limiter on every dispatch of a path the cache refuses", async () => {
+        expect.hasAssertions();
+
+        const shard = new MeteredShard(createFakeState(), () => false);
+
+        await rpc(shard, "posts:feed");
+        await rpc(shard, "posts:feed");
+        await rpc(shard, "posts:feed");
+
+        expect(shard.charged.get("posts:feed")).toBe(3);
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -5186,6 +5186,16 @@ abstract class ShardDO {
      * a cron-primed entry be served to an anonymous client. So a function the
      * gate can refuse is not cacheable, whatever its kind.
      *
+     * The same holds for a gate the APP author wrote. A procedure's `.use()`
+     * chain is part of the registered function's handler, so it too runs inside
+     * the callback: a `.use(rateLimit(...))` query was charged on its first
+     * dispatch and on none of the ones the memo answered — while every one of
+     * those still arrived at this Durable Object and still cost it a dispatch,
+     * so only the accounting was skipped. The builder marks such a chain
+     * (`perDispatch`) and the generated override refuses it here. Metering and
+     * memoizing are mutually exclusive: the memo's whole value is not running
+     * the thing again.
+     *
      * The base class has no function registry, so the default is `false`: the
      * conservative answer, since caching an `action` would skip its outbound
      * side effects on a hit and caching a `mutation` is meaningless. The

--- a/packages/ratelimit/__tests__/middleware.test.ts
+++ b/packages/ratelimit/__tests__/middleware.test.ts
@@ -3,8 +3,10 @@ import { fileURLToPath } from "node:url";
 
 import { toErrorBody } from "@lunora/errors";
 import type { Middleware, MiddlewareNext } from "@lunora/server";
+import { isPerDispatchMiddleware } from "@lunora/server";
 import { describe, expect, it, vi } from "vitest";
 
+import dbRateLimit from "../src/database-middleware";
 import { rateLimit } from "../src/middleware";
 import { RateLimiter } from "../src/rate-limiter";
 import type { RateLimitDbQuery } from "../src/store";
@@ -279,5 +281,30 @@ describe("rateLimit middleware", () => {
         } finally {
             logged.mockRestore();
         }
+    });
+});
+
+/**
+ * Consuming budget is an effect of the REQUEST, not of the response, so a
+ * memoized answer cannot stand in for it. The mark is what tells the rest of the
+ * stack that: the builder hoists it onto the registered function and the emitted
+ * `isCacheableQuery` keeps such a query out of the reactive cache. Without it a
+ * cache hit answers without running the `.use()` chain at all, and one dispatch's
+ * charge covered every request the memo served — each of which still reached the
+ * Durable Object.
+ */
+describe("rateLimit middleware — per-dispatch mark", () => {
+    it("marks the middleware it returns", () => {
+        expect.assertions(1);
+
+        expect(isPerDispatchMiddleware(rateLimit(new RateLimiter({ config: { probe: { kind: "token bucket", period: 1000, rate: 1 } } }), "probe"))).toBe(true);
+    });
+
+    it("marks the db-backed variant too", () => {
+        expect.assertions(1);
+
+        // Same factory underneath, but a second export is exactly where a mark
+        // gets forgotten.
+        expect(isPerDispatchMiddleware(dbRateLimit({ probe: { kind: "token bucket", period: 1000, rate: 1 } }, "probe"))).toBe(true);
     });
 });

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -1,5 +1,6 @@
 import { isInternalCode, isLunoraError, LunoraError } from "@lunora/errors";
 import type { Middleware } from "@lunora/server";
+import { tagPerDispatchMiddleware } from "@lunora/server";
 
 import type { RateLimiter } from "./rate-limiter";
 import type { RateLimitReason } from "./types";
@@ -91,9 +92,14 @@ const resolveKey = <Context>(name: string, context: Context, key: RateLimitMiddl
  * capacity) throws an `INTERNAL` `LunoraError` that is re-thrown as-is under
  * **both** policies — a config bug is never masked as a 503 or silently admitted.
  */
-const rateLimit =
-    <Context>(limiter: LimiterResolver<Context>, name: string, options: RateLimitMiddlewareOptions<Context> = {}): Middleware<Context, Context> =>
-    async ({ ctx, next }) => {
+const rateLimit = <Context>(limiter: LimiterResolver<Context>, name: string, options: RateLimitMiddlewareOptions<Context> = {}): Middleware<Context, Context> =>
+    // Tagged PER-DISPATCH: consuming budget is an effect of the request, not of
+    // the response, so a memoized answer cannot stand in for it. The builder
+    // hoists the mark onto the registered function and the generated
+    // `isCacheableQuery` keeps such a query out of the reactive cache — without
+    // it a hit answers without running this chain at all, and one dispatch's
+    // charge covered every request the memo served.
+    tagPerDispatchMiddleware(async ({ ctx, next }) => {
         let status;
 
         try {
@@ -141,7 +147,7 @@ const rateLimit =
         }
 
         return next();
-    };
+    });
 
 export type { LimiterResolver, RateLimitMiddlewareOptions };
 export { rateLimit, STATUS_BY_REASON };

--- a/packages/server/__tests__/per-dispatch-tag.test.ts
+++ b/packages/server/__tests__/per-dispatch-tag.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A middleware with a per-dispatch effect must reach the registered function.
+ *
+ * A procedure's `.use()` chain is part of the registered function's own handler,
+ * so it runs INSIDE the dispatch callback the reactive query cache wraps — and a
+ * cache HIT answers without invoking that callback. A `.use(rateLimit(...))`
+ * query was therefore charged on its first dispatch and on none of the ones the
+ * memo served, while every one of those still reached the Durable Object: the
+ * requests happened, only the accounting did not.
+ *
+ * The mark travels middleware → registered function (`perDispatch: true`) →
+ * emitted `isCacheableQuery`, which refuses to memoize such a query at all. This
+ * file pins the two hops on this side of that chain, including the one that is
+ * silent when it breaks: a composer (`protectPublic`, `composePluginMiddleware`)
+ * folds a chain into ONE fresh arrow, and a tag it forgets to re-stamp makes the
+ * procedure look unmetered.
+ */
+import { describe, expect, it } from "vitest";
+
+import composeMiddleware from "../src/builder/compose-middleware";
+import { isPerDispatchMiddleware, tagPerDispatchMiddleware } from "../src/builder/per-dispatch-tag";
+import type { Middleware } from "../src/index";
+import { composePluginMiddleware, definePlugin, initLunora, protectPublic } from "../src/index";
+
+const builders = initLunora.dataModel<unknown>().create();
+
+/** Register a query behind `middleware` and hand back the registration the builder produced. */
+const registerWith = (middleware: unknown): Record<string, unknown> =>
+    (builders.query as unknown as { use: (m: unknown) => { query: (h: () => unknown) => Record<string, unknown> } }).use(middleware).query(() => null);
+
+/** A pass-through that consumes budget — `rateLimit(...)` reduced to what matters here. */
+const metering = (): Middleware<unknown, unknown> => tagPerDispatchMiddleware(async ({ next }) => next());
+
+/** A pass-through with no per-dispatch effect — the shape that must stay cacheable. */
+const plain =
+    (): Middleware<unknown, unknown> =>
+    async ({ next }) =>
+        next();
+
+describe("per-dispatch middleware tag", () => {
+    it("hoists perDispatch onto a registration whose chain carries one", () => {
+        expect.assertions(1);
+
+        expect(registerWith(metering()).perDispatch).toBe(true);
+    });
+
+    it("leaves the key off a chain with no per-dispatch step", () => {
+        expect.assertions(2);
+
+        // ABSENT, not `false`: `isCacheableQuery` reads it off every registration
+        // and the overwhelming majority of queries must stay memoizable.
+        expect(registerWith(plain())).not.toHaveProperty("perDispatch");
+        expect(registerWith(undefined as unknown as Middleware<unknown, unknown>)).not.toHaveProperty("perDispatch");
+    });
+
+    it("hoists it onto a stream registration too", () => {
+        expect.assertions(1);
+
+        const stream = (
+            builders.query as unknown as {
+                use: (m: unknown) => { stream: (h: () => AsyncIterable<unknown>) => Record<string, unknown> };
+            }
+        )
+            .use(metering())
+            .stream(async function* source() {
+                yield 1;
+            });
+
+        expect(stream.perDispatch).toBe(true);
+    });
+
+    it("re-stamps the mark onto a composed chain", () => {
+        expect.assertions(2);
+
+        const composed = composeMiddleware<unknown, unknown>([plain(), metering()]);
+
+        expect(isPerDispatchMiddleware(composed)).toBe(true);
+        expect(registerWith(composed).perDispatch).toBe(true);
+    });
+
+    it("carries it through a protectPublic bundle", () => {
+        expect.assertions(1);
+
+        expect(registerWith(protectPublic({ rateLimit: metering() })).perDispatch).toBe(true);
+    });
+
+    it("carries it through a plugin middleware composition", () => {
+        expect.assertions(1);
+
+        const plugin = definePlugin("metered", { middleware: metering() });
+        const composed = composePluginMiddleware([plugin]);
+
+        expect(registerWith(composed).perDispatch).toBe(true);
+    });
+
+    it("leaves a composed chain of plain middlewares unmarked", () => {
+        expect.assertions(1);
+
+        expect(isPerDispatchMiddleware(composeMiddleware<unknown, unknown>([plain(), plain()]))).toBe(false);
+    });
+
+    it("still runs the middleware it marks", async () => {
+        expect.assertions(1);
+
+        // The tag is metadata, not a wrapper: a tagged middleware behaves exactly
+        // as it did before, so the chain it sits in is unaffected.
+        let charged = 0;
+        const chain: Middleware<unknown, unknown> = tagPerDispatchMiddleware(async ({ next }) => {
+            charged += 1;
+
+            return next();
+        });
+        const registered = registerWith(chain) as { handler: (context: unknown, args: Record<string, unknown>) => Promise<unknown> };
+
+        await registered.handler({}, {});
+
+        expect(charged).toBe(1);
+    });
+});

--- a/packages/server/src/builder/compose-middleware.ts
+++ b/packages/server/src/builder/compose-middleware.ts
@@ -1,5 +1,6 @@
 import { tagMaskMiddleware, unionMaskColumns } from "../mask/policy-tag";
 import { readRlsTags, tagRlsMiddleware } from "../rls/policy-tag";
+import { isPerDispatchMiddleware, tagPerDispatchMiddleware } from "./per-dispatch-tag";
 import runMiddlewareChain from "./run-middleware";
 import type { Middleware, MiddlewareNext } from "./types";
 
@@ -55,6 +56,16 @@ const composeMiddleware = <ContextIn, ContextOut>(chain: ReadonlyArray<Middlewar
 
     if (columns) {
         tagMaskMiddleware(composed, { columns });
+    }
+
+    // Re-stamped for the same reason and with the same consequence if forgotten:
+    // the builder reads the per-dispatch mark off the DIRECT `.use()` elements,
+    // so a `protectPublic({ rateLimit })` bundle that lost it would leave the
+    // procedure looking cacheable — and a reactive-cache hit answers without
+    // running the chain, so the limiter would meter one dispatch out of however
+    // many the memo serves.
+    if (chain.some((middleware) => isPerDispatchMiddleware(middleware))) {
+        tagPerDispatchMiddleware(composed);
     }
 
     return composed;

--- a/packages/server/src/builder/index.ts
+++ b/packages/server/src/builder/index.ts
@@ -15,6 +15,7 @@ import type {
     QueryCtx as QueryContext,
     X402ProcedureConfig,
 } from "../types";
+import { isPerDispatchMiddleware } from "./per-dispatch-tag";
 import runMiddlewareChain from "./run-middleware";
 import type {
     ActionBuilder,
@@ -211,6 +212,21 @@ const collectRls = (middlewares: ReadonlyArray<Middleware<unknown, unknown>>): u
 };
 
 /**
+ * Whether the chain carries a step with a per-dispatch effect — limiter budget
+ * consumed, a single-use token burned — that a memoized response cannot stand
+ * in for. Hoisted onto the registered function as `perDispatch: true`; the
+ * generated `isCacheableQuery` refuses such a query, because a reactive-cache
+ * hit answers without running the chain at all and the effect would silently
+ * happen once for an unbounded number of requests.
+ *
+ * Read off the DIRECT elements of the `.use(...)` chain, exactly like the
+ * `rls()` / `mask()` tags — which is why `composeMiddleware` re-stamps it onto
+ * the arrow it folds a chain into.
+ */
+const collectPerDispatch = (middlewares: ReadonlyArray<Middleware<unknown, unknown>>): boolean =>
+    middlewares.some((middleware) => isPerDispatchMiddleware(middleware));
+
+/**
  * Shadow the mutators `Object.freeze` cannot reach.
  *
  * A frozen `Map`/`Set` still accepts `.set()` / `.add()` / `.delete()` /
@@ -316,6 +332,7 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
         [kind]: <R>(userHandler: (options: { args: Record<string, unknown>; ctx: unknown }) => Promise<R> | R) => {
             const rls = collectRls(state.middlewares);
             const maskedTables = unionMaskColumns(state.middlewares);
+            const perDispatch = collectPerDispatch(state.middlewares);
 
             return {
                 args: state.args,
@@ -323,6 +340,7 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
                 handler: makeHandler(state.args, state.middlewares, userHandler, state.output, state.meta),
                 kind,
                 ...(maskedTables ? { maskedTables } : {}),
+                ...(perDispatch ? { perDispatch } : {}),
                 ...(rls ? { rls } : {}),
                 ...(visibility ? { visibility } : {}),
                 ...(state.x402 ? { x402: state.x402 } : {}),
@@ -356,6 +374,7 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
                   ) => {
                       const rls = collectRls(state.middlewares);
                       const maskedTables = unionMaskColumns(state.middlewares);
+                      const perDispatch = collectPerDispatch(state.middlewares);
                       // `durable: true` and `durable: { … }` are the same thing to
                       // the runtime — normalise here so it only ever sees the object
                       // (and `false`/omitted collapse to "not durable").
@@ -368,6 +387,7 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
                           handler: makeStreamHandler(state.args, state.middlewares, userHandler, state.meta),
                           kind: "stream" as const,
                           ...(maskedTables ? { maskedTables } : {}),
+                          ...(perDispatch ? { perDispatch } : {}),
                           ...(rls ? { rls } : {}),
                           ...(visibility ? { visibility } : {}),
                           ...(state.x402 ? { x402: state.x402 } : {}),

--- a/packages/server/src/builder/per-dispatch-tag.ts
+++ b/packages/server/src/builder/per-dispatch-tag.ts
@@ -1,0 +1,47 @@
+/**
+ * Mark a middleware as having a PER-DISPATCH effect: something that must happen
+ * once per request and that the response alone does not carry. Consuming rate
+ * limiter budget is the motivating case; burning a single-use captcha token is
+ * the same shape.
+ *
+ * The reactive query cache is what reads this. A cache HIT answers without
+ * running the dispatch callback, and a procedure's `.use()` chain runs INSIDE
+ * that callback (it is part of the registered function's own handler) — so a
+ * memoized query consumed limiter budget on its first dispatch and on none of
+ * the ones after, while every one of them still reached the Durable Object. The
+ * builder hoists this tag onto the registered function as `perDispatch: true`
+ * and the emitted `isCacheableQuery` refuses such a function, exactly as it
+ * already refuses an `internal` one whose refusal a hit would skip.
+ *
+ * Tagging the middleware FUNCTION rather than deriving the answer statically is
+ * what makes it truthful: the chain is assembled at runtime (a shared base
+ * builder, a `protectPublic` bundle, a plugin composer), and an AST-side guess
+ * that missed one would fail open on a security control.
+ *
+ * Non-enumerable and `Symbol.for`-keyed for the same two reasons as the `rls()`
+ * tag next to it: it never leaks into a spread of the middleware, and two
+ * independently-bundled copies of `@lunora/server` still agree on the key.
+ */
+
+const PER_DISPATCH_TAG = Symbol.for("lunora.middleware.per-dispatch");
+
+/**
+ * Mark a middleware as per-dispatch. Returns the same reference, so a factory
+ * can `return tagPerDispatchMiddleware(async ({ ctx, next }) => …)`.
+ */
+const tagPerDispatchMiddleware = <M extends object>(middleware: M): M => {
+    Object.defineProperty(middleware, PER_DISPATCH_TAG, { configurable: true, enumerable: false, value: true });
+
+    return middleware;
+};
+
+/** Whether a middleware carries the per-dispatch mark. `false` for anything else. */
+const isPerDispatchMiddleware = (middleware: unknown): boolean => {
+    if (middleware === null || (typeof middleware !== "function" && typeof middleware !== "object")) {
+        return false;
+    }
+
+    return (middleware as Record<PropertyKey, unknown>)[PER_DISPATCH_TAG] === true;
+};
+
+export { isPerDispatchMiddleware, tagPerDispatchMiddleware };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ export type {
     TerminalKind,
 } from "./builder/index";
 export { initLunora } from "./builder/index";
+export { isPerDispatchMiddleware, tagPerDispatchMiddleware } from "./builder/per-dispatch-tag";
 export { createSecrets } from "./create-secrets";
 export type { DeferredDeleteFlushResult } from "./deferred-deletes";
 export { beginDeferredDeletes, flushDeferredDeletes, withDeferredDeletes } from "./deferred-deletes";


### PR DESCRIPTION
## Stack

Third level. Based on `fix/r37-reactive-cache-ip-key` (#714), which sits on `fix/r37-do-ws-client-ip`
(#702). #714 has three siblings (#710, #713, #714) on the same base, so this diff is kept to what it
fixes.

The defect was found while auditing what else a skipped reactive-cache callback skips — the same
function #714 fixed two other defects in. It was reported and deliberately left for its own change,
because the fix is a contract decision rather than a patch.

## The defect

A reactive-cache **hit** returns the stored entry without invoking the dispatch callback, so nothing
inside `handleRpc` runs. A procedure's `.use()` chain is inside it: the builder composes the chain
into the registered function's own handler (`makeHandler` runs the chain, then the user handler), and
`handleRpc` calls that handler. So a `.use(rateLimit(...))` query consumed limiter budget on its
first dispatch and on none of the ones the memo answered.

The gates in the base `fetch` — paywall/x402 (`preDispatchAnswer`), the mutator watermark, the
mutation-replay dedup — run before `beginDispatch` and the callback, and were never affected. This is
specifically a guard the **app author** attached to the procedure.

The consequence is not a stale answer but an unmetered one. The requests still reach the Durable
Object (fetch → beginDispatch → hit) and still cost it a dispatch; only the accounting is skipped. So
a cached query can be hammered for free.

### Exposure

**Both halves need `.reactiveCache(true)`, which defaults off** — same bound as the two defects on
#714. `emit-app.ts` initialises `reactiveCacheConfig = false`, and no example, app or template in
this repo opts in. Reach is therefore limited to deployments that explicitly enabled the cache *and*
put a limiter on a `query` (not a mutation or action — those never enter the cache).

## Reproduction

Extends #714's harness, which drives the real `ShardDO` through `fetch` →
`beginDispatch` → `runCachedQuery`. The stand-in handler charges a limiter, exactly where the real
middleware chain charges it (inside `handleRpc`), and `isCacheableQuery` mirrors the emitted
override. Three identical requests:

```
 FAIL  __tests__/shard-do.reactive-cache-per-dispatch.test.ts >
       consumes no limiter budget on a hit when the path is admitted to the cache
AssertionError: expected 1 to be 3 // Object.is equality

- Expected
+ Received

- 3
+ 1
```

Three requests, one charge. With the path refused by `isCacheableQuery`, the same three requests
charge three times.

## Contract decision

Neither of the two shapes the report suggested is expressible as stated; the third is, and it is what
shipped.

**"The limiter moves outside the cached callback" — not expressible here.** It is *structurally*
closer than it looks: `makeHandler` already runs the chain and the user handler as two separate
awaits (`runMiddlewareChain`'s terminal only *builds* the context; middlewares are not wrapped around
the handler), so "run the chain, memoize only the body" is a coherent design. But acting on it means
moving the cache probe from the dispatch site in `ShardDO.fetch` to *inside* `handleRpc`, after the
chain — an inversion of the dispatch path across `@lunora/server`, `@lunora/codegen` and
`@lunora/do`, plus a new split registration shape. Not something to land at the third level of a
four-PR stack. Recorded as the better long-term shape below.

**"A hit consumes budget explicitly" — not expressible at all.** The Durable Object would have to
know *which* limiter and *which* key. The limiter is resolved from `ctx` at call time
(`(ctx) => new RateLimiter({ store: createDbStore({ db: ctx.db }) })`) and the key is a user closure
over the resolved context. There is nothing for the dispatch path to charge.

**What shipped: a query with a per-dispatch middleware is not cacheable.** Settled at
`isCacheableQuery` — the seam that already keeps `internal` functions out of the cache for exactly
this reason (a hit skips their refusal). A middleware whose effect belongs to the REQUEST rather than
the response carries a `Symbol.for`-keyed, non-enumerable mark; the builder hoists it onto the
registered function as `perDispatch: true`; the emitted override refuses such a query.

Metering and memoizing are mutually exclusive. The memo's whole value is not running the thing again;
a limiter's whole value is that it runs every time. The author asking for the first is choosing
against the second, and this makes that choice explicit rather than silently resolving it in the
cache's favour.

### Several middlewares, only some of them limits

The mark is per-chain, not per-step: **one** per-dispatch step makes the whole procedure uncacheable.
It has to be — the chain is one composed unit and the steps are ordered by the author, so there is no
"run these two and skip those three". A query with `rls()` + `rateLimit()` therefore loses its memo.
A query with `rls()` + `mask()` and no limiter keeps it, unchanged.

### A middleware that is not a limiter but has a side effect

That is the general case, and the mark is named for it rather than for rate limiting.
`verifyTurnstileMiddleware` is tagged in this PR on the same grounds: a Turnstile token is
single-use, so one solved token would otherwise admit every request the memo served. Anything else
with a per-request effect — a metering/billing step, an audit-log write, a nonce burn — should carry
the tag, and `tagPerDispatchMiddleware` is exported for third-party middlewares to do so.

**Residual, stated plainly:** an untagged custom limiter middleware is still cacheable and still
bypassed. Tagging is opt-in, so this fails open for middleware the framework does not own. The
alternative — treating *every* `.use()` chain as uncacheable — would have killed the memo for every
RLS'd query, which is the common case, so it was rejected. Deriving the answer statically was also
rejected: the chain is assembled at runtime (a shared base builder, a `protectPublic` bundle, a
plugin composer), and `discoverProcedureMiddleware`'s AST pass is a best-effort heuristic built for
lints — the same fail-open, with no runtime truth behind it. A tag on the function object is the only
signal that is true at dispatch time.

`composeMiddleware` re-stamps the tag onto the arrow it folds a chain into, for the same reason it
re-stamps the `rls()`/`mask()` tags and with the same consequence if forgotten: a composer returns a
fresh function object, and a dropped tag is silent. `protectPublic({ rateLimit, captcha })` and
`composePluginMiddleware` both route through it; both are covered by tests.

## Audit of the rest of the skipped callback

Everything inside `(scope) => this.handleRpc(path, args, headroom, scope, bookmark)`:

| Step (in order) | On a hit | Verdict |
| --- | --- | --- |
| `LUNORA_FUNCTIONS[path]` lookup + `FUNCTION_NOT_FOUND` | skipped | **Safe.** An entry can only exist for a path `isCacheableQuery` admitted, which requires it to be registered. An unregistered path never reaches `runCachedQuery`. |
| `internal` visibility refusal | skipped | **Safe** — closed on #714: `isCacheableQuery` excludes `visibility === "internal"`, so no entry is ever stored under one. |
| `ensureMigrated()` | skipped | **Safe via coupling** (#714): the `migrated` flag and `reactiveCache` are both per-instance and die together, so a hit implies a prior miss on that instance ran it. Fragile-by-coupling, not by check — worth keeping in mind if the cache ever becomes cross-instance. |
| `buildCtx(...)` | skipped | **Safe.** Pure construction — secrets facade, logger, trace anchor, storage/scheduler facades. Nothing observable happens; on a query ctx the deferral wrappers are not even installed (`contextKind === "query"`). |
| `validateArgs(args, raw)` (inside `makeHandler`) | skipped | **Safe.** The cache key is `(functionPath, decoded args, caller)`; an entry exists only because an identical-args dispatch already passed validation, and validation is deterministic. |
| **the `.use()` middleware chain** | skipped | **THE DEFECT.** Split by effect: a pure gate keyed on something already in the cache key (`rls()`, `mask()`, an auth check on `ctx.auth`) is safe, because #714 widened the key to the full caller (`userId`, claims, `system`, and `ip` for paths observed reading it) — two callers who would get different answers cannot share an entry. A step with a per-request EFFECT is not, and that is what this PR marks. |
| the user handler | skipped | **Safe** — this is what the memo exists to replace. |
| `applyOutput(output, result)` | skipped | **Safe.** Deterministic on the same value, and it ran on the value being served. |
| mutation branch / `runMutationTransaction` / `commitMutationBookkeeping` | skipped | **Unreachable.** `isCacheableQuery` admits `kind === "query"` only. |
| `deferPastResponse(flushDeferredDeletes(ctx))` | skipped | **Safe.** A query ctx is not wrapped with `withDeferredDeletes`, so no queue is registered and the flush returns `{ attempted: 0 }` on every dispatch, hit or miss. |
| handler-emitted `ctx.log` lines / `ctx.span` attributes | skipped | **Not a correctness issue, but a real gap.** A hit produces no handler-level telemetry. The dispatch's own request-log entry and root span are emitted by the base `fetch` tail (outside the callback) and `attribution.cacheHit` records which it was, so hits are countable — but a handler that logs per-call detail goes quiet on them. Pre-existing and inherent to memoizing; called out so it is a known property rather than a surprise. |

Out of scope but adjacent: `resolveReactiveOutcomeDeduped` de-duplicates *subscription* re-evaluation
within one flush pass. It skips re-running a query too, but a subscription refresh is server-driven
(a write happened), not a caller-driven request, so there is no per-caller budget to charge.

## Hit-rate impact

The cache is not weakened for any query that does not declare a limiter — that includes every RLS-
and mask-guarded query, which is the overwhelming majority. For a query that *does* declare one, the
hit rate for that path goes to zero by construction.

Counting this repo's own app code (`examples/`, `apps/`, `templates/`, excluding `_generated`): 13 of
57 registered `.query(...)` terminals carry a limiter (≈23%); 48 mutations and 11 actions also do,
and those never entered the cache. So on this corpus the affected set is 13 paths, in apps where the
cache is switched off anyway.

That cost is the fix, not a side effect of it: a limiter on a memoized query was already not
limiting. Nothing that used to be metered becomes slower — it becomes metered.

## Better long-term shape (not this PR)

Memoize only the user handler's body and run the middleware chain on every dispatch, hit or miss.
That preserves author ordering, keeps the hit rate for rate-limited queries, and makes the general
"middleware with a side effect" case correct rather than opt-in. It needs the cache probe moved
inside `handleRpc` after the chain, which is a cross-package restructure of the dispatch path — too
large to restack at this level of the stack. The tag introduced here is what that design would read
if it wanted to skip the memo entirely, so it is not wasted work either way.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm run build:packages` | pass (54 projects) |
| `@lunora/do` tests | pass — 65 files, 724 tests |
| `@lunora/codegen` tests | pass — 139 files, 1779 tests |
| `@lunora/server` tests | pass — 52 files, 844 tests |
| `@lunora/ratelimit` tests | pass — 8 files, 113 tests |
| `@lunora/auth` tests | pass — 37 files, 493 tests |
| `pnpm run test:workerd` | pass — all 11 workerd suites |
| `pnpm run lint:types` | pass (re-run `--no-cache` for do/server/codegen/ratelimit/auth) |
| `pnpm run api:check` | pass after `api:update` — 2 new `@lunora/server` exports, snapshot diff included |
| `node scripts/check-generated-files.mjs` | pass — all 16 generators reproduce their committed output |
| `pnpm run lint:package-json` | pass — 89 manifests sorted |
| prettier, then eslint (`--max-warnings=0`, per package) | pass |
| `pnpm run dist:check` | fails locally on `jsxDEV` — the local tree is a `build` (dev) build, not `build:prod`; unrelated to this change and not reproducible in CI, which builds prod |

Every new test was verified by breaking the code first:

- removing the builder hoist → 5 of 8 `per-dispatch-tag` tests fail
- removing the `composeMiddleware` re-stamp → the 3 composer/bundle/plugin tests fail
- untagging `rateLimit` → both `@lunora/ratelimit` marker tests fail
- dropping `perDispatch` from the emitted `isCacheableQuery` → the codegen emit test fails
- making `ShardDO.fetch` ignore `isCacheableQuery` → the do regression test fails (`expected 1 to be 3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
