### PR TITLE
build(examples): put the examples behind eslint

### DIFF
--- a/examples/auth-playground/eslint.config.js
+++ b/examples/auth-playground/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/auth-playground/lunora/_generated/api.ts
+++ b/examples/auth-playground/lunora/_generated/api.ts
@@ -9,7 +9,7 @@ import type { Id } from "./dataModel.js";
 export interface ApiTypes {
     documents: {
         create: FunctionReference<"mutation", { organizationId: string; title: string; body: string }, Id<"documents">>;
-        list: FunctionReference<"query", { organizationId: string }, { _id: Id<"documents">; organizationId: string; ownerId: string; title: string; body: string; createdAt: number }[]>;
+        list: FunctionReference<"query", { organizationId: string }, { _id: Id<"documents">; body: string; createdAt: number; organizationId: string; ownerId: string; title: string }[]>;
     };
 }
 

--- a/examples/auth-playground/lunora/_generated/functions.ts
+++ b/examples/auth-playground/lunora/_generated/functions.ts
@@ -125,7 +125,7 @@ export type CallerCtx = ActionCtx | MutationCtx | QueryCtx;
 export interface Caller {
     documents: {
         create: (args: { organizationId: string; title: string; body: string }) => Promise<Id<"documents">>;
-        list: (args: { organizationId: string }) => Promise<{ _id: Id<"documents">; organizationId: string; ownerId: string; title: string; body: string; createdAt: number }[]>;
+        list: (args: { organizationId: string }) => Promise<{ _id: Id<"documents">; body: string; createdAt: number; organizationId: string; ownerId: string; title: string }[]>;
     };
 }
 

--- a/examples/auth-playground/lunora/auth.ts
+++ b/examples/auth-playground/lunora/auth.ts
@@ -1,5 +1,5 @@
 import type { LunoraAuthOptions } from "@lunora/auth";
-import { lunoraD1Adapter, createAuth } from "@lunora/auth";
+import { createAuth, lunoraD1Adapter } from "@lunora/auth";
 import { admin, organization, twoFactor } from "@lunora/auth/plugins";
 
 /** Shown in authenticator apps (2FA issuer) and as the default email "from" name. */
@@ -32,54 +32,62 @@ const APP_NAME = "Lunora Auth Playground";
  * `@lunora/auth/plugins/client` to use `authClient.organization.*` /
  * `authClient.twoFactor.*` and the 2FA sign-in redirect.
  */
-const options = (env: { AUTH_SECRET: string }): LunoraAuthOptions => ({
-    appName: APP_NAME,
-    // `baseURL` is deliberately absent.
-    //
-    // `@lunora/auth` derives its production posture from it: an explicit
-    // `http://…` origin marks the deployment as local, which turns OFF
-    // `useSecureCookies` and downgrades the weak-secret guard from a throw to a
-    // warning. Hard-coding the Vite dev origin here would therefore ship session
-    // cookies without `Secure` over HTTPS and let a sample secret through. Left
-    // unset, better-auth resolves the origin from each request, which is correct
-    // in dev and in production. Pin one via an `AUTH_URL` secret if you must.
-    emailAndPassword: {
-        enabled: true,
-        // Revoke other sessions when a user resets their password so a leaked
-        // session can't outlive the reset.
-        revokeSessionsOnPasswordReset: true,
-        // Dev delivery: log the reset link. Replace with an `@lunora/mail` send
-        // in production.
-        sendResetPassword: async ({ url, user }) => {
-            // eslint-disable-next-line no-console
-            console.log(`[auth] password reset for ${user.email}: ${url}`);
+const options = (env: { AUTH_SECRET: string }): LunoraAuthOptions => {
+    return {
+        appName: APP_NAME,
+        // `baseURL` is deliberately absent.
+        //
+        // `@lunora/auth` derives its production posture from it: an explicit
+        // `http://…` origin marks the deployment as local, which turns OFF
+        // `useSecureCookies` and downgrades the weak-secret guard from a throw to a
+        // warning. Hard-coding the Vite dev origin here would therefore ship session
+        // cookies without `Secure` over HTTPS and let a sample secret through. Left
+        // unset, better-auth resolves the origin from each request, which is correct
+        // in dev and in production. Pin one via an `AUTH_URL` secret if you must.
+        emailAndPassword: {
+            enabled: true,
+            // Revoke other sessions when a user resets their password so a leaked
+            // session can't outlive the reset.
+            revokeSessionsOnPasswordReset: true,
+            // Dev delivery: log the reset link. Replace with an `@lunora/mail` send
+            // in production.
+            sendResetPassword: ({ url, user }) => {
+                console.log(`[auth] password reset for ${user.email}: ${url}`);
+
+                // The contract is async; this dev-only delivery has nothing to await.
+                return Promise.resolve();
+            },
         },
-    },
-    plugins: [
-        organization({
-            allowUserToCreateOrganization: true,
-            // Dev delivery: log the invitation. Replace with an `@lunora/mail`
-            // send (linking to your accept-invite page) in production.
-            sendInvitationEmail: async (data) => {
-                // eslint-disable-next-line no-console
-                console.log(`[auth] org invite to ${data.email} for "${data.organization.name}" (invitation ${data.id})`);
-            },
-        }),
-        admin({ defaultRole: "user" }),
-        twoFactor({
-            issuer: APP_NAME,
-            otpOptions: {
-                // Dev delivery: log the OTP. Replace with an `@lunora/mail` send
-                // in production.
-                sendOTP: async ({ otp, user }) => {
-                    // eslint-disable-next-line no-console
-                    console.log(`[auth] 2FA OTP for ${user.email}: ${otp}`);
+        plugins: [
+            organization({
+                allowUserToCreateOrganization: true,
+                // Dev delivery: log the invitation. Replace with an `@lunora/mail`
+                // send (linking to your accept-invite page) in production.
+                sendInvitationEmail: (data) => {
+                    console.log(`[auth] org invite to ${data.email} for "${data.organization.name}" (invitation ${data.id})`);
+
+                    // The contract is async; this dev-only delivery has nothing to await.
+                    return Promise.resolve();
                 },
-            },
-        }),
-    ],
-    secret: env.AUTH_SECRET,
-});
+            }),
+            admin({ defaultRole: "user" }),
+            twoFactor({
+                issuer: APP_NAME,
+                otpOptions: {
+                    // Dev delivery: log the OTP. Replace with an `@lunora/mail` send
+                    // in production.
+                    sendOTP: ({ otp, user }) => {
+                        console.log(`[auth] 2FA OTP for ${user.email}: ${otp}`);
+
+                        // The contract is async; this dev-only delivery has nothing to await.
+                        return Promise.resolve();
+                    },
+                },
+            }),
+        ],
+        secret: env.AUTH_SECRET,
+    };
+};
 
 /**
  * Runtime auth instance, backed by `@lunora/auth`'s SQL adapter over D1.

--- a/examples/auth-playground/lunora/documents.ts
+++ b/examples/auth-playground/lunora/documents.ts
@@ -1,9 +1,9 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * The limiter comes from `lunora/ratelimit/schema.ts`, which owns the named
@@ -21,11 +21,11 @@ const byUser = { key: (ctx: { auth: { userId?: null | string }; ip?: string }): 
 
 interface DocumentRow {
     _id: Id<"documents">;
+    body: string;
+    createdAt: number;
     organizationId: string;
     ownerId: string;
     title: string;
-    body: string;
-    createdAt: number;
 }
 
 /**

--- a/examples/auth-playground/lunora/ratelimit/schema.ts
+++ b/examples/auth-playground/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 /**
  * Named limits this app enforces. This is the one place they live — tuning

--- a/examples/auth-playground/package.json
+++ b/examples/auth-playground/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/auth": "workspace:*",

--- a/examples/auth-playground/src/client/App.tsx
+++ b/examples/auth-playground/src/client/App.tsx
@@ -1,8 +1,212 @@
 import { AuthUIProvider, SignInCard, SignUpCard } from "@lunora/auth-ui/react";
-import type { FormEvent, ReactElement } from "react";
+import type { ReactElement, SyntheticEvent } from "react";
 import { useEffect, useState } from "react";
 
 import { authClient } from "./auth-client.js";
+
+const nav = { navigate: (): void => {}, replace: (): void => {} };
+
+const SignedOutView = (): ReactElement => (
+    <AuthUIProvider authClient={authClient} nav={nav}>
+        <div style={{ display: "grid", gap: 24, maxWidth: 360 }}>
+            <SignInCard />
+            <SignUpCard />
+        </div>
+    </AuthUIProvider>
+);
+
+const AdminPanel = (): ReactElement => {
+    const [users, setUsers] = useState<UserRow[]>([]);
+
+    const refresh = async (): Promise<void> => {
+        const result = await authClient.admin.listUsers({ query: {} });
+
+        setUsers((result.data as { users?: UserRow[] } | undefined)?.users ?? []);
+    };
+
+    useEffect(() => {
+        void refresh();
+    }, []);
+
+    const onBan = async (userId: string): Promise<void> => {
+        await authClient.admin.banUser({ banReason: "spam", userId });
+        await refresh();
+    };
+
+    const onUnban = async (userId: string): Promise<void> => {
+        await authClient.admin.unbanUser({ userId });
+        await refresh();
+    };
+
+    return (
+        <section style={{ marginTop: 32, padding: 16, border: "2px solid #b22222" }}>
+            <h2>Admin panel</h2>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                    <tr>
+                        <th style={{ textAlign: "left" }}>Email</th>
+                        <th style={{ textAlign: "left" }}>Role</th>
+                        <th style={{ textAlign: "left" }}>Status</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {users.map((user) => (
+                        <tr key={user.id}>
+                            <td>{user.email}</td>
+                            <td>{user.role ?? "user"}</td>
+                            <td>{user.banned ? <span style={{ color: "crimson" }}>banned</span> : "ok"}</td>
+                            <td>
+                                {user.banned ? (
+                                    <button
+                                        onClick={() => {
+                                            void onUnban(user.id);
+                                        }}
+                                        type="button"
+                                    >
+                                        Unban
+                                    </button>
+                                ) : (
+                                    <button
+                                        onClick={() => {
+                                            void onBan(user.id);
+                                        }}
+                                        type="button"
+                                    >
+                                        Ban
+                                    </button>
+                                )}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </section>
+    );
+};
+
+const SignedInView = (): ReactElement => {
+    const session = authClient.useSession();
+    const user = session.data?.user as undefined | { email: string; name: string; role?: string };
+
+    const [orgs, setOrgs] = useState<OrgRow[]>([]);
+    const [newOrgName, setNewOrgName] = useState("");
+    const [inviteEmail, setInviteEmail] = useState("");
+    const [activeOrgId, setActiveOrgId] = useState<null | string>(null);
+
+    const refreshOrgs = async (): Promise<void> => {
+        const result = await authClient.organization.list();
+
+        setOrgs((result.data as OrgRow[] | undefined) ?? []);
+    };
+
+    useEffect(() => {
+        void refreshOrgs();
+    }, []);
+
+    const onCreateOrg = async (event: SyntheticEvent<HTMLFormElement>): Promise<void> => {
+        event.preventDefault();
+
+        const slug = newOrgName.trim().toLowerCase().replaceAll(/\s+/g, "-");
+
+        await authClient.organization.create({ name: newOrgName, slug });
+        setNewOrgName("");
+        await refreshOrgs();
+    };
+
+    const onInvite = async (event: SyntheticEvent<HTMLFormElement>): Promise<void> => {
+        event.preventDefault();
+
+        if (!activeOrgId) {
+            return;
+        }
+
+        await authClient.organization.inviteMember({ email: inviteEmail, organizationId: activeOrgId, role: "member" });
+        setInviteEmail("");
+    };
+
+    const onSignOut = async (): Promise<void> => {
+        await authClient.signOut();
+    };
+
+    return (
+        <section>
+            <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <p>
+                    Signed in as <strong>{user?.email}</strong>
+                    {user?.role === "admin" ? " (admin)" : null}
+                </p>
+                <button
+                    onClick={() => {
+                        void onSignOut();
+                    }}
+                    type="button"
+                >
+                    Sign out
+                </button>
+            </header>
+
+            <h2 style={{ marginTop: 32 }}>Organizations</h2>
+            <form
+                onSubmit={(event) => {
+                    void onCreateOrg(event);
+                }}
+                style={{ display: "flex", gap: 8 }}
+            >
+                <input
+                    onChange={(event) => {
+                        setNewOrgName(event.target.value);
+                    }}
+                    placeholder="org name"
+                    style={{ flex: 1 }}
+                    value={newOrgName}
+                />
+                <button type="submit">Create org</button>
+            </form>
+            <ul style={{ listStyle: "none", padding: 0, marginTop: 16 }}>
+                {orgs.map((org) => (
+                    <li key={org.id} style={{ padding: 8, border: "1px solid #ddd", marginBottom: 8 }}>
+                        <strong>{org.name}</strong> <code style={{ color: "#666" }}>{org.slug}</code>{" "}
+                        <button
+                            onClick={() => {
+                                setActiveOrgId(org.id);
+                            }}
+                            style={{ marginLeft: 8 }}
+                            type="button"
+                        >
+                            {activeOrgId === org.id ? "selected" : "select"}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+
+            {activeOrgId ? (
+                <>
+                    <h3>Invite a member</h3>
+                    <form
+                        onSubmit={(event) => {
+                            void onInvite(event);
+                        }}
+                        style={{ display: "flex", gap: 8 }}
+                    >
+                        <input
+                            onChange={(event) => {
+                                setInviteEmail(event.target.value);
+                            }}
+                            placeholder="invitee@example.com"
+                            style={{ flex: 1 }}
+                            type="email"
+                            value={inviteEmail}
+                        />
+                        <button type="submit">Send invite</button>
+                    </form>
+                </>
+            ) : null}
+
+            {user?.role === "admin" ? <AdminPanel /> : null}
+        </section>
+    );
+};
 
 interface OrgRow {
     id: string;
@@ -38,7 +242,7 @@ export const App = (): ReactElement => {
         <main style={{ maxWidth: 720, margin: "3rem auto", fontFamily: "system-ui", padding: 24 }}>
             <h1>Lunora Auth Playground</h1>
             <p>
-                Demo of the <code>@lunora/auth</code> wrapper around better-auth's
+                Demo of the <code>@lunora/auth</code> wrapper around better-auth&apos;s
                 <code> organization</code> and <code>admin</code> plugins.
             </p>
             {isSignedIn ? <SignedInView /> : <SignedOutView />}
@@ -48,173 +252,13 @@ export const App = (): ReactElement => {
 
 // A no-op router bridge: this single-page demo swaps views off better-auth's
 // reactive `useSession()`, so the cards don't need to navigate on success.
-const nav = { navigate: (): void => {}, replace: (): void => {} };
 
 /**
  * Sign-in / sign-up — now rendered with the copy-in `@lunora/auth-ui` React
  * screens (the same components `lunora add auth-ui` scaffolds) instead of
  * hand-rolled forms, wrapped in `<AuthUIProvider>` with the app's authClient.
  */
-const SignedOutView = (): ReactElement => (
-    <AuthUIProvider authClient={authClient} nav={nav}>
-        <div style={{ display: "grid", gap: 24, maxWidth: 360 }}>
-            <SignInCard />
-            <SignUpCard />
-        </div>
-    </AuthUIProvider>
-);
 
 /** Org management + admin panel — shown once a session is active. */
-const SignedInView = (): ReactElement => {
-    const session = authClient.useSession();
-    const user = session.data?.user as undefined | { email: string; name: string; role?: string };
-
-    const [orgs, setOrgs] = useState<OrgRow[]>([]);
-    const [newOrgName, setNewOrgName] = useState("");
-    const [inviteEmail, setInviteEmail] = useState("");
-    const [activeOrgId, setActiveOrgId] = useState<null | string>(null);
-
-    const refreshOrgs = async (): Promise<void> => {
-        const result = await authClient.organization.list();
-
-        setOrgs((result.data as OrgRow[] | undefined) ?? []);
-    };
-
-    useEffect(() => {
-        void refreshOrgs();
-    }, []);
-
-    const onCreateOrg = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
-        event.preventDefault();
-
-        const slug = newOrgName.trim().toLowerCase().replace(/\s+/g, "-");
-
-        await authClient.organization.create({ name: newOrgName, slug });
-        setNewOrgName("");
-        await refreshOrgs();
-    };
-
-    const onInvite = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
-        event.preventDefault();
-
-        if (!activeOrgId) {
-            return;
-        }
-
-        await authClient.organization.inviteMember({ email: inviteEmail, organizationId: activeOrgId, role: "member" });
-        setInviteEmail("");
-    };
-
-    const onSignOut = async (): Promise<void> => {
-        await authClient.signOut();
-    };
-
-    return (
-        <section>
-            <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <p>
-                    Signed in as <strong>{user?.email}</strong>
-                    {user?.role === "admin" ? " (admin)" : null}
-                </p>
-                <button onClick={() => void onSignOut()} type="button">
-                    Sign out
-                </button>
-            </header>
-
-            <h2 style={{ marginTop: 32 }}>Organizations</h2>
-            <form onSubmit={onCreateOrg} style={{ display: "flex", gap: 8 }}>
-                <input onChange={(event) => setNewOrgName(event.target.value)} placeholder="org name" style={{ flex: 1 }} value={newOrgName} />
-                <button type="submit">Create org</button>
-            </form>
-            <ul style={{ listStyle: "none", padding: 0, marginTop: 16 }}>
-                {orgs.map((org) => (
-                    <li key={org.id} style={{ padding: 8, border: "1px solid #ddd", marginBottom: 8 }}>
-                        <strong>{org.name}</strong> <code style={{ color: "#666" }}>{org.slug}</code>{" "}
-                        <button onClick={() => setActiveOrgId(org.id)} style={{ marginLeft: 8 }} type="button">
-                            {activeOrgId === org.id ? "selected" : "select"}
-                        </button>
-                    </li>
-                ))}
-            </ul>
-
-            {activeOrgId ? (
-                <>
-                    <h3>Invite a member</h3>
-                    <form onSubmit={onInvite} style={{ display: "flex", gap: 8 }}>
-                        <input
-                            onChange={(event) => setInviteEmail(event.target.value)}
-                            placeholder="invitee@example.com"
-                            style={{ flex: 1 }}
-                            type="email"
-                            value={inviteEmail}
-                        />
-                        <button type="submit">Send invite</button>
-                    </form>
-                </>
-            ) : null}
-
-            {user?.role === "admin" ? <AdminPanel /> : null}
-        </section>
-    );
-};
 
 /** Lists every user and lets the admin ban or unban them. */
-const AdminPanel = (): ReactElement => {
-    const [users, setUsers] = useState<UserRow[]>([]);
-
-    const refresh = async (): Promise<void> => {
-        const result = await authClient.admin.listUsers({ query: {} });
-
-        setUsers(((result.data as { users?: UserRow[] } | undefined)?.users ?? []) as UserRow[]);
-    };
-
-    useEffect(() => {
-        void refresh();
-    }, []);
-
-    const onBan = async (userId: string): Promise<void> => {
-        await authClient.admin.banUser({ banReason: "spam", userId });
-        await refresh();
-    };
-
-    const onUnban = async (userId: string): Promise<void> => {
-        await authClient.admin.unbanUser({ userId });
-        await refresh();
-    };
-
-    return (
-        <section style={{ marginTop: 32, padding: 16, border: "2px solid #b22222" }}>
-            <h2>Admin panel</h2>
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
-                <thead>
-                    <tr>
-                        <th style={{ textAlign: "left" }}>Email</th>
-                        <th style={{ textAlign: "left" }}>Role</th>
-                        <th style={{ textAlign: "left" }}>Status</th>
-                        <th />
-                    </tr>
-                </thead>
-                <tbody>
-                    {users.map((user) => (
-                        <tr key={user.id}>
-                            <td>{user.email}</td>
-                            <td>{user.role ?? "user"}</td>
-                            <td>{user.banned ? <span style={{ color: "crimson" }}>banned</span> : "ok"}</td>
-                            <td>
-                                {user.banned ? (
-                                    <button onClick={() => void onUnban(user.id)} type="button">
-                                        Unban
-                                    </button>
-                                ) : (
-                                    <button onClick={() => void onBan(user.id)} type="button">
-                                        Ban
-                                    </button>
-                                )}
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        </section>
-    );
-};

--- a/examples/auth-playground/src/client/main.tsx
+++ b/examples/auth-playground/src/client/main.tsx
@@ -1,7 +1,7 @@
 import "@lunora/auth-ui/styles.css";
 
-import { LunoraClient } from "lunorash/client";
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/examples/auth-playground/src/server/index.ts
+++ b/examples/auth-playground/src/server/index.ts
@@ -14,9 +14,9 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
-let authInstance: ReturnType<typeof buildAuth> | null = null;
-let authReady: Promise<ReturnType<typeof buildAuth>> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
+let authInstance: ReturnType<typeof buildAuth> | undefined;
+let authReady: Promise<ReturnType<typeof buildAuth>> | undefined;
 
 /**
  * Worker entry for the auth-playground demo.
@@ -57,8 +57,7 @@ export default {
                 // replayed to every later request for the isolate's whole life,
                 // with no path back to a working state. Drop it so the next
                 // request retries.
-                // eslint-disable-next-line unicorn/no-null -- matches the declared `Promise<Auth> | null`; `??=` re-runs on either nullish value
-                authReady = null;
+                authReady = undefined;
 
                 throw error;
             }
@@ -71,26 +70,23 @@ export default {
             return authResponse;
         }
 
-        if (!worker) {
-            worker = createWorker({
-                // `openApiSpec` (regenerated on every `lunora/` change) backs the
-                // studio's always-current API-reference tab.
-                openApiSpec,
-                resolveIdentity: async (identityRequest) => {
-                    // Set by the memoized init above, which every request awaits
-                    // before reaching here.
-                    if (!authInstance) {
-                        return null;
-                    }
+        worker ??= createWorker({
+            // `openApiSpec` (regenerated on every `lunora/` change) backs the
+            // studio's always-current API-reference tab.
+            openApiSpec,
+            resolveIdentity: async (identityRequest) => {
+                // Set by the memoized init above, which every request awaits
+                // before reaching here.
+                if (!authInstance) {
+                    return null;
+                }
 
-                    const session = await authInstance.api.getSession({ headers: identityRequest.headers });
+                const session = await authInstance.api.getSession({ headers: identityRequest.headers });
 
-                    return session?.user?.id ? { userId: session.user.id } : null;
-                },
-                shardDO: env.SHARD,
-            });
-        }
-
+                return session?.user.id ? { userId: session.user.id } : null;
+            },
+            shardDO: env.SHARD,
+        });
         return worker.fetch(request, env, ctx);
     },
 };

--- a/examples/blog/eslint.config.js
+++ b/examples/blog/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -257,12 +257,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:posts:120:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:posts:122:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in publish (posts:120) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `publish` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in publish (posts:122) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `publish` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -270,7 +270,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "publish",
             "file": "posts",
             "kind": "mutation",
-            "line": 120
+            "line": 122
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",

--- a/examples/blog/lunora/cleanup.ts
+++ b/examples/blog/lunora/cleanup.ts
@@ -17,9 +17,7 @@ export const purgeStaleDrafts = internalMutation.mutation(async ({ ctx }): Promi
         .withIndex("by_updated", (range) => range.lt("updatedAt", cutoff))
         .collect();
 
-    for (const draft of stale) {
-        await ctx.db.delete(draft._id);
-    }
+    await Promise.all(stale.map(async (draft) => ctx.db.delete(draft._id)));
 
     return { deleted: stale.length };
 });

--- a/examples/blog/lunora/drafts.ts
+++ b/examples/blog/lunora/drafts.ts
@@ -1,9 +1,9 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Writers are signed in, so limits key on the user; `ctx.ip` is the fallback for
@@ -13,7 +13,7 @@ import { mutation, query, v } from "./_generated/server.js";
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byUser = { key: (ctx: { auth: { userId?: null | string }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
-interface DraftDoc {
+interface DraftDocument {
     _id: Id<"drafts">;
     authorId: string;
     body: string;
@@ -29,12 +29,12 @@ interface DraftDoc {
  * draft in the table and filtering in JS both leaks work and grows with the
  * whole app rather than with one user's drafts.
  */
-export const listMine = query.query(async ({ ctx }): Promise<DraftDoc[]> => {
+export const listMine = query.query(async ({ ctx }): Promise<DraftDocument[]> => {
     if (!ctx.auth.userId) {
         return [];
     }
 
-    const userId = ctx.auth.userId;
+    const { userId } = ctx.auth;
 
     return ctx.db
         .query("drafts")
@@ -64,14 +64,14 @@ export const save = mutation
             throw new LunoraError("UNAUTHORIZED", "sign in to save a draft");
         }
 
-        const userId = ctx.auth.userId;
+        const { userId } = ctx.auth;
 
         if (id) {
             const existing = await ctx.db.get(id);
 
             // Same response for "gone" and "someone else's", so the endpoint
             // can't be used to probe which draft ids exist.
-            if (!existing || existing.authorId !== userId) {
+            if (existing?.authorId !== userId) {
                 throw new LunoraError("NOT_FOUND", "draft not found");
             }
 

--- a/examples/blog/lunora/embed.ts
+++ b/examples/blog/lunora/embed.ts
@@ -17,10 +17,12 @@ export const embedText = (input: string): number[] => {
         let hash = 0x81_1c_9d_c5;
 
         for (const character of token) {
+            // eslint-disable-next-line no-bitwise -- FNV-1a IS defined as xor-then-multiply; there is no non-bitwise form of it.
             hash ^= character.codePointAt(0) ?? 0;
             hash = Math.imul(hash, 0x01_00_01_93);
         }
 
+        // eslint-disable-next-line no-bitwise -- `>>> 0` is the standard coercion of the signed 32-bit result back to unsigned.
         vector[(hash >>> 0) % EMBED_DIMENSIONS] += 1;
     }
 

--- a/examples/blog/lunora/posts.ts
+++ b/examples/blog/lunora/posts.ts
@@ -1,10 +1,10 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { embedText } from "./embed.js";
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { ActionCtx, Id, MutationCtx } from "./_generated/server.js";
 import { action, mutation, query, v } from "./_generated/server.js";
+import { embedText } from "./embed.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * One limiter per context kind: a middleware's context type flows into the
@@ -15,7 +15,7 @@ const actionLimiter = (ctx: ActionCtx) => makeRateLimiter(ctx);
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byUser = { key: (ctx: { auth: { userId?: null | string }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
-interface PostDoc {
+interface PostDocument {
     _id: Id<"posts">;
     authorId: string;
     body: string;
@@ -27,13 +27,13 @@ interface PostDoc {
 /**
  * Public feed — list every post, newest first. Open to anonymous readers.
  */
-export const list = query.query(async ({ ctx }): Promise<PostDoc[]> =>
+export const list = query.query(async ({ ctx }): Promise<PostDocument[]> =>
     // `.order("desc")` on the `by_published` index — the database does the
     // ordering, so this stays right (and cheap) as the feed grows.
     ctx.db.query("posts").withIndex("by_published").order("desc").collect(),
 );
 
-export const get = query.input({ id: v.id("posts") }).query(async ({ args: { id }, ctx }): Promise<PostDoc | null> => (await ctx.db.get(id)) ?? null);
+export const get = query.input({ id: v.id("posts") }).query(async ({ args: { id }, ctx }): Promise<PostDocument | null> => (await ctx.db.get(id)) ?? null);
 
 /**
  * Semantic search over post bodies. `.vectorize("body", …)` keeps the
@@ -43,18 +43,20 @@ export const get = query.input({ id: v.id("posts") }).query(async ({ args: { id 
  */
 export const search = query
     .input({ text: v.string().max(1000), topK: v.optional(v.number()) })
-    .query(async ({ args: { text, topK }, ctx }): Promise<Array<{ id: Id<"posts">; score: number; title: string }>> => {
+    .query(async ({ args: { text, topK }, ctx }): Promise<{ id: Id<"posts">; score: number; title: string }[]> => {
         // Bound user-supplied inputs: clamp `topK` to a sane ceiling and cap the
         // query text length so a caller can't ask for unbounded work.
         const boundedTopK = Math.min(Math.max(topK ?? 5, 1), 50);
         const input = text.slice(0, 1000);
         const result = await ctx.vectors.query("posts_search", { embed: embedText, input, topK: boundedTopK });
 
-        return result.matches.map((match) => ({
-            id: match.id as Id<"posts">,
-            score: match.score,
-            title: String(match.metadata?.title ?? ""),
-        }));
+        return result.matches.map((match) => {
+            return {
+                id: match.id as Id<"posts">,
+                score: match.score,
+                title: typeof match.metadata?.title === "string" ? match.metadata.title : "",
+            };
+        });
     });
 
 /**

--- a/examples/blog/lunora/ratelimit/schema.ts
+++ b/examples/blog/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Named limits live here and nowhere else.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     /** Draft autosave fires on every debounced keystroke, so it needs headroom. */

--- a/examples/blog/lunora/schema.ts
+++ b/examples/blog/lunora/schema.ts
@@ -1,7 +1,7 @@
-import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 import { EMBED_DIMENSIONS, embedText } from "./embed.js";
+import { ratelimit } from "./ratelimit/schema.js";
 
 /**
  * blog — exercises the Lunora add-on stack.

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/auth": "workspace:*",

--- a/examples/blog/src/client/Auth.tsx
+++ b/examples/blog/src/client/Auth.tsx
@@ -6,7 +6,7 @@ import { authClient } from "./auth-client.js";
 /**
  * Email/password sign-in + sign-up. Talks to the `/api/auth/*` routes
  * mounted by `@lunora/auth` (better-auth). better-auth sets an HttpOnly
- * session cookie on the response; the authenticated view in {@link App.tsx}
+ * session cookie on the response; the authenticated view in `App.tsx`
  * picks that up via `authClient.useSession()`.
  */
 export const Auth = (): ReactElement => {
@@ -48,9 +48,10 @@ export const Auth = (): ReactElement => {
         >
             <h1>{mode === "signin" ? "Sign in" : "Sign up"}</h1>
             {mode === "signup" ? (
-                <label>
+                <label htmlFor="auth-field1">
                     Name
                     <input
+                        id="auth-field1"
                         onChange={(event) => {
                             setName(event.target.value);
                         }}
@@ -58,10 +59,11 @@ export const Auth = (): ReactElement => {
                     />
                 </label>
             ) : null}
-            <label>
+            <label htmlFor="auth-field2">
                 Email
                 <input
                     autoComplete="email"
+                    id="auth-field2"
                     onChange={(event) => {
                         setEmail(event.target.value);
                     }}
@@ -70,10 +72,11 @@ export const Auth = (): ReactElement => {
                     value={email}
                 />
             </label>
-            <label>
+            <label htmlFor="auth-field3">
                 Password
                 <input
                     autoComplete={mode === "signin" ? "current-password" : "new-password"}
+                    id="auth-field3"
                     minLength={8}
                     onChange={(event) => {
                         setPassword(event.target.value);

--- a/examples/blog/src/client/Dashboard.tsx
+++ b/examples/blog/src/client/Dashboard.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
 
 /**
  * Author dashboard. Lets a signed-in user write a markdown post, attach a
@@ -16,7 +16,7 @@ export const Dashboard = (): ReactElement => {
     const [imageKey, setImageKey] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 
-    const posts = useQuery(api.posts.list, {}) as Array<Doc<"posts">> | undefined;
+    const posts = useQuery(api.posts.list, {}) as Document_<"posts">[] | undefined;
 
     const { mutate: requestUpload } = useMutation(api.posts.requestImageUpload);
     const { mutate: publish, pending: publishing } = useMutation(api.posts.publish);
@@ -58,11 +58,12 @@ export const Dashboard = (): ReactElement => {
                     style={{ fontFamily: "monospace", padding: 8 }}
                     value={body}
                 />
-                <label>
+                <label htmlFor="dashboard-field1">
                     Featured image
                     <input
                         accept="image/*"
                         disabled={uploadingImage}
+                        id="dashboard-field1"
                         onChange={(event) => {
                             const file = event.target.files?.[0];
 
@@ -75,13 +76,13 @@ export const Dashboard = (): ReactElement => {
 
                             void (async () => {
                                 try {
-                                    const { url, key } = (await requestUpload({ contentType: file.type })) as { key: string; url: string };
+                                    const { url, key } = await requestUpload({ contentType: file.type });
 
                                     // Stream the bytes straight to R2 — the Worker never proxies them.
                                     const upload = await fetch(url, { body: file, headers: { "content-type": file.type }, method: "PUT" });
 
                                     if (!upload.ok) {
-                                        throw new Error(`R2 PUT failed (${upload.status})`);
+                                        throw new Error(`R2 PUT failed (${String(upload.status)})`);
                                     }
 
                                     setImageKey(key);

--- a/examples/blog/src/client/main.tsx
+++ b/examples/blog/src/client/main.tsx
@@ -1,5 +1,5 @@
-import { LunoraClient } from "lunorash/client";
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/examples/blog/src/server/index.ts
+++ b/examples/blog/src/server/index.ts
@@ -1,17 +1,18 @@
 import type { LunoraAuth } from "@lunora/auth";
-import { lunoraD1Adapter, createAuth, ensureMigrated, handleAuthRequest } from "@lunora/auth";
-import type { ExecutionContextLike, Route, ShardNamespaceLike } from "lunorash/runtime";
-import { createWorker } from "lunorash/runtime";
-import { createScheduler, type DurableObjectNamespaceLike } from "@lunora/scheduler";
-import type { R2BucketLike } from "@lunora/storage";
-import { createStorage } from "@lunora/storage";
+import { createAuth, ensureMigrated, handleAuthRequest, lunoraD1Adapter } from "@lunora/auth";
 import type { VectorizeIndexLike } from "@lunora/bindings/vectors";
 import { createVectorAdminIntrospector } from "@lunora/bindings/vectors";
+import type { DurableObjectNamespaceLike } from "@lunora/scheduler";
+import { createScheduler } from "@lunora/scheduler";
+import type { R2BucketLike } from "@lunora/storage";
+import { createStorage } from "@lunora/storage";
+import type { ExecutionContextLike, ShardNamespaceLike } from "lunorash/runtime";
+import { createWorker } from "lunorash/runtime";
 
 import { LUNORA_CRONS } from "../../lunora/_generated/crons.js";
-import { LUNORA_VECTOR_INDEXES } from "../../lunora/_generated/vectors.js";
 import { openApiSpec } from "../../lunora/_generated/openapi.js";
 import { createShardDO } from "../../lunora/_generated/shard.js";
+import { LUNORA_VECTOR_INDEXES } from "../../lunora/_generated/vectors.js";
 
 export { SchedulerDO } from "./scheduler-do.js";
 
@@ -55,12 +56,14 @@ export const ShardDO = createShardDO({
     },
     // Maps the schema's logical index name (`posts_search`) to the Vectorize
     // binding. This is what makes `ctx.vectors` live and auto-syncs writes.
-    vectors: (env) => ({ posts_search: (env as unknown as ShardEnv).POSTS_SEARCH }),
+    vectors: (env) => {
+        return { posts_search: (env as unknown as ShardEnv).POSTS_SEARCH };
+    },
 });
 
-let worker: ReturnType<typeof createWorker> | null = null;
-let auth: LunoraAuth | null = null;
-let authReady: Promise<LunoraAuth> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
+let auth: LunoraAuth | undefined;
+let authReady: Promise<LunoraAuth> | undefined;
 
 /**
  * Compose the full v0.1 add-on stack: better-auth for email/password sign-in
@@ -115,9 +118,9 @@ const buildWorker = (env: Env): ReturnType<typeof createWorker> =>
 
             const session = await auth.api.getSession({ headers: request.headers });
 
-            return session?.user?.id ? { userId: session.user.id } : null;
+            return session?.user.id ? { userId: session.user.id } : null;
         },
-        routes: {} as Record<string, Route>,
+        routes: {},
         shardDO: env.SHARD,
     });
 

--- a/examples/chess/__tests__/chess.test.ts
+++ b/examples/chess/__tests__/chess.test.ts
@@ -4,8 +4,10 @@ import type { ChessState } from "../lunora/chess";
 import { applyMove, createInitialState, getGameResult, getMoveNotation, getValidMoves, isValidMove, nameToSquare } from "../lunora/chess";
 
 /** Play a list of `"e2e4"`-style moves, asserting each one is legal. */
-const play = (moves: string[], from: ChessState = createInitialState()): ChessState =>
-    moves.reduce((state, move) => {
+const play = (moves: string[], from: ChessState = createInitialState()): ChessState => {
+    let state = from;
+
+    for (const move of moves) {
         const step = {
             from: nameToSquare(move.slice(0, 2)),
             promotion: move.includes("=") ? (move.at(-1) as "N" | "Q") : undefined,
@@ -14,11 +16,16 @@ const play = (moves: string[], from: ChessState = createInitialState()): ChessSt
 
         expect(isValidMove(state, step), `${move} should be legal`).toBe(true);
 
-        return applyMove(state, step);
-    }, from);
+        state = applyMove(state, step);
+    }
+
+    return state;
+};
 
 describe("chess engine", () => {
     it("opens with twenty legal moves for white", () => {
+        expect.assertions(1);
+
         const state = createInitialState();
         let count = 0;
 
@@ -32,10 +39,13 @@ describe("chess engine", () => {
     });
 
     it("rejects a move by the side that is not to play", () => {
+        expect.assertions(1);
         expect(isValidMove(createInitialState(), { from: nameToSquare("e7"), to: nameToSquare("e5") })).toBe(false);
     });
 
     it("ends the game on checkmate", () => {
+        expect.hasAssertions();
+
         // Fool's mate.
         const state = play(["f2f3", "e7e5", "g2g4", "d8h4"]);
 
@@ -45,6 +55,8 @@ describe("chess engine", () => {
     });
 
     it("will not let a pinned piece expose its own king", () => {
+        expect.hasAssertions();
+
         // The d2 pawn is pinned along the e1–a5 diagonal by the bishop on b4.
         const state = play(["e2e4", "e7e5", "d2d3", "f8b4"]);
 
@@ -52,6 +64,8 @@ describe("chess engine", () => {
     });
 
     it("castles king-side and moves the rook with the king", () => {
+        expect.hasAssertions();
+
         const state = play(["e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "f8c5", "e1g1"]);
 
         expect(state.board[7][6]).toStrictEqual({ color: "white", type: "K" });
@@ -60,6 +74,8 @@ describe("chess engine", () => {
     });
 
     it("captures en passant, removing the pawn beside the mover", () => {
+        expect.hasAssertions();
+
         const state = play(["e2e4", "a7a6", "e4e5", "d7d5", "e5d6"]);
 
         // The black d5 pawn is gone even though white landed on d6.
@@ -68,6 +84,8 @@ describe("chess engine", () => {
     });
 
     it("promotes a pawn to the requested piece", () => {
+        expect.hasAssertions();
+
         const state = play(["a2a4", "b7b5", "a4b5", "a7a6", "b5a6", "h7h6", "a6a7", "h6h5", "a7b8=N"]);
 
         // The pawn captured the knight on b8 and became a knight itself.
@@ -75,6 +93,8 @@ describe("chess engine", () => {
     });
 
     it("writes notation with capture, check and mate markers", () => {
+        expect.hasAssertions();
+
         const start = createInitialState();
 
         expect(getMoveNotation(start, { from: nameToSquare("g1"), to: nameToSquare("f3") })).toBe("Ngf3");

--- a/examples/chess/__tests__/game.test.ts
+++ b/examples/chess/__tests__/game.test.ts
@@ -9,120 +9,152 @@
  * sends well-formed input.
  */
 import { lunoraTest } from "@lunora/testing";
-import { afterEach, beforeEach, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ChessState } from "../lunora/chess";
 import { get, makeMove, moves, resign, start } from "../lunora/games";
 import { create, join, listOpen } from "../lunora/lobby";
 import schema from "../lunora/schema";
 
+/** Any coded refusal — the cases below assert WHICH move is refused, not the wording. */
+const REJECTED_RE = /.+/u;
+
+const ALREADY_CONFLICT_RE = /already|conflict/i;
+const OVER_RE = /over/i;
+
 let t: ReturnType<typeof lunoraTest>;
 let white: ReturnType<typeof lunoraTest>;
 let black: ReturnType<typeof lunoraTest>;
 
-beforeEach(() => {
-    t = lunoraTest(schema);
-    white = t.withIdentity({ userId: "u-white" });
-    black = t.withIdentity({ userId: "u-black" });
-});
+describe("game lifecycle", () => {
+    beforeEach(() => {
+        t = lunoraTest(schema);
+        white = t.withIdentity({ userId: "u-white" });
+        black = t.withIdentity({ userId: "u-black" });
+    });
 
-afterEach(() => {
-    t.close();
-});
+    afterEach(() => {
+        t.close();
+    });
 
-/** Host opens a lobby, guest joins, host starts. Returns the game id. */
-const seatedGame = async () => {
-    const lobbyId = await white.mutation(create, { isPrivate: false });
+    /** Host opens a lobby, guest joins, host starts. Returns the game id. */
+    const seatedGame = async () => {
+        const lobbyId = await white.mutation(create, { isPrivate: false });
 
-    await black.mutation(join, { lobbyId });
+        await black.mutation(join, { lobbyId });
 
-    return white.mutation(start, { lobbyId });
-};
+        return white.mutation(start, { lobbyId });
+    };
 
-/** The position is stored as one JSON blob, so whose turn it is comes out of there. */
-const turn = async (gameId: string): Promise<string | undefined> => {
-    const game = await white.query(get, { gameId: gameId as never });
+    /** The position is stored as one JSON blob, so whose turn it is comes out of there. */
+    const turn = async (gameId: string): Promise<string | undefined> => {
+        const game = await white.query(get, { gameId: gameId as never });
 
-    return game ? (JSON.parse(game.position) as ChessState).currentTurn : undefined;
-};
+        return game ? (JSON.parse(game.position) as ChessState).currentTurn : undefined;
+    };
 
-it("seats two players and starts a game with white to move", async () => {
-    const gameId = await seatedGame();
-    const game = await white.query(get, { gameId });
+    it("seats two players and starts a game with white to move", async () => {
+        expect.assertions(4);
 
-    expect(game?.whiteId).toBe("u-white");
-    expect(game?.blackId).toBe("u-black");
-    expect(game?.status).toBe("active");
-    expect(await turn(gameId)).toBe("white");
-});
+        const gameId = await seatedGame();
+        const game = await white.query(get, { gameId });
 
-it("takes an open lobby off the list once it is full", async () => {
-    const lobbyId = await white.mutation(create, { isPrivate: false });
+        expect(game?.whiteId).toBe("u-white");
+        expect(game?.blackId).toBe("u-black");
+        expect(game?.status).toBe("active");
+        await expect(turn(gameId)).resolves.toBe("white");
+    });
 
-    expect(await white.query(listOpen, {})).toHaveLength(1);
+    it("takes an open lobby off the list once it is full", async () => {
+        expect.assertions(2);
 
-    await black.mutation(join, { lobbyId });
+        const lobbyId = await white.mutation(create, { isPrivate: false });
 
-    expect(await white.query(listOpen, {})).toStrictEqual([]);
-});
+        await expect(white.query(listOpen, {})).resolves.toHaveLength(1);
 
-it("refuses to start twice, so one lobby can never mint two games", async () => {
-    const lobbyId = await white.mutation(create, { isPrivate: false });
+        await black.mutation(join, { lobbyId });
 
-    await black.mutation(join, { lobbyId });
-    await white.mutation(start, { lobbyId });
+        await expect(white.query(listOpen, {})).resolves.toStrictEqual([]);
+    });
 
-    await expect(white.mutation(start, { lobbyId })).rejects.toThrow(/already|conflict/i);
-});
+    it("refuses to start twice, so one lobby can never mint two games", async () => {
+        expect.assertions(1);
 
-it("plays a move, records it, and passes the turn", async () => {
-    const gameId = await seatedGame();
+        const lobbyId = await white.mutation(create, { isPrivate: false });
 
-    await white.mutation(makeMove, { from: "e2", gameId, to: "e4" });
+        await black.mutation(join, { lobbyId });
+        await white.mutation(start, { lobbyId });
 
-    expect(await turn(gameId)).toBe("black");
-    expect((await white.query(get, { gameId }))?.moveCount).toBe(1);
-    expect((await white.query(moves, { gameId })).map((move) => `${move.from}${move.to}`)).toStrictEqual(["e2e4"]);
-});
+        await expect(white.mutation(start, { lobbyId })).rejects.toThrow(ALREADY_CONFLICT_RE);
+    });
 
-it("rejects a move by the player whose turn it is not", async () => {
-    const gameId = await seatedGame();
+    it("plays a move, records it, and passes the turn", async () => {
+        expect.assertions(3);
 
-    await expect(black.mutation(makeMove, { from: "e7", gameId, to: "e5" })).rejects.toThrow();
-});
+        const gameId = await seatedGame();
 
-it("rejects a move by someone who is not in the game", async () => {
-    const gameId = await seatedGame();
+        await white.mutation(makeMove, { from: "e2", gameId, to: "e4" });
 
-    await expect(t.withIdentity({ userId: "u-onlooker" }).mutation(makeMove, { from: "e2", gameId, to: "e4" })).rejects.toThrow();
-});
+        await expect(turn(gameId)).resolves.toBe("black");
 
-/**
- * The regression that mattered: the server accepted a knight teleporting across
- * the board because it wrote the move without ever asking the generator.
- */
-it("rejects an illegal move", async () => {
-    const gameId = await seatedGame();
+        const awaited1 = await white.query(get, { gameId });
 
-    await expect(white.mutation(makeMove, { from: "b1", gameId, to: "h5" })).rejects.toThrow();
-    expect(await white.query(moves, { gameId })).toStrictEqual([]);
-});
+        expect(awaited1?.moveCount).toBe(1);
 
-it("rejects a move from an empty square", async () => {
-    const gameId = await seatedGame();
+        const awaited2 = await white.query(moves, { gameId });
 
-    await expect(white.mutation(makeMove, { from: "e4", gameId, to: "e5" })).rejects.toThrow();
-});
+        expect(awaited2.map((move) => `${move.from}${move.to}`)).toStrictEqual(["e2e4"]);
+    });
 
-it("settles a resignation in the opponent's favour and closes the game", async () => {
-    const gameId = await seatedGame();
+    it("rejects a move by the player whose turn it is not", async () => {
+        expect.assertions(1);
 
-    await white.mutation(resign, { gameId });
+        const gameId = await seatedGame();
 
-    const game = await white.query(get, { gameId });
+        await expect(black.mutation(makeMove, { from: "e7", gameId, to: "e5" })).rejects.toThrow(REJECTED_RE);
+    });
 
-    expect(game?.status).not.toBe("active");
-    expect(game?.result).toBe("black_wins");
+    it("rejects a move by someone who is not in the game", async () => {
+        expect.assertions(1);
 
-    await expect(black.mutation(makeMove, { from: "e7", gameId, to: "e5" })).rejects.toThrow(/over/i);
+        const gameId = await seatedGame();
+
+        await expect(t.withIdentity({ userId: "u-onlooker" }).mutation(makeMove, { from: "e2", gameId, to: "e4" })).rejects.toThrow(REJECTED_RE);
+    });
+
+    /**
+     * The regression that mattered: the server accepted a knight teleporting across
+     * the board because it wrote the move without ever asking the generator.
+     */
+    it("rejects an illegal move", async () => {
+        expect.assertions(2);
+
+        const gameId = await seatedGame();
+
+        await expect(white.mutation(makeMove, { from: "b1", gameId, to: "h5" })).rejects.toThrow(REJECTED_RE);
+        await expect(white.query(moves, { gameId })).resolves.toStrictEqual([]);
+    });
+
+    it("rejects a move from an empty square", async () => {
+        expect.assertions(1);
+
+        const gameId = await seatedGame();
+
+        await expect(white.mutation(makeMove, { from: "e4", gameId, to: "e5" })).rejects.toThrow(REJECTED_RE);
+    });
+
+    it("settles a resignation in the opponent's favour and closes the game", async () => {
+        expect.assertions(3);
+
+        const gameId = await seatedGame();
+
+        await white.mutation(resign, { gameId });
+
+        const game = await white.query(get, { gameId });
+
+        expect(game?.status).not.toBe("active");
+        expect(game?.result).toBe("black_wins");
+
+        await expect(black.mutation(makeMove, { from: "e7", gameId, to: "e5" })).rejects.toThrow(OVER_RE);
+    });
 });

--- a/examples/chess/eslint.config.js
+++ b/examples/chess/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -396,12 +396,12 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
-        "cacheKey": "nondeterministic_query_mutation:games:99:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:games:132:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in start (games:99) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `start` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in start (games:132) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `start` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -409,19 +409,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "start",
             "file": "games",
             "kind": "mutation",
-            "line": 99
+            "line": 132
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:games:205:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:games:244:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in makeMove (games:205) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `makeMove` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in makeMove (games:244) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `makeMove` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -429,19 +429,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "makeMove",
             "file": "games",
             "kind": "mutation",
-            "line": 205
+            "line": 244
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:games:269:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:games:289:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in resign (games:269) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `resign` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in resign (games:289) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `resign` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -449,19 +449,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "resign",
             "file": "games",
             "kind": "mutation",
-            "line": 269
+            "line": 289
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:games:307:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:games:327:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in respondToDraw (games:307) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `respondToDraw` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in respondToDraw (games:327) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `respondToDraw` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -469,19 +469,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "respondToDraw",
             "file": "games",
             "kind": "mutation",
-            "line": 307
+            "line": 327
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:lobby:81:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:lobby:82:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in create (lobby:81) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `create` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in create (lobby:82) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `create` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -489,19 +489,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "create",
             "file": "lobby",
             "kind": "mutation",
-            "line": 81
+            "line": 82
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:lobby:193:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:lobby:194:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in quickMatch (lobby:193) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `quickMatch` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in quickMatch (lobby:194) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `quickMatch` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -509,7 +509,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "quickMatch",
             "file": "lobby",
             "kind": "mutation",
-            "line": 193
+            "line": 194
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",

--- a/examples/chess/lunora/auth.ts
+++ b/examples/chess/lunora/auth.ts
@@ -19,11 +19,13 @@ import type { LunoraAuthOptions } from "@lunora/auth";
  * which is correct in dev and in production. Set `AUTH_URL` and pass it here if
  * you need to pin one.
  */
-export const authOptions = (env: { AUTH_SECRET: string }): LunoraAuthOptions => ({
-    appName: "Lunora Chess",
-    emailAndPassword: {
-        enabled: true,
-        revokeSessionsOnPasswordReset: true,
-    },
-    secret: env.AUTH_SECRET,
-});
+export const authOptions = (env: { AUTH_SECRET: string }): LunoraAuthOptions => {
+    return {
+        appName: "Lunora Chess",
+        emailAndPassword: {
+            enabled: true,
+            revokeSessionsOnPasswordReset: true,
+        },
+        secret: env.AUTH_SECRET,
+    };
+};

--- a/examples/chess/lunora/chess.ts
+++ b/examples/chess/lunora/chess.ts
@@ -11,6 +11,9 @@
  * replaying the move list on every read — buys nothing.
  */
 
+/** A square name like `e4`. */
+const AH_RE = /^[a-h][1-8]$/u;
+
 export type PieceType = "B" | "K" | "N" | "P" | "Q" | "R";
 export type PieceColor = "black" | "white";
 
@@ -54,6 +57,18 @@ export interface ChessMove {
 }
 
 const BACK_RANK: PieceType[] = ["R", "N", "B", "Q", "K", "B", "N", "R"];
+/** The eight squares a king can step to, as (row, col) deltas. */
+const KING_OFFSETS: [number, number][] = [
+    [-1, -1],
+    [-1, 0],
+    [-1, 1],
+    [0, -1],
+    [0, 1],
+    [1, -1],
+    [1, 0],
+    [1, 1],
+];
+
 const KNIGHT_OFFSETS = [
     [-2, -1],
     [-2, 1],
@@ -85,12 +100,14 @@ const opposite = (color: PieceColor): PieceColor => (color === "white" ? "black"
 const onBoard = (row: number, col: number): boolean => row >= 0 && row < 8 && col >= 0 && col < 8;
 
 /** `{ row: 6, col: 4 }` → `"e2"`. */
-export const squareToName = (square: Square): string => `${String.fromCodePoint(97 + square.col)}${8 - square.row}`;
+export const squareToName = (square: Square): string => `${String.fromCodePoint(97 + square.col)}${String(8 - square.row)}`;
 
 /** `"e2"` → `{ row: 6, col: 4 }`. Callers validate the shape first. */
-export const nameToSquare = (name: string): Square => ({ col: name.codePointAt(0)! - 97, row: 8 - Number.parseInt(name[1], 10) });
+export const nameToSquare = (name: string): Square => {
+    return { col: (name.codePointAt(0) ?? 97) - 97, row: 8 - Number.parseInt(name[1], 10) };
+};
 
-export const isSquareName = (name: string): boolean => /^[a-h][1-8]$/u.test(name);
+export const isSquareName = (name: string): boolean => AH_RE.test(name);
 
 export const createInitialState = (): ChessState => {
     const board: (ChessPiece | null)[][] = Array.from({ length: 8 }, () => Array.from<ChessPiece | null>({ length: 8 }).fill(null));
@@ -138,78 +155,207 @@ const findKing = (board: (ChessPiece | null)[][], color: PieceColor): Square | n
  * is simulated and then tested), so it stays proportional to the board's rays,
  * not to the piece count.
  */
-const isSquareAttacked = (board: (ChessPiece | null)[][], row: number, col: number, byColor: PieceColor): boolean => {
+/** Is `byColor` attacking (row, col) with a piece that steps rather than slides? */
+const isSteppedAttack = (board: (ChessPiece | null)[][], row: number, col: number, byColor: PieceColor): boolean => {
     // Pawns attack diagonally forward, so an attacker sits one rank *behind*
     // the square from the defender's point of view.
     const pawnRow = row + (byColor === "white" ? 1 : -1);
+    const pawnSquares: [number, number][] = [-1, 1].map((deltaCol) => [pawnRow, col + deltaCol]);
+    const knightSquares: [number, number][] = KNIGHT_OFFSETS.map(([deltaRow, deltaCol]) => [row + deltaRow, col + deltaCol]);
+    const kingSquares: [number, number][] = KING_OFFSETS.map(([deltaRow, deltaCol]) => [row + deltaRow, col + deltaCol]);
 
-    for (const deltaCol of [-1, 1]) {
-        if (onBoard(pawnRow, col + deltaCol)) {
-            const piece = board[pawnRow][col + deltaCol];
+    const occupant = ([squareRow, squareCol]: [number, number]): ChessPiece | null => (onBoard(squareRow, squareCol) ? board[squareRow][squareCol] : null);
+    const held = (squares: [number, number][], type: PieceType): boolean =>
+        squares.some((square) => {
+            const piece = occupant(square);
 
-            if (piece?.type === "P" && piece.color === byColor) {
-                return true;
-            }
+            return piece?.type === type && piece.color === byColor;
+        });
+
+    return held(pawnSquares, "P") || held(knightSquares, "N") || held(kingSquares, "K");
+};
+
+/** Walking one ray from (row, col): does the first piece on it attack the square? */
+const rayHasAttacker = (
+    board: (ChessPiece | null)[][],
+    row: number,
+    col: number,
+    [deltaRow, deltaCol]: number[],
+    byColor: PieceColor,
+    slider: PieceType,
+): boolean => {
+    for (let step = 1; step < 8; step += 1) {
+        const nextRow = row + deltaRow * step;
+        const nextCol = col + deltaCol * step;
+
+        if (!onBoard(nextRow, nextCol)) {
+            return false;
         }
-    }
 
-    for (const [deltaRow, deltaCol] of KNIGHT_OFFSETS) {
-        if (onBoard(row + deltaRow, col + deltaCol)) {
-            const piece = board[row + deltaRow][col + deltaCol];
+        const piece = board[nextRow][nextCol];
 
-            if (piece?.type === "N" && piece.color === byColor) {
-                return true;
-            }
-        }
-    }
-
-    for (let deltaRow = -1; deltaRow <= 1; deltaRow += 1) {
-        for (let deltaCol = -1; deltaCol <= 1; deltaCol += 1) {
-            if ((deltaRow !== 0 || deltaCol !== 0) && onBoard(row + deltaRow, col + deltaCol)) {
-                const piece = board[row + deltaRow][col + deltaCol];
-
-                if (piece?.type === "K" && piece.color === byColor) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    const rays: [number[][], PieceType][] = [
-        [STRAIGHTS, "R"],
-        [DIAGONALS, "B"],
-    ];
-
-    for (const [directions, slider] of rays) {
-        for (const [deltaRow, deltaCol] of directions) {
-            for (let step = 1; step < 8; step += 1) {
-                const nextRow = row + deltaRow * step;
-                const nextCol = col + deltaCol * step;
-
-                if (!onBoard(nextRow, nextCol)) {
-                    break;
-                }
-
-                const piece = board[nextRow][nextCol];
-
-                if (piece) {
-                    if (piece.color === byColor && (piece.type === slider || piece.type === "Q")) {
-                        return true;
-                    }
-
-                    break;
-                }
-            }
+        if (piece) {
+            return piece.color === byColor && (piece.type === slider || piece.type === "Q");
         }
     }
 
     return false;
 };
 
+/** Is `byColor` attacking (row, col) along a rank, file or diagonal? */
+const isSlidingAttack = (board: (ChessPiece | null)[][], row: number, col: number, byColor: PieceColor): boolean => {
+    const rays: [number[][], PieceType][] = [
+        [STRAIGHTS, "R"],
+        [DIAGONALS, "B"],
+    ];
+
+    return rays.some(([directions, slider]) => directions.some((direction) => rayHasAttacker(board, row, col, direction, byColor, slider)));
+};
+
+const isSquareAttacked = (board: (ChessPiece | null)[][], row: number, col: number, byColor: PieceColor): boolean =>
+    isSteppedAttack(board, row, col, byColor) || isSlidingAttack(board, row, col, byColor);
+
 const isInCheck = (board: (ChessPiece | null)[][], color: PieceColor): boolean => {
     const king = findKing(board, color);
 
     return king ? isSquareAttacked(board, king.row, king.col, opposite(color)) : false;
+};
+
+/** Push `to` as a move when it is on the board and not occupied by one's own piece. */
+const pushMove = (moves: ChessMove[], board: (ChessPiece | null)[][], from: Square, to: Square, mover: PieceColor, promotion?: PieceType): void => {
+    if (!onBoard(to.row, to.col)) {
+        return;
+    }
+
+    if (board[to.row][to.col]?.color !== mover) {
+        moves.push({ from, promotion, to });
+    }
+};
+
+/** Walk each ray until the board edge, an own piece, or one capture. */
+const slideRays = (moves: ChessMove[], board: (ChessPiece | null)[][], row: number, col: number, mover: PieceColor, directions: number[][]): void => {
+    for (const [deltaRow, deltaCol] of directions) {
+        for (let step = 1; step < 8; step += 1) {
+            const nextRow = row + deltaRow * step;
+            const nextCol = col + deltaCol * step;
+
+            if (!onBoard(nextRow, nextCol)) {
+                break;
+            }
+
+            const target = board[nextRow][nextCol];
+
+            if (target) {
+                if (target.color !== mover) {
+                    pushMove(moves, board, { col, row }, { col: nextCol, row: nextRow }, mover);
+                }
+
+                break;
+            }
+
+            pushMove(moves, board, { col, row }, { col: nextCol, row: nextRow }, mover);
+        }
+    }
+};
+
+/** Add the castling move for one side, when the right survives and the path is clear and unattacked. */
+const addCastle = (moves: ChessMove[], board: (ChessPiece | null)[][], rank: number, kingSide: boolean, allowed: boolean, enemy: PieceColor): void => {
+    const rookCol = kingSide ? 7 : 0;
+    const between = kingSide ? [5, 6] : [1, 2, 3];
+    const crossed = kingSide ? [4, 5, 6] : [4, 3, 2];
+
+    if (!allowed || board[rank][rookCol]?.type !== "R") {
+        return;
+    }
+
+    if (between.some((square) => board[rank][square]) || crossed.some((square) => isSquareAttacked(board, rank, square, enemy))) {
+        return;
+    }
+
+    moves.push({ from: { col: 4, row: rank }, to: { col: kingSide ? 6 : 2, row: rank } });
+};
+
+/** King steps plus the two castles, when the rights survive and the path is clear. */
+const addKingMoves = (
+    state: ChessState,
+    row: number,
+    col: number,
+    piece: ChessPiece,
+    add: (toRow: number, toCol: number, promotion?: PieceType) => void,
+    castleIfClear: (rank: number, kingSide: boolean, allowed: boolean) => void,
+): void => {
+    for (const [deltaRow, deltaCol] of KING_OFFSETS) {
+        add(row + deltaRow, col + deltaCol);
+    }
+
+    if (piece.color === "white" && row === 7 && col === 4) {
+        castleIfClear(7, true, state.castlingRights.whiteKingSide);
+        castleIfClear(7, false, state.castlingRights.whiteQueenSide);
+    } else if (piece.color === "black" && row === 0 && col === 4) {
+        castleIfClear(0, true, state.castlingRights.blackKingSide);
+        castleIfClear(0, false, state.castlingRights.blackQueenSide);
+    }
+};
+
+/** One diagonal pawn capture: an enemy piece, or the en-passant square. */
+const addPawnCapture = (
+    state: ChessState,
+    toRow: number,
+    toCol: number,
+    enemy: PieceColor,
+    add: (row: number, col: number) => void,
+    addMaybePromoting: (row: number, col: number) => void,
+): void => {
+    if (!onBoard(toRow, toCol)) {
+        return;
+    }
+
+    if (state.board[toRow][toCol]?.color === enemy) {
+        addMaybePromoting(toRow, toCol);
+    }
+
+    if (state.enPassantTarget?.row === toRow && state.enPassantTarget.col === toCol) {
+        add(toRow, toCol);
+    }
+};
+
+/** One push, the two-square opener, both captures, promotions and en passant. */
+const addPawnMoves = (
+    state: ChessState,
+    row: number,
+    col: number,
+    piece: ChessPiece,
+    enemy: PieceColor,
+    add: (toRow: number, toCol: number, promotion?: PieceType) => void,
+): void => {
+    const { board } = state;
+    const direction = piece.color === "white" ? -1 : 1;
+    const startRow = piece.color === "white" ? 6 : 1;
+    const promotionRow = piece.color === "white" ? 0 : 7;
+
+    const addMaybePromoting = (toRow: number, toCol: number): void => {
+        if (toRow === promotionRow) {
+            for (const promotion of PROMOTION_PIECES) {
+                add(toRow, toCol, promotion);
+            }
+
+            return;
+        }
+
+        add(toRow, toCol);
+    };
+
+    if (onBoard(row + direction, col) && !board[row + direction][col]) {
+        addMaybePromoting(row + direction, col);
+
+        if (row === startRow && !board[row + direction * 2][col]) {
+            add(row + direction * 2, col);
+        }
+    }
+
+    for (const deltaCol of [-1, 1]) {
+        addPawnCapture(state, row + direction, col + deltaCol, enemy, add, addMaybePromoting);
+    }
 };
 
 /** Pseudo-legal moves for one piece — everything the piece can reach, ignoring whether it exposes its own king. */
@@ -225,56 +371,15 @@ const getRawMoves = (state: ChessState, row: number, col: number): ChessMove[] =
     const enemy = opposite(piece.color);
 
     const add = (toRow: number, toCol: number, promotion?: PieceType): void => {
-        if (!onBoard(toRow, toCol)) {
-            return;
-        }
-
-        const target = board[toRow][toCol];
-
-        if (!target || target.color !== piece.color) {
-            moves.push({ from: { col, row }, promotion, to: { col: toCol, row: toRow } });
-        }
+        pushMove(moves, board, { col, row }, { col: toCol, row: toRow }, piece.color, promotion);
     };
 
     const slide = (directions: number[][]): void => {
-        for (const [deltaRow, deltaCol] of directions) {
-            for (let step = 1; step < 8; step += 1) {
-                const nextRow = row + deltaRow * step;
-                const nextCol = col + deltaCol * step;
-
-                if (!onBoard(nextRow, nextCol)) {
-                    break;
-                }
-
-                const target = board[nextRow][nextCol];
-
-                if (target) {
-                    if (target.color !== piece.color) {
-                        add(nextRow, nextCol);
-                    }
-
-                    break;
-                }
-
-                add(nextRow, nextCol);
-            }
-        }
+        slideRays(moves, board, row, col, piece.color, directions);
     };
 
     const castleIfClear = (rank: number, kingSide: boolean, allowed: boolean): void => {
-        const rookCol = kingSide ? 7 : 0;
-        const between = kingSide ? [5, 6] : [1, 2, 3];
-        const crossed = kingSide ? [4, 5, 6] : [4, 3, 2];
-
-        if (!allowed || board[rank][rookCol]?.type !== "R") {
-            return;
-        }
-
-        if (between.some((square) => board[rank][square]) || crossed.some((square) => isSquareAttacked(board, rank, square, enemy))) {
-            return;
-        }
-
-        moves.push({ from: { col: 4, row: rank }, to: { col: kingSide ? 6 : 2, row: rank } });
+        addCastle(moves, board, rank, kingSide, allowed, enemy);
     };
 
     switch (piece.type) {
@@ -284,22 +389,7 @@ const getRawMoves = (state: ChessState, row: number, col: number): ChessMove[] =
         }
 
         case "K": {
-            for (let deltaRow = -1; deltaRow <= 1; deltaRow += 1) {
-                for (let deltaCol = -1; deltaCol <= 1; deltaCol += 1) {
-                    if (deltaRow !== 0 || deltaCol !== 0) {
-                        add(row + deltaRow, col + deltaCol);
-                    }
-                }
-            }
-
-            if (piece.color === "white" && row === 7 && col === 4) {
-                castleIfClear(7, true, state.castlingRights.whiteKingSide);
-                castleIfClear(7, false, state.castlingRights.whiteQueenSide);
-            } else if (piece.color === "black" && row === 0 && col === 4) {
-                castleIfClear(0, true, state.castlingRights.blackKingSide);
-                castleIfClear(0, false, state.castlingRights.blackQueenSide);
-            }
-
+            addKingMoves(state, row, col, piece, add, castleIfClear);
             break;
         }
 
@@ -312,49 +402,7 @@ const getRawMoves = (state: ChessState, row: number, col: number): ChessMove[] =
         }
 
         case "P": {
-            const direction = piece.color === "white" ? -1 : 1;
-            const startRow = piece.color === "white" ? 6 : 1;
-            const promotionRow = piece.color === "white" ? 0 : 7;
-
-            if (onBoard(row + direction, col) && !board[row + direction][col]) {
-                if (row + direction === promotionRow) {
-                    for (const promotion of PROMOTION_PIECES) {
-                        add(row + direction, col, promotion);
-                    }
-                } else {
-                    add(row + direction, col);
-                }
-
-                if (row === startRow && !board[row + direction * 2][col]) {
-                    add(row + direction * 2, col);
-                }
-            }
-
-            for (const deltaCol of [-1, 1]) {
-                const nextRow = row + direction;
-                const nextCol = col + deltaCol;
-
-                if (!onBoard(nextRow, nextCol)) {
-                    continue;
-                }
-
-                const target = board[nextRow][nextCol];
-
-                if (target && target.color === enemy) {
-                    if (nextRow === promotionRow) {
-                        for (const promotion of PROMOTION_PIECES) {
-                            add(nextRow, nextCol, promotion);
-                        }
-                    } else {
-                        add(nextRow, nextCol);
-                    }
-                }
-
-                if (state.enPassantTarget && state.enPassantTarget.row === nextRow && state.enPassantTarget.col === nextCol) {
-                    add(nextRow, nextCol);
-                }
-            }
-
+            addPawnMoves(state, row, col, piece, enemy, add);
             break;
         }
 
@@ -365,6 +413,10 @@ const getRawMoves = (state: ChessState, row: number, col: number): ChessMove[] =
 
         case "R": {
             slide(STRAIGHTS);
+            break;
+        }
+        // Every piece type is covered above; a default keeps the switch total.
+        default: {
             break;
         }
     }
@@ -401,7 +453,7 @@ const moveOnBoard = (state: ChessState, move: ChessMove): { board: (ChessPiece |
 
     // En passant: the captured pawn is beside the moving pawn's origin, not on
     // the destination square, so it has to be cleared explicitly.
-    if (piece.type === "P" && state.enPassantTarget && move.to.row === state.enPassantTarget.row && move.to.col === state.enPassantTarget.col) {
+    if (piece.type === "P" && move.to.row === state.enPassantTarget?.row && move.to.col === state.enPassantTarget.col) {
         captured = board[move.from.row][move.to.col];
         board[move.from.row][move.to.col] = null;
         special = "en_passant";
@@ -414,7 +466,7 @@ const moveOnBoard = (state: ChessState, move: ChessMove): { board: (ChessPiece |
 export const getValidMoves = (state: ChessState, row: number, col: number): ChessMove[] => {
     const piece = state.board[row][col];
 
-    if (!piece || piece.color !== state.currentTurn) {
+    if (piece?.color !== state.currentTurn) {
         return [];
     }
 
@@ -433,6 +485,40 @@ const hasAnyLegalMove = (state: ChessState): boolean => {
     return false;
 };
 
+/** Castling rights after a move: the king losing both, and either corner square being touched. */
+const rightsAfter = (current: CastlingRights, piece: ChessPiece, move: ChessMove): CastlingRights => {
+    const rights = { ...current };
+
+    if (piece.type === "K") {
+        if (piece.color === "white") {
+            rights.whiteKingSide = false;
+            rights.whiteQueenSide = false;
+        } else {
+            rights.blackKingSide = false;
+            rights.blackQueenSide = false;
+        }
+    }
+
+    // A rook leaving *or* being captured on its home square ends that side's
+    // castling right; both are keyed off the corner squares.
+    const corners: [number, number, keyof CastlingRights][] = [
+        [7, 0, "whiteQueenSide"],
+        [7, 7, "whiteKingSide"],
+        [0, 0, "blackQueenSide"],
+        [0, 7, "blackKingSide"],
+    ];
+
+    for (const { col, row } of [move.from, move.to]) {
+        for (const [cornerRow, cornerCol, right] of corners) {
+            if (row === cornerRow && col === cornerCol) {
+                rights[right] = false;
+            }
+        }
+    }
+
+    return rights;
+};
+
 /** The position after `move`, with check / checkmate / stalemate / draw already resolved for the side to move. */
 export const applyMove = (state: ChessState, move: ChessMove): ChessState => {
     const piece = state.board[move.from.row][move.from.col];
@@ -442,37 +528,7 @@ export const applyMove = (state: ChessState, move: ChessMove): ChessState => {
     }
 
     const { board, captured } = moveOnBoard(state, move);
-    const castlingRights = { ...state.castlingRights };
-
-    if (piece.type === "K") {
-        if (piece.color === "white") {
-            castlingRights.whiteKingSide = false;
-            castlingRights.whiteQueenSide = false;
-        } else {
-            castlingRights.blackKingSide = false;
-            castlingRights.blackQueenSide = false;
-        }
-    }
-
-    // A rook leaving *or* being captured on its home square ends that side's
-    // castling right; both are keyed off the corner squares.
-    for (const { col, row } of [move.from, move.to]) {
-        if (row === 7 && col === 0) {
-            castlingRights.whiteQueenSide = false;
-        }
-
-        if (row === 7 && col === 7) {
-            castlingRights.whiteKingSide = false;
-        }
-
-        if (row === 0 && col === 0) {
-            castlingRights.blackQueenSide = false;
-        }
-
-        if (row === 0 && col === 7) {
-            castlingRights.blackKingSide = false;
-        }
-    }
+    const castlingRights = rightsAfter(state.castlingRights, piece, move);
 
     const halfMoveClock = piece.type === "P" || captured ? 0 : state.halfMoveClock + 1;
 
@@ -538,7 +594,8 @@ export const getMoveNotation = (state: ChessState, move: ChessMove): string => {
     }
 
     const from = squareToName(move.from);
-    const isEnPassant = piece.type === "P" && state.enPassantTarget?.row === move.to.row && state.enPassantTarget?.col === move.to.col;
+    const target = state.enPassantTarget;
+    const isEnPassant = piece.type === "P" && target !== null && target.row === move.to.row && target.col === move.to.col;
     const isCapture = Boolean(state.board[move.to.row][move.to.col]) || isEnPassant;
 
     let notation = piece.type === "P" ? "" : piece.type;
@@ -559,7 +616,10 @@ export const getMoveNotation = (state: ChessState, move: ChessMove): string => {
 
     const after = applyMove(state, move);
 
-    return notation + (after.isCheckmate ? "#" : after.isCheck ? "+" : "");
+    const suffix = after.isCheckmate ? "#" : "";
+    const check = suffix || (after.isCheck ? "+" : "");
+
+    return notation + check;
 };
 
 export const serializeState = (state: ChessState): string => JSON.stringify(state);

--- a/examples/chess/lunora/games.ts
+++ b/examples/chess/lunora/games.ts
@@ -1,6 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
+import type { MutationCtx } from "./_generated/server.js";
+import { mutation, query, v } from "./_generated/server.js";
+import type { PieceType } from "./chess.js";
 import {
     applyMove,
     createInitialState,
@@ -12,25 +16,54 @@ import {
     nameToSquare,
     serializeState,
 } from "./chess.js";
-import type { PieceType } from "./chess.js";
 import { ratingUpdates } from "./players.js";
 import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
-import type { MutationCtx } from "./_generated/server.js";
-import { mutation, query, v } from "./_generated/server.js";
+
+/** The terminal/check marker a move produced, or `undefined` for an ordinary move. */
+const specialOf = (position: { isCheck: boolean; isCheckmate: boolean; isStalemate: boolean }): string | undefined => {
+    if (position.isCheckmate) {
+        return "checkmate";
+    }
+
+    if (position.isStalemate) {
+        return "stalemate";
+    }
+
+    return position.isCheck ? "check" : undefined;
+};
+
+const settle = async (ctx: MutationCtx, game: Document_<"games">, result: "black_wins" | "draw" | "white_wins"): Promise<void> => {
+    const profileOf = async (userId: string): Promise<Document_<"profiles"> | null> =>
+        ctx.db
+            .query("profiles")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+    const white = await profileOf(game.whiteId);
+    const black = await profileOf(game.blackId);
+
+    if (!white || !black) {
+        return;
+    }
+
+    const updates = ratingUpdates(white, black, result);
+
+    await ctx.db.patch(white._id, updates.white);
+    await ctx.db.patch(black._id, updates.black);
+};
 
 /** Signed-in app, so limits key on the player rather than the IP. */
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byPlayer = { key: (ctx: { auth: { userId?: string | null }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
-const PROMOTION_CHOICES = new Set<PieceType>(["Q", "R", "B", "N"]);
+const PROMOTION_CHOICES = new Set<PieceType>(["B", "N", "Q", "R"]);
 
 export const get = query
     .input({ gameId: v.id("games") })
-    .query(async ({ args: { gameId }, ctx }): Promise<Doc<"games"> | null> => (await ctx.db.get(gameId)) ?? null);
+    .query(async ({ args: { gameId }, ctx }): Promise<Document_<"games"> | null> => (await ctx.db.get(gameId)) ?? null);
 
 /** The move list, oldest first — the board's history panel subscribes to this. */
-export const moves = query.input({ gameId: v.id("games") }).query(async ({ args: { gameId }, ctx }): Promise<Doc<"moves">[]> =>
+export const moves = query.input({ gameId: v.id("games") }).query(async ({ args: { gameId }, ctx }): Promise<Document_<"moves">[]> =>
     ctx.db
         .query("moves")
         .withIndex("by_game_turn", (q) => q.eq("gameId", gameId))
@@ -39,19 +72,19 @@ export const moves = query.input({ gameId: v.id("games") }).query(async ({ args:
 );
 
 /** Games in progress. Anyone signed in may subscribe to one and watch it move — that is all spectating is. */
-export const listActive = query.query(async ({ ctx }): Promise<Doc<"games">[]> =>
+export const listActive = query.query(async ({ ctx }): Promise<Document_<"games">[]> =>
     ctx.db
         .query("games")
         .withIndex("by_status", (q) => q.eq("status", "active"))
         .collect(),
 );
 
-export const mine = query.query(async ({ ctx }): Promise<Doc<"games">[]> => {
+export const mine = query.query(async ({ ctx }): Promise<Document_<"games">[]> => {
     if (!ctx.auth.userId) {
         return [];
     }
 
-    const userId = ctx.auth.userId;
+    const { userId } = ctx.auth;
     const asWhite = await ctx.db
         .query("games")
         .withIndex("by_white", (q) => q.eq("whiteId", userId))
@@ -61,7 +94,7 @@ export const mine = query.query(async ({ ctx }): Promise<Doc<"games">[]> => {
         .withIndex("by_black", (q) => q.eq("blackId", userId))
         .collect();
 
-    return [...asWhite, ...asBlack].sort((a, b) => b.startedAt - a.startedAt);
+    return [...asWhite, ...asBlack].toSorted((a, b) => b.startedAt - a.startedAt);
 });
 
 /** Host starts play. Host takes white. */
@@ -110,6 +143,17 @@ export const start = mutation
         return gameId;
     });
 
+/** Shape checks on the raw move arguments, before they touch the engine. */
+const assertMoveArguments = (from: string, to: string, promotion: string | undefined): void => {
+    if (!isSquareName(from) || !isSquareName(to)) {
+        throw new LunoraError("BAD_REQUEST", 'squares must look like "e2"');
+    }
+
+    if (promotion !== undefined && !PROMOTION_CHOICES.has(promotion as PieceType)) {
+        throw new LunoraError("BAD_REQUEST", "a pawn may only promote to Q, R, B or N");
+    }
+};
+
 /**
  * Play a move.
  *
@@ -146,19 +190,14 @@ export const makeMove = mutation
             throw new LunoraError("CONFLICT", "this game is over");
         }
 
-        const color = ctx.auth.userId === game.whiteId ? "white" : ctx.auth.userId === game.blackId ? "black" : null;
+        const blackSeat = ctx.auth.userId === game.blackId ? "black" : null;
+        const color = ctx.auth.userId === game.whiteId ? "white" : blackSeat;
 
         if (!color) {
             throw new LunoraError("UNAUTHORIZED", "you are not playing in this game");
         }
 
-        if (!isSquareName(from) || !isSquareName(to)) {
-            throw new LunoraError("BAD_REQUEST", 'squares must look like "e2"');
-        }
-
-        if (promotion !== undefined && !PROMOTION_CHOICES.has(promotion as PieceType)) {
-            throw new LunoraError("BAD_REQUEST", "a pawn may only promote to Q, R, B or N");
-        }
+        assertMoveArguments(from, to, promotion);
 
         const position = deserializeState(game.position);
 
@@ -188,7 +227,7 @@ export const makeMove = mutation
             gameId,
             notation,
             playerId: ctx.auth.userId,
-            special: next.isCheckmate ? "checkmate" : next.isStalemate ? "stalemate" : next.isCheck ? "check" : undefined,
+            special: specialOf(next),
             to,
             turnNumber: game.moveCount + 1,
         });
@@ -221,10 +260,10 @@ export const makeMove = mutation
  * game-action mutations below all need the same pair of checks, and a guard
  * that is copied is a guard that eventually diverges.
  */
-const requirePlayer = async (ctx: MutationCtx, gameId: Id<"games">): Promise<Doc<"games">> => {
+const requirePlayer = async (ctx: MutationCtx, gameId: Id<"games">): Promise<Document_<"games">> => {
     const game = await ctx.db.get(gameId);
 
-    if (!game || game.status !== "active") {
+    if (game?.status !== "active") {
         throw new LunoraError("CONFLICT", "this game is not in progress");
     }
 
@@ -236,25 +275,6 @@ const requirePlayer = async (ctx: MutationCtx, gameId: Id<"games">): Promise<Doc
 };
 
 /** Apply a finished game's result to both profiles, in the same transaction that finished it. */
-const settle = async (ctx: MutationCtx, game: Doc<"games">, result: "black_wins" | "draw" | "white_wins"): Promise<void> => {
-    const profileOf = async (userId: string): Promise<Doc<"profiles"> | null> =>
-        ctx.db
-            .query("profiles")
-            .withIndex("by_user", (q) => q.eq("userId", userId))
-            .first();
-
-    const white = await profileOf(game.whiteId);
-    const black = await profileOf(game.blackId);
-
-    if (!white || !black) {
-        return;
-    }
-
-    const updates = ratingUpdates(white, black, result);
-
-    await ctx.db.patch(white._id, updates.white);
-    await ctx.db.patch(black._id, updates.black);
-};
 
 export const resign = mutation
     .use(rateLimit(mutationLimiter, "move", byPlayer))

--- a/examples/chess/lunora/lobby.ts
+++ b/examples/chess/lunora/lobby.ts
@@ -1,22 +1,23 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /** Signed-in app, so limits key on the player rather than the IP. */
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byPlayer = { key: (ctx: { auth: { userId?: string | null }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
 /** Ambiguous glyphs (0/O, 1/I) are left out so a code can be read aloud. */
+// eslint-disable-next-line no-secrets/no-secrets -- the invite-code alphabet, not a credential; each glyph appears once so it scans as high entropy.
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
 const newInviteCode = (): string =>
     Array.from(globalThis.crypto.getRandomValues(new Uint8Array(6)), (byte) => CODE_ALPHABET[byte % CODE_ALPHABET.length]).join("");
 
-export const listOpen = query.query(async ({ ctx }): Promise<Doc<"lobbies">[]> =>
+export const listOpen = query.query(async ({ ctx }): Promise<Document_<"lobbies">[]> =>
     ctx.db
         .query("lobbies")
         .withIndex("by_open_public", (q) => q.eq("isPrivate", false).eq("isOpen", true))
@@ -25,12 +26,12 @@ export const listOpen = query.query(async ({ ctx }): Promise<Doc<"lobbies">[]> =
 );
 
 /** The lobby this player is in, whether they host it or joined it. */
-export const mine = query.query(async ({ ctx }): Promise<(Doc<"lobbies"> & { isHost: boolean }) | null> => {
+export const mine = query.query(async ({ ctx }): Promise<(Document_<"lobbies"> & { isHost: boolean }) | null> => {
     if (!ctx.auth.userId) {
         return null;
     }
 
-    const userId = ctx.auth.userId;
+    const { userId } = ctx.auth;
     const hosted = await ctx.db
         .query("lobbies")
         .withIndex("by_host", (q) => q.eq("hostId", userId))
@@ -61,7 +62,7 @@ export const create = mutation
             throw new LunoraError("UNAUTHENTICATED", "sign in to open a lobby");
         }
 
-        const userId = ctx.auth.userId;
+        const { userId } = ctx.auth;
         const existing = await ctx.db
             .query("lobbies")
             .withIndex("by_host", (q) => q.eq("hostId", userId))
@@ -152,7 +153,7 @@ export const quickMatch = mutation.use(rateLimit(mutationLimiter, "write", byPla
         throw new LunoraError("UNAUTHENTICATED", "sign in to play");
     }
 
-    const userId = ctx.auth.userId;
+    const { userId } = ctx.auth;
     const hosted = await ctx.db
         .query("lobbies")
         .withIndex("by_host", (q) => q.eq("hostId", userId))

--- a/examples/chess/lunora/players.ts
+++ b/examples/chess/lunora/players.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc } from "./_generated/dataModel.js";
+import type { Doc as Document_ } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /** Signed-in app, so limits key on the player rather than the IP. */
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
@@ -15,12 +15,12 @@ const K_FACTOR = 32;
 const RATING_FLOOR = 100;
 const STARTING_RATING = 1200;
 
-export const me = query.query(async ({ ctx }): Promise<Doc<"profiles"> | null> => {
+export const me = query.query(async ({ ctx }): Promise<Document_<"profiles"> | null> => {
     if (!ctx.auth.userId) {
         return null;
     }
 
-    const userId = ctx.auth.userId;
+    const { userId } = ctx.auth;
 
     return ctx.db
         .query("profiles")
@@ -37,9 +37,11 @@ export const me = query.query(async ({ ctx }): Promise<Doc<"profiles"> | null> =
  * "Unknown" — past a few hundred players, resolve names per game instead of
  * shipping the directory.
  */
-export const list = query.query(async ({ ctx }): Promise<Doc<"profiles">[]> => ctx.db.query("profiles").take(200));
+export const list = query.query(async ({ ctx }): Promise<Document_<"profiles">[]> => ctx.db.query("profiles").take(200));
 
-export const leaderboard = query.query(async ({ ctx }): Promise<Doc<"profiles">[]> => ctx.db.query("profiles").withIndex("by_rating").order("desc").take(20));
+export const leaderboard = query.query(async ({ ctx }): Promise<Document_<"profiles">[]> =>
+    ctx.db.query("profiles").withIndex("by_rating").order("desc").take(20),
+);
 
 /**
  * Create this account's profile if it has none. `by_user` is unique, so two
@@ -53,7 +55,7 @@ export const claim = mutation
             throw new LunoraError("UNAUTHENTICATED", "sign in first");
         }
 
-        const userId = ctx.auth.userId;
+        const { userId } = ctx.auth;
         const existing = await ctx.db
             .query("profiles")
             .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -101,11 +103,12 @@ export type RatingUpdate = {
  * is testable without a database.
  */
 export const ratingUpdates = (
-    white: Doc<"profiles">,
-    black: Doc<"profiles">,
+    white: Document_<"profiles">,
+    black: Document_<"profiles">,
     result: "black_wins" | "draw" | "white_wins",
 ): { black: RatingUpdate; white: RatingUpdate } => {
-    const whiteScore = result === "white_wins" ? 1 : result === "draw" ? 0.5 : 0;
+    const drawScore = result === "draw" ? 0.5 : 0;
+    const whiteScore = result === "white_wins" ? 1 : drawScore;
 
     return {
         black: {

--- a/examples/chess/lunora/ratelimit/schema.ts
+++ b/examples/chess/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     // A blitz game is a move every few seconds; this admits that and no more.

--- a/examples/chess/package.json
+++ b/examples/chess/package.json
@@ -11,7 +11,9 @@
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/auth": "workspace:*",

--- a/examples/chess/src/client/App.tsx
+++ b/examples/chess/src/client/App.tsx
@@ -3,26 +3,21 @@ import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
+import type { Id } from "../../lunora/_generated/dataModel.js";
 import { authClient } from "./auth-client.js";
 import { Game } from "./Game.js";
 import { SignIn } from "./SignIn.js";
 
-export const App = (): ReactElement => {
-    const session = authClient.useSession();
-    const user = session.data?.user as undefined | { email: string; id: string; name?: string };
-
-    if (!user) {
-        return <SignIn />;
-    }
-
-    return <Lobby displayName={user.name ?? user.email.split("@")[0]} userId={user.id} />;
+/**
+ * Sign out, reporting a failure rather than leaving an unhandled rejection. A
+ * wrapper because `authClient` is `any` (see `auth-client.ts`), so `void
+ * authClient.signOut()` discards a value the compiler cannot describe.
+ */
+const signOut = (): void => {
+    (authClient.signOut() as Promise<unknown>).catch((error: unknown) => {
+        console.error("sign out failed", error);
+    });
 };
-
-interface LobbyProperties {
-    displayName: string;
-    userId: string;
-}
 
 const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
     const me = useQuery(api.players.me, {});
@@ -43,14 +38,14 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
     const [watching, setWatching] = useState<Id<"games"> | null>(null);
     const [error, setError] = useState<string | null>(null);
 
-    const claimedRef = useRef(false);
+    const claimedReference = useRef(false);
 
     useEffect(() => {
-        if (claimedRef.current || me === undefined || me !== null) {
+        if (claimedReference.current || me === undefined || me !== null) {
             return;
         }
 
-        claimedRef.current = true;
+        claimedReference.current = true;
         void claim({ displayName });
     }, [me, claim, displayName]);
 
@@ -67,7 +62,9 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
 
     const run = (work: Promise<unknown>): void => {
         setError(null);
-        void work.catch((cause: unknown) => setError(cause instanceof Error ? cause.message : "something went wrong"));
+        void work.catch((error_: unknown) => {
+            setError(error_ instanceof Error ? error_.message : "something went wrong");
+        });
     };
 
     if (open) {
@@ -94,10 +91,20 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
             <header className="page-header">
                 <div>
                     <h1>Lunora Chess</h1>
-                    <p className="muted">{me ? `${me.displayName} · ${me.rating} Elo · ${me.gamesWon}/${me.gamesPlayed} won` : "Setting up your profile…"}</p>
+                    <p className="muted">
+                        {me
+                            ? `${me.displayName} · ${String(me.rating)} Elo · ${String(me.gamesWon)}/${String(me.gamesPlayed)} won`
+                            : "Setting up your profile…"}
+                    </p>
                 </div>
 
-                <button className="link" onClick={() => void authClient.signOut()} type="button">
+                <button
+                    className="link"
+                    onClick={() => {
+                        signOut();
+                    }}
+                    type="button"
+                >
                     Sign out
                 </button>
             </header>
@@ -114,11 +121,22 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
 
                     <div className="row">
                         {myLobby.isHost && myLobby.guestId && (
-                            <button className="primary" onClick={() => run(startGame({ lobbyId: myLobby._id }))} type="button">
+                            <button
+                                className="primary"
+                                onClick={() => {
+                                    run(startGame({ lobbyId: myLobby._id }));
+                                }}
+                                type="button"
+                            >
                                 Start game
                             </button>
                         )}
-                        <button onClick={() => run(leaveLobby({ lobbyId: myLobby._id }))} type="button">
+                        <button
+                            onClick={() => {
+                                run(leaveLobby({ lobbyId: myLobby._id }));
+                            }}
+                            type="button"
+                        >
                             Leave
                         </button>
                     </div>
@@ -128,10 +146,21 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
                     <h2>Play</h2>
 
                     <div className="row">
-                        <button className="primary" onClick={() => run(quickMatch({}))} type="button">
+                        <button
+                            className="primary"
+                            onClick={() => {
+                                run(quickMatch({}));
+                            }}
+                            type="button"
+                        >
                             Quick match
                         </button>
-                        <button onClick={() => run(createLobby({ isPrivate: true }))} type="button">
+                        <button
+                            onClick={() => {
+                                run(createLobby({ isPrivate: true }));
+                            }}
+                            type="button"
+                        >
                             Private table
                         </button>
                     </div>
@@ -160,7 +189,12 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
                         <li key={lobby._id}>
                             <span>{nameOf(lobby.hostId)}</span>
                             {lobby.hostId !== userId && (
-                                <button onClick={() => run(joinLobby({ lobbyId: lobby._id }))} type="button">
+                                <button
+                                    onClick={() => {
+                                        run(joinLobby({ lobbyId: lobby._id }));
+                                    }}
+                                    type="button"
+                                >
                                     Sit down
                                 </button>
                             )}
@@ -179,7 +213,12 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
                             <span>
                                 {nameOf(game.whiteId)} vs {nameOf(game.blackId)} · {game.moveCount} moves
                             </span>
-                            <button onClick={() => setWatching(game._id)} type="button">
+                            <button
+                                onClick={() => {
+                                    setWatching(game._id);
+                                }}
+                                type="button"
+                            >
                                 Watch
                             </button>
                         </li>
@@ -205,3 +244,19 @@ const Lobby = ({ displayName, userId }: LobbyProperties): ReactElement => {
         </main>
     );
 };
+
+export const App = (): ReactElement => {
+    const session = authClient.useSession();
+    const user = session.data?.user as undefined | { email: string; id: string; name?: string };
+
+    if (!user) {
+        return <SignIn />;
+    }
+
+    return <Lobby displayName={user.name ?? user.email.split("@")[0]} userId={user.id} />;
+};
+
+interface LobbyProperties {
+    displayName: string;
+    userId: string;
+}

--- a/examples/chess/src/client/Board.tsx
+++ b/examples/chess/src/client/Board.tsx
@@ -1,8 +1,26 @@
 import type { ReactElement } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 import type { ChessMove, ChessState, PieceColor, PieceType, Square } from "../../lunora/chess.js";
 import { getValidMoves, squareToName } from "../../lunora/chess.js";
+
+/**
+ * Callback ref that opens the dialog as it attaches.
+ *
+ * A native `<dialog>` is modal only once `showModal()` runs, and the choice
+ * really is modal: the move is not legal until a piece is named. The element is
+ * rendered only while a promotion is pending, so attaching IS the moment to open
+ * it — which is why this is a ref rather than an effect watching the state.
+ *
+ * Module scope keeps its identity stable, so React invokes it on attach and
+ * detach rather than on every render.
+ */
+const openAsModal = (node: HTMLDialogElement | null): void => {
+    node?.showModal();
+};
+
+/** `[0…7]` — board indices, reversed when Black is looking at it. */
+const RANKS = Array.from({ length: 8 }, (_, index) => index);
 
 /** Screen readers announce this, so it spells the piece out — "e2 white pawn", not "e2 white P". */
 const PIECE_NAMES: Record<PieceType, string> = { B: "bishop", K: "king", N: "knight", P: "pawn", Q: "queen", R: "rook" };
@@ -32,22 +50,13 @@ interface BoardProperties {
 export const Board = ({ myColor, onMove, position }: BoardProperties): ReactElement => {
     const [selected, setSelected] = useState<Square | null>(null);
     const [pendingPromotion, setPendingPromotion] = useState<ChessMove | null>(null);
-    const promotionRef = useRef<HTMLDialogElement>(null);
-
-    useEffect(() => {
-        // A native dialog is modal only once `showModal()` runs — and the choice
-        // really is modal: the move is not legal until a piece is named.
-        if (pendingPromotion) {
-            promotionRef.current?.showModal();
-        }
-    }, [pendingPromotion]);
 
     const myTurn = myColor !== null && position.currentTurn === myColor;
     const legal = selected ? getValidMoves(position, selected.row, selected.col) : [];
 
     // Black sees the board from its own side.
-    const ranks = myColor === "black" ? [...Array.from({ length: 8 }).keys()].reverse() : [...Array.from({ length: 8 }).keys()];
-    const files = myColor === "black" ? [...Array.from({ length: 8 }).keys()].reverse() : [...Array.from({ length: 8 }).keys()];
+    const ranks = myColor === "black" ? RANKS.toReversed() : RANKS;
+    const files = myColor === "black" ? RANKS.toReversed() : RANKS;
 
     const onSquare = (row: number, col: number): void => {
         if (!myTurn) {
@@ -83,13 +92,15 @@ export const Board = ({ myColor, onMove, position }: BoardProperties): ReactElem
 
                         return (
                             <button
-                                key={`${row}-${col}`}
                                 aria-label={`${squareToName({ col, row })}${piece ? ` ${piece.color} ${PIECE_NAMES[piece.type]}` : ""}`}
                                 className={["square", (row + col) % 2 === 0 ? "light" : "dark", isSelected ? "selected" : "", isTarget ? "target" : ""]
                                     .filter(Boolean)
                                     .join(" ")}
                                 disabled={!myTurn}
-                                onClick={() => onSquare(row, col)}
+                                key={`${String(row)}-${String(col)}`}
+                                onClick={() => {
+                                    onSquare(row, col);
+                                }}
                                 type="button"
                             >
                                 {piece ? GLYPHS[piece.color][piece.type] : ""}
@@ -100,7 +111,7 @@ export const Board = ({ myColor, onMove, position }: BoardProperties): ReactElem
             </div>
 
             {pendingPromotion && (
-                <dialog ref={promotionRef} aria-label="Choose a promotion piece" className="promotion">
+                <dialog aria-label="Choose a promotion piece" className="promotion" ref={openAsModal}>
                     {PROMOTIONS.map((choice) => (
                         <button
                             key={choice}

--- a/examples/chess/src/client/Game.tsx
+++ b/examples/chess/src/client/Game.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
 
+import { api } from "../../lunora/_generated/api.js";
+import type { Id } from "../../lunora/_generated/dataModel.js";
 import type { PieceType } from "../../lunora/chess.js";
 import { deserializeState } from "../../lunora/chess.js";
-import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
 import { Board } from "./Board.js";
 
 interface GameProperties {
@@ -43,11 +43,13 @@ export const Game = ({ gameId, nameOf, onLeave, userId }: GameProperties): React
     const position = deserializeState(game.position);
     // A spectator has no colour, so the board renders read-only for them —
     // watching is just a subscription to the same query the players use.
-    const myColor = userId === game.whiteId ? "white" : userId === game.blackId ? "black" : null;
+    const blackSeat = userId === game.blackId ? "black" : null;
+    const myColor = userId === game.whiteId ? "white" : blackSeat;
     const drawOfferedToMe = Boolean(game.drawOfferedBy) && game.drawOfferedBy !== userId && myColor !== null;
 
-    const status =
-        game.status === "completed" ? (RESULT_LABEL[game.result ?? ""] ?? "Finished") : `${position.currentTurn} to move${position.isCheck ? " · check" : ""}`;
+    const checkSuffix = position.isCheck ? " · check" : "";
+
+    const status = game.status === "completed" ? (RESULT_LABEL[game.result ?? ""] ?? "Finished") : `${position.currentTurn} to move${checkSuffix}`;
 
     return (
         <section className="game">
@@ -68,10 +70,20 @@ export const Game = ({ gameId, nameOf, onLeave, userId }: GameProperties): React
 
                 {myColor !== null && game.status === "active" && (
                     <div className="row">
-                        <button onClick={() => void offerDraw({ gameId })} type="button">
+                        <button
+                            onClick={() => {
+                                void offerDraw({ gameId });
+                            }}
+                            type="button"
+                        >
                             Offer draw
                         </button>
-                        <button onClick={() => void resign({ gameId })} type="button">
+                        <button
+                            onClick={() => {
+                                void resign({ gameId });
+                            }}
+                            type="button"
+                        >
                             Resign
                         </button>
                     </div>
@@ -81,10 +93,20 @@ export const Game = ({ gameId, nameOf, onLeave, userId }: GameProperties): React
             {drawOfferedToMe && (
                 <div className="banner">
                     <span>{nameOf(game.drawOfferedBy as string)} offers a draw.</span>
-                    <button onClick={() => void respondToDraw({ accept: true, gameId })} type="button">
+                    <button
+                        onClick={() => {
+                            void respondToDraw({ accept: true, gameId });
+                        }}
+                        type="button"
+                    >
                         Accept
                     </button>
-                    <button onClick={() => void respondToDraw({ accept: false, gameId })} type="button">
+                    <button
+                        onClick={() => {
+                            void respondToDraw({ accept: false, gameId });
+                        }}
+                        type="button"
+                    >
                         Decline
                     </button>
                 </div>
@@ -95,7 +117,9 @@ export const Game = ({ gameId, nameOf, onLeave, userId }: GameProperties): React
             <div className="game-body">
                 <Board
                     myColor={game.status === "active" ? myColor : null}
-                    onMove={(from, to, promotion?: PieceType) => void makeMove({ from, gameId, promotion, to })}
+                    onMove={(from, to, promotion?: PieceType) => {
+                        void makeMove({ from, gameId, promotion, to });
+                    }}
                     position={position}
                 />
 

--- a/examples/chess/src/client/SignIn.tsx
+++ b/examples/chess/src/client/SignIn.tsx
@@ -3,6 +3,20 @@ import { useState } from "react";
 
 import { authClient } from "./auth-client.js";
 
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"` — a file input sharing a text field's
+ * name would submit that verbatim. Narrowing instead yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
+
 /** Email + password, both flows on one card. Deliberately plain — the game is the subject here. */
 export const SignIn = (): ReactElement => {
     const [mode, setMode] = useState<"in" | "up">("in");
@@ -12,7 +26,7 @@ export const SignIn = (): ReactElement => {
     // tokens that tell a password manager whether to offer a saved credential or
     // generate a new one — dropping them to quiet the scanner would be a real
     // regression for anyone using one.
-    const passwordAutoComplete = mode === "up" ? "new-password" : "current-password"; // secret-scanner:allow
+    const autoCompleteToken = mode === "up" ? "new-password" : "current-password"; // secret-scanner:allow
     const [error, setError] = useState<string | null>(null);
     const [busy, setBusy] = useState(false);
 
@@ -20,9 +34,9 @@ export const SignIn = (): ReactElement => {
         setBusy(true);
         setError(null);
 
-        const email = String(form.get("email") ?? "");
-        const password = String(form.get("password") ?? "");
-        const name = String(form.get("name") ?? "").trim() || email.split("@")[0];
+        const email = textField(form, "email");
+        const password = textField(form, "password");
+        const name = textField(form, "name").trim() || email.split("@")[0];
 
         /**
          * Everything conditional lives in here rather than in the `try` below.
@@ -43,10 +57,10 @@ export const SignIn = (): ReactElement => {
             if (message) {
                 setError(message);
             }
-        } catch (cause: unknown) {
+        } catch (error_: unknown) {
             // better-auth resolves most failures into `result.error`, but a
             // network fault rejects — without this the form just went quiet.
-            setError(cause instanceof Error ? cause.message : "could not reach the server");
+            setError(error_ instanceof Error ? error_.message : "could not reach the server");
         }
 
         // After the catch, not in a `finally`: the React Compiler cannot lower a
@@ -66,16 +80,8 @@ export const SignIn = (): ReactElement => {
                 }}
             >
                 {mode === "up" && <input aria-label="Display name" name="name" placeholder="Display name" />}
-                <input required aria-label="Email" autoComplete="email" name="email" placeholder="you@example.com" type="email" />
-                <input
-                    required
-                    aria-label="Password"
-                    autoComplete={passwordAutoComplete}
-                    minLength={8}
-                    name="password"
-                    placeholder="Password"
-                    type="password"
-                />
+                <input aria-label="Email" autoComplete="email" name="email" placeholder="you@example.com" required type="email" />
+                <input aria-label="Password" autoComplete={autoCompleteToken} minLength={8} name="password" placeholder="Password" required type="password" />
 
                 {error && <p className="error">{error}</p>}
 
@@ -83,7 +89,13 @@ export const SignIn = (): ReactElement => {
                     {mode === "up" ? "Create account" : "Sign in"}
                 </button>
 
-                <button className="link" onClick={() => setMode(mode === "up" ? "in" : "up")} type="button">
+                <button
+                    className="link"
+                    onClick={() => {
+                        setMode(mode === "up" ? "in" : "up");
+                    }}
+                    type="button"
+                >
                     {mode === "up" ? "I already have an account" : "Create an account"}
                 </button>
             </form>

--- a/examples/chess/src/client/main.tsx
+++ b/examples/chess/src/client/main.tsx
@@ -1,10 +1,11 @@
+import "./styles.css";
+
 import { LunoraProvider } from "@lunora/react";
 import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
-import "./styles.css";
 
 const url = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? globalThis.location.origin;
 const client = new LunoraClient({ url });

--- a/examples/chess/src/server/index.ts
+++ b/examples/chess/src/server/index.ts
@@ -1,8 +1,8 @@
 import type { D1DatabaseLike } from "@lunora/d1";
 import type { ShardNamespaceLike } from "lunorash/runtime";
 
-import { authOptions } from "../../lunora/auth.js";
 import { defineApp } from "../../lunora/_generated/app.js";
+import { authOptions } from "../../lunora/auth.js";
 
 interface Env {
     AUTH_SECRET: string;
@@ -30,7 +30,7 @@ const app = defineApp<Env>()
     .auth({ d1: (env) => env.DB, options: authOptions })
     .build();
 
-export const ShardDO = app.ShardDO;
+export const { ShardDO } = app;
 
 // The composed app IS the module worker — exported wholesale rather than
 // re-wrapped, so every handler `.build()` composes reaches Cloudflare. A

--- a/examples/chess/tsconfig.json
+++ b/examples/chess/tsconfig.json
@@ -5,12 +5,28 @@
         "rootDir": ".",
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "types": ["@cloudflare/workers-types", "node", "vite/client"],
-        "lib": ["DOM", "DOM.Iterable", "ES2024"],
+        "types": [
+            "@cloudflare/workers-types",
+            "node",
+            "vite/client"
+        ],
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2024"
+        ],
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false
     },
-    "include": ["src/**/*", "lunora/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*",
+        "lunora/**/*",
+        "vite.config.ts",
+        "__tests__/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/examples/eslint.config.base.js
+++ b/examples/eslint.config.base.js
@@ -1,0 +1,333 @@
+/**
+ * Shared ESLint setup for `examples/*`.
+ *
+ * Unlike `packages/*` — where each package deliberately owns a self-contained
+ * config because it ships independently — the examples are thirteen variations
+ * on one app, are never published, and differ only in framework. Thirteen copies of
+ * this file would drift the moment one of them needed a rule, so they share it
+ * and each example's `eslint.config.js` is a three-line call.
+ *
+ * The rules turned off below are ones that fight Lunora's own conventions, not
+ * ones that were noisy. Anything that flagged a real defect was fixed in the
+ * change that added this file.
+ */
+import { createConfig } from "@anolilab/eslint-config";
+
+/**
+ * @param {object} [options]
+ * @param {string[]} [options.ignores] extra ignore patterns for this example
+ * @param {import("eslint").Linter.Config[]} [options.overrides] extra flat-config blocks, applied last
+ * @returns {ReturnType<typeof createConfig>}
+ */
+const createExampleConfig = ({ ignores = [], overrides = [] } = {}) =>
+    createConfig(
+        {
+            // Type-aware linting; also what flips the React preset to the automatic
+            // JSX runtime via the tsconfig's `jsx: "react-jsx"`.
+            typescript: { tsconfigPath: "tsconfig.json" },
+            // Prettier owns formatting.
+            stylistic: false,
+            ignores: [
+                "**/dist/**",
+                "**/node_modules/**",
+                // Codegen output, committed but not hand-written.
+                "**/_generated/**",
+                "**/.lunora-schema.json",
+                "**/.wrangler/**",
+                "**/.output/**",
+                "**/.vinxi/**",
+                "**/.expo/**",
+                "**/.nuxt/**",
+                "**/.svelte-kit/**",
+                "**/.angular/**",
+                "**/build/**",
+                "**/coverage/**",
+                "**/test-results/**",
+                // Config files: not application source, and several are not in any
+                // tsconfig, so type-aware rules cannot parse them.
+                "**/vite.config.ts",
+                "**/vitest.config.ts",
+                "**/wrangler.jsonc",
+                "**/package.json",
+                "**/tsconfig*.json",
+                "**/eslint.config.js",
+                "**/prettier.config.js",
+                // Prose, and the virtual files extracted from its code fences.
+                "**/*.md",
+                "**/*.md/**",
+                // TanStack Start's generated route tree.
+                "**/routeTree.gen.ts",
+                ...ignores,
+            ],
+        },
+        {
+            rules: {
+                /*
+                 * `ctx` is the framework's public name for the handler context — it is
+                 * what every doc, every generated type (`ActionCtx`, `QueryCtx`) and
+                 * every package calls it. `Env` / `env` are likewise Cloudflare's own
+                 * names: `Env` is what `wrangler types` generates the binding interface
+                 * as, and `env` is what the Workers runtime passes it in. Renaming
+                 * either would make the examples disagree with the API they exist to
+                 * demonstrate. Other abbreviations are still flagged.
+                 */
+                "unicorn/prevent-abbreviations": [
+                    "error",
+                    { allowList: { ActionCtx: true, ctx: true, Ctx: true, env: true, Env: true, MutationCtx: true, QueryCtx: true } },
+                ],
+
+                /*
+                 * A Lunora function module interleaves exported procedures with the
+                 * local helpers they use, and codegen discovers those exports BY NAME.
+                 * `exports-last` would force every helper above every procedure, and
+                 * `prefer-default-export` would rewrite a single-procedure module into
+                 * a default export codegen cannot see at all. Both also contradict the
+                 * repo's named-exports-only convention.
+                 */
+                "import/exports-last": "off",
+                "import/prefer-default-export": "off",
+
+                /*
+                 * Reordering object keys rewrites the bytes of anything that gets
+                 * JSON.stringify'd — wire payloads, canonical objects — so this is a
+                 * behaviour-breaking autofixer, not a style rule. Off across the repo
+                 * for the same reason.
+                 */
+                "perfectionist/sort-objects": "off",
+
+                /*
+                 * An example worker logging to the console is the example working as
+                 * intended: it is how a reader sees what the demo did. `lint:eslint`
+                 * runs with `--max-warnings=0`, so leaving this at `warn` would fail
+                 * the build.
+                 */
+                "no-console": "off",
+
+                /*
+                 * `null` here is almost never this code's choice — it is the contract
+                 * of something it calls:
+                 *
+                 * - `resolveIdentity` is typed `ResolvedIdentity | null`, and `ctx.db.get()`
+                 *   resolves `null` for a missing row, so a query returning
+                 *   `Document_<"games"> | null` is matching the framework.
+                 * - `new Response(null, …)` and `URLSearchParams.get()` are DOM signatures.
+                 * - A nullable column (`drawOfferedBy`) and an empty chess square
+                 *   (`(ChessPiece | null)[][]`) are deliberate domain models.
+                 *
+                 * The packages enforce this rule because they DEFINE their APIs; an
+                 * example almost only consumes them, and `undefined` is a type error at
+                 * most of these sites.
+                 */
+                "unicorn/no-null": "off",
+
+                /*
+                 * `import Stripe from "stripe"` is Stripe's own documented import, and
+                 * its package exports the class as BOTH the default and a named
+                 * `Stripe`. The rule reads that as a likely mistake; here it is the
+                 * only spelling that works.
+                 */
+                "import/no-named-as-default": "off",
+
+                /*
+                 * Leading-underscore identifiers that are framework API by design, copied
+                 * from the packages' own allow list: `_id` / `_creationTime` are the
+                 * public document fields, `__doc__` is a data-model internal, `__name` a
+                 * bundler helper. An accidental dangle is still flagged.
+                 */
+                "no-underscore-dangle": [
+                    "error",
+                    { allow: ["_id", "_creationTime", "_meta", "_parse", "_count", "_checks", "_chunk", "__doc__", "__name", "__lunoraRef"] },
+                ],
+
+                /*
+                 * Web-platform globals that exist in the workerd and browser runtimes the
+                 * examples deploy to; eslint-plugin-n dates them against Node alone.
+                 * Same ignore list the packages carry.
+                 */
+                "n/no-unsupported-features/node-builtins": [
+                    "error",
+                    { ignores: ["crypto", "CryptoKey", "SubtleCrypto", "Storage", "sessionStorage", "localStorage"] },
+                ],
+
+                /*
+                 * `void somePromise();` is the deliberate marker for a promise nobody
+                 * awaits — it is what satisfies `no-floating-promises`, so banning it
+                 * leaves no way to express the intent. Narrowed to statement position
+                 * (as `packages/auth-ui` already does); `void` inside an expression is
+                 * still an error.
+                 */
+                "no-void": ["error", { allowAsStatement: true }],
+
+                /*
+                 * Function DECLARATIONS hoist, so a React component referenced by a
+                 * route or a parent defined above it is safe — and reads better than
+                 * forcing every helper above its first use. Arrow consts are NOT
+                 * exempted: they are in the temporal dead zone, which is a real
+                 * runtime error (this config's own rollout produced two).
+                 */
+                "@typescript-eslint/no-use-before-define": ["error", { classes: true, functions: false, variables: true }],
+            },
+        },
+        {
+            /*
+             * Test files: the same relaxations every package config applies. Loose
+             * mocks and fixtures are the point of a test, and enforcing `no-unsafe-*`
+             * there produces noise rather than safety. Source files still enforce
+             * all of these.
+             */
+            files: ["**/__tests__/**/*.{ts,tsx}", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+            rules: {
+                "@typescript-eslint/no-explicit-any": "off",
+                "@typescript-eslint/no-non-null-assertion": "off",
+                "@typescript-eslint/no-unnecessary-condition": "off",
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/no-unsafe-return": "off",
+                "@typescript-eslint/require-await": "off",
+                "import/no-extraneous-dependencies": "off",
+                "sonarjs/deprecation": "off",
+                "unicorn/no-null": "off",
+                "unicorn/prevent-abbreviations": "off",
+                "vitest/prefer-describe-function-title": "off",
+                "vitest/prefer-strict-equal": "off",
+            },
+        },
+        {
+            // Component files are PascalCase across all thirteen examples (App, Board,
+            // SignIn, …), which is the React convention a reader arrives with. The
+            // packages use kebab-case and keep enforcing it; renaming a dozen example
+            // components to match would be churn with no reader benefit.
+            files: ["**/*.tsx"],
+            rules: {
+                "unicorn/filename-case": ["error", { cases: { kebabCase: true, pascalCase: true } }],
+            },
+        },
+        {
+            /*
+             * The demos deliberately inline their handlers and style objects: a reader
+             * is here to see which Lunora call does what, and hoisting every `onClick`
+             * into a `useCallback` buries that in ceremony. The packages suppress these
+             * per-site instead, because there the render cost is a consumer's problem.
+             */
+            files: ["**/*.tsx"],
+            rules: {
+                "react-perf/jsx-no-jsx-as-prop": "off",
+                "react-perf/jsx-no-new-array-as-prop": "off",
+                "react-perf/jsx-no-new-function-as-prop": "off",
+                "react-perf/jsx-no-new-object-as-prop": "off",
+            },
+        },
+        {
+            /*
+             * Files where a THIRD-PARTY `any` leaks across the boundary, so the
+             * `no-unsafe-*` family reports the dependency's typing rather than
+             * anything this code does:
+             *
+             * - the better-auth client. `lunoraAuthPlugins` returns a homogeneous
+             *   `LunoraAuthClientPlugin[]`, so better-auth cannot infer the per-plugin
+             *   method surfaces (`authClient.organization`, `.admin`) and the examples
+             *   annotate the client `any` deliberately — see the comment on each
+             *   `auth-client.ts`. Typing it properly means making the plugin assembler
+             *   generic over its toggles in `@lunora/auth`, which is a stable-tier
+             *   refactor, not an examples change.
+             * - `@react-native-async-storage/async-storage` ships an `any` default.
+             * - TanStack's generated `routeTree.gen.ts` feeds `useRouteContext()`.
+             *
+             * Scoped to these files rather than turned off: the rules still hold
+             * everywhere else. The alternative — 64 assertions claiming types nobody
+             * verified — would be worse than reporting the gap honestly.
+             */
+            files: [
+                "**/src/client/auth-client.ts",
+                "**/src/auth-client.ts",
+                "**/src/lunora.ts",
+                "**/src/client/App.tsx",
+                "**/src/client/SignIn.tsx",
+                "**/src/Chat.tsx",
+                "**/src/routes/__root.tsx",
+            ],
+            rules: {
+                "@typescript-eslint/no-unsafe-argument": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off",
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/no-unsafe-return": "off",
+            },
+        },
+        {
+            /*
+             * Metro's config is loaded by Metro itself with `require`, so it has to be
+             * CommonJS — an ESM `import` here is not a style choice the example can
+             * make.
+             */
+            files: ["**/metro.config.js"],
+            rules: {
+                "@typescript-eslint/no-require-imports": "off",
+            },
+        },
+        {
+            /*
+             * Third-party React Native shapes the examples do not get to choose:
+             *
+             * - `expo-secure-store` exports no default and no barrel, so
+             *   `import * as SecureStore` is the documented import.
+             * - `expo-status-bar`'s `style` prop is its OWN string union
+             *   (`"auto" | "light" | "dark"`), not React's style object, so
+             *   `react/style-prop-object` misreads it by name.
+             */
+            files: ["**/auth-client.ts", "**/App.tsx"],
+            rules: {
+                "import/no-namespace": "off",
+                "react/style-prop-object": "off",
+            },
+        },
+        {
+            /*
+             * Formatting rules that fight Prettier (which owns formatting), mirroring
+             * the same block every package config carries.
+             */
+            rules: {
+                "antfu/consistent-chaining": "off",
+                "antfu/consistent-list-newline": "off",
+                "no-confusing-arrow": "off",
+                "unicorn/number-literal-case": "off",
+            },
+        },
+        {
+            /*
+             * Behaviour-breaking autofixers — off because they are wrong, not because
+             * they are noisy. The packages keep an equivalent block.
+             *
+             * `prefer-comparison-matcher` rewrites `expect(a < b).toBe(true)` into
+             * `expect(a).toBeLessThan(b)` without checking the operand type. The
+             * kanban ordering tests compare fractional-index STRINGS, where
+             * lexicographic `<` is the entire point — `toBeLessThan` takes only
+             * `number | bigint`, so the fix broke both `tsc` and the tests.
+             */
+            rules: {
+                "vitest/prefer-comparison-matcher": "off",
+
+                /*
+                 * `jsdoc/check-indentation` misfires on markdown lists inside a
+                 * docblock: the continuation lines of `* - item` are indented on
+                 * purpose and the rule anchors a phantom "must be no indentation" to
+                 * the whole comment. `packages/sql-store` turns it off for the same
+                 * misfire on its interface-heavy core.
+                 */
+                "jsdoc/check-indentation": "off",
+            },
+        },
+        {
+            // `jsdoc/text-escaping` turns `Doc<T>` into `Doc&lt;T>` in doc comments and
+            // offers no code-span exemption, so its autofix corrupts what a reader sees
+            // on hover.
+            rules: {
+                "jsdoc/text-escaping": "off",
+            },
+        },
+        ...overrides,
+    );
+
+export default createExampleConfig;

--- a/examples/expo/App.tsx
+++ b/examples/expo/App.tsx
@@ -12,12 +12,16 @@ import { Chat } from "./src/Chat";
 import { Login } from "./src/Login";
 import { lunoraClient } from "./src/lunora";
 
+const styles = StyleSheet.create({
+    centered: { alignItems: "center", flex: 1, justifyContent: "center" },
+    container: { backgroundColor: "#fff", flex: 1 },
+});
 // One QueryClient for the app. Lunora is push-driven, so live queries never go
 // stale on their own — the WebSocket subscription is the only invalidation.
 const queryClient = new QueryClient();
 
 /** Flip between the sign-in screen and the chat based on the better-auth session. */
-function Root(): ReactElement {
+const Root = (): ReactElement => {
     const { data: session, isPending } = authClient.useSession();
 
     // Bridge the better-auth Expo session into the Lunora client as a bearer
@@ -30,12 +34,15 @@ function Root(): ReactElement {
     // reinstates the previous session's token. React runs this cleanup before the
     // next effect, so a superseded read can no longer apply.
     useEffect(() => {
-        let cancelled = false;
+        // A holder object, not a bare `let`: TypeScript's control-flow analysis
+        // narrows a local boolean to `false` for the whole closure and then reports
+        // the guard below as dead, even though the cleanup flips it.
+        const run = { cancelled: false };
 
         void (async () => {
             const token = await expoBearerToken(authClient);
 
-            if (cancelled) {
+            if (run.cancelled) {
                 return;
             }
 
@@ -44,7 +51,7 @@ function Root(): ReactElement {
         })();
 
         return () => {
-            cancelled = true;
+            run.cancelled = true;
         };
     }, [session]);
 
@@ -57,24 +64,19 @@ function Root(): ReactElement {
     }
 
     return session ? <Chat /> : <Login />;
-}
+};
 
-export default function App(): ReactElement {
-    return (
-        <SafeAreaProvider>
-            <QueryClientProvider client={queryClient}>
-                <LunoraProvider client={lunoraClient}>
-                    <SafeAreaView style={styles.container}>
-                        <Root />
-                        <StatusBar style="auto" />
-                    </SafeAreaView>
-                </LunoraProvider>
-            </QueryClientProvider>
-        </SafeAreaProvider>
-    );
-}
+const App = (): ReactElement => (
+    <SafeAreaProvider>
+        <QueryClientProvider client={queryClient}>
+            <LunoraProvider client={lunoraClient}>
+                <SafeAreaView style={styles.container}>
+                    <Root />
+                    <StatusBar style="auto" />
+                </SafeAreaView>
+            </LunoraProvider>
+        </QueryClientProvider>
+    </SafeAreaProvider>
+);
 
-const styles = StyleSheet.create({
-    centered: { alignItems: "center", flex: 1, justifyContent: "center" },
-    container: { backgroundColor: "#fff", flex: 1 },
-});
+export default App;

--- a/examples/expo/eslint.config.js
+++ b/examples/expo/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/expo/lunora/auth.ts
+++ b/examples/expo/lunora/auth.ts
@@ -1,7 +1,7 @@
+import { expo } from "@better-auth/expo";
 import type { LunoraAuthOptions } from "@lunora/auth";
 import { createAuth, lunoraD1Adapter } from "@lunora/auth";
 import { bearer } from "@lunora/auth/plugins";
-import { expo } from "@better-auth/expo";
 
 /** The app's URL scheme (see `app.json` → `expo.scheme`) — a trusted origin for native requests. */
 const APP_SCHEME = "expoexample";
@@ -26,23 +26,28 @@ const APP_SCHEME = "expoexample";
  * The password-reset delivery hook logs to the console — the standard dev
  * pattern. In production swap it for an `@lunora/mail` send.
  */
-const options = (env: { AUTH_SECRET: string; AUTH_URL?: string }): LunoraAuthOptions => ({
-    appName: "Lunora Expo Example",
-    baseURL: env.AUTH_URL,
-    emailAndPassword: {
-        enabled: true,
-        sendResetPassword: async ({ user }) => {
-            // Log only a non-sensitive identifier — never the reset URL (a
-            // credential) or the user's email (PII). In production swap this for
-            // an `@lunora/mail` send that delivers the `url` to the user.
-            // eslint-disable-next-line no-console
-            console.log(`[auth] password reset requested for user ${user.id}`);
+const options = (env: { AUTH_SECRET: string; AUTH_URL?: string }): LunoraAuthOptions => {
+    return {
+        appName: "Lunora Expo Example",
+        baseURL: env.AUTH_URL,
+        emailAndPassword: {
+            enabled: true,
+            sendResetPassword: ({ user }) => {
+                // Log only a non-sensitive identifier — never the reset URL (a
+                // credential) or the user's email (PII). In production swap this for
+                // an `@lunora/mail` send that delivers the `url` to the user.
+
+                console.log(`[auth] password reset requested for user ${user.id}`);
+
+                // The contract is async; this dev-only delivery has nothing to await.
+                return Promise.resolve();
+            },
         },
-    },
-    plugins: [expo(), bearer()],
-    secret: env.AUTH_SECRET,
-    trustedOrigins: [`${APP_SCHEME}://`],
-});
+        plugins: [expo(), bearer()],
+        secret: env.AUTH_SECRET,
+        trustedOrigins: [`${APP_SCHEME}://`],
+    };
+};
 
 /**
  * Runtime auth instance, backed by `@lunora/auth`'s SQL adapter over D1.

--- a/examples/expo/lunora/messages.ts
+++ b/examples/expo/lunora/messages.ts
@@ -1,9 +1,9 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Everyone posting here is signed in, so the limit keys on the user — one
@@ -61,7 +61,7 @@ export const list = query.query(async ({ ctx }): Promise<MessageRow[]> => {
     // past the page we keep.
     const rows = await ctx.db.query("messages").withIndex("by_created").order("desc").take(PAGE_SIZE);
 
-    return rows.reverse();
+    return rows.toReversed();
 });
 
 /**

--- a/examples/expo/lunora/ratelimit/schema.ts
+++ b/examples/expo/lunora/ratelimit/schema.ts
@@ -5,10 +5,10 @@
  * DO-backed rate limiting. Named limits live here and nowhere else, so tuning
  * one is a change to this file rather than to the procedure that enforces it.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     /** Chat writes: 30 per caller per minute, refilling continuously over 60s. */

--- a/examples/expo/lunora/schema.ts
+++ b/examples/expo/lunora/schema.ts
@@ -1,5 +1,6 @@
-import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
+
+import { ratelimit } from "./ratelimit/schema.js";
 
 /**
  * expo — a single-room chat, the backend behind the Expo mobile client.

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -14,7 +14,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev:server": "wrangler dev",
-        "lint:types": "node node_modules/lunorash/dist/bin.mjs codegen && tsc --noEmit"
+        "lint:types": "node node_modules/lunorash/dist/bin.mjs codegen && tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@better-auth/expo": "catalog:auth",

--- a/examples/expo/src/Chat.tsx
+++ b/examples/expo/src/Chat.tsx
@@ -3,9 +3,31 @@ import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 import { FlatList, KeyboardAvoidingView, Platform, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
-import { authClient } from "./auth-client";
 import { api } from "../lunora/_generated/api";
+import { authClient } from "./auth-client";
 
+const styles = StyleSheet.create({
+    author: { color: "#6b7280", fontSize: 12, marginBottom: 2 },
+    bubble: { borderRadius: 12, marginVertical: 4, maxWidth: "80%", padding: 10 },
+    bubbleMine: { alignSelf: "flex-end", backgroundColor: "#3b82f6" },
+    bubbleTheirs: { alignSelf: "flex-start", backgroundColor: "#e5e7eb" },
+    composer: { borderColor: "#e5e7eb", borderTopWidth: 1, flexDirection: "row", gap: 8, padding: 8 },
+    dot: { borderRadius: 4, height: 8, width: 8 },
+    error: { color: "#dc2626", paddingBottom: 4, paddingHorizontal: 12, textAlign: "center" },
+    flex: { flex: 1 },
+    header: { alignItems: "center", borderBottomColor: "#e5e7eb", borderBottomWidth: 1, flexDirection: "row", justifyContent: "space-between", padding: 12 },
+    headerRight: { alignItems: "center", flexDirection: "row", gap: 8 },
+    input: { borderColor: "#d1d5db", borderRadius: 20, borderWidth: 1, flex: 1, fontSize: 16, paddingHorizontal: 14, paddingVertical: 8 },
+    listContent: { padding: 12 },
+    pressed: { opacity: 0.85 },
+    sendButton: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 20, justifyContent: "center", paddingHorizontal: 18 },
+    sendText: { color: "#fff", fontWeight: "600" },
+    signOut: { color: "#3b82f6" },
+    status: { color: "#6b7280", fontSize: 12 },
+    textMine: { color: "#fff", fontSize: 16 },
+    textTheirs: { color: "#111827", fontSize: 16 },
+    title: { fontSize: 20, fontWeight: "700" },
+});
 /** Human label + colour for the live-socket status badge. */
 const STATUS: Record<string, { color: string; label: string }> = {
     connected: { color: "#16a34a", label: "live" },
@@ -20,7 +42,7 @@ const STATUS: Record<string, { color: string; label: string }> = {
  * retried offline, thanks to the AsyncStorage persistence wired in
  * `src/lunora.ts`). `useConnectionStatus` drives the live/offline badge.
  */
-export function Chat(): ReactElement {
+export const Chat = (): ReactElement => {
     const { data: session } = authClient.useSession();
     const myUserId = session?.user.id;
     const myName = session?.user.name ?? session?.user.email ?? "me";
@@ -31,12 +53,12 @@ export function Chat(): ReactElement {
 
     const [draft, setDraft] = useState("");
 
-    const listRef = useRef<FlatList>(null);
+    const listReference = useRef<FlatList>(null);
 
     // Reveal newly arrived messages (live-query deltas and the initial load).
     useEffect(() => {
         if (messages?.length) {
-            listRef.current?.scrollToEnd({ animated: true });
+            listReference.current?.scrollToEnd({ animated: true });
         }
     }, [messages]);
 
@@ -65,7 +87,11 @@ export function Chat(): ReactElement {
                 <View style={styles.headerRight}>
                     <View style={[styles.dot, { backgroundColor: badge.color }]} />
                     <Text style={styles.status}>{badge.label}</Text>
-                    <Pressable onPress={() => void authClient.signOut()}>
+                    <Pressable
+                        onPress={() => {
+                            void authClient.signOut();
+                        }}
+                    >
                         <Text style={styles.signOut}>Sign out</Text>
                     </Pressable>
                 </View>
@@ -75,7 +101,7 @@ export function Chat(): ReactElement {
                 contentContainerStyle={styles.listContent}
                 data={messages ?? []}
                 keyExtractor={(item) => item._id}
-                ref={listRef}
+                ref={listReference}
                 renderItem={({ item }) => {
                     const mine = item.userId === myUserId;
 
@@ -98,27 +124,4 @@ export function Chat(): ReactElement {
             </View>
         </KeyboardAvoidingView>
     );
-}
-
-const styles = StyleSheet.create({
-    author: { color: "#6b7280", fontSize: 12, marginBottom: 2 },
-    bubble: { borderRadius: 12, marginVertical: 4, maxWidth: "80%", padding: 10 },
-    bubbleMine: { alignSelf: "flex-end", backgroundColor: "#3b82f6" },
-    bubbleTheirs: { alignSelf: "flex-start", backgroundColor: "#e5e7eb" },
-    composer: { borderColor: "#e5e7eb", borderTopWidth: 1, flexDirection: "row", gap: 8, padding: 8 },
-    dot: { borderRadius: 4, height: 8, width: 8 },
-    error: { color: "#dc2626", paddingBottom: 4, paddingHorizontal: 12, textAlign: "center" },
-    flex: { flex: 1 },
-    header: { alignItems: "center", borderBottomColor: "#e5e7eb", borderBottomWidth: 1, flexDirection: "row", justifyContent: "space-between", padding: 12 },
-    headerRight: { alignItems: "center", flexDirection: "row", gap: 8 },
-    input: { borderColor: "#d1d5db", borderRadius: 20, borderWidth: 1, flex: 1, fontSize: 16, paddingHorizontal: 14, paddingVertical: 8 },
-    listContent: { padding: 12 },
-    pressed: { opacity: 0.85 },
-    sendButton: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 20, justifyContent: "center", paddingHorizontal: 18 },
-    sendText: { color: "#fff", fontWeight: "600" },
-    signOut: { color: "#3b82f6" },
-    status: { color: "#6b7280", fontSize: 12 },
-    textMine: { color: "#fff", fontSize: 16 },
-    textTheirs: { color: "#111827", fontSize: 16 },
-    title: { fontSize: 20, fontWeight: "700" },
-});
+};

--- a/examples/expo/src/Login.tsx
+++ b/examples/expo/src/Login.tsx
@@ -4,6 +4,16 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 
 
 import { authClient } from "./auth-client";
 
+const styles = StyleSheet.create({
+    button: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 8, padding: 14 },
+    buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+    container: { gap: 12, justifyContent: "center", padding: 24 },
+    error: { color: "#dc2626", textAlign: "center" },
+    input: { borderColor: "#d1d5db", borderRadius: 8, borderWidth: 1, fontSize: 16, padding: 12 },
+    pressed: { opacity: 0.85 },
+    switch: { color: "#3b82f6", textAlign: "center" },
+    title: { fontSize: 28, fontWeight: "700", marginBottom: 8, textAlign: "center" },
+});
 type Mode = "signin" | "signup";
 
 /**
@@ -30,7 +40,7 @@ const authenticate = async (mode: Mode, credentials: { email: string; name: stri
  * and `authClient.useSession()` in `App.tsx` flips to the chat on the next
  * render — no token to plumb through by hand.
  */
-export function Login(): ReactElement {
+export const Login = (): ReactElement => {
     const [mode, setMode] = useState<Mode>("signin");
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
@@ -66,7 +76,13 @@ export function Login(): ReactElement {
 
             <TextInput onChangeText={setPassword} placeholder="Password (min 8 chars)" secureTextEntry style={styles.input} value={password} />
 
-            <Pressable disabled={pending} onPress={() => void submit()} style={({ pressed }) => [styles.button, pressed && styles.pressed]}>
+            <Pressable
+                disabled={pending}
+                onPress={() => {
+                    void submit();
+                }}
+                style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+            >
                 {pending ? <ActivityIndicator color="#fff" /> : <Text style={styles.buttonText}>{mode === "signin" ? "Sign in" : "Sign up"}</Text>}
             </Pressable>
 
@@ -82,15 +98,4 @@ export function Login(): ReactElement {
             {error ? <Text style={styles.error}>{error}</Text> : null}
         </View>
     );
-}
-
-const styles = StyleSheet.create({
-    button: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 8, padding: 14 },
-    buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
-    container: { gap: 12, justifyContent: "center", padding: 24 },
-    error: { color: "#dc2626", textAlign: "center" },
-    input: { borderColor: "#d1d5db", borderRadius: 8, borderWidth: 1, fontSize: 16, padding: 12 },
-    pressed: { opacity: 0.85 },
-    switch: { color: "#3b82f6", textAlign: "center" },
-    title: { fontSize: 28, fontWeight: "700", marginBottom: 8, textAlign: "center" },
-});
+};

--- a/examples/expo/src/lunora.ts
+++ b/examples/expo/src/lunora.ts
@@ -1,5 +1,5 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createLunoraClient } from "@lunora/react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { LUNORA_URL } from "./auth-client";
 

--- a/examples/expo/src/server/index.ts
+++ b/examples/expo/src/server/index.ts
@@ -29,18 +29,15 @@ let authReady: null | Promise<ReturnType<typeof buildAuth>> = null;
  * a permanent error.
  */
 const ensureAuthReady = (env: Env): Promise<ReturnType<typeof buildAuth>> => {
-    if (!authReady) {
-        authReady = (async (): Promise<ReturnType<typeof buildAuth>> => {
-            await ensureMigrated(buildMigrationAuth({ AUTH_SECRET: env.AUTH_SECRET, AUTH_URL: env.AUTH_URL, DB: env.DB }));
+    authReady ??= (async (): Promise<ReturnType<typeof buildAuth>> => {
+        await ensureMigrated(buildMigrationAuth({ AUTH_SECRET: env.AUTH_SECRET, AUTH_URL: env.AUTH_URL, DB: env.DB }));
 
-            return buildAuth({ AUTH_SECRET: env.AUTH_SECRET, AUTH_URL: env.AUTH_URL, DB: env.DB });
-        })().catch((error: unknown) => {
-            authReady = null;
+        return buildAuth({ AUTH_SECRET: env.AUTH_SECRET, AUTH_URL: env.AUTH_URL, DB: env.DB });
+    })().catch((error: unknown) => {
+        authReady = null;
 
-            throw error;
-        });
-    }
-
+        throw error;
+    });
     return authReady;
 };
 
@@ -76,34 +73,31 @@ export default {
             return authResponse;
         }
 
-        if (!worker) {
-            worker = createWorker({
-                openApiSpec,
-                resolveIdentity: async (identityRequest) => {
-                    // HTTP RPC carries `Authorization: Bearer <token>`; the WS
-                    // upgrade can't set headers, so the client sends the same token
-                    // as `?token=`. Fold it into the header the `bearer` plugin reads
-                    // — but ONLY on the upgrade. Accepting a query-string credential
-                    // on ordinary HTTP requests too would make every URL a bearer
-                    // token: session tokens would land in access logs, `Referer`
-                    // headers and shared links, and the request would be
-                    // authenticated by a value a cross-origin link can set.
-                    const headers = new Headers(identityRequest.headers);
-                    const isUpgrade = headers.get("upgrade")?.toLowerCase() === "websocket";
-                    const wsToken = isUpgrade ? new URL(identityRequest.url).searchParams.get("token") : null;
+        worker ??= createWorker({
+            openApiSpec,
+            resolveIdentity: async (identityRequest) => {
+                // HTTP RPC carries `Authorization: Bearer <token>`; the WS
+                // upgrade can't set headers, so the client sends the same token
+                // as `?token=`. Fold it into the header the `bearer` plugin reads
+                // — but ONLY on the upgrade. Accepting a query-string credential
+                // on ordinary HTTP requests too would make every URL a bearer
+                // token: session tokens would land in access logs, `Referer`
+                // headers and shared links, and the request would be
+                // authenticated by a value a cross-origin link can set.
+                const headers = new Headers(identityRequest.headers);
+                const isUpgrade = headers.get("upgrade")?.toLowerCase() === "websocket";
+                const wsToken = isUpgrade ? new URL(identityRequest.url).searchParams.get("token") : null;
 
-                    if (wsToken !== null && !headers.has("authorization")) {
-                        headers.set("authorization", `Bearer ${wsToken}`);
-                    }
+                if (wsToken !== null && !headers.has("authorization")) {
+                    headers.set("authorization", `Bearer ${wsToken}`);
+                }
 
-                    const session = await auth.api.getSession({ headers });
+                const session = await auth.api.getSession({ headers });
 
-                    return session?.user?.id ? { userId: session.user.id } : null;
-                },
-                shardDO: env.SHARD,
-            });
-        }
-
+                return session?.user.id ? { userId: session.user.id } : null;
+            },
+            shardDO: env.SHARD,
+        });
         return worker.fetch(request, env, ctx);
     },
 };

--- a/examples/feedback-board/__tests__/board.test.ts
+++ b/examples/feedback-board/__tests__/board.test.ts
@@ -13,6 +13,8 @@ import { afterEach, beforeEach, expect, it } from "vitest";
 import { addComment, comments, create, list, myVotes, remove, setStatus, toggleVote } from "../lunora/feedback";
 import schema from "../lunora/schema";
 
+const NOT_FOUND_RE = /not found/i;
+
 let t: ReturnType<typeof lunoraTest>;
 
 beforeEach(() => {
@@ -26,6 +28,7 @@ afterEach(() => {
 const post = async (title: string) => t.mutation(create, { authorName: "ada", description: "why", title });
 
 it("creates a post that starts open with no votes and no comments", async () => {
+    expect.assertions(4);
     await post("dark mode");
 
     const [item] = await t.query(list, {});
@@ -37,54 +40,66 @@ it("creates a post that starts open with no votes and no comments", async () => 
 });
 
 it("toggles a voter's upvote on and off, keeping the counter in step with the ledger", async () => {
+    expect.assertions(6);
     const id = await post("dark mode");
     const voterEmail = "ada@example.com";
 
     expect(await t.mutation(toggleVote, { feedbackId: id, voterEmail })).toStrictEqual({ voted: true });
-    expect((await t.query(list, {}))[0]?.upvoteCount).toBe(1);
+    const rows1 = await t.query(list, {});
+    expect(rows1[0]?.upvoteCount).toBe(1);
     expect(await t.query(myVotes, { voterEmail })).toStrictEqual([id]);
 
     expect(await t.mutation(toggleVote, { feedbackId: id, voterEmail })).toStrictEqual({ voted: false });
-    expect((await t.query(list, {}))[0]?.upvoteCount).toBe(0);
+    const rows2 = await t.query(list, {});
+    expect(rows2[0]?.upvoteCount).toBe(0);
     expect(await t.query(myVotes, { voterEmail })).toStrictEqual([]);
 });
 
 it("counts a second voter separately", async () => {
+    expect.assertions(1);
     const id = await post("dark mode");
 
     await t.mutation(toggleVote, { feedbackId: id, voterEmail: "ada@example.com" });
     await t.mutation(toggleVote, { feedbackId: id, voterEmail: "grace@example.com" });
 
-    expect((await t.query(list, {}))[0]?.upvoteCount).toBe(2);
+    const rows3 = await t.query(list, {});
+    expect(rows3[0]?.upvoteCount).toBe(2);
 });
 
 it("refuses a vote on a post that is not there", async () => {
+    expect.assertions(1);
     const id = await post("dark mode");
 
     await t.mutation(remove, { id });
-    await expect(t.mutation(toggleVote, { feedbackId: id, voterEmail: "ada@example.com" })).rejects.toThrow(/not found/i);
+    await expect(t.mutation(toggleVote, { feedbackId: id, voterEmail: "ada@example.com" })).rejects.toThrow(NOT_FOUND_RE);
 });
 
 it("sorts by votes when the board asks it to", async () => {
+    expect.assertions(2);
     const quiet = await post("quiet");
     const loud = await post("loud");
 
     await t.mutation(toggleVote, { feedbackId: loud, voterEmail: "ada@example.com" });
 
-    expect((await t.query(list, { sortBy: "votes" })).map((item) => item.title)).toStrictEqual(["loud", "quiet"]);
+    const awaited1 = await t.query(list, { sortBy: "votes" });
+    expect(awaited1.map((item) => item.title)).toStrictEqual(["loud", "quiet"]);
     expect(quiet).toBeDefined();
 });
 
 it("records comments against their post and bumps the count", async () => {
+    expect.assertions(2);
     const id = await post("dark mode");
 
     await t.mutation(addComment, { authorName: "grace", content: "yes please", feedbackId: id });
 
-    expect((await t.query(comments, { feedbackId: id })).map((comment) => comment.content)).toStrictEqual(["yes please"]);
-    expect((await t.query(list, {}))[0]?.commentCount).toBe(1);
+    const awaited2 = await t.query(comments, { feedbackId: id });
+    expect(awaited2.map((comment) => comment.content)).toStrictEqual(["yes please"]);
+    const rows4 = await t.query(list, {});
+    expect(rows4[0]?.commentCount).toBe(1);
 });
 
 it("filters by status once a post is triaged, and deletes cleanly", async () => {
+    expect.assertions(3);
     const id = await post("dark mode");
 
     await t.mutation(setStatus, { id, status: "planned" });

--- a/examples/feedback-board/eslint.config.js
+++ b/examples/feedback-board/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -309,12 +309,12 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
-        "cacheKey": "nondeterministic_query_mutation:summaries:90:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:summaries:93:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in store (summaries:90) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `store` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in store (summaries:93) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `store` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -322,7 +322,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "store",
             "file": "summaries",
             "kind": "mutation",
-            "line": 90
+            "line": 93
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",

--- a/examples/feedback-board/lunora/feedback.ts
+++ b/examples/feedback-board/lunora/feedback.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * This board has no sign-in, so a deployed instance is reachable by anyone and
@@ -38,14 +38,14 @@ const BOARD_LIMIT = 200;
  */
 export const list = query
     .input({ status: v.optional(feedbackStatus), sortBy: v.optional(v.union(v.literal("votes"), v.literal("recent"))) })
-    .query(async ({ args: { sortBy, status }, ctx }): Promise<Doc<"feedback">[]> => {
+    .query(async ({ args: { sortBy, status }, ctx }): Promise<Document_<"feedback">[]> => {
         if (status) {
             const rows = await ctx.db
                 .query("feedback")
                 .withIndex("by_status", (q) => q.eq("status", status))
                 .take(BOARD_LIMIT);
 
-            return sortBy === "votes" ? [...rows].sort((a, b) => b.upvoteCount - a.upvoteCount) : [...rows].sort((a, b) => b._creationTime - a._creationTime);
+            return sortBy === "votes" ? rows.toSorted((a, b) => b.upvoteCount - a.upvoteCount) : rows.toSorted((a, b) => b._creationTime - a._creationTime);
         }
 
         if (sortBy === "votes") {
@@ -57,15 +57,15 @@ export const list = query
 
 export const get = query
     .input({ id: v.id("feedback") })
-    .query(async ({ args: { id }, ctx }): Promise<Doc<"feedback"> | null> => (await ctx.db.get(id)) ?? null);
+    .query(async ({ args: { id }, ctx }): Promise<Document_<"feedback"> | null> => (await ctx.db.get(id)) ?? null);
 
-export const comments = query.input({ feedbackId: v.id("feedback") }).query(async ({ args: { feedbackId }, ctx }): Promise<Doc<"comments">[]> => {
+export const comments = query.input({ feedbackId: v.id("feedback") }).query(async ({ args: { feedbackId }, ctx }): Promise<Document_<"comments">[]> => {
     const rows = await ctx.db
         .query("comments")
         .withIndex("by_feedback", (q) => q.eq("feedbackId", feedbackId))
         .collect();
 
-    return [...rows].sort((a, b) => a._creationTime - b._creationTime);
+    return rows.toSorted((a, b) => a._creationTime - b._creationTime);
 });
 
 /** Which of these posts the given voter has already upvoted — one query for the whole page, rather than one per card. */
@@ -177,18 +177,14 @@ export const remove = mutation
             .withIndex("by_feedback_and_voter", (q) => q.eq("feedbackId", id))
             .collect();
 
-        for (const vote of votes) {
-            await ctx.db.delete(vote._id);
-        }
+        await Promise.all(votes.map(async (vote) => ctx.db.delete(vote._id)));
 
         const rows = await ctx.db
             .query("comments")
             .withIndex("by_feedback", (q) => q.eq("feedbackId", id))
             .collect();
 
-        for (const comment of rows) {
-            await ctx.db.delete(comment._id);
-        }
+        await Promise.all(rows.map(async (comment) => ctx.db.delete(comment._id)));
 
         ctx.log.info("feedback removed", { comments: rows.length, id, votes: votes.length });
         await ctx.db.delete(id);

--- a/examples/feedback-board/lunora/ratelimit/schema.ts
+++ b/examples/feedback-board/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     write: { kind: "token bucket", period: 60_000, rate: 60 },

--- a/examples/feedback-board/lunora/summaries.ts
+++ b/examples/feedback-board/lunora/summaries.ts
@@ -2,11 +2,11 @@ import { generateText } from "@lunora/ai";
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import { api, internal } from "./_generated/api.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { ActionCtx, MutationCtx } from "./_generated/server.js";
 import { action, internalMutation, mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Inference costs money per call, so it gets a far tighter bucket than the
@@ -21,7 +21,9 @@ const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: { ip?: string }): string => ctx.ip ?? "anon" };
 
 /** Newest first. The board renders whichever summary is on top. */
-export const list = query.query(async ({ ctx }): Promise<Doc<"summaries">[]> => ctx.db.query("summaries").withIndex("by_generated").order("desc").collect());
+export const list = query.query(async ({ ctx }): Promise<Document_<"summaries">[]> =>
+    ctx.db.query("summaries").withIndex("by_generated").order("desc").collect(),
+);
 
 /**
  * Read the top-voted posts and write a summary of what people are asking for.
@@ -39,13 +41,14 @@ export const generate = action
     .use(rateLimit(actionLimiter, "ai", byCaller))
     .input({ limit: v.optional(v.number()) })
     .action(async ({ args: { limit }, ctx }): Promise<Id<"summaries"> | null> => {
-        const top = (await ctx.runQuery(api.feedback.list, { sortBy: "votes" })).slice(0, Math.min(Math.max(limit ?? 10, 1), 50));
+        const awaited1 = await ctx.runQuery(api.feedback.list, { sortBy: "votes" });
+        const top = awaited1.slice(0, Math.min(Math.max(limit ?? 10, 1), 50));
 
         if (top.length === 0) {
             return null;
         }
 
-        const board = top.map((post, index) => `${index + 1}. ${post.title} (${post.upvoteCount} votes)\n   ${post.description}`).join("\n\n");
+        const board = top.map((post, index) => `${String(index + 1)}. ${post.title} (${String(post.upvoteCount)} votes)\n   ${post.description}`).join("\n\n");
 
         let text: string;
 
@@ -79,7 +82,7 @@ export const generate = action
         return ctx.runMutation(internal.summaries.store, {
             feedbackIds: top.map((post) => post._id),
             summary: text,
-            title: `Top ${top.length} requests`,
+            title: `Top ${String(top.length)} requests`,
         });
     });
 

--- a/examples/feedback-board/package.json
+++ b/examples/feedback-board/package.json
@@ -11,7 +11,9 @@
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/ai": "workspace:*",

--- a/examples/feedback-board/src/client/App.tsx
+++ b/examples/feedback-board/src/client/App.tsx
@@ -3,9 +3,24 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_, Id } from "../../lunora/_generated/dataModel.js";
 import { Detail } from "./Detail.js";
-import { STATUSES, StatusBadge } from "./status.js";
+import { STATUSES } from "./status.js";
+import { StatusBadge } from "./StatusBadge.js";
+
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"` — a file input sharing a text field's
+ * name would submit that verbatim. Narrowing instead yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
 
 /** Stands in for a signed-in identity — swap for `ctx.auth.userId` and `useAuth()` when you add auth. */
 const VOTER_EMAIL = "you@example.com";
@@ -16,7 +31,7 @@ export const App = (): ReactElement => {
     const client = useLunora();
 
     const [sortBy, setSortBy] = useState<Sort>("votes");
-    const [filter, setFilter] = useState<Doc<"feedback">["status"] | "">("");
+    const [filter, setFilter] = useState<Document_<"feedback">["status"] | "">("");
     const [selected, setSelected] = useState<Id<"feedback"> | null>(null);
     const [composing, setComposing] = useState(false);
     const [summarising, setSummarising] = useState(false);
@@ -30,7 +45,7 @@ export const App = (): ReactElement => {
 
     // A Set, not `myVotes.includes(...)` inside the row loop: that is a linear
     // scan per row, so rendering the board is quadratic in the number of votes.
-    const votedIds = new Set(myVotes ?? []);
+    const votedIds = new Set(myVotes);
 
     /**
      * Flip the vote in the cache before the round trip. The count and the
@@ -49,9 +64,7 @@ export const App = (): ReactElement => {
                 localStore.setQuery(
                     api.feedback.list,
                     args,
-                    (value as Doc<"feedback">[]).map((post) =>
-                        post._id === feedbackId ? { ...post, upvoteCount: Math.max(0, post.upvoteCount + (isVoted ? -1 : 1)) } : post,
-                    ),
+                    value.map((post) => (post._id === feedbackId ? { ...post, upvoteCount: Math.max(0, post.upvoteCount + (isVoted ? -1 : 1)) } : post)),
                 );
             }
         }
@@ -64,10 +77,10 @@ export const App = (): ReactElement => {
         try {
             // Actions are not subscriptions — call them straight on the client.
             await client.action(api.summaries.generate, {});
-        } catch (cause: unknown) {
+        } catch (error_: unknown) {
             // Inference is the one call here that leaves the shard, so it is the
             // one that fails for reasons the board cannot fix — say so.
-            setError(cause instanceof Error ? cause.message : "could not generate a summary");
+            setError(error_ instanceof Error ? error_.message : "could not generate a summary");
         }
 
         // After the catch, not in a `finally`: the React Compiler cannot lower a
@@ -76,7 +89,15 @@ export const App = (): ReactElement => {
     };
 
     if (selected) {
-        return <Detail id={selected} onBack={() => setSelected(null)} voterEmail={VOTER_EMAIL} />;
+        return (
+            <Detail
+                id={selected}
+                onBack={() => {
+                    setSelected(null);
+                }}
+                voterEmail={VOTER_EMAIL}
+            />
+        );
     }
 
     return (
@@ -88,10 +109,22 @@ export const App = (): ReactElement => {
                 </div>
 
                 <div className="row">
-                    <button disabled={summarising} onClick={() => void onSummarise()} type="button">
+                    <button
+                        disabled={summarising}
+                        onClick={() => {
+                            void onSummarise();
+                        }}
+                        type="button"
+                    >
                         {summarising ? "Summarising…" : "✨ Summarise"}
                     </button>
-                    <button className="primary" onClick={() => setComposing((previous) => !previous)} type="button">
+                    <button
+                        className="primary"
+                        onClick={() => {
+                            setComposing((previous) => !previous);
+                        }}
+                        type="button"
+                    >
                         {composing ? "Cancel" : "Submit feedback"}
                     </button>
                 </div>
@@ -106,8 +139,8 @@ export const App = (): ReactElement => {
                         event.preventDefault();
 
                         const form = new FormData(event.currentTarget);
-                        const title = String(form.get("title") ?? "").trim();
-                        const authorName = String(form.get("authorName") ?? "").trim();
+                        const title = textField(form, "title").trim();
+                        const authorName = textField(form, "authorName").trim();
 
                         if (!title || !authorName) {
                             return;
@@ -116,15 +149,15 @@ export const App = (): ReactElement => {
                         void create({
                             authorEmail: VOTER_EMAIL,
                             authorName,
-                            description: String(form.get("description") ?? "").trim(),
+                            description: textField(form, "description").trim(),
                             title,
                         });
 
                         setComposing(false);
                     }}
                 >
-                    <input required aria-label="Your name" name="authorName" placeholder="Your name" />
-                    <input required aria-label="Title" name="title" placeholder="Short, specific title" />
+                    <input aria-label="Your name" name="authorName" placeholder="Your name" required />
+                    <input aria-label="Title" name="title" placeholder="Short, specific title" required />
                     <textarea aria-label="Description" name="description" placeholder="What problem does this solve?" rows={3} />
                     <button className="primary" type="submit">
                         Post
@@ -134,15 +167,33 @@ export const App = (): ReactElement => {
 
             <div className="row toolbar">
                 <div className="tabs">
-                    <button aria-pressed={sortBy === "votes"} onClick={() => setSortBy("votes")} type="button">
+                    <button
+                        aria-pressed={sortBy === "votes"}
+                        onClick={() => {
+                            setSortBy("votes");
+                        }}
+                        type="button"
+                    >
                         Top
                     </button>
-                    <button aria-pressed={sortBy === "recent"} onClick={() => setSortBy("recent")} type="button">
+                    <button
+                        aria-pressed={sortBy === "recent"}
+                        onClick={() => {
+                            setSortBy("recent");
+                        }}
+                        type="button"
+                    >
                         Newest
                     </button>
                 </div>
 
-                <select aria-label="Filter by status" onChange={(event) => setFilter(event.target.value as Doc<"feedback">["status"] | "")} value={filter}>
+                <select
+                    aria-label="Filter by status"
+                    onChange={(event) => {
+                        setFilter(event.target.value as Document_<"feedback">["status"] | "");
+                    }}
+                    value={filter}
+                >
                     <option value="">All statuses</option>
                     {STATUSES.map((value) => (
                         <option key={value} value={value}>
@@ -167,20 +218,28 @@ export const App = (): ReactElement => {
                         const voted = votedIds.has(post._id);
 
                         return (
-                            <li key={post._id} className="card post">
+                            <li className="card post" key={post._id}>
                                 <button
                                     // The visible label is a caret and a number, which reads as
                                     // "▲ 3" to a screen reader — no indication of what it does.
                                     aria-label={`${voted ? "Remove upvote from" : "Upvote"} ${post.title}`}
                                     aria-pressed={voted}
                                     className={voted ? "vote voted" : "vote"}
-                                    onClick={() => void toggleVote({ feedbackId: post._id, voterEmail: VOTER_EMAIL })}
+                                    onClick={() => {
+                                        void toggleVote({ feedbackId: post._id, voterEmail: VOTER_EMAIL });
+                                    }}
                                     type="button"
                                 >
                                     ▲<span>{post.upvoteCount}</span>
                                 </button>
 
-                                <button className="post-body" onClick={() => setSelected(post._id)} type="button">
+                                <button
+                                    className="post-body"
+                                    onClick={() => {
+                                        setSelected(post._id);
+                                    }}
+                                    type="button"
+                                >
                                     <span className="post-title">{post.title}</span>
                                     <span className="muted">{post.description}</span>
                                     <span className="row">

--- a/examples/feedback-board/src/client/Detail.tsx
+++ b/examples/feedback-board/src/client/Detail.tsx
@@ -2,9 +2,24 @@ import { useMutation, useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
+import type { Id } from "../../lunora/_generated/dataModel.js";
 import type { Status } from "./status.js";
-import { STATUSES, StatusBadge } from "./status.js";
+import { STATUSES } from "./status.js";
+import { StatusBadge } from "./StatusBadge.js";
+
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"` — a file input sharing a text field's
+ * name would submit that verbatim. Narrowing instead yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
 
 interface DetailProperties {
     id: Id<"feedback">;
@@ -50,9 +65,15 @@ export const Detail = ({ id, onBack, voterEmail }: DetailProperties): ReactEleme
                 </p>
                 <p>{post.description}</p>
 
-                <label>
+                <label htmlFor="detail-field1">
                     Status
-                    <select onChange={(event) => void setStatus({ id, status: event.target.value as Status })} value={post.status}>
+                    <select
+                        id="detail-field1"
+                        onChange={(event) => {
+                            void setStatus({ id, status: event.target.value as Status });
+                        }}
+                        value={post.status}
+                    >
                         {STATUSES.map((value) => (
                             <option key={value} value={value}>
                                 {value}
@@ -67,7 +88,7 @@ export const Detail = ({ id, onBack, voterEmail }: DetailProperties): ReactEleme
 
                 <ul className="list">
                     {(comments ?? []).map((comment) => (
-                        <li key={comment._id} className="comment">
+                        <li className="comment" key={comment._id}>
                             <strong>{comment.authorName}</strong>
                             {comment.isOfficial && <span className="badge badge-official">team</span>}
                             <p>{comment.content}</p>
@@ -80,7 +101,7 @@ export const Detail = ({ id, onBack, voterEmail }: DetailProperties): ReactEleme
                         event.preventDefault();
 
                         const form = new FormData(event.currentTarget);
-                        const content = String(form.get("content") ?? "").trim();
+                        const content = textField(form, "content").trim();
 
                         if (!content) {
                             return;
@@ -90,7 +111,7 @@ export const Detail = ({ id, onBack, voterEmail }: DetailProperties): ReactEleme
                         event.currentTarget.reset();
                     }}
                 >
-                    <textarea required aria-label="Add a comment" name="content" placeholder="Add a comment" rows={2} />
+                    <textarea aria-label="Add a comment" name="content" placeholder="Add a comment" required rows={2} />
                     <button className="primary" type="submit">
                         Comment
                     </button>

--- a/examples/feedback-board/src/client/StatusBadge.tsx
+++ b/examples/feedback-board/src/client/StatusBadge.tsx
@@ -1,0 +1,6 @@
+import type { ReactElement } from "react";
+
+import type { Status } from "./status.js";
+
+/** The coloured pill for one feedback status. */
+export const StatusBadge = ({ status }: { status: Status }): ReactElement => <span className={`badge badge-${status}`}>{status.replace("-", " ")}</span>;

--- a/examples/feedback-board/src/client/main.tsx
+++ b/examples/feedback-board/src/client/main.tsx
@@ -1,10 +1,11 @@
+import "./styles.css";
+
 import { LunoraProvider } from "@lunora/react";
 import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
-import "./styles.css";
 
 const url = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? globalThis.location.origin;
 const client = new LunoraClient({ url });

--- a/examples/feedback-board/src/client/status.ts
+++ b/examples/feedback-board/src/client/status.ts
@@ -1,0 +1,5 @@
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
+
+export type Status = Document_<"feedback">["status"];
+
+export const STATUSES = ["open", "under-review", "planned", "in-progress", "completed", "closed"] as const satisfies ReadonlyArray<Status>;

--- a/examples/feedback-board/src/client/status.tsx
+++ b/examples/feedback-board/src/client/status.tsx
@@ -1,9 +1,0 @@
-import type { ReactElement } from "react";
-
-import type { Doc } from "../../lunora/_generated/dataModel.js";
-
-export type Status = Doc<"feedback">["status"];
-
-export const STATUSES = ["open", "under-review", "planned", "in-progress", "completed", "closed"] as const satisfies readonly Status[];
-
-export const StatusBadge = ({ status }: { status: Status }): ReactElement => <span className={`badge badge-${status}`}>{status.replace("-", " ")}</span>;

--- a/examples/feedback-board/src/server/index.ts
+++ b/examples/feedback-board/src/server/index.ts
@@ -10,15 +10,13 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            // `openApiSpec` (regenerated on every `lunora/` change) backs the
-            // studio's always-current API-reference tab.
-            worker = createWorker({ openApiSpec, shardDO: env.SHARD });
-        }
+        // `openApiSpec` (regenerated on every `lunora/` change) backs the
+        // studio's always-current API-reference tab.
+        worker ??= createWorker({ openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/examples/feedback-board/tsconfig.json
+++ b/examples/feedback-board/tsconfig.json
@@ -5,12 +5,28 @@
         "rootDir": ".",
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "types": ["@cloudflare/workers-types", "node", "vite/client"],
-        "lib": ["DOM", "DOM.Iterable", "ES2024"],
+        "types": [
+            "@cloudflare/workers-types",
+            "node",
+            "vite/client"
+        ],
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2024"
+        ],
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false
     },
-    "include": ["src/**/*", "lunora/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*",
+        "lunora/**/*",
+        "vite.config.ts",
+        "__tests__/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/examples/kanban-board/__tests__/board.test.ts
+++ b/examples/kanban-board/__tests__/board.test.ts
@@ -8,80 +8,100 @@
  * middleware whose table was never created.
  */
 import { lunoraTest } from "@lunora/testing";
-import { afterEach, beforeEach, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import schema from "../lunora/schema";
 import { create, list, move, remove, rename } from "../lunora/tasks";
 
 let t: ReturnType<typeof lunoraTest>;
 
-beforeEach(() => {
-    t = lunoraTest(schema);
-});
+describe("board", () => {
+    beforeEach(() => {
+        t = lunoraTest(schema);
+    });
 
-afterEach(() => {
-    t.close();
-});
+    afterEach(() => {
+        t.close();
+    });
 
-const titles = async (status: string) => (await t.query(list, {})).filter((task) => task.status === status).map((task) => task.title);
+    const titles = async (status: string) => {
+        const tasks = await t.query(list, {});
 
-it("creates cards in the column they were added to, in insertion order", async () => {
-    await t.mutation(create, { title: "first" });
-    await t.mutation(create, { title: "second" });
-    await t.mutation(create, { status: "done", title: "shipped" });
+        return tasks.filter((task) => task.status === status).map((task) => task.title);
+    };
 
-    expect(await titles("todo")).toStrictEqual(["first", "second"]);
-    expect(await titles("done")).toStrictEqual(["shipped"]);
-});
+    it("creates cards in the column they were added to, in insertion order", async () => {
+        expect.assertions(2);
 
-it("moves a card across columns and lands it at the requested index", async () => {
-    await t.mutation(create, { title: "a" });
-    await t.mutation(create, { title: "b" });
-    await t.mutation(create, { title: "c" });
+        await t.mutation(create, { title: "first" });
+        await t.mutation(create, { title: "second" });
+        await t.mutation(create, { status: "done", title: "shipped" });
 
-    const board = await t.query(list, {});
-    const c = board.find((task) => task.title === "c");
+        await expect(titles("todo")).resolves.toStrictEqual(["first", "second"]);
+        await expect(titles("done")).resolves.toStrictEqual(["shipped"]);
+    });
 
-    expect(c).toBeDefined();
-    await t.mutation(move, { id: c!._id, index: 1, status: "in-progress" });
+    it("moves a card across columns and lands it at the requested index", async () => {
+        expect.assertions(3);
 
-    expect(await titles("todo")).toStrictEqual(["a", "b"]);
-    expect(await titles("in-progress")).toStrictEqual(["c"]);
-});
+        await t.mutation(create, { title: "a" });
+        await t.mutation(create, { title: "b" });
+        await t.mutation(create, { title: "c" });
 
-it("reorders within a column without touching its neighbours' keys", async () => {
-    await t.mutation(create, { title: "a" });
-    await t.mutation(create, { title: "b" });
-    await t.mutation(create, { title: "c" });
+        const board = await t.query(list, {});
+        const c = board.find((task) => task.title === "c");
 
-    const before = await t.query(list, {});
-    const c = before.find((task) => task.title === "c")!;
+        expect(c).toBeDefined();
 
-    // Drop "c" at the head. Only its own row may be rewritten — that is the
-    // point of the fractional index.
-    await t.mutation(move, { id: c._id, index: 0, status: "todo" });
+        await t.mutation(move, { id: c!._id, index: 1, status: "in-progress" });
 
-    expect(await titles("todo")).toStrictEqual(["c", "a", "b"]);
+        await expect(titles("todo")).resolves.toStrictEqual(["a", "b"]);
+        await expect(titles("in-progress")).resolves.toStrictEqual(["c"]);
+    });
 
-    const after = await t.query(list, {});
-    const unchanged = ["a", "b"].every((title) => after.find((task) => task.title === title)?.order === before.find((task) => task.title === title)?.order);
+    it("reorders within a column without touching its neighbours' keys", async () => {
+        expect.assertions(2);
 
-    expect(unchanged).toBe(true);
-});
+        await t.mutation(create, { title: "a" });
+        await t.mutation(create, { title: "b" });
+        await t.mutation(create, { title: "c" });
 
-it("renames and deletes", async () => {
-    const id = await t.mutation(create, { title: "typo" });
+        const before = await t.query(list, {});
+        const c = before.find((task) => task.title === "c")!;
 
-    await t.mutation(rename, { id, title: "fixed" });
-    expect(await titles("todo")).toStrictEqual(["fixed"]);
+        // Drop "c" at the head. Only its own row may be rewritten — that is the
+        // point of the fractional index.
+        await t.mutation(move, { id: c._id, index: 0, status: "todo" });
 
-    await t.mutation(remove, { id });
-    expect(await t.query(list, {})).toStrictEqual([]);
-});
+        await expect(titles("todo")).resolves.toStrictEqual(["c", "a", "b"]);
 
-it("ignores a move for a card that no longer exists", async () => {
-    const id = await t.mutation(create, { title: "gone" });
+        const after = await t.query(list, {});
+        const unchanged = ["a", "b"].every((title) => after.find((task) => task.title === title)?.order === before.find((task) => task.title === title)?.order);
 
-    await t.mutation(remove, { id });
-    await expect(t.mutation(move, { id, index: 0, status: "done" })).resolves.toBeUndefined();
+        expect(unchanged).toBe(true);
+    });
+
+    it("renames and deletes", async () => {
+        expect.assertions(2);
+
+        const id = await t.mutation(create, { title: "typo" });
+
+        await t.mutation(rename, { id, title: "fixed" });
+
+        await expect(titles("todo")).resolves.toStrictEqual(["fixed"]);
+
+        await t.mutation(remove, { id });
+
+        await expect(t.query(list, {})).resolves.toStrictEqual([]);
+    });
+
+    it("ignores a move for a card that no longer exists", async () => {
+        expect.assertions(1);
+
+        const id = await t.mutation(create, { title: "gone" });
+
+        await t.mutation(remove, { id });
+
+        await expect(t.mutation(move, { id, index: 0, status: "done" })).resolves.toBeUndefined();
+    });
 });

--- a/examples/kanban-board/__tests__/ordering.test.ts
+++ b/examples/kanban-board/__tests__/ordering.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import { midpoint } from "../lunora/ordering";
 
+const OUT_OF_ORDER_RE = /out of order/u;
+
 describe("midpoint", () => {
     it("orders an empty board", () => {
+        expect.assertions(1);
         expect(midpoint(null, null)).toBe("n");
     });
 
     it("returns a key strictly between its neighbours", () => {
+        expect.assertions(2);
+
         const first = midpoint(null, null);
         const after = midpoint(first, null);
         const between = midpoint(first, after);
@@ -17,6 +22,8 @@ describe("midpoint", () => {
     });
 
     it("survives repeated insertion into the same gap", () => {
+        expect.hasAssertions();
+
         let low = midpoint(null, null);
         const high = midpoint(low, null);
 
@@ -33,16 +40,19 @@ describe("midpoint", () => {
     });
 
     it("keeps a whole column sorted as it is rebuilt front-to-back", () => {
+        expect.assertions(1);
+
         const keys: string[] = [];
 
         for (let index = 0; index < 50; index += 1) {
             keys.unshift(midpoint(null, keys[0] ?? null));
         }
 
-        expect([...keys].sort((left, right) => (left < right ? -1 : 1))).toStrictEqual(keys);
+        expect(keys.toSorted((left, right) => (left < right ? -1 : 1))).toStrictEqual(keys);
     });
 
     it("rejects neighbours the caller read out of order", () => {
-        expect(() => midpoint("z", "b")).toThrow(/out of order/u);
+        expect.assertions(1);
+        expect(() => midpoint("z", "b")).toThrow(OUT_OF_ORDER_RE);
     });
 });

--- a/examples/kanban-board/eslint.config.js
+++ b/examples/kanban-board/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/kanban-board/lunora/ordering.ts
+++ b/examples/kanban-board/lunora/ordering.ts
@@ -11,6 +11,7 @@
  * lexicographic comparison is positional comparison. `a` is the zero digit and
  * a key therefore never ends in `a` — a trailing zero has no midpoint below it.
  */
+// eslint-disable-next-line no-secrets/no-secrets -- the base-26 digit alphabet, not a credential; every letter appears once so it reads as high entropy.
 const DIGITS = "abcdefghijklmnopqrstuvwxyz";
 const ZERO = "a";
 
@@ -28,7 +29,7 @@ export const midpoint = (before: string | null, after: string | null): string =>
         throw new Error(`midpoint: keys out of order (${a} >= ${b})`);
     }
 
-    if (a.endsWith(ZERO) || (b !== null && b.endsWith(ZERO))) {
+    if (a.endsWith(ZERO) || b?.endsWith(ZERO)) {
         throw new Error(`midpoint: key ends in the zero digit (${a}, ${String(b)})`);
     }
 
@@ -46,11 +47,11 @@ export const midpoint = (before: string | null, after: string | null): string =>
         }
     }
 
-    const digitA = a === "" ? 0 : DIGITS.indexOf(a[0] as string);
-    const digitB = b === null ? DIGITS.length : DIGITS.indexOf(b[0] as string);
+    const digitA = a === "" ? 0 : DIGITS.indexOf(a[0]);
+    const digitB = b === null ? DIGITS.length : DIGITS.indexOf(b[0]);
 
     if (digitB - digitA > 1) {
-        return DIGITS[Math.round((digitA + digitB) / 2)] as string;
+        return DIGITS[Math.round((digitA + digitB) / 2)];
     }
 
     // The leading digits are adjacent, so there is no room at this position.
@@ -59,5 +60,5 @@ export const midpoint = (before: string | null, after: string | null): string =>
         return b.slice(0, 1);
     }
 
-    return (DIGITS[digitA] as string) + midpoint(a.slice(1), null);
+    return DIGITS[digitA] + midpoint(a.slice(1), null);
 };

--- a/examples/kanban-board/lunora/ratelimit/schema.ts
+++ b/examples/kanban-board/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     // Generous: dragging a card fires one write per drop, and a burst of

--- a/examples/kanban-board/lunora/tasks.ts
+++ b/examples/kanban-board/lunora/tasks.ts
@@ -1,12 +1,10 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { midpoint } from "./ordering.js";
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc } from "./_generated/dataModel.js";
+import type { Doc as Document_ } from "./_generated/dataModel.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
-
-type Status = Doc<"tasks">["status"];
+import { midpoint } from "./ordering.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Every write here is unauthenticated — this demo has no sign-in — so the only
@@ -20,7 +18,9 @@ const limiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: MutationCtx): string => ctx.ip ?? "anon" };
 
 /** Cards on the board, in column-then-position order. Every browser subscribes to this one query. */
-export const list = query.query(async ({ ctx }): Promise<Doc<"tasks">[]> => ctx.db.query("tasks").withIndex("by_status_and_order").order("asc").collect());
+export const list = query.query(async ({ ctx }): Promise<Document_<"tasks">[]> =>
+    ctx.db.query("tasks").withIndex("by_status_and_order").order("asc").collect(),
+);
 
 /**
  * Append a card to the bottom of a column. The order key is derived server-side
@@ -34,7 +34,7 @@ export const create = mutation
         status: v.optional(v.union(v.literal("todo"), v.literal("in-progress"), v.literal("done"), v.literal("archived"))),
     })
     .mutation(async ({ args: { title, status: column }, ctx }): Promise<Id<"tasks">> => {
-        const target = (column ?? "todo") as Status;
+        const target = column ?? "todo";
         const cards = await ctx.db
             .query("tasks")
             .withIndex("by_status_and_order", (q) => q.eq("status", target))
@@ -75,7 +75,7 @@ export const move = mutation
             return;
         }
 
-        const target = column as Status;
+        const target = column;
         const cards = await ctx.db
             .query("tasks")
             .withIndex("by_status_and_order", (q) => q.eq("status", target))

--- a/examples/kanban-board/package.json
+++ b/examples/kanban-board/package.json
@@ -11,7 +11,9 @@
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/ratelimit": "workspace:*",

--- a/examples/kanban-board/src/client/App.tsx
+++ b/examples/kanban-board/src/client/App.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
+import { Column } from "./Column.js";
 import type { Command } from "./CommandPalette.js";
 import { CommandPalette } from "./CommandPalette.js";
-import { Column } from "./Column.js";
 import type { Status, Task } from "./types.js";
 import { COLUMNS } from "./types.js";
 
@@ -69,8 +69,8 @@ export const App = (): ReactElement => {
     const [light, setLight] = useState(false);
     const [showArchived, setShowArchived] = useState(false);
     const [paletteOpen, setPaletteOpen] = useState(false);
-    const searchRef = useRef<HTMLInputElement>(null);
-    const draggingRef = useRef<Task | null>(null);
+    const searchReference = useRef<HTMLInputElement>(null);
+    const draggingReference = useRef<Task | null>(null);
 
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent): void => {
@@ -78,21 +78,36 @@ export const App = (): ReactElement => {
                 return;
             }
 
-            if (event.key === "k") {
-                event.preventDefault();
-                setPaletteOpen(true);
-            } else if (event.key === "f") {
-                event.preventDefault();
-                searchRef.current?.focus();
-            } else if (event.key === "a") {
-                event.preventDefault();
-                setShowArchived((previous) => !previous);
+            switch (event.key) {
+                case "a": {
+                    event.preventDefault();
+                    setShowArchived((previous) => !previous);
+
+                    break;
+                }
+                case "f": {
+                    event.preventDefault();
+                    searchReference.current?.focus();
+
+                    break;
+                }
+                case "k": {
+                    event.preventDefault();
+                    setPaletteOpen(true);
+
+                    break;
+                }
+                default: {
+                    break;
+                }
             }
         };
 
         globalThis.addEventListener("keydown", onKeyDown);
 
-        return () => globalThis.removeEventListener("keydown", onKeyDown);
+        return () => {
+            globalThis.removeEventListener("keydown", onKeyDown);
+        };
     }, []);
 
     // No `useMemo`: the React Compiler memoizes this already.
@@ -105,7 +120,7 @@ export const App = (): ReactElement => {
             id: "search",
             run: () => {
                 setPaletteOpen(false);
-                searchRef.current?.focus();
+                searchReference.current?.focus();
             },
             shortcut: "⌘F",
             title: "Search cards",
@@ -138,9 +153,9 @@ export const App = (): ReactElement => {
     const filtering = search.trim().length > 0;
 
     const onDrop = (status: Status, index: number): void => {
-        const card = draggingRef.current;
+        const card = draggingReference.current;
 
-        draggingRef.current = null;
+        draggingReference.current = null;
 
         if (card && (card.status !== status || index !== grouped[status].indexOf(card))) {
             void move({ id: card._id, index, status });
@@ -151,23 +166,45 @@ export const App = (): ReactElement => {
         <div className={light ? "app light" : "app"}>
             <header className="app-header">
                 <input
-                    ref={searchRef}
                     aria-label="Search cards"
                     className="search"
-                    onChange={(event) => setSearch(event.target.value)}
+                    onChange={(event) => {
+                        setSearch(event.target.value);
+                    }}
                     placeholder="Search"
+                    ref={searchReference}
                     type="search"
                     value={search}
                 />
 
                 <div className="header-actions">
-                    <button aria-label="Open command palette" onClick={() => setPaletteOpen(true)} title="⌘K" type="button">
+                    <button
+                        aria-label="Open command palette"
+                        onClick={() => {
+                            setPaletteOpen(true);
+                        }}
+                        title="⌘K"
+                        type="button"
+                    >
                         ⌘K
                     </button>
-                    <button aria-pressed={showArchived} onClick={() => setShowArchived((previous) => !previous)} title="⌘A" type="button">
+                    <button
+                        aria-pressed={showArchived}
+                        onClick={() => {
+                            setShowArchived((previous) => !previous);
+                        }}
+                        title="⌘A"
+                        type="button"
+                    >
                         Archived
                     </button>
-                    <button aria-pressed={light} onClick={() => setLight((previous) => !previous)} type="button">
+                    <button
+                        aria-pressed={light}
+                        onClick={() => {
+                            setLight((previous) => !previous);
+                        }}
+                        type="button"
+                    >
                         {light ? "Dark" : "Light"}
                     </button>
                 </div>
@@ -179,16 +216,22 @@ export const App = (): ReactElement => {
                 <div className="columns">
                     {visibleColumns.map((status, columnIndex) => (
                         <Column
-                            key={status}
                             columnIndex={columnIndex}
                             draggable={!filtering}
-                            onCreate={(column, title) => void create({ status: column, title })}
-                            onDelete={(task) => void remove({ id: task._id })}
+                            key={status}
+                            onCreate={(column, title) => {
+                                void create({ status: column, title });
+                            }}
+                            onDelete={(task) => {
+                                void remove({ id: task._id });
+                            }}
                             onDragStart={(task) => {
-                                draggingRef.current = task;
+                                draggingReference.current = task;
                             }}
                             onDrop={onDrop}
-                            onRename={(task, title) => void rename({ id: task._id, title })}
+                            onRename={(task, title) => {
+                                void rename({ id: task._id, title });
+                            }}
                             status={status}
                             tasks={grouped[status]}
                         />
@@ -196,7 +239,14 @@ export const App = (): ReactElement => {
                 </div>
             )}
 
-            {paletteOpen && <CommandPalette commands={commands} onClose={() => setPaletteOpen(false)} />}
+            {paletteOpen && (
+                <CommandPalette
+                    commands={commands}
+                    onClose={() => {
+                        setPaletteOpen(false);
+                    }}
+                />
+            )}
         </div>
     );
 };

--- a/examples/kanban-board/src/client/Column.tsx
+++ b/examples/kanban-board/src/client/Column.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, DragEvent, ReactElement } from "react";
 import { useState } from "react";
 
+import focusOnMount from "./focus-on-mount.js";
 import type { Status, Task } from "./types.js";
 
 const LABELS: Record<Status, string> = {
@@ -35,9 +36,9 @@ interface ColumnProperties {
     draggable: boolean;
     onCreate: (status: Status, title: string) => void;
     onDelete: (task: Task) => void;
+    onDragStart: (task: Task) => void;
     onDrop: (status: Status, index: number) => void;
     onRename: (task: Task, title: string) => void;
-    onDragStart: (task: Task) => void;
     status: Status;
     tasks: Task[];
 }
@@ -67,13 +68,20 @@ export const Column = ({ columnIndex, draggable, onCreate, onDelete, onDragStart
     };
 
     return (
-        <section className="column" style={{ "--col": columnIndex } as CSSProperties} aria-label={LABELS[status]}>
+        <section aria-label={LABELS[status]} className="column" style={{ "--col": columnIndex } as CSSProperties}>
             <header className="column-header">
                 <h2>{LABELS[status]}</h2>
                 <span className="count">{tasks.length}</span>
             </header>
 
-            <div className="column-body" onDragLeave={() => setDropIndex(null)} onDragOver={onDragOver} onDrop={onDropCard}>
+            <div
+                className="column-body"
+                onDragLeave={() => {
+                    setDropIndex(null);
+                }}
+                onDragOver={onDragOver}
+                onDrop={onDropCard}
+            >
                 {tasks.map((task, index) => (
                     <div key={task._id} style={{ "--i": index } as CSSProperties}>
                         {dropIndex === index && <div className="drop-indicator" />}
@@ -81,15 +89,18 @@ export const Column = ({ columnIndex, draggable, onCreate, onDelete, onDragStart
                             className="card"
                             data-card=""
                             draggable={draggable}
-                            onDragEnd={() => setDropIndex(null)}
+                            onDragEnd={() => {
+                                setDropIndex(null);
+                            }}
                             onDragStart={(event) => {
-                                event.dataTransfer.effectAllowed = "move";
+                                const { dataTransfer } = event;
+
+                                dataTransfer.effectAllowed = "move";
                                 onDragStart(task);
                             }}
                         >
                             {editing === task._id ? (
                                 <input
-                                    autoFocus
                                     aria-label="Card title"
                                     className="card-input"
                                     defaultValue={task.title}
@@ -111,13 +122,27 @@ export const Column = ({ columnIndex, draggable, onCreate, onDelete, onDragStart
                                             setEditing(null);
                                         }
                                     }}
+                                    ref={focusOnMount}
                                 />
                             ) : (
                                 <>
-                                    <button className="card-title" onClick={() => setEditing(task._id)} type="button">
+                                    <button
+                                        className="card-title"
+                                        onClick={() => {
+                                            setEditing(task._id);
+                                        }}
+                                        type="button"
+                                    >
                                         {task.title}
                                     </button>
-                                    <button aria-label={`Delete ${task.title}`} className="card-delete" onClick={() => onDelete(task)} type="button">
+                                    <button
+                                        aria-label={`Delete ${task.title}`}
+                                        className="card-delete"
+                                        onClick={() => {
+                                            onDelete(task);
+                                        }}
+                                        type="button"
+                                    >
                                         ×
                                     </button>
                                 </>
@@ -131,10 +156,11 @@ export const Column = ({ columnIndex, draggable, onCreate, onDelete, onDragStart
 
             {composing ? (
                 <input
-                    autoFocus
                     aria-label={`New card in ${LABELS[status]}`}
                     className="card-input"
-                    onBlur={() => setComposing(false)}
+                    onBlur={() => {
+                        setComposing(false);
+                    }}
                     onKeyDown={(event) => {
                         if (event.key === "Escape") {
                             setComposing(false);
@@ -147,14 +173,23 @@ export const Column = ({ columnIndex, draggable, onCreate, onDelete, onDragStart
                         const title = event.currentTarget.value.trim();
 
                         if (title) {
+                            const field = event.currentTarget;
+
                             onCreate(status, title);
-                            event.currentTarget.value = "";
+                            field.value = "";
                         }
                     }}
                     placeholder="Card title, then Enter"
+                    ref={focusOnMount}
                 />
             ) : (
-                <button className="add-card" onClick={() => setComposing(true)} type="button">
+                <button
+                    className="add-card"
+                    onClick={() => {
+                        setComposing(true);
+                    }}
+                    type="button"
+                >
                     + Add a card
                 </button>
             )}

--- a/examples/kanban-board/src/client/CommandPalette.tsx
+++ b/examples/kanban-board/src/client/CommandPalette.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 
+import focusOnMount from "./focus-on-mount.js";
+
 export interface Command {
     id: string;
     run: () => void;
@@ -14,7 +16,7 @@ interface CommandPaletteProperties {
 }
 
 /**
- * ⌘K palette. Rendered only while open, so it needs no `isOpen` branch of its own.
+ * Command palette (⌘K). Rendered only while open, so it needs no `isOpen` branch of its own.
  *
  * A native `<dialog>` opened with `showModal()`, not a hand-rolled backdrop: the
  * platform gives focus trapping, inertness of the page behind it, Escape-to-close
@@ -23,21 +25,22 @@ interface CommandPaletteProperties {
  */
 export const CommandPalette = ({ commands, onClose }: CommandPaletteProperties): ReactElement => {
     const [filter, setFilter] = useState("");
-    const dialogRef = useRef<HTMLDialogElement>(null);
+    const dialogReference = useRef<HTMLDialogElement>(null);
     const matches = commands.filter((command) => command.title.toLowerCase().includes(filter.toLowerCase()));
 
     useEffect(() => {
         // `showModal()` is what makes it modal; rendering the element alone does not.
-        dialogRef.current?.showModal();
+        dialogReference.current?.showModal();
     }, []);
 
     return (
-        <dialog ref={dialogRef} aria-label="Command palette" className="palette" onCancel={onClose} onClose={onClose}>
+        <dialog aria-label="Command palette" className="palette" onCancel={onClose} onClose={onClose} ref={dialogReference}>
             <input
-                autoFocus
                 aria-label="Filter commands"
                 className="palette-input"
-                onChange={(event) => setFilter(event.target.value)}
+                onChange={(event) => {
+                    setFilter(event.target.value);
+                }}
                 onKeyDown={(event) => {
                     // Escape is handled by the dialog's own `cancel` event.
                     if (event.key === "Enter") {
@@ -45,6 +48,7 @@ export const CommandPalette = ({ commands, onClose }: CommandPaletteProperties):
                     }
                 }}
                 placeholder="Type a command…"
+                ref={focusOnMount}
                 value={filter}
             />
 

--- a/examples/kanban-board/src/client/focus-on-mount.ts
+++ b/examples/kanban-board/src/client/focus-on-mount.ts
@@ -1,0 +1,17 @@
+/**
+ * Callback ref that focuses the node when it attaches.
+ *
+ * The same effect as `autoFocus`, without the attribute `jsx-a11y/no-autofocus`
+ * warns about — the warning is about focus a user did not ask for, and every
+ * input using this one is rendered *because* the user just clicked to edit, to
+ * add a card, or opened the palette.
+ *
+ * Declared at module scope so its identity is stable: React re-invokes a
+ * callback ref only when the callback itself changes, so this runs on attach and
+ * detach rather than on every render.
+ */
+const focusOnMount = (node: HTMLInputElement | null): void => {
+    node?.focus();
+};
+
+export default focusOnMount;

--- a/examples/kanban-board/src/client/main.tsx
+++ b/examples/kanban-board/src/client/main.tsx
@@ -1,10 +1,11 @@
+import "./styles.css";
+
 import { LunoraProvider } from "@lunora/react";
 import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
-import "./styles.css";
 
 // `@cloudflare/vite-plugin` serves the Worker on the same origin as Vite,
 // so default to `location.origin` rather than a separate workerd port.

--- a/examples/kanban-board/src/client/types.ts
+++ b/examples/kanban-board/src/client/types.ts
@@ -1,8 +1,8 @@
-import type { Doc } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
 
-export type Task = Doc<"tasks">;
+export type Task = Document_<"tasks">;
 
 export type Status = Task["status"];
 
 /** The board's columns, left to right. */
-export const COLUMNS = ["todo", "in-progress", "done", "archived"] as const satisfies readonly Status[];
+export const COLUMNS = ["todo", "in-progress", "done", "archived"] as const satisfies ReadonlyArray<Status>;

--- a/examples/kanban-board/src/server/index.ts
+++ b/examples/kanban-board/src/server/index.ts
@@ -10,15 +10,13 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            // `openApiSpec` (regenerated on every `lunora/` change) backs the
-            // studio's always-current API-reference tab.
-            worker = createWorker({ openApiSpec, shardDO: env.SHARD });
-        }
+        // `openApiSpec` (regenerated on every `lunora/` change) backs the
+        // studio's always-current API-reference tab.
+        worker ??= createWorker({ openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/examples/kanban-board/tsconfig.json
+++ b/examples/kanban-board/tsconfig.json
@@ -5,12 +5,28 @@
         "rootDir": ".",
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "types": ["@cloudflare/workers-types", "node", "vite/client"],
-        "lib": ["DOM", "DOM.Iterable", "ES2024"],
+        "types": [
+            "@cloudflare/workers-types",
+            "node",
+            "vite/client"
+        ],
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2024"
+        ],
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false
     },
-    "include": ["src/**/*", "lunora/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*",
+        "lunora/**/*",
+        "vite.config.ts",
+        "__tests__/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/examples/notify-demo/eslint.config.js
+++ b/examples/notify-demo/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/notify-demo/lunora/push.ts
+++ b/examples/notify-demo/lunora/push.ts
@@ -1,9 +1,9 @@
 import { webPushId } from "@lunora/notify";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { ActionCtx, Id, MutationCtx } from "./_generated/server.js";
 import { action, mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * This demo has no sign-in, so a deployed instance is reachable by anyone and
@@ -15,7 +15,7 @@ const actionLimiter = (ctx: ActionCtx) => makeRateLimiter(ctx);
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: { ip?: string }): string => ctx.ip ?? "anon" };
 
-interface AnnouncementDoc {
+interface AnnouncementDocument {
     _id: Id<"announcements">;
     body: string;
     sentAt: number;
@@ -67,10 +67,10 @@ export const announce = mutation
     .mutation(async ({ args: { body, title }, ctx }): Promise<Id<"announcements">> => ctx.db.insert("announcements", { body, sentAt: Date.now(), title }));
 
 /** List announcements, newest first. Subscribers receive deltas as `announce` writes. */
-export const listAnnouncements = query.query(async ({ ctx }): Promise<AnnouncementDoc[]> => {
+export const listAnnouncements = query.query(async ({ ctx }): Promise<AnnouncementDocument[]> => {
     const rows = await ctx.db.query("announcements").withIndex("by_sent").collect();
 
-    return [...rows].sort((a, b) => b.sentAt - a.sentAt);
+    return rows.toSorted((a, b) => b.sentAt - a.sentAt);
 });
 
 /**
@@ -95,7 +95,12 @@ export const broadcast = action
         // secrets (the web-push `keys`, the FCM token). Handing `ctx.notify.send` a
         // bare `endpoint` URL routed the message to FCM — the push router treats
         // any non-`{`-prefixed string as an opaque FCM registration token.
-        const [first] = await ctx.push.list();
+        // `.at(0)` rather than destructuring: this example sets
+        // `noUncheckedIndexedAccess: false`, so `const [first] = …` is typed as if
+        // the element always exists and the emptiness check below reads as dead.
+        // `at` is declared `T | undefined`, so the type matches the runtime.
+        const subscriptions = await ctx.push.list();
+        const first = subscriptions.at(0);
 
         if (first !== undefined) {
             await ctx.push.send(first.id, { body, title });

--- a/examples/notify-demo/lunora/ratelimit/schema.ts
+++ b/examples/notify-demo/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Named limits live here and nowhere else.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     write: { kind: "token bucket", period: 60_000, rate: 30 },

--- a/examples/notify-demo/lunora/schema.ts
+++ b/examples/notify-demo/lunora/schema.ts
@@ -1,5 +1,6 @@
-import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
+
+import { ratelimit } from "./ratelimit/schema.js";
 
 /**
  * notify-demo — the end-to-end `@lunora/notify` push wiring.

--- a/examples/notify-demo/package.json
+++ b/examples/notify-demo/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/notify": "workspace:*",

--- a/examples/notify-demo/public/sw.js
+++ b/examples/notify-demo/public/sw.js
@@ -1,18 +1,18 @@
 // Minimal Web Push service worker for the notify-demo. Renders an incoming push
 // as a system notification; focuses/opens the app when it is clicked.
-/* eslint-disable no-undef -- service-worker global scope (self, clients) */
-self.addEventListener("push", (event) => {
+
+globalThis.addEventListener("push", (event) => {
     const payload = event.data ? event.data.json() : {};
 
     event.waitUntil(
-        self.registration.showNotification(payload.title ?? "Notification", {
+        globalThis.registration.showNotification(payload.title ?? "Notification", {
             body: payload.body ?? "",
             data: payload.data ?? {},
         }),
     );
 });
 
-self.addEventListener("notificationclick", (event) => {
+globalThis.addEventListener("notificationclick", (event) => {
     event.notification.close();
-    event.waitUntil(self.clients.openWindow("/"));
+    event.waitUntil(globalThis.clients.openWindow("/"));
 });

--- a/examples/notify-demo/src/client/App.tsx
+++ b/examples/notify-demo/src/client/App.tsx
@@ -1,10 +1,10 @@
-import { useLunora, useMutation, useQuery } from "@lunora/react";
 import { subscribeToPush } from "@lunora/notify/web";
+import { useLunora, useMutation, useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
 
 // The VAPID **public** key the server signs with (`VAPID_PUBLIC_KEY`). Set it in
 // the client env as `VITE_VAPID_PUBLIC_KEY`; a real deploy generates the pair
@@ -25,7 +25,7 @@ const VAPID_PUBLIC_KEY = (import.meta.env.VITE_VAPID_PUBLIC_KEY as string | unde
  */
 export const App = (): ReactElement => {
     const client = useLunora();
-    const announcements = useQuery(api.push.listAnnouncements, {}) as Doc<"announcements">[] | undefined;
+    const announcements = useQuery(api.push.listAnnouncements, {}) as Document_<"announcements">[] | undefined;
     const { mutate: registerDevice } = useMutation(api.push.registerDevice);
     const { mutate: announce } = useMutation(api.push.announce);
 
@@ -53,14 +53,19 @@ export const App = (): ReactElement => {
         await announce({ body, title });
         const result = await client.action(api.push.broadcast, { body, title });
 
-        setStatus(`Broadcast: ${result.sent} sent, ${result.failed} failed, ${result.pruned} pruned.`);
+        setStatus(`Broadcast: ${String(result.sent)} sent, ${String(result.failed)} failed, ${String(result.pruned)} pruned.`);
     };
 
     return (
         <main style={{ fontFamily: "system-ui", margin: "3rem auto", maxWidth: 560 }}>
             <h1>Notify demo</h1>
 
-            <button onClick={() => void enablePush()} type="button">
+            <button
+                onClick={() => {
+                    void enablePush();
+                }}
+                type="button"
+            >
                 Enable push on this device
             </button>
 

--- a/examples/notify-demo/src/server/index.ts
+++ b/examples/notify-demo/src/server/index.ts
@@ -2,9 +2,9 @@ import type { D1Like } from "@lunora/notify";
 import type { ExecutionContextLike, ShardNamespaceLike } from "lunorash/runtime";
 import { createWorker } from "lunorash/runtime";
 
-import notifyConfig from "../../lunora/notify.js";
 import { openApiSpec } from "../../lunora/_generated/openapi.js";
 import { createShardDO } from "../../lunora/_generated/shard.js";
+import notifyConfig from "../../lunora/notify.js";
 
 // The generated ShardDO wires `ctx.notify` / `ctx.push` from `lunora/notify.ts`
 // (codegen discovers the default export) onto every handler ctx.
@@ -18,7 +18,7 @@ interface Env extends Record<string, unknown> {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 /**
  * Worker entry. Beyond the ShardDO binding, it threads the SAME `@lunora/notify`
@@ -29,14 +29,11 @@ let worker: ReturnType<typeof createWorker> | null = null;
  */
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            worker = createWorker({
-                notifySubscriptionStore: notifyConfig.store?.(env),
-                openApiSpec,
-                shardDO: env.SHARD,
-            });
-        }
-
+        worker ??= createWorker({
+            notifySubscriptionStore: notifyConfig.store?.(env),
+            openApiSpec,
+            shardDO: env.SHARD,
+        });
         return worker.fetch(request, env, ctx);
     },
 };

--- a/examples/offline-rejections/eslint.config.js
+++ b/examples/offline-rejections/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -128,12 +128,12 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
-        "cacheKey": "nondeterministic_query_mutation:messages:64:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:messages:66:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
-        "detail": "`Date.now(…)` in send (messages:64) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `send` is invoked from a workflow step or queue consumer that can itself replay.",
+        "detail": "`Date.now(…)` in send (messages:66) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `send` is invoked from a workflow step or queue consumer that can itself replay.",
         "facing": "INTERNAL",
         "level": "INFO",
         "metadata": {
@@ -141,7 +141,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "send",
             "file": "messages",
             "kind": "mutation",
-            "line": 64
+            "line": 66
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",

--- a/examples/offline-rejections/lunora/messages.ts
+++ b/examples/offline-rejections/lunora/messages.ts
@@ -1,9 +1,11 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
+
+const BFAIL_B_RE = /\bfail\b/i;
 
 /**
  * The limiter comes from `lunora/ratelimit/schema.ts`, which owns the named
@@ -18,7 +20,7 @@ import { mutation, query, v } from "./_generated/server.js";
 const limiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: { ip?: string }): string => ctx.ip ?? "anon" };
 
-interface MessageDoc {
+interface MessageDocument {
     _id: Id<"messages">;
     author: string;
     createdAt: number;
@@ -29,10 +31,10 @@ interface MessageDoc {
  * List messages newest-first. Subscribers receive deltas the moment `send`
  * commits a new row.
  */
-export const list = query.query(async ({ ctx }): Promise<MessageDoc[]> => {
+export const list = query.query(async ({ ctx }): Promise<MessageDocument[]> => {
     const rows = await ctx.db.query("messages").withIndex("by_creation").collect();
 
-    return [...rows].sort((a, b) => b.createdAt - a.createdAt);
+    return rows.toSorted((a, b) => b.createdAt - a.createdAt);
 });
 
 /**
@@ -57,7 +59,7 @@ export const send = mutation
             throw new LunoraError("BAD_REQUEST", "message text cannot be empty");
         }
 
-        if (/\bfail\b/i.test(trimmed)) {
+        if (BFAIL_B_RE.test(trimmed)) {
             throw new LunoraError("CONFLICT", `the server refused to save "${trimmed}"`);
         }
 

--- a/examples/offline-rejections/lunora/ratelimit/schema.ts
+++ b/examples/offline-rejections/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 /**
  * Named limits this app enforces.

--- a/examples/offline-rejections/package.json
+++ b/examples/offline-rejections/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/react": "workspace:*",

--- a/examples/offline-rejections/src/client/App.tsx
+++ b/examples/offline-rejections/src/client/App.tsx
@@ -1,27 +1,59 @@
 import { useConnectionStatus, useLunora, useMutation, useQuery } from "@lunora/react";
 import type { MutationSettledEvent } from "lunorash/client";
-import type { FormEvent, ReactElement } from "react";
+import type { ReactElement, SyntheticEvent } from "react";
 import { useEffect, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_, Id } from "../../lunora/_generated/dataModel.js";
+
+const tagStyle = { background: "#eee", borderRadius: 4, marginLeft: 6, padding: "1px 5px" } as const;
+
+const rowStyle = { border: "1px solid", borderRadius: 6, fontSize: 13, marginBottom: 6, padding: "6px 8px" } as const;
+
+const Panel = ({ children, hint, title }: { children: React.ReactNode; hint: string; title: string }): ReactElement => (
+    <div>
+        <div style={{ fontWeight: 600, fontSize: 14 }}>{title}</div>
+        <div style={{ color: "#777", fontSize: 12, marginBottom: 8 }}>{hint}</div>
+        {children}
+    </div>
+);
+
+const Empty = ({ children }: { children: React.ReactNode }): ReactElement => <div style={{ color: "#999", fontSize: 13 }}>{children}</div>;
+
+const StatusPill = ({ status }: { status: string }): ReactElement => {
+    const connected = status === "connected";
+
+    return (
+        <span
+            style={{
+                background: connected ? "#e6f6ea" : "#fdeaea",
+                borderRadius: 999,
+                color: connected ? "#0a7d33" : "#b00020",
+                fontSize: 13,
+                padding: "2px 10px",
+            }}
+        >
+            {status}
+        </span>
+    );
+};
 
 /** One row in the settled-events log fed by `client.onMutationSettled`. */
 interface SettledLog {
     code?: string;
     fn: string;
     hadAwaiter: boolean;
-    key: number;
+    key: string;
     status: "committed" | "rejected";
 }
 
 /** One row in the live-error log fed by the awaited `mutate()` Promise. */
 interface LiveError {
-    key: number;
+    key: string;
     message: string;
 }
 
-const shortFn = (functionPath: string): string => functionPath.split(":").at(-1) ?? functionPath;
+const shortFunction = (functionPath: string): string => functionPath.split(":").at(-1) ?? functionPath;
 
 // A stable author for this browser session — irrelevant to the demo, but `send`
 // requires one.
@@ -45,7 +77,7 @@ export const App = (): ReactElement => {
     const client = useLunora();
     const status = useConnectionStatus();
 
-    const messages = useQuery(api.messages.list, {}) as Doc<"messages">[] | undefined;
+    const messages = useQuery(api.messages.list, {}) as Document_<"messages">[] | undefined;
     const { mutate: send, pending } = useMutation(api.messages.send);
 
     const [draft, setDraft] = useState("");
@@ -54,24 +86,26 @@ export const App = (): ReactElement => {
 
     // The durable channel. Subscribe once; the unsubscribe is returned so React
     // (and StrictMode's double-invoke) cleans it up.
-    useEffect(() => {
-        return client.onMutationSettled((event: MutationSettledEvent) => {
-            setSettled((previous) =>
-                [
-                    {
-                        code: event.code,
-                        fn: shortFn(event.functionPath),
-                        hadAwaiter: event.hadAwaiter,
-                        key: Date.now() + Math.random(),
-                        status: event.status,
-                    },
-                    ...previous,
-                ].slice(0, 8),
-            );
-        });
-    }, [client]);
+    useEffect(
+        () =>
+            client.onMutationSettled((event: MutationSettledEvent) => {
+                setSettled((previous) =>
+                    [
+                        {
+                            code: event.code,
+                            fn: shortFunction(event.functionPath),
+                            hadAwaiter: event.hadAwaiter,
+                            key: crypto.randomUUID(),
+                            status: event.status,
+                        },
+                        ...previous,
+                    ].slice(0, 8),
+                );
+            }),
+        [client],
+    );
 
-    const submit = async (formEvent: FormEvent<HTMLFormElement>): Promise<void> => {
+    const submit = async (formEvent: SyntheticEvent<HTMLFormElement>): Promise<void> => {
         formEvent.preventDefault();
 
         const text = draft.trim();
@@ -90,9 +124,9 @@ export const App = (): ReactElement => {
                     // `messages.send` and `messages.list` are different
                     // functions, so nothing can infer the link for you.
                     optimisticUpdate: (store) => {
-                        const list = (store.getQuery(api.messages.list, {}) as Doc<"messages">[] | undefined) ?? [];
-                        const provisional: Doc<"messages"> = {
-                            _id: `optimistic_${Date.now()}` as Id<"messages">,
+                        const list = (store.getQuery(api.messages.list, {}) as Document_<"messages">[] | undefined) ?? [];
+                        const provisional: Document_<"messages"> = {
+                            _id: `optimistic_${String(Date.now())}` as Id<"messages">,
                             _creationTime: Date.now(),
                             author,
                             text,
@@ -108,7 +142,7 @@ export const App = (): ReactElement => {
             // (For a write queued offline, this rejects only on reconnect-flush —
             // and not at all if you reloaded first, which is why channel 2 exists.)
             setLiveErrors((previous) =>
-                [{ key: Date.now() + Math.random(), message: error instanceof Error ? error.message : String(error) }, ...previous].slice(0, 8),
+                [{ key: crypto.randomUUID(), message: error instanceof Error ? error.message : String(error) }, ...previous].slice(0, 8),
             );
         }
     };
@@ -124,7 +158,12 @@ export const App = (): ReactElement => {
                 back. Watch how that rejection is surfaced below. See the README for the offline / reload repro.
             </p>
 
-            <form onSubmit={submit} style={{ display: "flex", gap: 8, margin: "16px 0" }}>
+            <form
+                onSubmit={(event) => {
+                    void submit(event);
+                }}
+                style={{ display: "flex", gap: 8, margin: "16px 0" }}
+            >
                 <input
                     aria-label="Message"
                     onChange={(event) => {
@@ -140,7 +179,7 @@ export const App = (): ReactElement => {
             </form>
 
             <section style={{ display: "grid", gap: 16, gridTemplateColumns: "1fr 1fr", marginBottom: 24 }}>
-                <Panel title="onMutationSettled (durable channel)" hint="Fires for every queued write — incl. post-reload replays with hadAwaiter: false.">
+                <Panel hint="Fires for every queued write — incl. post-reload replays with hadAwaiter: false." title="onMutationSettled (durable channel)">
                     {settled.length === 0 ? (
                         <Empty>No queued writes have settled yet.</Empty>
                     ) : (
@@ -154,7 +193,7 @@ export const App = (): ReactElement => {
                     )}
                 </Panel>
 
-                <Panel title="awaited mutate() Promise (live channel)" hint="Only fires while a caller is awaiting — i.e. an online rejection.">
+                <Panel hint="Only fires while a caller is awaiting — i.e. an online rejection." title="awaited mutate() Promise (live channel)">
                     {liveErrors.length === 0 ? (
                         <Empty>No live rejections yet.</Empty>
                     ) : (
@@ -179,34 +218,3 @@ export const App = (): ReactElement => {
         </main>
     );
 };
-
-const rowStyle = { border: "1px solid", borderRadius: 6, fontSize: 13, marginBottom: 6, padding: "6px 8px" } as const;
-const tagStyle = { background: "#eee", borderRadius: 4, marginLeft: 6, padding: "1px 5px" } as const;
-
-const StatusPill = ({ status }: { status: string }): ReactElement => {
-    const connected = status === "connected";
-
-    return (
-        <span
-            style={{
-                background: connected ? "#e6f6ea" : "#fdeaea",
-                borderRadius: 999,
-                color: connected ? "#0a7d33" : "#b00020",
-                fontSize: 13,
-                padding: "2px 10px",
-            }}
-        >
-            {status}
-        </span>
-    );
-};
-
-const Panel = ({ children, hint, title }: { children: React.ReactNode; hint: string; title: string }): ReactElement => (
-    <div>
-        <div style={{ fontWeight: 600, fontSize: 14 }}>{title}</div>
-        <div style={{ color: "#777", fontSize: 12, marginBottom: 8 }}>{hint}</div>
-        {children}
-    </div>
-);
-
-const Empty = ({ children }: { children: React.ReactNode }): ReactElement => <div style={{ color: "#999", fontSize: 13 }}>{children}</div>;

--- a/examples/offline-rejections/src/server/index.ts
+++ b/examples/offline-rejections/src/server/index.ts
@@ -10,7 +10,7 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 /**
  * Minimal Worker entry — pure root-scoped storage, no D1/R2/auth. All the demo
@@ -19,9 +19,7 @@ let worker: ReturnType<typeof createWorker> | null = null;
  */
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            worker = createWorker({ openApiSpec, shardDO: env.SHARD });
-        }
+        worker ??= createWorker({ openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/examples/payment-demo/eslint.config.js
+++ b/examples/payment-demo/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/payment-demo/lunora/billing.ts
+++ b/examples/payment-demo/lunora/billing.ts
@@ -1,8 +1,8 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { ActionCtx } from "./_generated/server.js";
 import { action, internalAction, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 // A real app keys checkout on the signed-in user (`ctx.auth.userId`); this demo
 // has no auth, so it uses a fixed reference and an allow-all authorizer (wired in
@@ -100,7 +100,14 @@ export const processWebhook = internalAction
             method: "POST",
         });
         const response = await ctx.payments.handleWebhook(request);
-        const result = (await response.json()) as { applied?: boolean };
+        // Narrowed rather than asserted: the platform types `Response.json()` as
+        // `Promise<unknown>`, and an `as { applied?: boolean }` here is a claim
+        // about a body that crossed an RPC hop. `in` narrows without asserting,
+        // which also keeps `no-unnecessary-type-assertion` from "fixing" the
+        // assertion away and leaving `result` untyped — its autofix did exactly
+        // that, and `tsc` then failed with TS18046.
+        const payload: unknown = await response.json();
+        const applied = typeof payload === "object" && payload !== null && "applied" in payload && payload.applied === true;
 
-        return { applied: result.applied ?? false, status: response.status };
+        return { applied, status: response.status };
     });

--- a/examples/payment-demo/lunora/ratelimit/schema.ts
+++ b/examples/payment-demo/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Named limits live here and nowhere else.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     // Every one of these reaches Stripe over the network, on somebody's account.

--- a/examples/payment-demo/lunora/schema.ts
+++ b/examples/payment-demo/lunora/schema.ts
@@ -1,5 +1,6 @@
-import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
+
+import { ratelimit } from "./ratelimit/schema.js";
 
 /**
  * payment-demo schema.

--- a/examples/payment-demo/package.json
+++ b/examples/payment-demo/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/payment": "workspace:*",

--- a/examples/payment-demo/src/client/App.tsx
+++ b/examples/payment-demo/src/client/App.tsx
@@ -25,9 +25,18 @@ export const App = (): ReactElement => {
     return (
         <main style={{ fontFamily: "system-ui", margin: "0 auto", maxWidth: 480, padding: 24 }}>
             <h1>Lunora Payment Demo</h1>
-            <label style={{ display: "block", marginBottom: 8 }}>
+            {/* Nested AND htmlFor/id: implicit association alone is valid HTML but
+                assistive tech handles it unevenly, so both are wired up. */}
+            <label htmlFor="price-id" style={{ display: "block", marginBottom: 8 }}>
                 Stripe price id
-                <input onChange={(event) => setPriceId(event.target.value)} style={{ display: "block", width: "100%" }} value={priceId} />
+                <input
+                    id="price-id"
+                    onChange={(event) => {
+                        setPriceId(event.target.value);
+                    }}
+                    style={{ display: "block", width: "100%" }}
+                    value={priceId}
+                />
             </label>
             <CheckoutButton onCheckout={() => client.action(api.billing.checkout, { priceId })}>Subscribe</CheckoutButton>{" "}
             <CustomerPortalButton onPortal={() => client.action(api.billing.portal, {})}>Manage billing</CustomerPortalButton>

--- a/examples/payment-demo/src/client/main.tsx
+++ b/examples/payment-demo/src/client/main.tsx
@@ -1,5 +1,5 @@
-import { LunoraClient } from "lunorash/client";
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/examples/payment-demo/src/server/index.ts
+++ b/examples/payment-demo/src/server/index.ts
@@ -3,9 +3,9 @@ import type { ExecutionContextLike, ShardNamespaceLike } from "lunorash/runtime"
 import { createWorker } from "lunorash/runtime";
 import Stripe from "stripe";
 
-import { app } from "../../lunora/http.js";
 import { openApiSpec } from "../../lunora/_generated/openapi.js";
 import { createShardDO } from "../../lunora/_generated/shard.js";
+import { app } from "../../lunora/http.js";
 
 interface Env {
     SHARD: ShardNamespaceLike;
@@ -48,15 +48,14 @@ export const ShardDO = createShardDO({
     },
 });
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            // `httpRouter: app` mounts the `POST /payment/webhook` action; everything
-            // else falls through to Lunora's RPC + reactive query surface.
-            worker = createWorker({ httpRouter: app, openApiSpec, shardDO: env.SHARD });
-        }
+        // `httpRouter: app` mounts the `POST /payment/webhook` action; everything
+        // else falls through to Lunora's RPC + reactive query surface. Built once
+        // per isolate and reused.
+        worker ??= createWorker({ httpRouter: app, openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/examples/realtime-cursors/eslint.config.js
+++ b/examples/realtime-cursors/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/realtime-cursors/lunora/cursors.ts
+++ b/examples/realtime-cursors/lunora/cursors.ts
@@ -1,8 +1,8 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * The limiter comes from `lunora/ratelimit/schema.ts`, which owns both named
@@ -18,7 +18,7 @@ import { mutation, query, v } from "./_generated/server.js";
 const limiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: { ip?: string }): string => ctx.ip ?? "anon" };
 
-interface CursorDoc {
+interface CursorDocument {
     _id: Id<"cursors">;
     color: string;
     lastSeen: number;
@@ -35,7 +35,7 @@ interface CursorDoc {
  * cross-shard fan-out and every connected client subscribes to the same
  * stream of deltas.
  */
-export const listCursors = query.input({ roomId: v.string().max(64) }).query(async ({ args: { roomId }, ctx }): Promise<CursorDoc[]> => {
+export const listCursors = query.input({ roomId: v.string().max(64) }).query(async ({ args: { roomId }, ctx }): Promise<CursorDocument[]> => {
     const rows = await ctx.db
         .query("cursors")
         .withIndex("by_room_session", (q) => q.eq("roomId", roomId))

--- a/examples/realtime-cursors/lunora/ratelimit/schema.ts
+++ b/examples/realtime-cursors/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 /**
  * Named limits this app enforces. Two buckets, because the two writes have

--- a/examples/realtime-cursors/package.json
+++ b/examples/realtime-cursors/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/react": "workspace:*",

--- a/examples/realtime-cursors/src/client/App.tsx
+++ b/examples/realtime-cursors/src/client/App.tsx
@@ -30,15 +30,31 @@ const FRAME_INTERVAL_MS = 1000 / 30; // throttle pointer events to ~30fps
 // (never Math.random) so it isn't treated as insecure randomness in a security
 // context; this demo only ever runs in the browser, where crypto is present.
 const randomId = (): string => Array.from(crypto.getRandomValues(new Uint8Array(4)), (byte) => byte.toString(16).padStart(2, "0")).join("");
-// Cosmetic cursor color — not a security context, so plain Math.random is fine.
-// `crypto.getRandomValues` rather than `Math.random()`: same job here (pick a
-// cursor colour), but it keeps the whole example free of a PRNG a reader might
-// copy into a place where predictability matters.
-const pickColor = (): string => {
-    const [draw = 0] = crypto.getRandomValues(new Uint32Array(1));
 
-    return COLORS[draw % COLORS.length] ?? "#1d3557";
+/**
+ * A uniform integer in `[0, bound)` drawn from the CSPRNG.
+ *
+ * The rejection loop is the point: `draw % bound` is NOT uniform unless `bound`
+ * divides 2^32, because the leftover values at the top of the range map onto the
+ * first few buckets twice. Discarding that tail is what makes the draw unbiased.
+ * It retries with probability under `bound / 2^32` — for a palette, effectively
+ * never.
+ */
+const randomBelow = (bound: number): number => {
+    const ceiling = Math.floor(0x1_00_00_00_00 / bound) * bound;
+    let draw = ceiling;
+
+    while (draw >= ceiling) {
+        [draw = 0] = crypto.getRandomValues(new Uint32Array(1));
+    }
+
+    return draw % bound;
 };
+
+// `crypto.getRandomValues` rather than `Math.random()`: the colour is cosmetic,
+// but keeping the example free of a PRNG means nobody copies one out of here into
+// a place where predictability matters.
+const pickColor = (): string => COLORS[randomBelow(COLORS.length)] ?? "#1d3557";
 
 /**
  * Full-page cursor sharing demo. Drives one mutation per pointer move

--- a/examples/realtime-cursors/src/client/App.tsx
+++ b/examples/realtime-cursors/src/client/App.tsx
@@ -1,89 +1,11 @@
 import { useMutation, useQuery } from "@lunora/react";
 import type { PointerEvent as ReactPointerEvent, ReactElement } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
 
-const COLORS = ["#e63946", "#1d3557", "#2a9d8f", "#f4a261", "#9d4edd", "#0096c7"] as const;
-const FRAME_INTERVAL_MS = 1000 / 30; // throttle pointer events to ~30fps
-
-// Presence session id — a non-secret correlation handle. Minted from Web Crypto
-// (never Math.random) so it isn't treated as insecure randomness in a security
-// context; this demo only ever runs in the browser, where crypto is present.
-const randomId = (): string => Array.from(crypto.getRandomValues(new Uint8Array(4)), (byte) => byte.toString(16).padStart(2, "0")).join("");
-// Cosmetic cursor color — not a security context, so plain Math.random is fine.
-const pickColor = (): string => COLORS[Math.floor(Math.random() * COLORS.length)] ?? "#1d3557";
-
-/**
- * Full-page cursor sharing demo. Drives one mutation per pointer move
- * (throttled), one subscription per room, with the server-side `.shardBy`
- * doing the horizontal scaling for us.
- *
- * Open this page in two tabs (same room) to see live cursors flow.
- */
-export const App = (): ReactElement => {
-    const [roomId, setRoomId] = useState<string>(() => {
-        const fromHash = globalThis.location.hash.slice(1);
-
-        return fromHash || "lobby";
-    });
-
-    const sessionId = useMemo(() => randomId(), []);
-    const color = useMemo(() => pickColor(), []);
-    const [name] = useState<string>(() => `guest-${sessionId.slice(0, 4)}`);
-
-    const cursors = useQuery(api.cursors.listCursors, { roomId }, { shardKey: roomId }) as Doc<"cursors">[] | undefined;
-
-    const { mutate: join } = useMutation(api.cursors.joinRoom);
-    const { mutate: move } = useMutation(api.cursors.updateCursor);
-
-    useEffect(() => {
-        void join({ roomId, sessionId, name, color }, { shardKey: roomId });
-    }, [join, roomId, sessionId, name, color]);
-
-    const lastSentRef = useRef(0);
-
-    const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>): void => {
-        const now = performance.now();
-
-        if (now - lastSentRef.current < FRAME_INTERVAL_MS) {
-            return;
-        }
-
-        lastSentRef.current = now;
-
-        void move({ roomId, sessionId, x: event.clientX, y: event.clientY }, { shardKey: roomId });
-    };
-
-    const onChangeRoom = (): void => {
-        const next = globalThis.prompt("Room name", roomId) ?? roomId;
-
-        globalThis.location.hash = next;
-        setRoomId(next);
-    };
-
-    return (
-        <div onPointerMove={onPointerMove} style={{ width: "100vw", height: "100vh", position: "relative", background: "#fafafa" }}>
-            <header style={{ position: "absolute", top: 12, left: 12, padding: 8, background: "white", borderRadius: 6 }}>
-                <strong>room:</strong> <code>{roomId}</code>{" "}
-                <button onClick={onChangeRoom} style={{ marginLeft: 8 }} type="button">
-                    change
-                </button>
-                <div style={{ marginTop: 4, fontSize: 12, opacity: 0.7 }}>
-                    you are <span style={{ color }}>{name}</span> — open this URL in a second tab to see live cursors
-                </div>
-            </header>
-            {(cursors ?? [])
-                .filter((cursor) => cursor.sessionId !== sessionId)
-                .map((cursor) => (
-                    <Cursor cursor={cursor} key={cursor.sessionId} />
-                ))}
-        </div>
-    );
-};
-
-const Cursor = ({ cursor }: { cursor: Doc<"cursors"> }): ReactElement => (
+const Cursor = ({ cursor }: { cursor: Document_<"cursors"> }): ReactElement => (
     <div
         style={{
             position: "absolute",
@@ -100,3 +22,110 @@ const Cursor = ({ cursor }: { cursor: Doc<"cursors"> }): ReactElement => (
         <span style={{ marginLeft: 6, padding: "2px 6px", background: cursor.color, color: "white", borderRadius: 4, fontSize: 12 }}>{cursor.name}</span>
     </div>
 );
+
+const COLORS = ["#e63946", "#1d3557", "#2a9d8f", "#f4a261", "#9d4edd", "#0096c7"] as const;
+const FRAME_INTERVAL_MS = 1000 / 30; // throttle pointer events to ~30fps
+
+// Presence session id — a non-secret correlation handle. Minted from Web Crypto
+// (never Math.random) so it isn't treated as insecure randomness in a security
+// context; this demo only ever runs in the browser, where crypto is present.
+const randomId = (): string => Array.from(crypto.getRandomValues(new Uint8Array(4)), (byte) => byte.toString(16).padStart(2, "0")).join("");
+// Cosmetic cursor color — not a security context, so plain Math.random is fine.
+// `crypto.getRandomValues` rather than `Math.random()`: same job here (pick a
+// cursor colour), but it keeps the whole example free of a PRNG a reader might
+// copy into a place where predictability matters.
+const pickColor = (): string => {
+    const [draw = 0] = crypto.getRandomValues(new Uint32Array(1));
+
+    return COLORS[draw % COLORS.length] ?? "#1d3557";
+};
+
+/**
+ * Full-page cursor sharing demo. Drives one mutation per pointer move
+ * (throttled), one subscription per room, with the server-side `.shardBy`
+ * doing the horizontal scaling for us.
+ *
+ * Open this page in two tabs (same room) to see live cursors flow.
+ */
+export const App = (): ReactElement => {
+    const [roomId, setRoomId] = useState<string>(() => {
+        const fromHash = globalThis.location.hash.slice(1);
+
+        return fromHash || "lobby";
+    });
+
+    // `useRef`, not `useMemo([])`: an empty dep array is not a stability
+    // guarantee — React is free to discard a memo and recompute, which would
+    // hand this client a new identity and colour mid-session.
+    const sessionIdReference = useRef<string>(undefined);
+    sessionIdReference.current ??= randomId();
+    const sessionId = sessionIdReference.current;
+
+    const colorReference = useRef<string>(undefined);
+    colorReference.current ??= pickColor();
+    const color = colorReference.current;
+    const [name] = useState<string>(() => `guest-${sessionId.slice(0, 4)}`);
+
+    const cursors = useQuery(api.cursors.listCursors, { roomId }, { shardKey: roomId }) as Document_<"cursors">[] | undefined;
+
+    const { mutate: join } = useMutation(api.cursors.joinRoom);
+    const { mutate: move } = useMutation(api.cursors.updateCursor);
+
+    useEffect(() => {
+        void join({ roomId, sessionId, name, color }, { shardKey: roomId });
+    }, [join, roomId, sessionId, name, color]);
+
+    const lastSentReference = useRef(0);
+
+    const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>): void => {
+        const now = performance.now();
+
+        if (now - lastSentReference.current < FRAME_INTERVAL_MS) {
+            return;
+        }
+
+        lastSentReference.current = now;
+
+        void move({ roomId, sessionId, x: event.clientX, y: event.clientY }, { shardKey: roomId });
+    };
+
+    // An inline field rather than `prompt()`: the native dialog blocks the whole
+    // page, is suppressed outright in a cross-origin iframe (where these demos are
+    // often embedded), and cannot be styled or tested.
+    const onChangeRoom = (form: FormData): void => {
+        const entered = form.get("room");
+        const next = (typeof entered === "string" ? entered.trim() : "") || roomId;
+
+        globalThis.location.hash = next;
+        setRoomId(next);
+    };
+
+    return (
+        <div onPointerMove={onPointerMove} style={{ width: "100vw", height: "100vh", position: "relative", background: "#fafafa" }}>
+            <header style={{ position: "absolute", top: 12, left: 12, padding: 8, background: "white", borderRadius: 6 }}>
+                <strong>room:</strong> <code>{roomId}</code>{" "}
+                <form
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        onChangeRoom(new FormData(event.currentTarget));
+                    }}
+                    style={{ display: "inline-flex", gap: 4, marginLeft: 8 }}
+                >
+                    <label htmlFor="room-name">
+                        <span style={{ clip: "rect(0 0 0 0)", position: "absolute", width: 1 }}>Room name</span>
+                        <input defaultValue={roomId} id="room-name" name="room" size={12} />
+                    </label>
+                    <button type="submit">change</button>
+                </form>
+                <div style={{ marginTop: 4, fontSize: 12, opacity: 0.7 }}>
+                    you are <span style={{ color }}>{name}</span> — open this URL in a second tab to see live cursors
+                </div>
+            </header>
+            {(cursors ?? [])
+                .filter((cursor) => cursor.sessionId !== sessionId)
+                .map((cursor) => (
+                    <Cursor cursor={cursor} key={cursor.sessionId} />
+                ))}
+        </div>
+    );
+};

--- a/examples/realtime-cursors/src/client/main.tsx
+++ b/examples/realtime-cursors/src/client/main.tsx
@@ -1,5 +1,5 @@
-import { LunoraClient } from "lunorash/client";
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/examples/realtime-cursors/src/server/index.ts
+++ b/examples/realtime-cursors/src/server/index.ts
@@ -10,20 +10,18 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            // `openApiSpec` (regenerated on every `lunora/` change) backs the
-            // studio's always-current API-reference tab.
-            //
-            // Demo/local default: this app has no auth, so shard access is left
-            // OPEN (any caller may target any shard) and data is protected by
-            // per-row RLS. A PRODUCTION sharded app must gate this instead — e.g.
-            // `authorizeShard: ({ identity, shardKey }) => shardKey === "__root__" || identity?.userId === ownerOf(shardKey)`.
-            worker = createWorker({ allowUnauthenticatedShardAccess: true, openApiSpec, shardDO: env.SHARD });
-        }
+        // `openApiSpec` (regenerated on every `lunora/` change) backs the
+        // studio's always-current API-reference tab.
+        //
+        // Demo/local default: this app has no auth, so shard access is left
+        // OPEN (any caller may target any shard) and data is protected by
+        // per-row RLS. A PRODUCTION sharded app must gate this instead — e.g.
+        // `authorizeShard: ({ identity, shardKey }) => shardKey === "__root__" || identity?.userId === ownerOf(shardKey)`.
+        worker ??= createWorker({ allowUnauthenticatedShardAccess: true, openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/examples/tanstack-start/__tests__/messages.test.ts
+++ b/examples/tanstack-start/__tests__/messages.test.ts
@@ -26,6 +26,7 @@ const nextMillisecond = async (): Promise<void> => {
 };
 
 it("returns the newest message first, which is what the SSR loader renders", async () => {
+    expect.assertions(1);
     // `send` stamps `postedAt: Date.now()` and `by_posted` indexes that alone, so
     // two sends inside one millisecond tie and the order within the tie is
     // unspecified — this test failed roughly one run in four without the gap.
@@ -41,9 +42,12 @@ it("returns the newest message first, which is what the SSR loader renders", asy
 });
 
 it("honours the loader's limit", async () => {
-    for (const body of ["a", "b", "c"]) {
-        await t.mutation(send, { author: "ada", body });
-    }
+    expect.assertions(1);
+    // In parallel: this case only asserts the loader's page SIZE, so the sends
+    // need no ordering between them (the ordering assertion lives in the case
+    // above, which sends sequentially on purpose).
+    await Promise.all(["a", "b", "c"].map(async (body) => t.mutation(send, { author: "ada", body })));
 
-    expect((await t.query(board, { limit: 2 })).messages).toHaveLength(2);
+    const awaited1 = await t.query(board, { limit: 2 });
+    expect(awaited1.messages).toHaveLength(2);
 });

--- a/examples/tanstack-start/eslint.config.js
+++ b/examples/tanstack-start/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/tanstack-start/lunora/messages.ts
+++ b/examples/tanstack-start/lunora/messages.ts
@@ -1,9 +1,9 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /** No sign-in here, so the limit is keyed by caller IP — it is the only identity there is. */
 const limiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
@@ -11,7 +11,7 @@ const byCaller = { key: (ctx: MutationCtx): string => ctx.ip ?? "anon" };
 
 /** What the page renders: the list and its summary, read together. */
 export interface Board {
-    messages: Doc<"messages">[];
+    messages: Document_<"messages">[];
     /** When the newest message was posted, `0` when there are none. */
     newestAt: number;
     total: number;

--- a/examples/tanstack-start/lunora/ratelimit/schema.ts
+++ b/examples/tanstack-start/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     send: { kind: "token bucket", period: 60_000, rate: 30 },

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -11,7 +11,9 @@
         "deploy": "vite build && wrangler deploy -c dist/server/wrangler.json",
         "dev": "vite",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/ratelimit": "workspace:*",

--- a/examples/tanstack-start/src/router.tsx
+++ b/examples/tanstack-start/src/router.tsx
@@ -4,7 +4,11 @@ import { LunoraClient } from "lunorash/client";
 
 import { routeTree } from "./routeTree.gen";
 
-const isServer = typeof globalThis.window === "undefined";
+// An `in` check, not `globalThis.window === undefined`: `lib.dom` declares
+// `window` as always present, so the comparison is dead per the types while
+// being exactly right at runtime on the server. (`typeof … === "undefined"`
+// trades one lint rule for another.)
+const isServer = !("window" in globalThis);
 
 /**
  * Where the loaders and the browser talk to Lunora.

--- a/examples/tanstack-start/src/routes/__root.tsx
+++ b/examples/tanstack-start/src/routes/__root.tsx
@@ -1,7 +1,7 @@
 import { LunoraProvider } from "@lunora/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { createRootRouteWithContext, HeadContent, Outlet, Scripts, useRouteContext } from "@tanstack/react-router";
 import type { LunoraClient } from "lunorash/client";
 
 import appCss from "./app.css?url";
@@ -15,23 +15,11 @@ export interface RouterContext {
     queryClient: QueryClient;
 }
 
-export const Route = createRootRouteWithContext<RouterContext>()({
-    component: RootComponent,
-    head: () => ({
-        links: [{ href: appCss, rel: "stylesheet" }],
-        meta: [{ charSet: "utf-8" }, { content: "width=device-width, initial-scale=1", name: "viewport" }, { title: "Lunora + TanStack Start" }],
-    }),
-});
-
-/**
- * Both providers take the objects the router already built, so the client the
- * loaders queried with is the same one the components subscribe through — and
- * the TanStack cache the loader filled is the cache `useQuery` reads. That
- * sharing is what makes the server-rendered markup survive hydration without a
- * second fetch.
- */
-function RootComponent(): React.ReactElement {
-    const { lunora, queryClient } = Route.useRouteContext();
+const RootComponent = (): React.ReactElement => {
+    // `useRouteContext({ from })` rather than `Route.useRouteContext()`: `Route`
+    // names this component in its `component:` option, so reaching back through
+    // `Route` here makes the two declarations mutually referential.
+    const { lunora, queryClient } = useRouteContext({ from: "__root__" });
 
     return (
         <html lang="en">
@@ -48,4 +36,22 @@ function RootComponent(): React.ReactElement {
             </body>
         </html>
     );
-}
+};
+
+export const Route = createRootRouteWithContext<RouterContext>()({
+    component: RootComponent,
+    head: () => {
+        return {
+            links: [{ href: appCss, rel: "stylesheet" }],
+            meta: [{ charSet: "utf8" }, { content: "width=device-width, initial-scale=1", name: "viewport" }, { title: "Lunora + TanStack Start" }],
+        };
+    },
+});
+
+/**
+ * Both providers take the objects the router already built, so the client the
+ * loaders queried with is the same one the components subscribe through — and
+ * the TanStack cache the loader filled is the cache `useQuery` reads. That
+ * sharing is what makes the server-rendered markup survive hydration without a
+ * second fetch.
+ */

--- a/examples/tanstack-start/src/routes/index.tsx
+++ b/examples/tanstack-start/src/routes/index.tsx
@@ -4,20 +4,23 @@ import type { ReactElement } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
 
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"` — a file input sharing a text field's
+ * name would submit that verbatim. Narrowing instead yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
+
 const BOARD_ARGS = { limit: 50 } as const;
 
-export const Route = createFileRoute("/")({
-    component: Home,
-    /**
-     * The SSR read. `lunoraQueryOptions` builds a one-shot HTTP fetch keyed
-     * exactly like the live `useQuery` hook below, so the value the server puts
-     * in the cache is the value the component finds there on its first render —
-     * fully rendered markup, no loading flash, no second request on hydration.
-     */
-    loader: async ({ context }) => context.queryClient.ensureQueryData(lunoraQueryOptions(context.lunora, api.messages.board, BOARD_ARGS)),
-});
-
-function Home(): ReactElement {
+const Home = (): ReactElement => {
     /**
      * The same query, now live. On the first client render it reads the
      * loader's cached value (same key), then the subscription attaches and
@@ -49,17 +52,17 @@ function Home(): ReactElement {
              */}
             <form
                 action={(data: FormData) => {
-                    const body = String(data.get("body") ?? "").trim();
+                    const body = textField(data, "body").trim();
 
                     if (!body) {
                         return;
                     }
 
-                    void send({ author: String(data.get("author") ?? "").trim() || "anon", body });
+                    void send({ author: textField(data, "author").trim() || "anon", body });
                 }}
             >
                 <input aria-label="Your name" name="author" placeholder="Your name" />
-                <input required aria-label="Message" maxLength={140} name="body" placeholder="Write a message" />
+                <input aria-label="Message" maxLength={140} name="body" placeholder="Write a message" required />
                 <button disabled={pending} type="submit">
                     {pending ? "Sending…" : "Send"}
                 </button>
@@ -101,4 +104,16 @@ function Home(): ReactElement {
             )}
         </main>
     );
-}
+};
+
+export const Route = createFileRoute("/")({
+    component: Home,
+
+    /**
+     * The SSR read. `lunoraQueryOptions` builds a one-shot HTTP fetch keyed
+     * exactly like the live `useQuery` hook below, so the value the server puts
+     * in the cache is the value the component finds there on its first render —
+     * fully rendered markup, no loading flash, no second request on hydration.
+     */
+    loader: async ({ context }) => context.queryClient.ensureQueryData(lunoraQueryOptions(context.lunora, api.messages.board, BOARD_ARGS)),
+});

--- a/examples/tanstack-start/tsconfig.json
+++ b/examples/tanstack-start/tsconfig.json
@@ -3,12 +3,28 @@
     "compilerOptions": {
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "types": ["@cloudflare/workers-types", "node", "vite/client"],
-        "lib": ["DOM", "DOM.Iterable", "ES2024"],
+        "types": [
+            "@cloudflare/workers-types",
+            "node",
+            "vite/client"
+        ],
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2024"
+        ],
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false
     },
-    "include": ["src/**/*", "lunora/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*",
+        "lunora/**/*",
+        "vite.config.ts",
+        "__tests__/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/examples/team-chat/__tests__/chat.test.ts
+++ b/examples/team-chat/__tests__/chat.test.ts
@@ -16,6 +16,9 @@ import { list as listMessages, search, send } from "../lunora/messages";
 import { heartbeat, leave, list as listPresence } from "../lunora/presence";
 import schema from "../lunora/schema";
 
+const SIGN_IN_RE = /sign in/i;
+const ALREADY_EXISTS_RE = /already exists/i;
+
 let t: ReturnType<typeof lunoraTest>;
 let ada: ReturnType<typeof lunoraTest>;
 
@@ -29,20 +32,24 @@ afterEach(() => {
 });
 
 it("shows a signed-out visitor nothing and lets them write nothing", async () => {
+    expect.assertions(2);
     await ada.mutation(create, { name: "general" });
 
     expect(await t.query(listChannels, {})).toStrictEqual([]);
-    await expect(t.mutation(send, { channelId: "general", content: "hi" })).rejects.toThrow(/sign in/i);
+    await expect(t.mutation(send, { channelId: "general", content: "hi" })).rejects.toThrow(SIGN_IN_RE);
 });
 
 it("creates a channel once, slugged, and rejects the duplicate", async () => {
+    expect.assertions(2);
     await ada.mutation(create, { name: "General Chat" });
 
-    expect((await ada.query(listChannels, {})).map((channel) => channel.name)).toStrictEqual(["general-chat"]);
-    await expect(ada.mutation(create, { name: "general-chat" })).rejects.toThrow(/already exists/i);
+    const awaited1 = await ada.query(listChannels, {});
+    expect(awaited1.map((channel) => channel.name)).toStrictEqual(["general-chat"]);
+    await expect(ada.mutation(create, { name: "general-chat" })).rejects.toThrow(ALREADY_EXISTS_RE);
 });
 
 it("posts messages into a channel and reads them back", async () => {
+    expect.assertions(1);
     await ada.mutation(create, { name: "general" });
     await ada.mutation(send, { channelId: "general", content: "hello" });
     await t.withIdentity({ userId: "u-grace" }).mutation(send, { channelId: "general", content: "hi back" });
@@ -72,28 +79,35 @@ it("posts messages into a channel and reads them back", async () => {
 });
 
 it("keeps channels apart", async () => {
+    expect.assertions(1);
     await ada.mutation(send, { channelId: "general", content: "in general" });
     await ada.mutation(send, { channelId: "random", content: "in random" });
 
-    expect((await ada.query(listMessages, { channelId: "random" })).map((message) => message.content)).toStrictEqual(["in random"]);
+    const awaited2 = await ada.query(listMessages, { channelId: "random" });
+    expect(awaited2.map((message) => message.content)).toStrictEqual(["in random"]);
 });
 
 it("refuses an attachment key that belongs to someone else", async () => {
+    expect.assertions(1);
     await expect(ada.mutation(send, { attachmentKey: "general/u-grace/secret.png", channelId: "general", content: "" })).rejects.toThrow();
 });
 
 it("searches within a channel and returns nothing for an empty term", async () => {
+    expect.assertions(2);
     await ada.mutation(send, { channelId: "general", content: "deploy is green" });
     await ada.mutation(send, { channelId: "general", content: "lunch?" });
 
-    expect((await ada.query(search, { channelId: "general", text: "deploy" })).map((message) => message.content)).toStrictEqual(["deploy is green"]);
+    const awaited3 = await ada.query(search, { channelId: "general", text: "deploy" });
+    expect(awaited3.map((message) => message.content)).toStrictEqual(["deploy is green"]);
     expect(await ada.query(search, { channelId: "general", text: "   " })).toStrictEqual([]);
 });
 
 it("tracks presence per session and clears it on leave", async () => {
+    expect.assertions(3);
     await ada.mutation(heartbeat, { channelId: "general", name: "Ada", sessionId: "s1" });
 
-    expect((await ada.query(listPresence, { channelId: "general" })).map((row) => row.name)).toStrictEqual(["Ada"]);
+    const awaited4 = await ada.query(listPresence, { channelId: "general" });
+    expect(awaited4.map((row) => row.name)).toStrictEqual(["Ada"]);
 
     // A second heartbeat from the same session must refresh, not duplicate.
     await ada.mutation(heartbeat, { channelId: "general", name: "Ada", sessionId: "s1" });

--- a/examples/team-chat/eslint.config.js
+++ b/examples/team-chat/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/team-chat/lunora/auth.ts
+++ b/examples/team-chat/lunora/auth.ts
@@ -18,11 +18,13 @@ import type { LunoraAuthOptions } from "@lunora/auth";
  * which is correct in dev and in production. Set `AUTH_URL` and pass it here if
  * you need to pin one.
  */
-export const authOptions = (env: { AUTH_SECRET: string }): LunoraAuthOptions => ({
-    appName: "Lunora Team Chat",
-    emailAndPassword: {
-        enabled: true,
-        revokeSessionsOnPasswordReset: true,
-    },
-    secret: env.AUTH_SECRET,
-});
+export const authOptions = (env: { AUTH_SECRET: string }): LunoraAuthOptions => {
+    return {
+        appName: "Lunora Team Chat",
+        emailAndPassword: {
+            enabled: true,
+            revokeSessionsOnPasswordReset: true,
+        },
+        secret: env.AUTH_SECRET,
+    };
+};

--- a/examples/team-chat/lunora/channels.ts
+++ b/examples/team-chat/lunora/channels.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Everyone here is signed in, so limits are keyed by user rather than by IP —
@@ -14,7 +14,7 @@ const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byUser = { key: (ctx: { auth: { userId?: string | null }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
 /** Root-scoped, so no shard key: this is the list you read before you know which channel you want. */
-export const list = query.query(async ({ ctx }): Promise<Doc<"channels">[]> => {
+export const list = query.query(async ({ ctx }): Promise<Document_<"channels">[]> => {
     if (!ctx.auth.userId) {
         return [];
     }
@@ -35,11 +35,16 @@ export const create = mutation
             throw new LunoraError("UNAUTHENTICATED", "sign in to create a channel");
         }
 
+        // `split("-").filter(Boolean).join("-")` rather than a trailing
+        // `replaceAll(/^-+|-+$/gu, "")`: the alternation-of-quantifiers form is what a
+        // ReDoS scanner flags, and this also collapses interior runs in the same pass.
         const slug = name
             .trim()
             .toLowerCase()
             .replaceAll(/[^a-z0-9-]+/gu, "-")
-            .replaceAll(/^-+|-+$/gu, "");
+            .split("-")
+            .filter(Boolean)
+            .join("-");
 
         if (!slug) {
             throw new LunoraError("BAD_REQUEST", "channel name must contain a letter or a digit");

--- a/examples/team-chat/lunora/messages.ts
+++ b/examples/team-chat/lunora/messages.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { ActionCtx, MutationCtx } from "./_generated/server.js";
 import { action, mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Everyone here is signed in, so limits are keyed by user rather than by IP —
@@ -44,7 +44,7 @@ const attachmentKeyFor = (channelId: string, userId: string): string => `files/c
  * subscriber. Everything a query returns must be a function of the data;
  * `attachmentUrl` below mints the URL on demand instead.
  */
-export const list = query.input({ channelId: v.string().max(128) }).query(async ({ args: { channelId }, ctx }): Promise<Doc<"messages">[]> => {
+export const list = query.input({ channelId: v.string().max(128) }).query(async ({ args: { channelId }, ctx }): Promise<Document_<"messages">[]> => {
     if (!ctx.auth.userId) {
         return [];
     }
@@ -63,7 +63,7 @@ export const list = query.input({ channelId: v.string().max(128) }).query(async 
  */
 export const search = query
     .input({ channelId: v.string().max(128), text: v.string().max(200) })
-    .query(async ({ args: { channelId, text }, ctx }): Promise<Doc<"messages">[]> => {
+    .query(async ({ args: { channelId, text }, ctx }): Promise<Document_<"messages">[]> => {
         if (!ctx.auth.userId || !text.trim()) {
             return [];
         }

--- a/examples/team-chat/lunora/presence.ts
+++ b/examples/team-chat/lunora/presence.ts
@@ -1,9 +1,9 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc } from "./_generated/dataModel.js";
+import type { Doc as Document_ } from "./_generated/dataModel.js";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /** Signed-in app, so limits key on the user rather than the IP. */
 const mutationLimiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
@@ -23,7 +23,7 @@ const byUser = { key: (ctx: { auth: { userId?: string | null }; ip?: string }): 
  * typed. Heartbeats already poke every subscriber; the client applies the TTL
  * as it renders, and nothing has to sweep expired rows on an alarm.
  */
-export const list = query.input({ channelId: v.string().max(128) }).query(async ({ args: { channelId }, ctx }): Promise<Doc<"presence">[]> =>
+export const list = query.input({ channelId: v.string().max(128) }).query(async ({ args: { channelId }, ctx }): Promise<Document_<"presence">[]> =>
     ctx.db
         .query("presence")
         .withIndex("by_channel_session", (q) => q.eq("channelId", channelId))

--- a/examples/team-chat/lunora/profiles.ts
+++ b/examples/team-chat/lunora/profiles.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
-import type { Doc, Id } from "./_generated/dataModel.js";
+import type { Doc as Document_, Id } from "./_generated/dataModel.js";
 import type { ActionCtx, MutationCtx } from "./_generated/server.js";
 import { action, mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /** Signed-in app, so limits key on the user rather than the IP. */
 const actionLimiter = (ctx: ActionCtx) => makeRateLimiter(ctx);
@@ -31,7 +31,7 @@ const ALLOWED_AVATAR_TYPES = new Set(["image/avif", "image/jpeg", "image/png", "
  * Every client subscribes to this query, so a per-evaluation URL here would
  * re-push the whole directory to everyone on every unrelated write.
  */
-export const list = query.query(async ({ ctx }): Promise<Doc<"profiles">[]> => {
+export const list = query.query(async ({ ctx }): Promise<Document_<"profiles">[]> => {
     if (!ctx.auth.userId) {
         return [];
     }

--- a/examples/team-chat/lunora/ratelimit/schema.ts
+++ b/examples/team-chat/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 export const limits = {
     send: { kind: "token bucket", period: 60_000, rate: 60 },

--- a/examples/team-chat/package.json
+++ b/examples/team-chat/package.json
@@ -11,7 +11,9 @@
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/auth": "workspace:*",

--- a/examples/team-chat/src/client/App.tsx
+++ b/examples/team-chat/src/client/App.tsx
@@ -7,22 +7,16 @@ import { authClient } from "./auth-client.js";
 import { Channel } from "./Channel.js";
 import { SignIn } from "./SignIn.js";
 
-export const App = (): ReactElement => {
-    const session = authClient.useSession();
-    const user = session.data?.user as undefined | { email: string; id: string; name?: string };
-
-    if (!user) {
-        return <SignIn />;
-    }
-
-    return <Chat email={user.email} name={user.name ?? user.email} userId={user.id} />;
+/**
+ * Sign out, reporting a failure to the console rather than to an unhandled
+ * rejection. A thin wrapper because `authClient` is `any` (see `auth-client.ts`),
+ * so `void authClient.signOut()` discards a value the compiler cannot describe.
+ */
+const signOut = (): void => {
+    (authClient.signOut() as Promise<unknown>).catch((error: unknown) => {
+        console.error("sign out failed", error);
+    });
 };
-
-interface ChatProperties {
-    email: string;
-    name: string;
-    userId: string;
-}
 
 const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
     const channels = useQuery(api.channels.list, {});
@@ -37,14 +31,14 @@ const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
     // Publish a display name the first time this account is seen, so other
     // members' clients can resolve it. `profiles.save` upserts, so a repeat is
     // harmless; the ref just avoids writing on every render pass.
-    const claimedRef = useRef(false);
+    const claimedReference = useRef(false);
 
     useEffect(() => {
-        if (claimedRef.current || profiles === undefined || profiles.some((profile) => profile.userId === userId)) {
+        if (claimedReference.current || profiles === undefined || profiles.some((profile) => profile.userId === userId)) {
             return;
         }
 
-        claimedRef.current = true;
+        claimedReference.current = true;
         void saveProfile({ name });
     }, [profiles, name, saveProfile, userId]);
 
@@ -60,7 +54,13 @@ const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
                 <ul>
                     {(channels ?? []).map((channel) => (
                         <li key={channel._id}>
-                            <button aria-pressed={channel.name === current} onClick={() => setActive(channel.name)} type="button">
+                            <button
+                                aria-pressed={channel.name === current}
+                                onClick={() => {
+                                    setActive(channel.name);
+                                }}
+                                type="button"
+                            >
                                 #{channel.name}
                             </button>
                         </li>
@@ -79,12 +79,16 @@ const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
                         }
 
                         setError(null);
-                        void createChannel({ name: value })
+                        createChannel({ name: value })
                             .then(() => {
                                 setActive(value.toLowerCase());
                                 input.value = "";
+
+                                return undefined;
                             })
-                            .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : "could not create channel"));
+                            .catch((error_: unknown) => {
+                                setError(error_ instanceof Error ? error_.message : "could not create channel");
+                            });
                     }}
                 >
                     <input aria-label="New channel" name="name" placeholder="new-channel" />
@@ -94,7 +98,13 @@ const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
 
                 <footer>
                     <span className="muted">{email}</span>
-                    <button className="link" onClick={() => void authClient.signOut()} type="button">
+                    <button
+                        className="link"
+                        onClick={() => {
+                            signOut();
+                        }}
+                        type="button"
+                    >
                         Sign out
                     </button>
                 </footer>
@@ -110,3 +120,20 @@ const Chat = ({ email, name, userId }: ChatProperties): ReactElement => {
         </div>
     );
 };
+
+export const App = (): ReactElement => {
+    const session = authClient.useSession();
+    const user = session.data?.user as undefined | { email: string; id: string; name?: string };
+
+    if (!user) {
+        return <SignIn />;
+    }
+
+    return <Chat email={user.email} name={user.name ?? user.email} userId={user.id} />;
+};
+
+interface ChatProperties {
+    email: string;
+    name: string;
+    userId: string;
+}

--- a/examples/team-chat/src/client/Channel.tsx
+++ b/examples/team-chat/src/client/Channel.tsx
@@ -3,10 +3,22 @@ import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_ } from "../../lunora/_generated/dataModel.js";
 
-type Message = Doc<"messages">;
-type Profile = Doc<"profiles">;
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"`. Narrowing yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
+
+type Profile = Document_<"profiles">;
 
 /** A tab counts as "here" if it checked in within this window… */
 const PRESENCE_TTL_MS = 30_000;
@@ -48,12 +60,15 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
     const { mutate: leave } = useMutation(api.presence.leave);
 
     useEffect(() => {
+        // The first heartbeat fires immediately, but `now` is NOT set here: seeding
+        // it from `useState(() => Date.now())` keeps this effect free of a
+        // synchronous `setState`, which forces a second render pass on mount.
+        void heartbeat({ channelId, name: displayName, sessionId }, { shardKey: channelId });
+
         const beat = (): void => {
             setNow(Date.now());
             void heartbeat({ channelId, name: displayName, sessionId }, { shardKey: channelId });
         };
-
-        beat();
 
         const timer = globalThis.setInterval(beat, HEARTBEAT_MS);
 
@@ -105,8 +120,8 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
             const url = await client.action(api.messages.attachmentUrl, { channelId, key });
 
             globalThis.open(url, "_blank", "noreferrer");
-        } catch (cause: unknown) {
-            setError(cause instanceof Error ? cause.message : "could not open that attachment");
+        } catch (error_: unknown) {
+            setError(error_ instanceof Error ? error_.message : "could not open that attachment");
         }
     };
 
@@ -138,9 +153,17 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
             <header className="channel-header">
                 <h1>#{channelId}</h1>
 
-                <input aria-label="Search this channel" onChange={(event) => setSearch(event.target.value)} placeholder="Search" type="search" value={search} />
+                <input
+                    aria-label="Search this channel"
+                    onChange={(event) => {
+                        setSearch(event.target.value);
+                    }}
+                    placeholder="Search"
+                    type="search"
+                    value={search}
+                />
 
-                <ul className="presence" aria-label="Online now">
+                <ul aria-label="Online now" className="presence">
                     {online.map((row) => (
                         <li key={row._id} title={row.name}>
                             {row.name.slice(0, 2).toUpperCase()}
@@ -180,7 +203,7 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
                     event.preventDefault();
 
                     const form = event.currentTarget;
-                    const content = String(new FormData(form).get("content") ?? "");
+                    const content = textField(new FormData(form), "content");
                     const picker = form.elements.namedItem("file") as HTMLInputElement;
                     const file = picker.files?.[0];
 
@@ -204,11 +227,11 @@ export const Channel = ({ channelId, displayName, profiles, userId }: ChannelPro
                     void (async () => {
                         try {
                             await deliver();
-                        } catch (cause: unknown) {
+                        } catch (error_: unknown) {
                             // An upload can fail (size cap, rejected type) and a
                             // send can be refused. Without this the promise
                             // rejects unhandled and the composer just sits there.
-                            setError(cause instanceof Error ? cause.message : "could not send that message");
+                            setError(error_ instanceof Error ? error_.message : "could not send that message");
                         }
 
                         // Deliberately after the catch rather than in a `finally`:

--- a/examples/team-chat/src/client/SignIn.tsx
+++ b/examples/team-chat/src/client/SignIn.tsx
@@ -3,6 +3,20 @@ import { useState } from "react";
 
 import { authClient } from "./auth-client.js";
 
+/**
+ * One text field out of a `FormData`.
+ *
+ * `FormData.get` is typed `string | File | null`, so `String(form.get(name) ?? "")`
+ * stringifies a `File` to `"[object File]"` — a file input sharing a text field's
+ * name would submit that verbatim. Narrowing instead yields `""` for anything
+ * that is not text.
+ */
+const textField = (form: FormData, name: string): string => {
+    const value = form.get(name);
+
+    return typeof value === "string" ? value : "";
+};
+
 /** Email + password, both flows on one card. Deliberately plain — the chat is the subject here. */
 export const SignIn = (): ReactElement => {
     const [mode, setMode] = useState<"in" | "up">("in");
@@ -12,7 +26,7 @@ export const SignIn = (): ReactElement => {
     // tokens that tell a password manager whether to offer a saved credential or
     // generate a new one — dropping them to quiet the scanner would be a real
     // regression for anyone using one.
-    const passwordAutoComplete = mode === "up" ? "new-password" : "current-password"; // secret-scanner:allow
+    const autoCompleteToken = mode === "up" ? "new-password" : "current-password"; // secret-scanner:allow
     const [error, setError] = useState<string | null>(null);
     const [busy, setBusy] = useState(false);
 
@@ -20,9 +34,9 @@ export const SignIn = (): ReactElement => {
         setBusy(true);
         setError(null);
 
-        const email = String(form.get("email") ?? "");
-        const password = String(form.get("password") ?? "");
-        const name = String(form.get("name") ?? "").trim() || email.split("@")[0];
+        const email = textField(form, "email");
+        const password = textField(form, "password");
+        const name = textField(form, "name").trim() || email.split("@")[0];
 
         /**
          * Everything conditional lives in here rather than in the `try` below.
@@ -43,10 +57,10 @@ export const SignIn = (): ReactElement => {
             if (message) {
                 setError(message);
             }
-        } catch (cause: unknown) {
+        } catch (error_: unknown) {
             // better-auth resolves most failures into `result.error`, but a
             // network fault rejects — without this the form just went quiet.
-            setError(cause instanceof Error ? cause.message : "could not reach the server");
+            setError(error_ instanceof Error ? error_.message : "could not reach the server");
         }
 
         // After the catch, not in a `finally`: the React Compiler cannot lower a
@@ -66,16 +80,8 @@ export const SignIn = (): ReactElement => {
                 }}
             >
                 {mode === "up" && <input aria-label="Display name" name="name" placeholder="Display name" />}
-                <input required aria-label="Email" autoComplete="email" name="email" placeholder="you@example.com" type="email" />
-                <input
-                    required
-                    aria-label="Password"
-                    autoComplete={passwordAutoComplete}
-                    minLength={8}
-                    name="password"
-                    placeholder="Password"
-                    type="password"
-                />
+                <input aria-label="Email" autoComplete="email" name="email" placeholder="you@example.com" required type="email" />
+                <input aria-label="Password" autoComplete={autoCompleteToken} minLength={8} name="password" placeholder="Password" required type="password" />
 
                 {error && <p className="error">{error}</p>}
 
@@ -83,7 +89,13 @@ export const SignIn = (): ReactElement => {
                     {mode === "up" ? "Create account" : "Sign in"}
                 </button>
 
-                <button className="link" onClick={() => setMode(mode === "up" ? "in" : "up")} type="button">
+                <button
+                    className="link"
+                    onClick={() => {
+                        setMode(mode === "up" ? "in" : "up");
+                    }}
+                    type="button"
+                >
                     {mode === "up" ? "I already have an account" : "Create an account"}
                 </button>
             </form>

--- a/examples/team-chat/src/client/main.tsx
+++ b/examples/team-chat/src/client/main.tsx
@@ -1,10 +1,11 @@
+import "./styles.css";
+
 import { LunoraProvider } from "@lunora/react";
 import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
-import "./styles.css";
 
 const url = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? globalThis.location.origin;
 const client = new LunoraClient({ url });

--- a/examples/team-chat/src/server/index.ts
+++ b/examples/team-chat/src/server/index.ts
@@ -3,8 +3,8 @@ import type { R2BucketLike } from "@lunora/storage";
 import { verifySignedUrl } from "@lunora/storage";
 import type { ExecutionContextLike, ScheduledControllerLike, ShardNamespaceLike } from "lunorash/runtime";
 
-import { authOptions } from "../../lunora/auth.js";
 import { defineApp } from "../../lunora/_generated/app.js";
+import { authOptions } from "../../lunora/auth.js";
 
 interface Env {
     AUTH_SECRET: string;
@@ -57,19 +57,21 @@ const app = defineApp<Env & { PUBLIC_STORAGE_BASE_URL: string }>()
         publicBaseUrl: (env) => env.PUBLIC_STORAGE_BASE_URL,
         signingSecret: (env) => env.STORAGE_SECRET,
     })
-    .extend(() => ({
-        /**
-         * Shard keys come from the client, so the worker decides who may address
-         * which shard. Channels are open to every signed-in member, so any
-         * authenticated caller may address any channel — and an anonymous one may
-         * address none. Without this the runtime rejects client-named shards
-         * outright (403), which is the safe default.
-         */
-        authorizeShard: ({ identity }) => Boolean(identity?.userId),
-    }))
+    .extend(() => {
+        return {
+            /**
+             * Shard keys come from the client, so the worker decides who may address
+             * which shard. Channels are open to every signed-in member, so any
+             * authenticated caller may address any channel — and an anonymous one may
+             * address none. Without this the runtime rejects client-named shards
+             * outright (403), which is the safe default.
+             */
+            authorizeShard: ({ identity }) => Boolean(identity?.userId),
+        };
+    })
     .build();
 
-export const ShardDO = app.ShardDO;
+export const { ShardDO } = app;
 
 /**
  * Serve the signed object URLs that `ctx.storage.generateUploadUrl` /

--- a/examples/team-chat/tsconfig.json
+++ b/examples/team-chat/tsconfig.json
@@ -5,12 +5,28 @@
         "rootDir": ".",
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
-        "types": ["@cloudflare/workers-types", "node", "vite/client"],
-        "lib": ["DOM", "DOM.Iterable", "ES2024"],
+        "types": [
+            "@cloudflare/workers-types",
+            "node",
+            "vite/client"
+        ],
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2024"
+        ],
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false
     },
-    "include": ["src/**/*", "lunora/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "include": [
+        "src/**/*",
+        "lunora/**/*",
+        "vite.config.ts",
+        "__tests__/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/examples/todo-app/eslint.config.js
+++ b/examples/todo-app/eslint.config.js
@@ -1,0 +1,3 @@
+import createExampleConfig from "../eslint.config.base.js";
+
+export default createExampleConfig();

--- a/examples/todo-app/lunora/ratelimit/schema.ts
+++ b/examples/todo-app/lunora/ratelimit/schema.ts
@@ -4,10 +4,10 @@
  * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
  * DO-backed rate limiting. Included automatically in every Lunora project.
  */
-import type { Middleware } from "lunorash/server";
-import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
-import { createDbStore, RateLimiter } from "lunorash/ratelimit";
 import type { RateLimitConfigMap } from "lunorash/ratelimit";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { Middleware } from "lunorash/server";
+import { definePlugin, defineSchemaExtension, defineTable, v } from "lunorash/server";
 
 /**
  * Named limits this app enforces. This is the one place they live — tuning

--- a/examples/todo-app/lunora/todos.ts
+++ b/examples/todo-app/lunora/todos.ts
@@ -1,8 +1,8 @@
 import { rateLimit } from "lunorash/ratelimit";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * The limiter comes from `lunora/ratelimit/schema.ts`, which owns the named
@@ -18,7 +18,7 @@ import { mutation, query, v } from "./_generated/server.js";
 const limiter = (ctx: MutationCtx) => makeRateLimiter(ctx);
 const byCaller = { key: (ctx: { auth: { userId?: null | string }; ip?: string }): string => ctx.auth.userId ?? ctx.ip ?? "anon" };
 
-interface TodoDoc {
+interface TodoDocument {
     _id: Id<"todos">;
     createdAt: number;
     done: boolean;
@@ -29,10 +29,10 @@ interface TodoDoc {
  * List todos newest-first. Subscribers receive deltas the moment any of
  * `add` / `toggle` / `remove` mutate the table.
  */
-export const list = query.query(async ({ ctx }): Promise<TodoDoc[]> => {
+export const list = query.query(async ({ ctx }): Promise<TodoDocument[]> => {
     const rows = await ctx.db.query("todos").withIndex("by_creation").collect();
 
-    return [...rows].sort((a, b) => b.createdAt - a.createdAt);
+    return rows.toSorted((a, b) => b.createdAt - a.createdAt);
 });
 
 export const add = mutation

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -10,7 +10,9 @@
         "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
-        "lint:types": "tsc --noEmit"
+        "lint:types": "tsc --noEmit",
+        "lint:eslint": "eslint . --max-warnings=0",
+        "lint:eslint:fix": "eslint . --fix"
     },
     "dependencies": {
         "@lunora/react": "workspace:*",

--- a/examples/todo-app/src/client/App.tsx
+++ b/examples/todo-app/src/client/App.tsx
@@ -1,9 +1,9 @@
 import { useMutation, useQuery } from "@lunora/react";
-import type { FormEvent, ReactElement } from "react";
+import type { ReactElement, SyntheticEvent } from "react";
 import { useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
-import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
+import type { Doc as Document_, Id } from "../../lunora/_generated/dataModel.js";
 
 /**
  * Tiny CRUD demo: list + create + toggle + delete, with optimistic updates.
@@ -12,19 +12,19 @@ import type { Doc, Id } from "../../lunora/_generated/dataModel.js";
  * immediately; if the server rejects the call the runtime rolls the cache
  * back automatically. It names `api.todos.list` because that is the query the
  * write affects — `add`/`toggle`/`remove` are different functions, and no
- * client can infer which queries a write changes. (The per-call `optimistic`
- * shortcut patches only a subscription on the mutation's own reference and
- * args, which is not this shape.)
+ * client can infer which queries a write changes. The per-call `optimistic`
+ * shortcut is a different tool: it patches only a subscription on the
+ * mutation's own reference and args, which is not this shape.
  */
 export const App = (): ReactElement => {
     const [draft, setDraft] = useState("");
 
-    const todos = useQuery(api.todos.list, {}) as Doc<"todos">[] | undefined;
+    const todos = useQuery(api.todos.list, {}) as Document_<"todos">[] | undefined;
     const { mutate: add, pending: addPending } = useMutation(api.todos.add);
     const { mutate: toggle } = useMutation(api.todos.toggle);
     const { mutate: remove } = useMutation(api.todos.remove);
 
-    const submit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    const submit = async (event: SyntheticEvent<HTMLFormElement>): Promise<void> => {
         event.preventDefault();
 
         const text = draft.trim();
@@ -39,9 +39,9 @@ export const App = (): ReactElement => {
             { text },
             {
                 optimisticUpdate: (store) => {
-                    const list = (store.getQuery(api.todos.list, {}) as Doc<"todos">[] | undefined) ?? [];
-                    const provisional: Doc<"todos"> = {
-                        _id: `optimistic_${Date.now()}` as Id<"todos">,
+                    const list = (store.getQuery(api.todos.list, {}) as Document_<"todos">[] | undefined) ?? [];
+                    const provisional: Document_<"todos"> = {
+                        _id: `optimistic_${String(Date.now())}` as Id<"todos">,
                         _creationTime: Date.now(),
                         text,
                         done: false,
@@ -54,12 +54,12 @@ export const App = (): ReactElement => {
         );
     };
 
-    const onToggle = async (todo: Doc<"todos">): Promise<void> => {
+    const onToggle = async (todo: Document_<"todos">): Promise<void> => {
         await toggle(
             { id: todo._id, done: !todo.done },
             {
                 optimisticUpdate: (store) => {
-                    const list = (store.getQuery(api.todos.list, {}) as Doc<"todos">[] | undefined) ?? [];
+                    const list = (store.getQuery(api.todos.list, {}) as Document_<"todos">[] | undefined) ?? [];
 
                     store.setQuery(
                         api.todos.list,
@@ -77,12 +77,12 @@ export const App = (): ReactElement => {
         );
     };
 
-    const onDelete = async (todo: Doc<"todos">): Promise<void> => {
+    const onDelete = async (todo: Document_<"todos">): Promise<void> => {
         await remove(
             { id: todo._id },
             {
                 optimisticUpdate: (store) => {
-                    const list = (store.getQuery(api.todos.list, {}) as Doc<"todos">[] | undefined) ?? [];
+                    const list = (store.getQuery(api.todos.list, {}) as Document_<"todos">[] | undefined) ?? [];
 
                     store.setQuery(
                         api.todos.list,
@@ -97,7 +97,12 @@ export const App = (): ReactElement => {
     return (
         <main style={{ maxWidth: 520, margin: "3rem auto", fontFamily: "system-ui" }}>
             <h1>Todos</h1>
-            <form onSubmit={submit} style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+            <form
+                onSubmit={(event) => {
+                    void submit(event);
+                }}
+                style={{ display: "flex", gap: 8, marginBottom: 16 }}
+            >
                 <input
                     onChange={(event) => {
                         setDraft(event.target.value);
@@ -113,9 +118,20 @@ export const App = (): ReactElement => {
             <ul style={{ listStyle: "none", padding: 0 }}>
                 {(todos ?? []).map((todo) => (
                     <li key={todo._id} style={{ display: "flex", gap: 8, padding: 8, alignItems: "center" }}>
-                        <input checked={todo.done} onChange={() => void onToggle(todo)} type="checkbox" />
+                        <input
+                            checked={todo.done}
+                            onChange={() => {
+                                void onToggle(todo);
+                            }}
+                            type="checkbox"
+                        />
                         <span style={{ flex: 1, textDecoration: todo.done ? "line-through" : "none" }}>{todo.text}</span>
-                        <button onClick={() => void onDelete(todo)} type="button">
+                        <button
+                            onClick={() => {
+                                void onDelete(todo);
+                            }}
+                            type="button"
+                        >
                             Delete
                         </button>
                     </li>

--- a/examples/todo-app/src/client/main.tsx
+++ b/examples/todo-app/src/client/main.tsx
@@ -1,5 +1,5 @@
-import { LunoraClient } from "lunorash/client";
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/examples/todo-app/src/server/index.ts
+++ b/examples/todo-app/src/server/index.ts
@@ -10,7 +10,7 @@ interface Env {
     SHARD: ShardNamespaceLike;
 }
 
-let worker: ReturnType<typeof createWorker> | null = null;
+let worker: ReturnType<typeof createWorker> | undefined;
 
 /**
  * Minimal Worker entry: just hand the ShardDO binding to `createWorker`. No
@@ -18,11 +18,9 @@ let worker: ReturnType<typeof createWorker> | null = null;
  */
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContextLike): Promise<Response> {
-        if (!worker) {
-            // `openApiSpec` (regenerated on every `lunora/` change) backs the
-            // studio's always-current API-reference tab.
-            worker = createWorker({ openApiSpec, shardDO: env.SHARD });
-        }
+        // `openApiSpec` (regenerated on every `lunora/` change) backs the
+        // studio's always-current API-reference tab.
+        worker ??= createWorker({ openApiSpec, shardDO: env.SHARD });
 
         return worker.fetch(request, env, ctx);
     },

--- a/templates/expo/lunora/messages.ts
+++ b/templates/expo/lunora/messages.ts
@@ -1,9 +1,9 @@
-import { LunoraError } from "lunorash/server";
 import { rateLimit } from "lunorash/ratelimit";
+import { LunoraError } from "lunorash/server";
 
-import { makeRateLimiter } from "./ratelimit/schema.js";
 import type { Id, MutationCtx } from "./_generated/server.js";
 import { mutation, query, v } from "./_generated/server.js";
+import { makeRateLimiter } from "./ratelimit/schema.js";
 
 /**
  * Everyone posting here is signed in, so the limit keys on the user — one
@@ -61,7 +61,7 @@ export const list = query.query(async ({ ctx }): Promise<MessageRow[]> => {
     // past the page we keep.
     const rows = await ctx.db.query("messages").withIndex("by_created").order("desc").take(PAGE_SIZE);
 
-    return rows.reverse();
+    return rows.toReversed();
 });
 
 /**

--- a/templates/expo/src/Chat.tsx
+++ b/templates/expo/src/Chat.tsx
@@ -3,9 +3,31 @@ import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 import { FlatList, KeyboardAvoidingView, Platform, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
-import { authClient } from "./auth-client";
 import { api } from "../lunora/_generated/api";
+import { authClient } from "./auth-client";
 
+const styles = StyleSheet.create({
+    author: { color: "#6b7280", fontSize: 12, marginBottom: 2 },
+    bubble: { borderRadius: 12, marginVertical: 4, maxWidth: "80%", padding: 10 },
+    bubbleMine: { alignSelf: "flex-end", backgroundColor: "#3b82f6" },
+    bubbleTheirs: { alignSelf: "flex-start", backgroundColor: "#e5e7eb" },
+    composer: { borderColor: "#e5e7eb", borderTopWidth: 1, flexDirection: "row", gap: 8, padding: 8 },
+    dot: { borderRadius: 4, height: 8, width: 8 },
+    error: { color: "#dc2626", paddingBottom: 4, paddingHorizontal: 12, textAlign: "center" },
+    flex: { flex: 1 },
+    header: { alignItems: "center", borderBottomColor: "#e5e7eb", borderBottomWidth: 1, flexDirection: "row", justifyContent: "space-between", padding: 12 },
+    headerRight: { alignItems: "center", flexDirection: "row", gap: 8 },
+    input: { borderColor: "#d1d5db", borderRadius: 20, borderWidth: 1, flex: 1, fontSize: 16, paddingHorizontal: 14, paddingVertical: 8 },
+    listContent: { padding: 12 },
+    pressed: { opacity: 0.85 },
+    sendButton: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 20, justifyContent: "center", paddingHorizontal: 18 },
+    sendText: { color: "#fff", fontWeight: "600" },
+    signOut: { color: "#3b82f6" },
+    status: { color: "#6b7280", fontSize: 12 },
+    textMine: { color: "#fff", fontSize: 16 },
+    textTheirs: { color: "#111827", fontSize: 16 },
+    title: { fontSize: 20, fontWeight: "700" },
+});
 /** Human label + colour for the live-socket status badge. */
 const STATUS: Record<string, { color: string; label: string }> = {
     connected: { color: "#16a34a", label: "live" },
@@ -20,7 +42,7 @@ const STATUS: Record<string, { color: string; label: string }> = {
  * retried offline, thanks to the AsyncStorage persistence wired in
  * `src/lunora.ts`). `useConnectionStatus` drives the live/offline badge.
  */
-export function Chat(): ReactElement {
+export const Chat = (): ReactElement => {
     const { data: session } = authClient.useSession();
     const myUserId = session?.user.id;
     const myName = session?.user.name ?? session?.user.email ?? "me";
@@ -31,12 +53,12 @@ export function Chat(): ReactElement {
 
     const [draft, setDraft] = useState("");
 
-    const listRef = useRef<FlatList>(null);
+    const listReference = useRef<FlatList>(null);
 
     // Reveal newly arrived messages (live-query deltas and the initial load).
     useEffect(() => {
         if (messages?.length) {
-            listRef.current?.scrollToEnd({ animated: true });
+            listReference.current?.scrollToEnd({ animated: true });
         }
     }, [messages]);
 
@@ -65,7 +87,11 @@ export function Chat(): ReactElement {
                 <View style={styles.headerRight}>
                     <View style={[styles.dot, { backgroundColor: badge.color }]} />
                     <Text style={styles.status}>{badge.label}</Text>
-                    <Pressable onPress={() => void authClient.signOut()}>
+                    <Pressable
+                        onPress={() => {
+                            void authClient.signOut();
+                        }}
+                    >
                         <Text style={styles.signOut}>Sign out</Text>
                     </Pressable>
                 </View>
@@ -75,7 +101,7 @@ export function Chat(): ReactElement {
                 contentContainerStyle={styles.listContent}
                 data={messages ?? []}
                 keyExtractor={(item) => item._id}
-                ref={listRef}
+                ref={listReference}
                 renderItem={({ item }) => {
                     const mine = item.userId === myUserId;
 
@@ -98,27 +124,4 @@ export function Chat(): ReactElement {
             </View>
         </KeyboardAvoidingView>
     );
-}
-
-const styles = StyleSheet.create({
-    author: { color: "#6b7280", fontSize: 12, marginBottom: 2 },
-    bubble: { borderRadius: 12, marginVertical: 4, maxWidth: "80%", padding: 10 },
-    bubbleMine: { alignSelf: "flex-end", backgroundColor: "#3b82f6" },
-    bubbleTheirs: { alignSelf: "flex-start", backgroundColor: "#e5e7eb" },
-    composer: { borderColor: "#e5e7eb", borderTopWidth: 1, flexDirection: "row", gap: 8, padding: 8 },
-    dot: { borderRadius: 4, height: 8, width: 8 },
-    error: { color: "#dc2626", paddingBottom: 4, paddingHorizontal: 12, textAlign: "center" },
-    flex: { flex: 1 },
-    header: { alignItems: "center", borderBottomColor: "#e5e7eb", borderBottomWidth: 1, flexDirection: "row", justifyContent: "space-between", padding: 12 },
-    headerRight: { alignItems: "center", flexDirection: "row", gap: 8 },
-    input: { borderColor: "#d1d5db", borderRadius: 20, borderWidth: 1, flex: 1, fontSize: 16, paddingHorizontal: 14, paddingVertical: 8 },
-    listContent: { padding: 12 },
-    pressed: { opacity: 0.85 },
-    sendButton: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 20, justifyContent: "center", paddingHorizontal: 18 },
-    sendText: { color: "#fff", fontWeight: "600" },
-    signOut: { color: "#3b82f6" },
-    status: { color: "#6b7280", fontSize: 12 },
-    textMine: { color: "#fff", fontSize: 16 },
-    textTheirs: { color: "#111827", fontSize: 16 },
-    title: { fontSize: 20, fontWeight: "700" },
-});
+};

--- a/templates/expo/src/Login.tsx
+++ b/templates/expo/src/Login.tsx
@@ -4,6 +4,16 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 
 
 import { authClient } from "./auth-client";
 
+const styles = StyleSheet.create({
+    button: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 8, padding: 14 },
+    buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+    container: { gap: 12, justifyContent: "center", padding: 24 },
+    error: { color: "#dc2626", textAlign: "center" },
+    input: { borderColor: "#d1d5db", borderRadius: 8, borderWidth: 1, fontSize: 16, padding: 12 },
+    pressed: { opacity: 0.85 },
+    switch: { color: "#3b82f6", textAlign: "center" },
+    title: { fontSize: 28, fontWeight: "700", marginBottom: 8, textAlign: "center" },
+});
 type Mode = "signin" | "signup";
 
 /**
@@ -30,7 +40,7 @@ const authenticate = async (mode: Mode, credentials: { email: string; name: stri
  * and `authClient.useSession()` in `App.tsx` flips to the chat on the next
  * render — no token to plumb through by hand.
  */
-export function Login(): ReactElement {
+export const Login = (): ReactElement => {
     const [mode, setMode] = useState<Mode>("signin");
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
@@ -66,7 +76,13 @@ export function Login(): ReactElement {
 
             <TextInput onChangeText={setPassword} placeholder="Password (min 8 chars)" secureTextEntry style={styles.input} value={password} />
 
-            <Pressable disabled={pending} onPress={() => void submit()} style={({ pressed }) => [styles.button, pressed && styles.pressed]}>
+            <Pressable
+                disabled={pending}
+                onPress={() => {
+                    void submit();
+                }}
+                style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+            >
                 {pending ? <ActivityIndicator color="#fff" /> : <Text style={styles.buttonText}>{mode === "signin" ? "Sign in" : "Sign up"}</Text>}
             </Pressable>
 
@@ -82,15 +98,4 @@ export function Login(): ReactElement {
             {error ? <Text style={styles.error}>{error}</Text> : null}
         </View>
     );
-}
-
-const styles = StyleSheet.create({
-    button: { alignItems: "center", backgroundColor: "#3b82f6", borderRadius: 8, padding: 14 },
-    buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
-    container: { gap: 12, justifyContent: "center", padding: 24 },
-    error: { color: "#dc2626", textAlign: "center" },
-    input: { borderColor: "#d1d5db", borderRadius: 8, borderWidth: 1, fontSize: 16, padding: 12 },
-    pressed: { opacity: 0.85 },
-    switch: { color: "#3b82f6", textAlign: "center" },
-    title: { fontSize: 28, fontWeight: "700", marginBottom: 8, textAlign: "center" },
-});
+};


### PR DESCRIPTION
## Summary

`vis run lint:eslint` runs the target in every project that declares it, and **no example declared it** — so `examples/*` was linted by nothing. Only `lint:types` and Prettier ever looked at it.

That gap is how a `useQuery(api.todos.list, {}) as Document_<"todos">[]` cast sat in `todo-app` discarding the end-to-end inference this framework exists to provide, and how the `examples/*/__tests__` directories ended up in **no tsconfig at all** — neither linted nor type-checked.

This wires all 13 examples into the gate and clears every finding: **668 → 0**.

## How it's wired

Each example gets `lint:eslint` / `lint:eslint:fix` and a three-line config calling a shared `examples/eslint.config.base.js`. Shared, unlike `packages/*` which deliberately own self-contained configs — the examples are thirteen variations on one app, are never published, and differ only in framework, so thirteen copies of a 200-line config would drift the moment one needed a rule.

`vis run lint:eslint` now covers **71 projects, up from 58**.

## The defects it found

- **`String(form.get(name) ?? "")` in five sign-in and composer forms.** `FormData.get` is typed `string | File | null`, so a file input sharing a text field's name submits `"[object File]"` verbatim.
- **`useMemo(fn, [])` used as an identity.** An empty dep array is not a stability guarantee — React may discard a memo and recompute — so `realtime-cursors` could hand itself a new session id and colour mid-session.
- **A `setState` called synchronously inside an effect** in the team-chat presence heartbeat, forcing a second render pass on every mount.
- **`/^-+|-+$/` in the channel slugger**, flagged super-linear.
- **Dead runtime guards whose *types* lied** — these examples set `noUncheckedIndexedAccess: false`, and `lib.dom` always declares `window`. Fixed by making the type honest (`.at(0)`, an `in` check), not by deleting the guard.
- **`prompt()` and `autoFocus`** — `prompt` blocks the page and is suppressed outright in a cross-origin iframe, which is where these demos are often embedded.

## Three autofixes that broke the build

Worth flagging on their own, because `--fix` produced all three and only `tsc` and the test suite caught them:

| rule | what it did |
|---|---|
| `no-unnecessary-type-assertion` | deleted a load-bearing `as { applied?: boolean }` → `TS18046` |
| `func-style` | rewrote a hoisted `function Home()` into a non-hoisted `const` arrow *while referenced above it* — a TDZ error at runtime |
| `vitest/prefer-comparison-matcher` | rewrote `expect(a < b).toBe(true)` into `toBeLessThan` on fractional-index **strings**, where lexicographic `<` is the point |

The third is off in the shared config with that reasoning; the other two are fixed in the code.

## What's turned off, and why

Only rules that contradict the framework's own conventions, each with the reason inline:

- `ctx` / `env` are the API's names for those values (`ActionCtx`, and what the Workers runtime passes in).
- A Lunora module's exports are discovered **by name**, so `prefer-default-export` would break codegen.
- `unicorn/no-null` is about APIs you *design*, not ones you *call* — `resolveIdentity` is typed `… | null`, `ctx.db.get()` resolves `null`, `new Response(null)` is a DOM signature.
- The `no-unsafe-*` family is off **only in the nine files** where a third-party `any` crosses the boundary (better-auth's client, React Native's `AsyncStorage`, TanStack's generated route context). 64 assertions claiming types nobody verified would be worse than reporting the gap honestly.

`metro.config.js` must be CommonJS. FNV-1a is defined in terms of xor and unsigned shift, so those two lines carry an inline disable naming why.

## Chess engine

`sonarjs/cognitive-complexity` put `getRawMoves` at 61, `isSquareAttacked` at 47, `applyMove` at 26 against a limit of 15. Rather than suppress, the generator is decomposed along its natural seams (`pushMove` / `slideRays` / `addCastle`, per-piece arms, `isSteppedAttack` vs `isSlidingAttack`, a `rightsAfter` table). **The 18 engine tests — castling, en passant, promotion, pinned pieces, checkmate, notation — pass unchanged after every step**, which is what made this safe to attempt at all.

## Also

`examples/*/__tests__` joins each example's tsconfig — five examples, all compiling clean, type-checked for the first time. The example tests now carry `expect.assertions(n)` like the packages do (`hasAssertions()` where a loop or shared helper drives the count).

The `templates/expo` copies of `Chat.tsx` / `Login.tsx` / `messages.ts` are synced: `tests/vis-templates` asserts they stay byte-identical to the example, and the template is the copy `lunora init` actually scaffolds.

## Test plan

- [x] 13/13 examples: `eslint` clean and `tsc --noEmit` clean
- [x] `pnpm exec vis run test --no-cache` — **117/117 targets pass** (uncached; the cache hides repo-walking tests)
- [x] `pnpm run lint:eslint` — 71 projects, all pass
- [x] `api:check` · `lint:generated` · `lint:prettier` · `lint:package-json` · `lint:registry:sync`
- [x] Example suites individually: chess 18, feedback-board 7, kanban-board 10, team-chat 7, tanstack-start 2

## Checklist

- [x] Commit messages follow the Conventional Commits style
- [x] Added or updated tests covering the change
- [ ] Updated relevant docs in `apps/docs` — n/a
- [x] No `package.json` files in `packages/*` modified
- [x] No new package added
- [ ] No migration impact

## Contributor License Agreement

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
