### PR TITLE
fix(client): align the cookie-seed case with the identity contract

### DIFF
--- a/packages/client/__tests__/read-cache-bearer-seed.test.ts
+++ b/packages/client/__tests__/read-cache-bearer-seed.test.ts
@@ -459,7 +459,15 @@ describe("durable read cache on a cookie-session cold start", () => {
 
         expect(seeded).toBeUndefined();
         expect(client.peekHydratedQuery("todos.list", {})).toBeUndefined();
-        await expect(client.getCurrentUser()).resolves.toBeNull();
+
+        // `getCurrentUser()` REJECTS here rather than resolving `null`: an
+        // unreachable endpoint is not the same answer as "you are signed out",
+        // and collapsing the two made an offline reload with a valid stored
+        // token read as a sign-out in every adapter's auth gate. The property
+        // this case pins is the refusal to seed above — the identity call is
+        // asserted only to show the client still learns nothing about the
+        // cached subject, which is why it cannot evidence it.
+        await expect(client.getCurrentUser()).rejects.toThrow("offline");
 
         client.close();
     });


### PR DESCRIPTION
`alpha` is currently red: `packages/client/__tests__/read-cache-bearer-seed.test.ts` fails with

```
AssertionError: promise rejected "Error: offline" instead of resolving
Tests  1 failed | 7 passed (8)
```

Two changes that were each green on their own base disagree once both are on `alpha`:

- the cookie-session cold-start case asserts `getCurrentUser()` **resolves `null`** when the endpoint is unreachable;
- the identity contract was deliberately changed so an unreachable endpoint **rejects**, because collapsing it into `null` made an offline reload with a valid stored token read as a sign-out in every adapter auth gate.

The second is the intended behaviour, so the test moves to it.

**What the case actually pins is unchanged.** Its property is that a cookie-session client refuses to seed the durable read cache — `seeded` undefined, `peekHydratedQuery` undefined — because possession of a bearer token is the only evidence of identity the client has offline, and an `HttpOnly` cookie provides none. Both assertions stay. Only the incidental identity assertion changes, with a comment saying why it rejects.

## Verification

- the case alone: 8/8 pass (was 1 failed | 7 passed)
- full `@lunora/client` suite: 51 files, 982 passed + 1 expected fail
- prettier clean

Test-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz