### PR TITLE
fix(server): hold deferred schedules in a durable outbox

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -428,6 +428,9 @@ abstract class ShardDO {
     protected ttlSweeps(): ReadonlyArray<TtlSweepSpec>;
     protected pollTtlSweeps(trace?: TraceRefLike): Promise<number | undefined>;
     protected scheduleTtlSweep(): Promise<void>;
+    protected scheduleOutbox(): ScheduleOutbox;
+    protected scheduleOutboxScheduler(): SchedulerLike | undefined;
+    protected pollScheduleOutbox(trace?: TraceRefLike): Promise<number | undefined>;
     protected currentShardKey(): string;
     protected ensureShardInit(): Promise<void>;
     protected runShardInit(): Promise<void>;

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -3317,7 +3317,7 @@ const withDeferredDeletes: (storage: unknown) => unknown;
 ### `withDeferredSchedules` (const)
 
 ```ts
-const withDeferredSchedules: <S extends SchedulerLike>(scheduler: S) => S;
+const withDeferredSchedules: <S extends SchedulerLike>(scheduler: S, outbox?: ScheduleOutbox) => S;
 ```
 
 ## `@lunora/server/data-model`
@@ -6016,6 +6016,21 @@ interface SchedulableWorkflowReference {
     readonly binding?: string;
     readonly isLunoraWorkflow: true;
     readonly name?: string;
+}
+```
+
+### `ScheduleOutbox` (interface)
+
+```ts
+interface ScheduleOutbox {
+    forget: (id: string) => void;
+    record: (id: string, envelope: {
+        args: unknown;
+        options: Record<string, unknown> | undefined;
+        target: unknown;
+        when: number;
+    }) => void;
+    wake: () => void;
 }
 ```
 

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -2439,6 +2439,12 @@ interface RunTriggersOptions {
 const SCAN_DEP = "*scan";
 ```
 
+### `SCHEDULE_OUTBOX_TABLE` (const)
+
+```ts
+const SCHEDULE_OUTBOX_TABLE = "__schedule_outbox";
+```
+
 ### `SCHEMA_HISTORY_MAX_VERSIONS` (const)
 
 ```ts
@@ -2464,6 +2470,38 @@ interface SchedulableWorkflowReferenceLike {
     readonly binding?: string;
     readonly isLunoraWorkflow: true;
     readonly name?: string;
+}
+```
+
+### `ScheduleOutbox` (interface)
+
+```ts
+interface ScheduleOutbox {
+    forget: (id: string) => void;
+    record: (id: string, envelope: ScheduleOutboxEnvelope) => void;
+    wake: () => void;
+}
+```
+
+### `ScheduleOutboxEnvelope` (interface)
+
+```ts
+interface ScheduleOutboxEnvelope {
+    args: unknown;
+    options: Record<string, unknown> | undefined;
+    target: unknown;
+    when: number;
+}
+```
+
+### `ScheduleOutboxRow` (interface)
+
+```ts
+interface ScheduleOutboxRow {
+    attempts: number;
+    envelopeJson: string;
+    id: string;
+    nextAttemptAt: number;
 }
 ```
 
@@ -3777,6 +3815,12 @@ const decodeCursor: (cursor: string) => unknown[];
 const decodeFloat64SqlKey: (raw: string) => number | undefined;
 ```
 
+### `deferScheduleOutbox` (const)
+
+```ts
+const deferScheduleOutbox: (sql: SqlExec, id: string, attempts: number, nextAttemptAt: number) => void;
+```
+
 ### `deleteGlobalShapeSnapshot` (const)
 
 ```ts
@@ -3955,6 +3999,12 @@ const float64SqlKey: (value: number) => string;
 
 ```ts
 const foldAggregateTally: (tallies: Map<string, AggregateTally>, encoded: string, index: AggregateIndexDefinitionLike, record: Record<string, unknown>) => void;
+```
+
+### `forgetScheduleOutbox` (const)
+
+```ts
+const forgetScheduleOutbox: (sql: SqlExec, id: string) => void;
 ```
 
 ### `gateReplicaDispatch` (const)
@@ -4213,6 +4263,12 @@ const migrateIdempotency: (sql: SqlExec) => void;
 const migrateReactorState: (sql: SqlExec) => void;
 ```
 
+### `migrateScheduleOutbox` (const)
+
+```ts
+const migrateScheduleOutbox: (sql: SqlExec) => void;
+```
+
 ### `migrateSearchState` (const)
 
 ```ts
@@ -4285,6 +4341,12 @@ const normalizeSourceValue: (value: unknown) => unknown;
 const param: (value: unknown) => SQL;
 ```
 
+### `parkScheduleOutbox` (const)
+
+```ts
+const parkScheduleOutbox: (sql: SqlExec, id: string, attempts: number) => void;
+```
+
 ### `parseExportShardArgs` (const)
 
 ```ts
@@ -4307,6 +4369,15 @@ const planAggregateLookup: (index: AggregateIndexDefinitionLike, requestedWhere:
 
 ```ts
 const pointInBoundingBox: (point: GeoPoint, box: GeoBoundingBox) => boolean;
+```
+
+### `probeScheduleOutbox` (const)
+
+```ts
+const probeScheduleOutbox: (sql: SqlExec) => {
+    dueAt: number | undefined;
+    populated: boolean;
+};
 ```
 
 ### `projectColumns` (const)
@@ -4478,6 +4549,12 @@ const readCommitSeq: (sql: SqlExec) => number;
 const readDeployInfo: (rawEnv: unknown) => DeployInfo;
 ```
 
+### `readDueScheduleOutbox` (const)
+
+```ts
+const readDueScheduleOutbox: (sql: SqlExec, nowMs: number, limit: number) => ScheduleOutboxRow[];
+```
+
 ### `readExternalSourceBaseline` (const)
 
 ```ts
@@ -4596,6 +4673,12 @@ const recordGlobalPollPass: (counters: GlobalPollCounters, drains: number, pairs
 const recordQueueMessages: (sql: SqlExec, inputs: ReadonlyArray<RecordQueueMessageInput>, capturedAt: number) => {
     recorded: number;
 };
+```
+
+### `recordScheduleOutbox` (const)
+
+```ts
+const recordScheduleOutbox: (sql: SqlExec, id: string, envelopeJson: string, now: number) => void;
 ```
 
 ### `recordSchemaVersion` (const)
@@ -4916,6 +4999,12 @@ const trimCdcChanges: (sql: SqlExec, throughSeq: number, maxRows: number) => voi
 
 ```ts
 const trimIdempotent: (sql: SqlExec, olderThanTs: number) => void;
+```
+
+### `trimScheduleOutbox` (const)
+
+```ts
+const trimScheduleOutbox: (sql: SqlExec, olderThanTs: number) => void;
 ```
 
 ### `trimStreamRuns` (const)

--- a/apps/docs/src/content/docs/concepts/scheduling.mdx
+++ b/apps/docs/src/content/docs/concepts/scheduling.mdx
@@ -101,6 +101,28 @@ export const orderPlaced = mutation.input({ orderId: v.id("orders") }).mutation(
 transaction" hand-off — literally so: the job reaches the scheduler after the
 `COMMIT`, in the order the handler scheduled them.
 
+#### If the job can't reach the scheduler
+
+Everything between the `COMMIT` and the scheduler's acknowledgement happens
+outside the transaction, so it can fail on its own: the `SchedulerDO`
+unreachable, the shard evicted mid-hand-off. The write is durable by then and the
+job is not, and rolling back is no longer on the table.
+
+So the shard takes **durable custody** of each deferred job as the handler
+schedules it — a row written inside the same transaction as the writes, released
+once the scheduler has the job. A hand-off that fails still raises (a caller
+error like a duplicate job id has to reach you), but what it can no longer do is
+lose the job: the entry survives, and the shard re-offers it on a backoff ladder
+until the scheduler accepts it. The retry reuses the id you were handed, so a job
+that did land is recognised rather than scheduled twice, and the `cancel(id)` you
+stored on a row keeps working throughout.
+
+A job the scheduler refuses eight times over is **parked**: it stops being
+retried, is logged at `error` naming its id and target, and is kept for a week so
+you can see what was promised and never enqueued. That is the one case where a
+scheduled job is dropped without the mutation being rolled back — and it is
+reported rather than silent.
+
 ### Inspecting and cancelling
 
 `ctx.scheduler` also exposes `list()`, `get(id)`, and `cancel(id)` for managing

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -598,6 +598,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1033,7 +1042,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -920,6 +920,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1375,7 +1384,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -1386,6 +1386,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1821,7 +1830,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -591,6 +591,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1026,7 +1035,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -1064,6 +1064,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1511,7 +1520,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/kanban-board/lunora/_generated/shard.ts
+++ b/examples/kanban-board/lunora/_generated/shard.ts
@@ -629,6 +629,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1064,7 +1073,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -674,6 +674,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1109,7 +1118,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -586,6 +586,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1021,7 +1030,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -1135,6 +1135,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1570,7 +1579,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -691,6 +691,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1126,7 +1135,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/tanstack-start/lunora/_generated/shard.ts
+++ b/examples/tanstack-start/lunora/_generated/shard.ts
@@ -568,6 +568,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1003,7 +1012,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/team-chat/lunora/_generated/shard.ts
+++ b/examples/team-chat/lunora/_generated/shard.ts
@@ -1109,6 +1109,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async runRelationFanoutRead(functionPath: string, args: Record<string, unknown>): Promise<unknown> {
             this.ensureMigrated();
 
@@ -1561,7 +1570,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -672,6 +672,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
 
@@ -1107,7 +1116,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/__tests__/emit-shard-schedule-outbox.dispatch.test.ts
+++ b/packages/codegen/__tests__/emit-shard-schedule-outbox.dispatch.test.ts
@@ -1,0 +1,334 @@
+/**
+ * A deferred `ctx.scheduler` job that fails to reach the scheduler, driven
+ * through the REAL dispatch.
+ *
+ * The defect this suite pins is invisible to every substring assertion around the
+ * emitter, and to every unit test of the deferral facade: each piece behaved
+ * exactly as documented. The mutation's writes committed. Its replay-dedup row
+ * committed inside the same span, as a later fix deliberately arranged. The
+ * post-commit settle dispatched the buffered call and rethrew when it failed, as
+ * its docblock promises. And the sum of those three correct behaviours was that a
+ * client replaying the failed mutation short-circuited on the dedup row, was told
+ * it had succeeded, and the scheduled job existed nowhere. Only running the whole
+ * path shows that.
+ *
+ * So this suite drives the committed golden `_generated/shard.ts`
+ * (`fixtures/delta-sync`) against the real `@lunora/do` base class and the real
+ * `@lunora/server` deferral modules, on Node's own SQLite — the same harness
+ * `emit-shard-deferred-deletes.dispatch.test.ts` established, and for the same
+ * reason. The only doubles are the HOST's: `storage.transaction` (BEGIN/ROLLBACK
+ * on `node:sqlite`, the semantics workerd gives `state.storage.transaction`) and
+ * the scheduler, which records what it was asked to schedule and can be made to
+ * fail. `handleRpc`, `buildCtx`, `runMutationTransaction` and the outbox are
+ * generated or shipped code, executed.
+ */
+import { DatabaseSync } from "node:sqlite";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { LUNORA_FUNCTIONS } from "./fixtures/delta-sync/lunora/_generated/functions";
+import { createShardDO } from "./fixtures/delta-sync/lunora/_generated/shard";
+
+/** The slice of a dispatch ctx these handlers touch. */
+interface TestCtx {
+    db: { insert: (table: string, row: Record<string, unknown>) => Promise<unknown>; query: (table: string) => { collect: () => Promise<unknown[]> } };
+    runMutation: (reference: { __lunoraRef: string }, args: Record<string, unknown>) => Promise<unknown>;
+    scheduler: { runAfter: (delayMs: number, target: unknown, args: unknown) => Promise<string> };
+}
+
+/** One call the fake scheduler accepted. */
+interface AcceptedJob {
+    args: unknown;
+    id: string | undefined;
+    target: unknown;
+}
+
+/**
+ * The DO state the shard is constructed with. `transaction` is the host primitive
+ * the rollback under test actually needs — a state without it falls through to a
+ * bare call and every assertion below would pass for the wrong reason.
+ */
+const createState = (): { run: (query: string, ...parameters: unknown[]) => unknown; state: unknown } => {
+    const database = new DatabaseSync(":memory:");
+    const run = (query: string, ...parameters: unknown[]): unknown => {
+        const rows = database.prepare(query).all(...(parameters as never[])) as unknown[];
+
+        return { one: () => rows[0], toArray: () => rows, [Symbol.iterator]: () => rows[Symbol.iterator]() };
+    };
+
+    return {
+        run,
+        state: {
+            acceptWebSocket: () => undefined,
+            getWebSockets: () => [],
+            id: { name: "shard-a" },
+            storage: {
+                sql: { exec: run },
+                transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+                    run("BEGIN");
+
+                    try {
+                        const result = await closure();
+
+                        run("COMMIT");
+
+                        return result;
+                    } catch (error) {
+                        run("ROLLBACK");
+
+                        throw error;
+                    }
+                },
+            },
+        },
+    };
+};
+
+interface Harness {
+    /** Make every live entry due now, so the retry ladder can be driven without waiting it out. */
+    makeDue: () => void;
+    /** Every entry still in `__schedule_outbox`, oldest first. */
+    outbox: () => { attempts: number; dead: number; id: string }[];
+    /** Drive the outbox retry tier the shared poll alarm runs. */
+    retry: () => Promise<number | undefined>;
+    /** Jobs the scheduler accepted. */
+    scheduled: AcceptedJob[];
+    /** Flip the scheduler between "unreachable" and "healthy". */
+    setReachable: (reachable: boolean) => void;
+    shard: {
+        cached: (mutationId: string) => { value: unknown } | undefined;
+        handleRpc: (path: string, args: Record<string, unknown>) => Promise<unknown>;
+        underMutationId: (id: string) => void;
+    };
+}
+
+const createHarness = (): Harness => {
+    const scheduled: AcceptedJob[] = [];
+    let reachable = true;
+
+    const accept = async (target: unknown, args: unknown, options?: { id?: string }): Promise<string> => {
+        if (!reachable) {
+            throw new Error("SchedulerDO unreachable");
+        }
+
+        const id = options?.id ?? "minted";
+
+        scheduled.push({ args, id, target });
+
+        return id;
+    };
+
+    const ShardClass = createShardDO({
+        scheduler: () => {
+            return {
+                cancel: async (): Promise<{ cancelled: boolean }> => {
+                    return { cancelled: false };
+                },
+                runAfter: async (_delayMs: number, target: unknown, args: unknown, options?: { id?: string }): Promise<string> => accept(target, args, options),
+                runAt: async (_timestampMs: number, target: unknown, args: unknown, options?: { id?: string }): Promise<string> =>
+                    accept(target, args, options),
+            };
+        },
+    });
+
+    const { run, state } = createState();
+
+    /**
+     * The protected surface this suite has to reach. `underMutationId` stands in
+     * for the `x-lunora-mutation-id` header `fetch` stashes — the dedup namespace
+     * and the id are what decide whether a replay short-circuits, and they are
+     * request state, not dispatch arguments.
+     */
+    class Probe extends (ShardClass as unknown as new (state: unknown, env: unknown) => Record<string, unknown>) {
+        public cached(mutationId: string): { value: unknown } | undefined {
+            return (this as unknown as { readIdempotentResult: (id: string) => { value: unknown } | undefined }).readIdempotentResult(mutationId);
+        }
+
+        public retry(): Promise<number | undefined> {
+            return (this as unknown as { pollScheduleOutbox: () => Promise<number | undefined> }).pollScheduleOutbox();
+        }
+
+        public underMutationId(id: string): void {
+            Object.assign(this, { currentRequestMutationId: id, currentRequestSystem: true });
+        }
+    }
+
+    const shard = new Probe(state, {}) as unknown as Harness["shard"] & { retry: () => Promise<number | undefined> };
+
+    return {
+        makeDue: () => {
+            run("UPDATE __schedule_outbox SET next_attempt_at = 0 WHERE dead = 0");
+        },
+        // Re-shaped into plain objects: `node:sqlite` answers null-prototype rows,
+        // which `toStrictEqual` reports as unequal with no visible difference.
+        outbox: () =>
+            (
+                run("SELECT id, attempts, dead FROM __schedule_outbox ORDER BY created_at ASC, id ASC") as {
+                    toArray: () => { attempts: number; dead: number; id: string }[];
+                }
+            )
+                .toArray()
+                .map((row) => {
+                    return { attempts: row.attempts, dead: row.dead, id: row.id };
+                }),
+        retry: () => shard.retry(),
+        scheduled,
+        shard,
+        setReachable: (next: boolean) => {
+            reachable = next;
+        },
+    };
+};
+
+const register = (path: string, kind: "action" | "mutation" | "query", handler: (ctx: TestCtx) => unknown): void => {
+    (LUNORA_FUNCTIONS as unknown as Record<string, unknown>)[path] = { args: {}, handler, kind };
+};
+
+describe("emitted shard — a deferred schedule that never reaches the scheduler", () => {
+    beforeAll(() => {
+        register("outbox:orderPlaced", "mutation", async (ctx) => {
+            await ctx.db.insert("notes", { boardId: "b1", body: "order", ownerId: "u1" });
+
+            const jobId = await ctx.scheduler.runAfter(0, { __lunoraRef: "outbox:charge" }, { orderId: "o-1" });
+
+            return { jobId, ok: true };
+        });
+
+        register("outbox:rollback", "mutation", async (ctx) => {
+            await ctx.db.insert("notes", { boardId: "b1", body: "doomed", ownerId: "u1" });
+            await ctx.scheduler.runAfter(0, { __lunoraRef: "outbox:charge" }, { orderId: "doomed" });
+
+            throw new Error("boom after runAfter");
+        });
+
+        // `ctx.runMutation` from INSIDE a mutation: no savepoints, so the inner
+        // dispatch rides the enclosing span — which COMMITS even though the inner
+        // handler threw. Its schedules are dropped anyway.
+        register("outbox:outerOverInnerRollback", "mutation", async (ctx) => {
+            await ctx.scheduler.runAfter(0, { __lunoraRef: "outbox:outer" }, {});
+
+            try {
+                await ctx.runMutation({ __lunoraRef: "outbox:rollback" }, {});
+            } catch {
+                // swallowed, exactly as the documented action shape does
+            }
+        });
+
+        register("outbox:countNotes", "query", async (ctx) => {
+            const rows = await ctx.db.query("notes").collect();
+
+            return rows.length;
+        });
+    });
+
+    it("keeps custody of the job when the post-commit dispatch fails, and retries it to the same id", async () => {
+        expect.assertions(8);
+
+        const harness = createHarness();
+
+        harness.setReachable(false);
+        harness.shard.underMutationId("m-1");
+
+        await expect(harness.shard.handleRpc("outbox:orderPlaced", {})).rejects.toThrow("SchedulerDO unreachable");
+
+        // The mutation's writes are durable...
+        await expect(harness.shard.handleRpc("outbox:countNotes", {})).resolves.toBe(1);
+
+        // ...and so is its replay-dedup row, carrying the job id the handler was
+        // handed. This pair is the whole defect: a client replaying `m-1` is
+        // answered from this row and told the mutation succeeded.
+        const cached = harness.shard.cached("m-1") as { value: { jobId: string; ok: boolean } } | undefined;
+
+        expect(cached?.value.ok).toBe(true);
+        expect(harness.scheduled).toStrictEqual([]);
+
+        // So the job has to be somewhere, and it is: one live outbox entry, under
+        // the id the caller was told its job had.
+        expect(harness.outbox()).toStrictEqual([{ attempts: 0, dead: 0, id: cached?.value.jobId }]);
+
+        // The scheduler comes back; the retry tier hands it the job — same id, so
+        // a caller holding it can still `cancel`, and a duplicate cannot be minted.
+        harness.setReachable(true);
+
+        await expect(harness.retry()).resolves.toBeUndefined();
+
+        expect(harness.scheduled).toStrictEqual([{ args: { orderId: "o-1" }, id: cached?.value.jobId, target: { __lunoraRef: "outbox:charge" } }]);
+        expect(harness.outbox()).toStrictEqual([]);
+    });
+
+    it("takes no custody at all when the dispatch succeeds", async () => {
+        expect.assertions(2);
+
+        const harness = createHarness();
+
+        await expect(harness.shard.handleRpc("outbox:orderPlaced", {})).resolves.toStrictEqual({ jobId: expect.any(String) as unknown as string, ok: true });
+
+        // Custody lasts from the COMMIT to the acknowledgement and no longer, so
+        // the steady state leaves the table empty and the alarm tier dormant.
+        expect(harness.outbox()).toStrictEqual([]);
+    });
+
+    it("drops custody with the transaction when the mutation rolls back", async () => {
+        expect.assertions(3);
+
+        const harness = createHarness();
+
+        await expect(harness.shard.handleRpc("outbox:rollback", {})).rejects.toThrow("boom after runAfter");
+        await expect(harness.shard.handleRpc("outbox:countNotes", {})).resolves.toBe(0);
+
+        // The entry was written inside the span, so ROLLBACK took it. Retrying a
+        // job whose writes never landed is the failure mode the buffering exists
+        // to prevent, and the outbox must not reintroduce it.
+        expect(harness.outbox()).toStrictEqual([]);
+    });
+
+    it("drops only the inner window's custody when a nested mutation throws inside a committing one", async () => {
+        expect.assertions(3);
+
+        const harness = createHarness();
+
+        await expect(harness.shard.handleRpc("outbox:outerOverInnerRollback", {})).resolves.toBeUndefined();
+
+        // The inner dispatch shares the enclosing span, so its entry is NOT rolled
+        // back by its own throw — the settle has to release it explicitly, or the
+        // retry loop resurrects a job the design deliberately dropped.
+        expect(harness.outbox()).toStrictEqual([]);
+        expect(harness.scheduled).toStrictEqual([{ args: {}, id: expect.any(String), target: { __lunoraRef: "outbox:outer" } }]);
+    });
+
+    it("parks an entry the scheduler never accepts, rather than retrying it forever", async () => {
+        expect.assertions(4);
+
+        const harness = createHarness();
+
+        harness.setReachable(false);
+
+        await expect(harness.shard.handleRpc("outbox:orderPlaced", {})).rejects.toThrow("SchedulerDO unreachable");
+
+        // Seven attempts fail and each pushes the entry out along the ladder; the
+        // test skips the wait rather than the attempt, so the ceiling being
+        // exercised is the real one.
+        for (let attempt = 1; attempt < 8; attempt += 1) {
+            harness.makeDue();
+            // eslint-disable-next-line no-await-in-loop -- the ladder is sequential by construction: each attempt reads the row the previous one wrote
+            await harness.retry();
+        }
+
+        expect(harness.outbox()).toStrictEqual([{ attempts: 7, dead: 0, id: expect.any(String) }]);
+
+        // The eighth exhausts it. The entry is PARKED, not deleted: a job that was
+        // promised to a caller and will not be enqueued is evidence, and the
+        // operator needs to be able to find it.
+        harness.makeDue();
+
+        await harness.retry();
+
+        expect(harness.outbox()).toStrictEqual([{ attempts: 8, dead: 1, id: expect.any(String) }]);
+
+        // And it is out of the loop for good — a dead entry is not re-offered, so
+        // the alarm goes quiet instead of spinning on a job that will never land.
+        harness.makeDue();
+
+        await expect(harness.retry()).resolves.toBeUndefined();
+    });
+});

--- a/packages/codegen/__tests__/emit-shard-transactional-run.test.ts
+++ b/packages/codegen/__tests__/emit-shard-transactional-run.test.ts
@@ -103,7 +103,13 @@ describe("emitShard — deferred scheduling", () => {
         // admin/lifecycle ctx with no registered kind — got the BEGIN/COMMIT span
         // for a mutation they composed with the schedule buffer missing, and the
         // job reached the SchedulerDO while that span was still open.
-        expect(emitted).toContain('const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);');
+        //
+        // The second argument is the durable custody the buffer needs to be honest:
+        // everything between the COMMIT and the scheduler's acknowledgement is
+        // outside the transaction, so without it a failure there leaves durable
+        // writes, a durable replay-dedup row answering the client's retry with a
+        // cached success, and a job that exists nowhere.
+        expect(emitted).toContain('const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());');
         expect(emitted).toContain("scheduler,");
     });
 
@@ -128,7 +134,7 @@ describe("emitShard — deferred scheduling", () => {
         expect(emitted).toContain(
             'const schedulerBase = markUnvouchableReads((config.scheduler?.(env) ?? schedulerStub) as SchedulerLike, options.onRead, ["get", "list"]);',
         );
-        expect(emitted.indexOf("const schedulerBase =")).toBeLessThan(emitted.indexOf("withDeferredSchedules(schedulerBase)"));
+        expect(emitted.indexOf("const schedulerBase =")).toBeLessThan(emitted.indexOf("withDeferredSchedules(schedulerBase,"));
     });
 
     it("settles the buffer against the transaction outcome, and only after it resolves", () => {

--- a/packages/codegen/__tests__/emitted-shard-contract.ts
+++ b/packages/codegen/__tests__/emitted-shard-contract.ts
@@ -27,7 +27,8 @@
  */
 import type { SubscriptionIdentity, TraceRefLike } from "@lunora/do";
 import { ShardDO } from "@lunora/do";
-import { beginDeferredDeletes, beginDeferredSchedules, flushDeferredDeletes } from "@lunora/server";
+import { beginDeferredDeletes, beginDeferredSchedules, flushDeferredDeletes, withDeferredSchedules } from "@lunora/server";
+import type { SchedulerLike } from "@lunora/shard-engine";
 
 class EmittedShardContract extends ShardDO {
     public override async handleRpc(): Promise<unknown> {
@@ -56,6 +57,26 @@ class EmittedShardContract extends ShardDO {
         await this.scheduleSourcePoll();
 
         return undefined;
+    }
+
+    /**
+     * Mirrors the generated `scheduleOutboxScheduler` override — the seam the
+     * deferred-schedule outbox retries through. The generated body answers
+     * `config.scheduler?.(env)`, so the base's return type has to admit
+     * `undefined`; if it stops doing so, every generated shard stops compiling and
+     * this is where that surfaces.
+     */
+    // eslint-disable-next-line class-methods-use-this -- mirrors the generated override's shape; the real body reads `config.scheduler`
+    protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+        return undefined;
+    }
+
+    /**
+     * Mirrors the generated `buildCtx`'s scheduler wiring: the facade is handed
+     * `this.scheduleOutbox()`, which is `protected` for exactly this call.
+     */
+    protected wrapScheduler(scheduler: SchedulerLike): SchedulerLike {
+        return withDeferredSchedules(scheduler, this.scheduleOutbox());
     }
 
     /**

--- a/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/delta-sync/lunora/_generated/shard.ts
@@ -535,6 +535,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async runRelationFanoutRead(functionPath: string, args: Record<string, unknown>): Promise<unknown> {
             this.ensureMigrated();
 
@@ -1094,7 +1103,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -673,6 +673,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
 
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to `schedulerStub` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // `ctx.scheduler` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
+
         protected override async runRelationFanoutRead(functionPath: string, args: Record<string, unknown>): Promise<unknown> {
             this.ensureMigrated();
 
@@ -1125,7 +1134,16 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so `get`/`list` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // `this.scheduleOutbox()` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by `pollScheduleOutbox` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between `ctx.storage`
             // and `ctx.db.system._storage` so both read the same R2 binding. The
             // `storageStub` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -5761,6 +5761,15 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
         protected override isMutationFunction(functionPath: string): boolean {
             return LUNORA_FUNCTIONS[functionPath]?.kind === "mutation";
         }
+
+        // The scheduler the deferred-schedule outbox retries through. Only the
+        // CONFIGURED one: falling back to \`schedulerStub\` would have an app with no
+        // scheduler retry every entry against a thrower until the attempt ceiling
+        // parked it, and there is nothing to park — an app with no scheduler has no
+        // \`ctx.scheduler\` call that reached the buffer in the first place.
+        protected override scheduleOutboxScheduler(): SchedulerLike | undefined {
+            return config.scheduler?.((this.env ?? {}) as Record<string, unknown>) as SchedulerLike | undefined;
+        }
 ${relationFanout.override}
         protected override async executeSubscription(functionPath: string, args: Record<string, unknown>, identity?: SubscriptionIdentity): Promise<{ ranges?: Map<string, KeyRange[]>; result: unknown; tables: Set<string> } | null> {
             const registered = LUNORA_FUNCTIONS[functionPath];
@@ -6170,7 +6179,16 @@ ${vectorsBuild}${aiBuild}${everyContextBuild}${containersBuild}${workflowsBuild}
             // stays unwrapped.
             //
             // Wrapped OUTSIDE the read-stamping facade so \`get\`/\`list\` stay stamped.
-            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase);
+            //
+            // \`this.scheduleOutbox()\` is what keeps the buffer honest. Everything
+            // between the COMMIT and the scheduler's acknowledgement is outside the
+            // transaction, so a failure there leaves writes that are durable and a
+            // job that exists nowhere — and the mutation's replay-dedup row committed
+            // inside the span, so the client's retry is answered from cache and told
+            // it succeeded. The outbox takes custody of each buffered call inside the
+            // transaction and releases it once the scheduler has the job; what
+            // survives is retried by \`pollScheduleOutbox\` on the shared poll alarm.
+            const scheduler = contextKind === "query" ? schedulerBase : withDeferredSchedules(schedulerBase, this.scheduleOutbox());
             // Build the storage adapter once and share it between \`ctx.storage\`
             // and \`ctx.db.system._storage\` so both read the same R2 binding. The
             // \`storageStub\` fallback satisfies SystemReaderStorageLike structurally

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -100,6 +100,10 @@ import type {
     ResolvedShape,
     RlsPoliciesResult,
     RpcRequest,
+    ScheduleOutbox,
+    ScheduleOutboxEnvelope,
+    ScheduleOutboxRow,
+    SchedulerLike,
     SearchBackfillProgress,
     ShapeDiffCache,
     ShapePokeCursorRow,
@@ -155,6 +159,7 @@ import {
     cursorBelowRetainedFloor,
     DATA_MIGRATION_STATE_TABLE,
     DEFAULT_MAX_RELAYS,
+    deferScheduleOutbox,
     deleteGlobalShapeSnapshot,
     deleteGlobalShapeSnapshotsForConnection,
     deleteShapePokeCursor,
@@ -163,6 +168,7 @@ import {
     DurableStreamRunner,
     envOptionalPositiveInt,
     FLAGS_FUNCTION_PREFIX,
+    forgetScheduleOutbox,
     gateReplicaDispatch,
     GlobalPollTick,
     globalShapeReadKey,
@@ -177,8 +183,10 @@ import {
     minCdcReplayableSeq,
     minCdcSeq,
     minShapePokeCursor,
+    parkScheduleOutbox,
     parseExportShardArgs,
     parseImportShardArgs,
+    probeScheduleOutbox,
     projectColumns,
     ReactiveCache,
     reactiveCacheKey,
@@ -190,6 +198,7 @@ import {
     readCdcEpoch,
     readClientWatermark,
     readDeployInfo,
+    readDueScheduleOutbox,
     readGlobalShapeSnapshot,
     readIdempotent,
     readMigrationStatus,
@@ -202,6 +211,7 @@ import {
     recordFanoutPass,
     recordGlobalPollPass,
     recordQueueMessages,
+    recordScheduleOutbox,
     recordShapeProbePass,
     RELATION_FUNCTION_PREFIX,
     runSocketPool,
@@ -217,6 +227,7 @@ import {
     summarizeSubscriptions,
     TransactionHeadroomTracker,
     trimIdempotent,
+    trimScheduleOutbox,
     trySendFrame,
     UNVOUCHABLE_DEP,
     writeGlobalShapeSnapshot,
@@ -1058,6 +1069,51 @@ const IDEMPOTENCY_GC_INTERVAL_MS = 3_600_000;
 const ANONYMOUS_CALLER = stableStringify({ claims: null, ip: null, system: false, userId: null });
 
 /**
+ * How many deferred-schedule outbox entries one alarm tick may attempt. The
+ * dispatches are outbound RPCs, so a backlog is drained across several ticks
+ * rather than held open in one — the same bound `TTL_SWEEP_BATCH` puts on the
+ * sweep tier for the same reason.
+ */
+const SCHEDULE_OUTBOX_BATCH = 32;
+
+/**
+ * How many times a deferred schedule is re-offered to the scheduler before the
+ * entry is parked. Together with {@link SCHEDULE_OUTBOX_BACKOFF_MS} this spans a
+ * little over an hour — long enough to ride out a scheduler restart or a
+ * rebalance, short enough that a job the scheduler will never accept (a caller
+ * error it refuses as `INVALID_INPUT`) stops costing alarms and starts being a
+ * reported fact instead.
+ */
+const SCHEDULE_OUTBOX_MAX_ATTEMPTS = 8;
+
+/**
+ * The retry ladder, indexed by attempt count: 5s, 15s, 45s, 2m, 6m, 18m, 30m,
+ * 30m. Exponential until it flattens, so a transient blip is picked up almost
+ * immediately while a persistent outage does not spin the alarm.
+ */
+const SCHEDULE_OUTBOX_BACKOFF_MS: ReadonlyArray<number> = [5000, 15_000, 45_000, 120_000, 360_000, 1_080_000, 1_800_000, 1_800_000];
+
+/**
+ * How long after a failed hand-off the first retry is offered — also the wake the
+ * settle and the cold-start probe ask for, so custody that survived a dispatch is
+ * re-offered promptly rather than at whatever cadence another tier happens to
+ * want.
+ */
+const SCHEDULE_OUTBOX_FIRST_RETRY_MS = 5000;
+
+/** The ladder's rung for `attempts` failures so far, flattening at its last entry. */
+const scheduleOutboxBackoffFor = (attempts: number): number =>
+    SCHEDULE_OUTBOX_BACKOFF_MS[Math.min(attempts, SCHEDULE_OUTBOX_BACKOFF_MS.length - 1)] ?? SCHEDULE_OUTBOX_FIRST_RETRY_MS;
+
+/**
+ * How long a PARKED outbox entry is kept. A job that exhausted its attempts is
+ * evidence — the operator needs to know what was promised and never enqueued —
+ * so it is retained for a week rather than deleted, and trimmed after. Live
+ * entries are never trimmed; the attempt ceiling is what bounds those.
+ */
+const SCHEDULE_OUTBOX_RETENTION_MS = 604_800_000;
+
+/**
  * The refusal a paid (`.x402`) procedure gets on a socket. The paywall lives at
  * the origin worker (`/_lunora/rpc`, REST, `serverQuery`), which a WebSocket
  * never crosses — and neither a live subscription (seed plus every poke) nor a
@@ -1418,22 +1474,26 @@ abstract class ShardDO {
      * polled). External-source ingest instead reports the earliest NEXT-DUE
      * timestamp across its non-manual sources (or `undefined` when none exist) —
      * a source with a large `refresh.everyMs` must sleep until it's actually due,
-     * not spin at the global-shape floor. Returns `undefined` when NEITHER tier
-     * has pending work, so the DO can go fully idle instead of re-arming for no
-     * reason; otherwise the earlier of the two candidate times (never later than
-     * `nowMs`, so a source that's already due arms essentially immediately).
+     * not spin at the global-shape floor. The TTL sweep and the deferred-schedule
+     * outbox report the same way; the outbox is `undefined` in the steady state,
+     * since an entry exists only between a mutation's COMMIT and the moment the
+     * scheduler accepts its job. Returns `undefined` when NO tier has pending
+     * work, so the DO can go fully idle instead of re-arming for no reason;
+     * otherwise the earliest candidate time (never later than `nowMs`, so a tier
+     * that's already due arms essentially immediately).
      */
     private static nextPollAlarmTarget(
         globalShapesRemaining: number,
         nextSourceDueAt: number | undefined,
         nextTtlDueAt: number | undefined,
+        nextOutboxDueAt: number | undefined,
         nowMs: number,
     ): number | undefined {
         const globalTarget = globalShapesRemaining > 0 ? nowMs + ShardDO.GLOBAL_SHAPE_POLL_INTERVAL_MS : undefined;
 
         // The earliest of the tiers that report a pending time; a tier that's
         // already due (past timestamp) is floored to `nowMs` so it arms promptly.
-        const candidates = [globalTarget, nextSourceDueAt, nextTtlDueAt]
+        const candidates = [globalTarget, nextSourceDueAt, nextTtlDueAt, nextOutboxDueAt]
             .filter((value): value is number => value !== undefined)
             .map((value) => Math.max(value, nowMs));
 
@@ -4707,6 +4767,126 @@ abstract class ShardDO {
         return this.scheduleGlobalPoll();
     }
 
+    /**
+     * Durable custody for this shard's deferred `ctx.scheduler` calls — the
+     * `ScheduleOutbox` the generated `buildCtx` hands to
+     * `withDeferredSchedules`.
+     *
+     * The two halves land on opposite sides of the COMMIT on purpose:
+     *
+     * - `record` runs while the handler is still inside its transaction, so the
+     * entry is durable exactly when the writes are and rolls back with them.
+     * It deliberately does NOT swallow: a failure here is still inside the span,
+     * so letting it throw rolls the mutation back — the one moment at which
+     * failing is free. Swallowing would put us back where we started, committing
+     * writes whose job nothing is holding.
+     * - `forget` runs after the dispatch, so it must never fail the response. A
+     * delete that does not land leaves an entry the retry loop re-offers, which
+     * the scheduler refuses as a duplicate and which is then dropped — the error
+     * self-heals into one wasted RPC.
+     *
+     * What survives a settle is therefore exactly the set of jobs that were
+     * promised and not enqueued, which is what {@link ShardDO.pollScheduleOutbox}
+     * drains.
+     */
+    protected scheduleOutbox(): ScheduleOutbox {
+        return {
+            forget: (id: string): void => {
+                try {
+                    forgetScheduleOutbox(this.sql as SqlExec, id);
+                } catch {
+                    // Post-commit: a missing table (pre-migration shard / test stub)
+                    // or a stub handle must not fail a mutation that succeeded. The
+                    // stale entry is re-offered and refused as a duplicate.
+                }
+            },
+            record: (id, envelope): void => {
+                recordScheduleOutbox(this.sql as SqlExec, id, JSON.stringify(envelope), Date.now());
+            },
+            wake: (): void => {
+                // Fire-and-forget: this is called from a settle that is about to
+                // throw, and arming the alarm is not allowed to change what it
+                // throws. `scheduleGlobalPoll` already no-ops when an earlier wake
+                // is pending and absorbs a host that cannot arm.
+                this.scheduleGlobalPoll(Date.now() + SCHEDULE_OUTBOX_FIRST_RETRY_MS).catch(() => {
+                    /* the host could not arm; the next cold start probes again */
+                });
+            },
+        };
+    }
+
+    /**
+     * The scheduler the outbox retry loop dispatches through.
+     *
+     * A seam, like {@link ShardDO.ttlSweeps}: the base has no `createShardDO`
+     * config to read, so it reports `undefined` and the tier stays dormant. The
+     * generated subclass overrides it with the app's configured scheduler —
+     * and only when one is configured, so a shard whose `ctx.scheduler` is the
+     * throwing stub does not retry against a stub eight times before parking.
+     * @returns the scheduler to retry through, or `undefined` when this shard has none
+     */
+    // eslint-disable-next-line class-methods-use-this -- base-class override hook: the generated subclass returns `config.scheduler?.(env)`
+    protected scheduleOutboxScheduler(): SchedulerLike | undefined {
+        return undefined;
+    }
+
+    /**
+     * Re-offer the deferred schedules that were promised to a caller and never
+     * reached the scheduler — the retry half of {@link ShardDO.scheduleOutbox}.
+     * Shares the poll alarm with the source-ingest and TTL tiers, and reports the
+     * earliest next-due time the same way, so a shard with an empty outbox (the
+     * steady state — an entry lives only between a COMMIT and its dispatch) arms
+     * nothing.
+     *
+     * Each attempt reuses the id the caller was already handed, so an entry whose
+     * original dispatch DID land — the failure was the `forget`, or the isolate
+     * died between the two — is refused as a duplicate rather than scheduled
+     * twice. A refusal and an acceptance are therefore both "the scheduler has
+     * it", and both end custody.
+     *
+     * The bound is {@link SCHEDULE_OUTBOX_MAX_ATTEMPTS}: a job the scheduler will
+     * never accept stops costing alarms and becomes a reported fact instead —
+     * parked, logged at `error` with its id and target, and kept for
+     * {@link SCHEDULE_OUTBOX_RETENTION_MS} so an operator can see what was
+     * promised and never enqueued. The queue is bounded on both sides: the
+     * ceiling stops live entries accumulating, the retention sweep stops parked
+     * ones doing so. The sweep rides whatever tick reaches this tier, so a shard
+     * holding ONLY parked entries keeps them until something else wakes it —
+     * which is the right trade: they are one row per genuinely lost job, not a
+     * loop that grows on its own.
+     */
+    protected async pollScheduleOutbox(trace?: TraceRefLike): Promise<number | undefined> {
+        const sql = this.sql as SqlExec;
+        const now = Date.now();
+        let probe: { dueAt: number | undefined; populated: boolean };
+
+        try {
+            probe = probeScheduleOutbox(sql);
+        } catch {
+            // No table (a shard whose store predates it, a harness with a stub
+            // handle) means no custody, which is a dormant tier and not a tier
+            // failure — re-arming the alarm over it would wake an idle DO forever.
+            return undefined;
+        }
+
+        if (!probe.populated) {
+            return undefined;
+        }
+
+        if (probe.dueAt !== undefined && probe.dueAt <= now) {
+            const scheduler = this.scheduleOutboxScheduler();
+
+            for (const entry of readDueScheduleOutbox(sql, now, SCHEDULE_OUTBOX_BATCH)) {
+                // eslint-disable-next-line no-await-in-loop -- each attempt is an outbound RPC to one DO; firing the batch at once is what the per-tick bound exists to prevent
+                await this.retryScheduleOutboxEntry(sql, scheduler, entry, trace);
+            }
+        }
+
+        trimScheduleOutbox(sql, now - SCHEDULE_OUTBOX_RETENTION_MS);
+
+        return probeScheduleOutbox(sql).dueAt;
+    }
+
     /** This DO's shard key (its DO name), or `__root__` for the single-DO default. The `tenantBy` mapper binds it into the source query. */
     protected currentShardKey(): string {
         return this.runner.shardKey ?? ROOT_SHARD_NAME;
@@ -4747,9 +4927,17 @@ abstract class ShardDO {
      * error is recorded rather than swallowed.
      */
     protected async ensureShardInit(): Promise<void> {
-        this.shardInitOnce ??= this.runShardInit().catch((error: unknown) => {
-            this.recordShardInitError("__shard_init__", error);
-        });
+        this.shardInitOnce ??= (async (): Promise<void> => {
+            try {
+                await this.runShardInit();
+            } catch (error: unknown) {
+                this.recordShardInitError("__shard_init__", error);
+            }
+
+            // After init, not instead of it: the probe is a read, and a shard whose
+            // init failed is exactly one that may be holding custody.
+            this.armScheduleOutboxRetry();
+        })();
 
         await this.shardInitOnce;
     }
@@ -6559,6 +6747,12 @@ abstract class ShardDO {
         // reports its next-due.
         const nextTtlDueAt = await pollTier("ttl:sweep", async () => this.pollTtlSweeps(trace));
 
+        // Deferred-schedule custody shares this alarm too. Entries exist only
+        // between a mutation's COMMIT and the scheduler accepting its job, so in
+        // the steady state this reports `undefined` and arms nothing; when a
+        // dispatch failed (or never ran) it is what stops the job being lost.
+        const nextOutboxDueAt = await pollTier("scheduler:outbox", async () => this.pollScheduleOutbox(trace));
+
         // Drain the tables the ingest poll just wrote: a sourced table is local, so
         // its `defineShape` subscribers are poked through the standard
         // changed-table → `pokeShapeSubscribers` path (the same one a mutation
@@ -6567,7 +6761,7 @@ abstract class ShardDO {
         // when nothing was queued (non-sourced DOs, or a steady-state tick).
         await this.flushChangedTables();
 
-        const nextAlarmAt = ShardDO.nextPollAlarmTarget(globalShapesRemaining, nextSourceDueAt, nextTtlDueAt, Date.now());
+        const nextAlarmAt = ShardDO.nextPollAlarmTarget(globalShapesRemaining, nextSourceDueAt, nextTtlDueAt, nextOutboxDueAt, Date.now());
 
         if (nextAlarmAt !== undefined) {
             await this.scheduleGlobalPoll(nextAlarmAt);
@@ -11117,6 +11311,116 @@ abstract class ShardDO {
             if (this.globalPollArmedAt === target) {
                 this.globalPollArmedAt = pendingAt;
             }
+        }
+    }
+
+    /**
+     * One outbox attempt: replay the stored call, then either end custody or push
+     * the entry out along {@link SCHEDULE_OUTBOX_BACKOFF_MS} — parking it once the
+     * ladder runs out.
+     *
+     * An envelope that will not parse is parked immediately rather than retried:
+     * no number of attempts turns malformed JSON into a job, and the log line is
+     * the only useful output left.
+     */
+    private async retryScheduleOutboxEntry(sql: SqlExec, scheduler: SchedulerLike | undefined, entry: ScheduleOutboxRow, trace?: TraceRefLike): Promise<void> {
+        const attempts = entry.attempts + 1;
+        let envelope: ScheduleOutboxEnvelope | undefined;
+
+        try {
+            envelope = JSON.parse(entry.envelopeJson) as ScheduleOutboxEnvelope;
+        } catch {
+            envelope = undefined;
+        }
+
+        if (scheduler === undefined || envelope === undefined) {
+            this.parkScheduleOutboxEntry(
+                sql,
+                entry.id,
+                attempts,
+                envelope?.target,
+                scheduler === undefined ? "no scheduler is configured on this shard" : "its stored payload is unreadable",
+                trace,
+            );
+
+            return;
+        }
+
+        try {
+            // `runAt`, never `runAfter`: the envelope stores the absolute instant
+            // the caller asked for, so an entry that spent an hour in custody still
+            // fires when it was meant to rather than an hour late.
+            await (scheduler.runAt as (timestampMs: number, target: never, args: never, options?: never) => Promise<string>)(
+                envelope.when,
+                envelope.target as never,
+                decodeWire(envelope.args) as never,
+                { ...envelope.options, id: entry.id } as never,
+            );
+
+            forgetScheduleOutbox(sql, entry.id);
+        } catch (error) {
+            // A duplicate id means the scheduler already has this job — the first
+            // dispatch landed and only the bookkeeping was lost. Custody ends the
+            // same way an acceptance ends it.
+            if (isLunoraError(error) && error.code === "DUPLICATE_SCHEDULE_ID") {
+                forgetScheduleOutbox(sql, entry.id);
+
+                return;
+            }
+
+            if (attempts >= SCHEDULE_OUTBOX_MAX_ATTEMPTS) {
+                this.parkScheduleOutboxEntry(
+                    sql,
+                    entry.id,
+                    attempts,
+                    envelope.target,
+                    `${String(SCHEDULE_OUTBOX_MAX_ATTEMPTS)} attempts all failed — last: ${error instanceof Error ? error.message : String(error)}`,
+                    trace,
+                );
+
+                return;
+            }
+
+            deferScheduleOutbox(sql, entry.id, attempts, Date.now() + scheduleOutboxBackoffFor(attempts));
+        }
+    }
+
+    /** Park one entry and say so at `error` — a job was promised to a caller and will not be enqueued. */
+    private parkScheduleOutboxEntry(sql: SqlExec, id: string, attempts: number, target: unknown, why: string, trace?: TraceRefLike): void {
+        parkScheduleOutbox(sql, id, attempts);
+
+        this.logs.push({
+            functionPath: "scheduler:outbox",
+            level: "error",
+            message: `deferred schedule ${id} (target ${target === undefined ? "<unreadable>" : JSON.stringify(target)}) will not be enqueued: ${why}. Its mutation committed; the job did not.`,
+            timestamp: Date.now(),
+            traceId: trace?.traceId,
+        });
+    }
+
+    /**
+     * Arm the poll alarm once per warm instance if this shard is holding deferred
+     * schedules nobody has enqueued.
+     *
+     * The settle asks for a wake when its own dispatch fails, but the window that
+     * loses a job most quietly is the one where no settle ran at all: the DO is
+     * evicted between the COMMIT and the dispatch, and the entry sits with nothing
+     * pointing at it. Every entry point into this object goes through shard init,
+     * so hooking it here means the next time anything wakes this shard the retry
+     * loop starts — for the cost of one indexed read per cold start.
+     *
+     * Swallows: a shard whose store predates the table (or a harness with a stub
+     * handle) simply has no custody to resume, and init must not fail for it.
+     */
+    private armScheduleOutboxRetry(): void {
+        try {
+            if (probeScheduleOutbox(this.sql as SqlExec).dueAt !== undefined) {
+                this.scheduleGlobalPoll(Date.now() + SCHEDULE_OUTBOX_FIRST_RETRY_MS).catch(() => {
+                    /* the host could not arm; the next cold start probes again */
+                });
+            }
+        } catch {
+            // No table, no custody to resume.
         }
     }
 

--- a/packages/server/src/deferred-schedules.ts
+++ b/packages/server/src/deferred-schedules.ts
@@ -1,5 +1,7 @@
 import { assertScheduleDelay, assertScheduleInstant, resolveScheduleId } from "@lunora/scheduler";
 
+import { encodeArgsOrThrow } from "../../../shared/wire-codec";
+
 /**
  * `ctx.scheduler.runAfter(0, …)` — documented as "the deterministic equivalent
  * of an `afterCommit` hook" — held until the mutation's transaction has actually
@@ -19,6 +21,23 @@ import { assertScheduleDelay, assertScheduleInstant, resolveScheduleId } from "@
  * {@link beginDeferredSchedules}) a `runAfter`/`runAt` call records the call and
  * returns, and the window's settle either dispatches the buffered calls — in
  * declaration order, after the commit — or drops them.
+ *
+ * ## Why buffering alone is not enough
+ *
+ * Everything between the COMMIT and the scheduler's acknowledgement is outside
+ * the transaction, and a failure there leaves writes that are durable and a job
+ * that exists nowhere: the scheduler unreachable, the DO evicted mid-settle, the
+ * isolate killed. That is not merely an error the caller sees — the mutation's
+ * replay-dedup row commits INSIDE the span, so the client's retry short-circuits
+ * on it and is told the mutation succeeded. The job is lost with nothing
+ * reported.
+ *
+ * So a buffered call also takes out durable custody ({@link ScheduleOutbox}) as
+ * it is buffered — inside the transaction, next to the writes — and releases it
+ * only once the scheduler has the job. What survives a settle is precisely the
+ * set of jobs that were promised and not enqueued, and the host retries them
+ * until they land. The id is decided before the call, so a retry of a job that
+ * did land is refused as a duplicate rather than double-scheduled.
  *
  * ## The job id
  *
@@ -62,8 +81,55 @@ import { assertScheduleDelay, assertScheduleInstant, resolveScheduleId } from "@
  * enclosing window) or hands them to the window that will commit on its behalf.
  */
 
-/** A buffered `runAfter`/`runAt`, ready to be replayed against the real scheduler. */
-type PendingSchedule = () => Promise<unknown>;
+/**
+ * A buffered `runAfter`/`runAt`, ready to be replayed against the real scheduler.
+ *
+ * The `id` rides along because the window owes the outbox a `forget(id)` on both
+ * exits — the job landed, or the window it belonged to was dropped — and the
+ * closure alone cannot say which entry it is.
+ */
+interface PendingSchedule {
+    id: string;
+    run: () => Promise<unknown>;
+}
+
+/**
+ * Durable custody for a buffered schedule, between the COMMIT and the moment the
+ * scheduler accepts the job.
+ *
+ * A structural mirror of `@lunora/shard-engine`'s `ScheduleOutbox`, for the same
+ * reason {@link SchedulerLike} below mirrors rather than imports: this type
+ * appears in `withDeferredSchedules`'s exported signature, and naming a
+ * `@lunora/shard-engine` type there pulls that package into the declaration
+ * bundle of everything that re-exports this one. `@lunora/do` supplies the real
+ * implementation and the shapes match structurally.
+ *
+ * The two halves land on opposite sides of the COMMIT on purpose. `record` runs
+ * while the handler is still inside its transaction, so the entry is durable
+ * exactly when the writes are and rolls back with them; `forget` runs after the
+ * dispatch settles. What survives is precisely the set of jobs that were promised
+ * and not enqueued.
+ *
+ * Optional throughout: a ctx with no outbox (a unit harness, a host with no
+ * store) keeps the previous best-effort behaviour rather than failing to build.
+ */
+interface ScheduleOutbox {
+    /** Release custody — the scheduler has the job, or the window that owned it was dropped. */
+    forget: (id: string) => void;
+
+    /**
+     * Take custody of one buffered call. Runs INSIDE the transaction, so a throw
+     * here rolls the mutation back — which is the right answer, and the only
+     * moment at which failing is free.
+     *
+     * `when` is always the ABSOLUTE instant, even for a `runAfter`: a delay
+     * replayed after an hour in custody would fire an hour late, and the retry has
+     * to reproduce the fire time the caller asked for, not the wait.
+     */
+    record: (id: string, envelope: { args: unknown; options: Record<string, unknown> | undefined; target: unknown; when: number }) => void;
+    /** Ask the host to wake its retry loop — called when a dispatch left entries behind. */
+    wake: () => void;
+}
 
 /** One open deferral window: one transaction's buffered calls. */
 interface ScheduleWindow {
@@ -80,6 +146,8 @@ interface ScheduleQueue {
      * through — an action schedules immediately, as documented.
      */
     innermost: ScheduleWindow | undefined;
+    /** Durable custody for this facade's buffered calls; absent on a harness with no store. */
+    outbox: ScheduleOutbox | undefined;
 }
 
 /**
@@ -88,6 +156,24 @@ interface ScheduleQueue {
  * and a queue stamped onto it would show up in anything that walks the context.
  */
 const queues = new WeakMap<object, ScheduleQueue>();
+
+/**
+ * Name a schedule target for an error message — a bare `"ns:fn"` string, a
+ * function reference's path, or a workflow/agent binding. Mirrors
+ * `@lunora/scheduler`'s own `targetLabel`, which cannot be imported: it is
+ * module-private there, and the point of naming the target is that the message is
+ * useful, not that the two spellings are shared.
+ */
+const scheduleTargetLabel = (target: unknown): string => {
+    if (typeof target === "string") {
+        return target;
+    }
+
+    const reference = (target ?? {}) as { __lunoraRef?: unknown; binding?: unknown };
+    const named = reference.__lunoraRef ?? reference.binding;
+
+    return typeof named === "string" ? named : "<unknown>";
+};
 
 /** The nearest window up the chain that has not settled yet, if any. */
 const enclosingWindow = (from: ScheduleWindow | undefined): ScheduleWindow | undefined => {
@@ -142,9 +228,9 @@ interface SchedulerLike {
  * — could not be type-checked against the contract this docblock describes.
  * @param scheduler the `ctx.scheduler` implementation to wrap
  */
-export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S => {
+export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S, outbox?: ScheduleOutbox): S => {
     const inner = scheduler as unknown as Record<string, unknown>;
-    const queue: ScheduleQueue = { innermost: undefined };
+    const queue: ScheduleQueue = { innermost: undefined, outbox };
 
     const call = (method: "runAfter" | "runAt", when: number, target: unknown, args: unknown, options: unknown): Promise<string> =>
         (inner[method] as (when: number, target: unknown, args: unknown, options: unknown) => Promise<string>).call(inner, when, target, args, options);
@@ -169,9 +255,28 @@ export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S 
         // stored under, and an id already taken still reaches the DO's refusal.
         const id = resolveScheduleId(options?.id);
 
+        // Durable custody, taken HERE — while the handler is still inside its
+        // transaction. That placement is the whole point: the entry commits with
+        // the writes, rolls back with them, and is what the shard retries from when
+        // the dispatch below never happens (the scheduler unreachable, the isolate
+        // gone). Deferring the record to the settle would put it back outside the
+        // transaction, next to the failure it exists to survive.
+        //
+        // The encode runs here for the same reason. `@lunora/scheduler` encodes
+        // `args` on its way to the DO and refuses a value the codec cannot carry;
+        // doing it at settle time made that refusal land AFTER the commit, on a
+        // mutation that had already succeeded. Encoded here it rolls the mutation
+        // back, which is the answer a caller can act on.
+        queue.outbox?.record(id, {
+            args: encodeArgsOrThrow(`ctx.scheduler.${method}`, scheduleTargetLabel(target), args),
+            options,
+            target,
+            when: method === "runAfter" ? Date.now() + when : when,
+        });
+
         // Buffered against the window that is innermost RIGHT NOW, so it is
         // dropped only if THAT transaction rolls back.
-        open.pending.push(async () => call(method, when, target, args, { ...options, id }));
+        open.pending.push({ id, run: async () => call(method, when, target, args, { ...options, id }) });
 
         return Promise.resolve(id);
     };
@@ -228,6 +333,12 @@ export const withDeferredSchedules = <S extends SchedulerLike>(scheduler: S): S 
  * order, and what failed is reported once at the end — as itself when one job
  * failed, so its code and status survive, and as an `AggregateError` when several
  * did.
+ *
+ * A failure still throws, and that is deliberate: a caller error the scheduler
+ * refuses (`DUPLICATE_SCHEDULE_ID`, `INVALID_INPUT`) must reach the developer who
+ * caused it. What changed is that the throw is no longer the only thing standing
+ * between the job and oblivion — the outbox entry survives it, so the answer to
+ * "the caller swallowed that error" is a retry rather than a lost job.
  * The caller's own post-commit work must still run: a settle that throws does not
  * excuse skipping the deferred-delete flush behind it.
  * @param context the dispatch context whose `scheduler` carries the queue
@@ -260,7 +371,20 @@ export const beginDeferredSchedules = (context: DeferredScheduleContext): ((comm
 
         const draining = opened.pending.splice(0);
 
-        if (!committed || draining.length === 0) {
+        if (draining.length === 0) {
+            return;
+        }
+
+        if (!committed) {
+            // Dropped, so the outbox must let go too — otherwise the retry loop
+            // resurrects exactly the jobs this window decided not to run. Not
+            // merely belt-and-braces: a `ctx.runMutation` nested inside a mutation
+            // has no savepoint, so its own throw settles it `false` while the
+            // ENCLOSING span still commits, and its entries would survive.
+            for (const { id } of draining) {
+                queue.outbox?.forget(id);
+            }
+
             return;
         }
 
@@ -276,10 +400,15 @@ export const beginDeferredSchedules = (context: DeferredScheduleContext): ((comm
 
         const failures: unknown[] = [];
 
-        for (const dispatch of draining) {
+        for (const { id, run } of draining) {
             try {
                 // eslint-disable-next-line no-await-in-loop -- declaration order is the contract: `runAfter(0, a)` then `runAfter(0, b)` must enqueue a before b
-                await dispatch();
+                await run();
+
+                // Accepted, so custody ends. Anything still in the outbox after
+                // this loop is a job the caller was told it had and the scheduler
+                // does not — which is exactly what the retry loop is for.
+                queue.outbox?.forget(id);
             } catch (error) {
                 failures.push(error);
             }
@@ -288,6 +417,10 @@ export const beginDeferredSchedules = (context: DeferredScheduleContext): ((comm
         const [first, ...rest] = failures;
 
         if (first !== undefined) {
+            // Entries survived this drain, so the host's retry loop has work. Asked
+            // for before the throw, which is the only other exit from here.
+            queue.outbox?.wake();
+
             // A lone failure is rethrown AS ITSELF: the SchedulerDO's refusals are
             // coded (`DUPLICATE_SCHEDULE_ID`, `INVALID_INPUT`) and that code decides
             // the status and whether the message survives redaction, all of which an

--- a/packages/shard-engine/src/ctx-db-migrations.ts
+++ b/packages/shard-engine/src/ctx-db-migrations.ts
@@ -33,6 +33,7 @@ import { migrateCommitSeq } from "./ctx-db-commit-seq";
 import { migrateGlobalShapeSnapshot } from "./ctx-db-global-shape-snapshot";
 import { migrateIdempotency } from "./ctx-db-idempotency";
 import { migrateRelayShapes } from "./ctx-db-relay-shapes";
+import { migrateScheduleOutbox } from "./ctx-db-schedule-outbox";
 import { migrateSearchState } from "./ctx-db-search-state";
 import { migrateShapePokeCursor } from "./ctx-db-shape-poke-cursor";
 import { runDrizzle } from "./do-exec";
@@ -446,6 +447,14 @@ export const runShardMigrations = (
     // Always present: the mutation-replay dedup table is independent of CDC and
     // costs nothing until the first id-bearing mutation writes to it.
     migrateIdempotency(sql);
+
+    // Always present, and always NEXT TO the dedup table: the outbox is what makes
+    // that table honest. A dedup row says "this mutation succeeded"; without the
+    // outbox it can say that about a mutation whose deferred `ctx.scheduler` job
+    // never reached the SchedulerDO. A `ctx.scheduler` call needs no schema change
+    // to appear, so the table must exist before the first mutation makes one. Empty
+    // (and free) on a shard that schedules nothing.
+    migrateScheduleOutbox(sql);
 
     // Always present: the durable per-socket baseline for `.global()`-shape diff
     // pokes. Independent of CDC (global shapes are polled, not poke-live) and

--- a/packages/shard-engine/src/ctx-db-schedule-outbox.ts
+++ b/packages/shard-engine/src/ctx-db-schedule-outbox.ts
@@ -1,0 +1,232 @@
+/**
+ * The `__schedule_outbox` table: durable custody of a deferred
+ * `ctx.scheduler.runAfter`/`runAt` between the mutation's COMMIT and the moment
+ * the SchedulerDO actually accepts the job.
+ *
+ * A deferred schedule is buffered until the transaction commits and only then
+ * dispatched (see `@lunora/server`'s `deferred-schedules.ts`). Everything between
+ * those two points is outside the transaction, so a failure there — the
+ * SchedulerDO unreachable, the DO evicted, the isolate killed — leaves writes
+ * that are durable and a job that exists nowhere. The mutation's replay-dedup row
+ * commits inside the same span, so the client's retry short-circuits on it and is
+ * told the mutation succeeded: the job is lost with nothing reported.
+ *
+ * The row closes that window. It is written while the handler runs — INSIDE the
+ * transaction, so it is durable exactly when the writes are and disappears with
+ * them on a rollback — and deleted once the scheduler has accepted the job. A row
+ * that outlives its dispatch is a job that was promised and not enqueued, and the
+ * shard's poll alarm retries it with backoff until it lands or the attempt
+ * ceiling parks it.
+ *
+ * Retries are safe because the job id is decided BEFORE the call (see
+ * `resolveScheduleId`): re-dispatching an entry the SchedulerDO already accepted
+ * is refused as a duplicate rather than double-scheduled.
+ *
+ * Extracted as a cohesive unit next to `ctx-db-idempotency.ts`, which it exists
+ * to make honest, and it touches the store only through `SqlExec`.
+ */
+
+/* eslint-disable unicorn/prevent-abbreviations -- "ctx-db-schedule-outbox" mirrors its parent "ctx-db.ts" (the established public module name). */
+
+import { sql as dsql } from "drizzle-orm";
+
+import type { SqlExec } from "./ctx-db";
+import { runDrizzle } from "./do-exec";
+
+const SCHEDULE_OUTBOX_TABLE = "__schedule_outbox";
+
+/** One deferred schedule that has not been confirmed by the SchedulerDO yet. */
+interface ScheduleOutboxRow {
+    /** How many dispatch attempts have already failed. `0` until the first retry. */
+    attempts: number;
+    /** The buffered call, JSON-encoded — see {@link ScheduleOutboxEnvelope}. */
+    envelopeJson: string;
+    /** The job id the caller was already handed, and the id the retry must reuse. */
+    id: string;
+    /** Wall-clock millis the next retry becomes due. */
+    nextAttemptAt: number;
+}
+
+/**
+ * The buffered `runAfter`/`runAt` call, in the form the retry replays it.
+ *
+ * `args` is stored WIRE-ENCODED (the same encode `@lunora/scheduler` applies on
+ * the way to the DO), so a `bigint`/`ArrayBuffer` argument survives the JSON hop
+ * and a value the codec refuses fails inside the transaction rather than after
+ * the commit.
+ */
+interface ScheduleOutboxEnvelope {
+    args: unknown;
+    options: Record<string, unknown> | undefined;
+    target: unknown;
+
+    /**
+     * The ABSOLUTE instant the job was asked to fire at — a `runAfter`'s delay is
+     * normalised against the clock at buffer time. A delay replayed after an hour
+     * in custody would fire an hour late; the retry has to reproduce the fire time
+     * the caller asked for, not the wait.
+     */
+    when: number;
+}
+
+/**
+ * Durable custody for one shard's deferred schedules — the seam between the
+ * buffering facade (`@lunora/server`) and the store that holds the entries
+ * (`@lunora/do`). Declared here, beside the table, because both sides depend on
+ * this package and neither depends on the other.
+ *
+ * The two halves land on opposite sides of the COMMIT on purpose. `record` runs
+ * while the handler is still inside its transaction, so the entry is durable
+ * exactly when the writes are and rolls back with them; `forget` runs after the
+ * dispatch settles. What survives is precisely the set of jobs that were promised
+ * and not enqueued.
+ */
+interface ScheduleOutbox {
+    /** Release custody — the scheduler has the job, or the window that owned it was dropped. */
+    forget: (id: string) => void;
+
+    /**
+     * Take custody of one buffered call. Runs INSIDE the transaction, so a throw
+     * here rolls the mutation back — which is the right answer, and the only
+     * moment at which failing is free.
+     *
+     * `when` is always the ABSOLUTE instant, even for a `runAfter`: a delay
+     * replayed after an hour in custody would fire an hour late, and the retry has
+     * to reproduce the fire time the caller asked for, not the wait.
+     */
+    record: (id: string, envelope: ScheduleOutboxEnvelope) => void;
+    /** Ask the host to wake its retry loop — called when a dispatch left entries behind. */
+    wake: () => void;
+}
+
+/**
+ * Create the `__schedule_outbox` table. Created on every shard (empty, and free,
+ * until the first deferred schedule) for the same reason `__idempotency` is: a
+ * `ctx.scheduler` call needs no schema change to appear, so the table has to
+ * exist before the first mutation makes one.
+ *
+ * `dead` marks an entry that exhausted its attempts: it is no longer retried, and
+ * is kept for inspection until {@link trimScheduleOutbox} drops it. The index
+ * leads with it so the due-scan reads only live rows.
+ */
+const migrateScheduleOutbox = (sql: SqlExec): void => {
+    runDrizzle(
+        sql,
+        dsql`CREATE TABLE IF NOT EXISTS ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} (
+            id TEXT PRIMARY KEY,
+            envelope_json TEXT NOT NULL,
+            attempts INTEGER NOT NULL,
+            next_attempt_at REAL NOT NULL,
+            created_at REAL NOT NULL,
+            dead INTEGER NOT NULL DEFAULT 0
+        )`,
+    );
+
+    runDrizzle(
+        sql,
+        dsql`CREATE INDEX IF NOT EXISTS ${dsql.identifier(`${SCHEDULE_OUTBOX_TABLE}_due`)} ON ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} (dead, next_attempt_at)`,
+    );
+};
+
+/**
+ * Take custody of one buffered schedule. Called from inside the mutation's
+ * transaction, so the row commits with the writes and rolls back with them.
+ *
+ * `INSERT OR REPLACE` rather than `OR IGNORE`: the id is fresh per call except
+ * when the caller supplied their own `options.id`, and a re-dispatch under that
+ * id must carry the NEW envelope, not resurrect the old one.
+ */
+const recordScheduleOutbox = (sql: SqlExec, id: string, envelopeJson: string, now: number): void => {
+    runDrizzle(
+        sql,
+        dsql`INSERT OR REPLACE INTO ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} (id, envelope_json, attempts, next_attempt_at, created_at, dead)
+            VALUES (${id}, ${envelopeJson}, 0, ${now}, ${now}, 0)`,
+    );
+};
+
+/**
+ * Release custody — the SchedulerDO has the job (or has refused it as a
+ * duplicate, which means it already had it). Idempotent, so a settle that runs
+ * twice, or a retry racing the original dispatch, is a no-op the second time.
+ */
+const forgetScheduleOutbox = (sql: SqlExec, id: string): void => {
+    runDrizzle(sql, dsql`DELETE FROM ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} WHERE id = ${id}`);
+};
+
+/**
+ * The live entries due for a retry attempt at `nowMs`, oldest first so a backlog
+ * drains in the order it accumulated. `limit` bounds ONE alarm tick's work; the
+ * remainder is picked up by the next tick, which {@link probeScheduleOutbox}
+ * arms.
+ */
+const readDueScheduleOutbox = (sql: SqlExec, nowMs: number, limit: number): ScheduleOutboxRow[] => {
+    const rows = runDrizzle<{ attempts: number; envelope_json: string; id: string; next_attempt_at: number }>(
+        sql,
+        dsql`SELECT id, envelope_json, attempts, next_attempt_at FROM ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)}
+            WHERE dead = 0 AND next_attempt_at <= ${nowMs}
+            ORDER BY next_attempt_at ASC LIMIT ${limit}`,
+    ).toArray();
+
+    return rows.map((row) => {
+        return { attempts: row.attempts, envelopeJson: row.envelope_json, id: row.id, nextAttemptAt: row.next_attempt_at };
+    });
+};
+
+/** Record a failed attempt and push the entry out to `nextAttemptAt`. */
+const deferScheduleOutbox = (sql: SqlExec, id: string, attempts: number, nextAttemptAt: number): void => {
+    runDrizzle(sql, dsql`UPDATE ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} SET attempts = ${attempts}, next_attempt_at = ${nextAttemptAt} WHERE id = ${id}`);
+};
+
+/**
+ * Stop retrying an entry that exhausted its attempts. The row stays — parked, not
+ * deleted — so the job that was promised and never enqueued can be found and
+ * re-driven by hand; {@link trimScheduleOutbox} is what eventually bounds it.
+ */
+const parkScheduleOutbox = (sql: SqlExec, id: string, attempts: number): void => {
+    runDrizzle(sql, dsql`UPDATE ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} SET attempts = ${attempts}, dead = 1 WHERE id = ${id}`);
+};
+
+/**
+ * Everything the poll tier needs to decide what to do, in one indexed pass —
+ * because in the steady state (an empty outbox) that pass IS the whole tick.
+ *
+ * `dueAt` is when the earliest LIVE entry next becomes due, and doubles as the
+ * alarm's wake time; `undefined` means nothing is being retried and the tier can
+ * stay dormant. `populated` says whether the table holds anything at all,
+ * including parked entries — which is what tells the retention sweep it is worth
+ * issuing, on a shard whose live entries have all drained.
+ */
+const probeScheduleOutbox = (sql: SqlExec): { dueAt: number | undefined; populated: boolean } => {
+    const rows = runDrizzle<{ due: number | null; total: number }>(
+        sql,
+        dsql`SELECT MIN(CASE WHEN dead = 0 THEN next_attempt_at END) AS due, COUNT(*) AS total FROM ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)}`,
+    ).toArray();
+
+    const row = rows[0];
+    const due = row?.due;
+
+    return { dueAt: due ?? undefined, populated: (row?.total ?? 0) > 0 };
+};
+
+/**
+ * Drop PARKED entries created before `olderThanTs` (millis). Live entries are
+ * never trimmed — a job still being retried is not garbage — so the table is
+ * bounded in both directions: by the attempt ceiling on one side and by this
+ * retention sweep on the other.
+ */
+const trimScheduleOutbox = (sql: SqlExec, olderThanTs: number): void => {
+    runDrizzle(sql, dsql`DELETE FROM ${dsql.identifier(SCHEDULE_OUTBOX_TABLE)} WHERE dead = 1 AND created_at < ${olderThanTs}`);
+};
+
+export {
+    deferScheduleOutbox,
+    forgetScheduleOutbox,
+    migrateScheduleOutbox,
+    parkScheduleOutbox,
+    probeScheduleOutbox,
+    readDueScheduleOutbox,
+    recordScheduleOutbox,
+    SCHEDULE_OUTBOX_TABLE,
+    trimScheduleOutbox,
+};
+export type { ScheduleOutbox, ScheduleOutboxEnvelope, ScheduleOutboxRow };

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -96,6 +96,18 @@ export { IDEMPOTENCY_TABLE, migrateIdempotency, readIdempotent, trimIdempotent, 
 export { clearMemoryTables, isMemoryTable, memoryTableNames } from "./ctx-db-memory";
 export type { RankPageComputation, RankPageDeps } from "./ctx-db-rank-page";
 export { computeRankPage, resolveRankSeekTuple } from "./ctx-db-rank-page";
+export type { ScheduleOutbox, ScheduleOutboxEnvelope, ScheduleOutboxRow } from "./ctx-db-schedule-outbox";
+export {
+    deferScheduleOutbox,
+    forgetScheduleOutbox,
+    migrateScheduleOutbox,
+    parkScheduleOutbox,
+    probeScheduleOutbox,
+    readDueScheduleOutbox,
+    recordScheduleOutbox,
+    SCHEDULE_OUTBOX_TABLE,
+    trimScheduleOutbox,
+} from "./ctx-db-schedule-outbox";
 export { migrateSearchState, readSearchBackfillState, SEARCH_STATE_TABLE, writeSearchBackfillState } from "./ctx-db-search-state";
 export type { ShapePokeCursorRow } from "./ctx-db-shape-poke-cursor";
 export {


### PR DESCRIPTION
## The defect

A `ctx.scheduler.runAfter`/`runAt` issued from a mutation is buffered and dispatched **after** the COMMIT, which puts the dispatch outside the transaction. Three individually-correct behaviours summed to a silent job loss:

1. `packages/server/src/deferred-schedules.ts` dispatches the buffered call post-commit and rethrows on failure — as documented.
2. The mutation's replay-dedup row commits **inside** the span (`commitMutationBookkeeping`), deliberately, to close the crash window where writes commit without a replay guard.
3. The client's replay short-circuits on that dedup row (`readIdempotentResult`) and is answered with the cached success.

So a failed hand-off left durable writes, a durable "it succeeded" answer for every retry, and a job that existed nowhere.

Two paths lost the job without needing a replay at all:

- an **eviction** between the COMMIT and the dispatch — no settle runs, nothing raises;
- a caller that **swallows** the error — the documented `ctx.runMutation`-from-an-action shape, and every lifecycle hook, which swallows by design.

### Reproduction

Driven through the committed golden `_generated/shard.ts` against the real `ShardDO`, doubling only the host (`node:sqlite` BEGIN/ROLLBACK + a scheduler that refuses), against the code **before** this change:

```
notes rows: 1
dedup row: {"value":{"jobId":"tyPS0JRMPUpZxE7H","ok":true}}
```

The dispatch rejected with `SchedulerDO unreachable`, the write is durable, and the dedup row carries `ok: true` plus a job id for a job that never reached the scheduler. A replay of that mutation id is answered from this row.

## The fix

A buffered call takes **durable custody** in `__schedule_outbox` as it is buffered — inside the transaction, so the entry commits with the writes and rolls back with them — and releases it once the scheduler has the job. What survives a settle is exactly the set of jobs that were promised and not enqueued.

- **Drain**: a new tier on the shard's existing shared poll alarm (alongside source-ingest and TTL), plus a wake asked for by the failing settle and a probe on cold start, which is what covers the eviction window.
- **Retry**: 5s → 15s → 45s → 2m → 6m → 18m → 30m → 30m. Each attempt reuses the id the caller was handed, so a job whose first dispatch landed is refused as a duplicate rather than double-scheduled, and a stored `cancel(id)` keeps working. A `DUPLICATE_SCHEDULE_ID` refusal ends custody the same way an acceptance does.
- **Bound**: eight failed attempts **park** the entry — no longer retried, logged at `error` naming its id and target, kept for a week. The table is bounded by the attempt ceiling on one side and the retention sweep on the other; it is not an unbounded queue. Per-tick work is capped at 32 entries.
- **Migration**: `CREATE TABLE IF NOT EXISTS` in the always-run system migration, next to `__idempotency`. An existing shard picks it up on its next boot; the table starts empty and no data migration is needed.
- **Cost**: one row written and one deleted per deferred schedule, both local SQLite inside a transaction that is already open. In the steady state the alarm tier is one indexed probe that reports "nothing pending" and arms nothing.

### Which contract, and why

I kept the visibility half of the existing contract and added the durability half. A failed dispatch **still raises** — a refusal the caller caused (`DUPLICATE_SCHEDULE_ID`, `INVALID_INPUT`) has to reach the developer who caused it. What changed is that the raise is no longer the only thing between the job and oblivion.

The alternative — withholding the dedup row so the caller's retry genuinely re-runs — is rejected, and not on size. The **writes are durable either way**: the enqueue failure is only knowable after the COMMIT. Withholding the dedup row therefore does not un-write anything; it makes the retry re-execute a handler whose rows already landed. That trades silent job loss for silent double-writes (a second charge, a second outbound call) and re-opens the crash window that putting the dedup row inside the span was written to close. It is strictly worse for a non-idempotent mutation, which is the only kind that makes this bug matter.

For an operator the mental model becomes: *an enqueue failure is an error you see, and the job is in the outbox and will be retried; a job the scheduler never accepts is parked and logged, never silently dropped.* The previous model — "an enqueue failure is an error you see" — was only half true, because the failure was visible exactly once and the retry that followed it lied.

## Sibling post-commit effects

- **`flushDeferredDeletes`** (same position in `runMutationTransaction`) differs in **direction**: its failure mode is a leaked R2 object — inert, recoverable, and reported through `ctx.log`. It never raises by design, so it cannot make a success look like a failure, and it errs toward keeping data rather than destroying data a surviving row points at. Left alone.
- **`advanceClientMutationWatermark`** is inside the span for a mutation (`strict`). On the action/query path it is post-dispatch and documented self-healing: a replay re-classifies as `"next"` and re-advances. Not the same shape.
- **`recordPostDispatchBookkeeping`** (the action dedup row) fails toward at-least-once — the replay re-runs. The safe direction.
- **`flushChangedTables`** is a subscription re-run, not an effect: a missed poke is staleness until the next write or a reconnect reseed, and the shape is re-read rather than applied as a delta the client could miss.
- **Reactors, lifecycle hooks and composed `ctx.runMutation`** all route through the same `runMutationTransaction`, so they are covered by this change rather than needing their own — which is the point of fixing it below all of them.

## Platform parity

No new `ctx.*` surface and no new host contract: the outbox is SQL through the existing `SqlExec`, the existing `ShardHost.alarms` seam, and the existing scheduler contract. `PlatformCapabilities` is unchanged. A host that cannot arm an alarm keeps the pre-existing behaviour of every other alarm tier (the entry is re-offered on the next cold-start probe instead).

## Tests

`packages/codegen/__tests__/emit-shard-schedule-outbox.dispatch.test.ts` — five cases driving the golden shard through the real dispatch. Each was verified by breaking the code first:

| Sabotage | Failure |
|---|---|
| drop `outbox.record` (pre-fix behaviour) | `expected [] to strictly equal [{ attempts: 0, dead: 0, id }]` ×2 |
| no `forget` on a dropped window | nested-rollback case: `expected [{…}] to strictly equal []` |
| no `forget` on success | happy path + nested case both leak an entry |
| remove the attempt ceiling | `expected [{ attempts: 8, dead: 0 }] to strictly equal [{ attempts: 8, dead: 1 }]` |
| mint a fresh id on retry | the scheduled job no longer carries the caller's id |

## Gates

| Gate | Result |
|---|---|
| `pnpm run build:packages` / `:prod` | 54/54 |
| `@lunora/server` | 849 passed |
| `@lunora/codegen` | 1806 passed |
| `@lunora/do` | 723 passed |
| `@lunora/scheduler` | 179 passed |
| `@lunora/shard-engine` | 1477 passed, 1 todo |
| `pnpm run test:workerd` | all 11 suites passed |
| `pnpm run lint:types` (`--no-cache`) | 75 projects |
| `pnpm run api:check` | 54 snapshots match (3 updated in this PR) |
| `pnpm run dist:check` | 1401 files clean |
| `node scripts/check-generated-files.mjs` | 17 generators reproduce |
| prettier, then eslint | clean in all four packages |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for scheduled jobs created during mutations.
  - Prevented deferred scheduling requests from being lost if acknowledgement is delayed or a shard restarts.
  - Added automatic retries with backoff for temporarily unavailable scheduling services.
  - Prevented duplicate jobs when retrying previously recorded requests.
- **New Features**
  - Added durable handling for deferred scheduling requests, including complex argument types.
  - Added cleanup for scheduling requests that remain unsuccessful over an extended period.
  - Improved request-context tracking for caller address access and reactive caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->