### PR TITLE
fix(react): mirror the priceIds field payment now declares

### DIFF
--- a/api-snapshots/react.api.md
+++ b/api-snapshots/react.api.md
@@ -1125,6 +1125,7 @@ interface Subscription {
     readonly currentPeriodStart?: number;
     readonly id: string;
     readonly priceId: string;
+    readonly priceIds?: ReadonlyArray<string>;
     readonly provider: ProviderId;
     readonly quantity: number;
     readonly referenceId: string;

--- a/packages/react/src/payment.tsx
+++ b/packages/react/src/payment.tsx
@@ -25,6 +25,17 @@ interface Subscription {
     readonly currentPeriodStart?: number;
     readonly id: string;
     readonly priceId: string;
+
+    /**
+     * EVERY price/product id the subscription bills, not just the primary one. A Stripe
+     * subscription can carry an add-on or a metered price alongside the base plan, and a
+     * customer paying for one is entitled to it — so entitlements test membership here.
+     *
+     * Optional because the webhook path and any pre-existing stored row carry only
+     * `priceId`; absent reads as `[priceId]`, which is exactly right for the single-item
+     * case every other provider has.
+     */
+    readonly priceIds?: ReadonlyArray<string>;
     readonly provider: ProviderId;
     readonly quantity: number;
     readonly referenceId: string;


### PR DESCRIPTION
`alpha` is red: `packages/react/__tests__/payment-mirror.test.ts` fails with

```
AssertionError: expected [ 'cancelAtPeriodEnd', …(10) ] to strictly equal [ 'cancelAtPeriodEnd', …(11) ]
```

`@lunora/payment`'s `Subscription` gained `priceIds` — every price/product id a subscription bills, so an add-on or metered price entitles the customer paying for it. The React kit **re-declares** that type in `src/payment.tsx` rather than importing it, so this browser entry never pulls the server-only payment module graph into a bundle. The mirror was left behind.

This PR adds the field to the mirror, with the same doc text.

## Why the guard did not fire on the PR that broke it

The drift gate exists for exactly this, and it could not run: the mirror's whole purpose is that the two packages share no dependency edge, so `vis affected` has no path from a `packages/payment` change to `@lunora/react`. The test only runs once something else pulls React into the affected set — here, an unrelated PR merging `alpha` in.

That is a structural blind spot, not an oversight by the change that landed. Worth a follow-up: either give the react project an explicit input on `packages/payment/src/types.ts`, or run the mirror gate unconditionally.

## Verification

- mirror test: 3/3 pass (was 1 failed | 2 passed)
- full `@lunora/react` suite: 36 files, 204/204 pass
- prettier clean

Note for reviewers: an unbuilt tree makes 11 unrelated `useAuth` tests fail with `getSnapshot is not a function`, because React resolves `@lunora/client` from `dist/`. Run `pnpm run build:packages` first — those are not real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subscription details can now include all billed price and product IDs through an optional list.
  - Existing subscriptions that provide a single price ID continue to be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->