### PR TITLE
fix(storage): close four silently-bypassed guards

### DIFF
--- a/api-snapshots/storage.api.md
+++ b/api-snapshots/storage.api.md
@@ -149,12 +149,12 @@ interface Storage {
         truncated?: boolean;
     }>;
     resumeMultipartUpload: (key: string, uploadId: string) => R2MultipartUploadLike;
-    store: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{
+    store: (key: string, body: ReadableStream | ArrayBuffer | ArrayBufferView | Blob | string, options?: UploadOptions) => Promise<{
         etag: string;
         httpEtag: string;
         key: string;
     }>;
-    upload: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{
+    upload: (key: string, body: ReadableStream | ArrayBuffer | ArrayBufferView | Blob | string, options?: UploadOptions) => Promise<{
         etag: string;
         httpEtag: string;
         key: string;

--- a/packages/storage/__tests__/create-storage.test.ts
+++ b/packages/storage/__tests__/create-storage.test.ts
@@ -184,6 +184,50 @@ describe("createStorage", () => {
         expect(bucket.puts).toHaveLength(0);
     });
 
+    it("upload() enforces maxSize for an ArrayBufferView and a string body", async () => {
+        expect.assertions(3);
+
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket, bucketName: "default" });
+
+        // R2's `put` stores bytes from a view and a string too, and both were
+        // measured as `body.size` — `undefined` for either, and
+        // `undefined > maxSize` is false, so the uncapped body was forwarded
+        // verbatim and stored.
+        await expect(storage.upload("view.bin", new Uint8Array(100).fill(65), { maxSize: 10 })).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+        await expect(storage.upload("string.txt", "x".repeat(100), { maxSize: 10 })).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+        expect(bucket.puts).toHaveLength(0);
+    });
+
+    it("upload() measures a string body in UTF-8 bytes, not UTF-16 code units", async () => {
+        expect.assertions(3);
+
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket, bucketName: "default" });
+
+        // 6 characters, 12 bytes: counting `String.length` would wave this
+        // through a 10-byte cap and let R2 store more than the cap allows.
+        await expect(storage.upload("accents.txt", "é".repeat(6), { maxSize: 10 })).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+        expect(bucket.puts).toHaveLength(0);
+
+        await storage.upload("ascii.txt", "abcdefghij", { maxSize: 10 });
+
+        expect(bucket.puts).toHaveLength(1);
+    });
+
+    it("upload() refuses a body whose length it cannot measure rather than uploading it uncapped", async () => {
+        expect.assertions(2);
+
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket, bucketName: "default" });
+
+        // Untyped JS reaches this path. Anything that is not one of R2's body
+        // shapes has no length to compare, and the old `body.size` read answered
+        // `undefined` for all of them — which compares false against any cap.
+        await expect(storage.upload("weird.bin", { not: "a body" } as never, { maxSize: 10 })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        expect(bucket.puts).toHaveLength(0);
+    });
+
     it("upload() accepts ArrayBuffer and DataView chunks in a streamed body", async () => {
         expect.assertions(2);
 
@@ -434,7 +478,7 @@ describe("createStorage", () => {
         await expect(storage.head("missing")).resolves.toBeNull();
     });
 
-    it("head() falls back to a 0-length ranged get on a binding with no HEAD", async () => {
+    it("head() falls back to a plain get on a binding with no HEAD", async () => {
         expect.assertions(2);
 
         const bucket = fakeBucket();
@@ -449,7 +493,11 @@ describe("createStorage", () => {
         const object = await storage.head("k");
 
         expect(object?.size).toBe(99);
-        expect(bucket.get).toHaveBeenCalledWith("k", { range: { length: 0 } });
+        // Not a ranged get: R2 refuses a zero-length range outright
+        // (`The requested range is not satisfiable (10039)`), so the fallback
+        // this branch documents used to throw on every call against a real
+        // bucket. A 1-byte range fails the same way on a 0-byte object.
+        expect(bucket.get).toHaveBeenCalledWith("k");
     });
 
     it("getMetadata() derives a hex sha256 from R2 checksums", async () => {
@@ -474,12 +522,12 @@ describe("createStorage", () => {
         expect(meta?.sha256).toBe("deadbeef");
     });
 
-    it("getMetadata() falls back to a 0-length ranged GET when the bucket has no head()", async () => {
+    it("getMetadata() falls back to a plain GET when the bucket has no head()", async () => {
         expect.assertions(3);
 
         const bucket = fakeBucket();
 
-        // No `head` on this double — exercises the ranged-GET fallback path.
+        // No `head` on this double — exercises the body-discarding GET fallback.
         delete bucket.head;
 
         vi.spyOn(bucket, "get").mockImplementation(async (key) => {
@@ -501,7 +549,7 @@ describe("createStorage", () => {
         const meta = await storage.getMetadata("hello.txt");
 
         expect(meta).toMatchObject({ contentType: "text/plain", key: "hello.txt", size: 7 });
-        expect(bucket.get).toHaveBeenCalledWith("hello.txt", { range: { length: 0 } });
+        expect(bucket.get).toHaveBeenCalledWith("hello.txt");
 
         const missing = await storage.getMetadata("missing");
 
@@ -532,7 +580,7 @@ describe("createStorage", () => {
         expect(bucket.list).not.toHaveBeenCalled();
     });
 
-    it("list() clamps the page limit into the [1, 1000] window", async () => {
+    it("list() clamps the page limit to R2's 1000 ceiling", async () => {
         expect.assertions(2);
 
         const bucket = fakeBucket();
@@ -542,9 +590,64 @@ describe("createStorage", () => {
 
         expect(bucket.list).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1000 }));
 
-        await storage.list("p/", { limit: 0 });
+        await storage.list("p/", { limit: 50 });
 
-        expect(bucket.list).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }));
+        expect(bucket.list).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 50 }));
+    });
+
+    it("list() rejects a limit that is not a positive integer instead of forwarding it to R2", async () => {
+        expect.assertions(5);
+
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket, bucketName: "default" });
+
+        // `Math.floor(NaN)` is `NaN` and passed both clamps, so a
+        // `limit: Number(env.PAGE_SIZE)` with the variable unset reached R2,
+        // which answers `MaxKeys params must be positive integer <= 1000.
+        // (10022)` — a remote error naming a parameter the caller never wrote.
+        await expect(storage.list("p/", { limit: Number.NaN })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        // `0` used to be clamped up to a 1-row page, and a fractional limit
+        // silently floored — both answer a page size nobody asked for.
+        await expect(storage.list("p/", { limit: 0 })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        await expect(storage.list("p/", { limit: -5 })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        await expect(storage.list("p/", { limit: 12.5 })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+        expect(bucket.list).not.toHaveBeenCalled();
+    });
+
+    it("head() reads metadata through a head-less binding without asking for a byte range", async () => {
+        expect.assertions(3);
+
+        const bucket = fakeBucket();
+        const cancel = vi.fn<() => Promise<void>>(async () => undefined);
+        // A binding without `head` — the case `R2BucketLike.head?` exists for.
+        // `get` mirrors real R2: a zero-length range is refused outright
+        // (`The requested range is not satisfiable (10039)`), which is what the
+        // old fallback asked for on every call.
+        const headless: R2BucketLike = {
+            ...bucket,
+            get: vi.fn<R2BucketLike["get"]>(async (key, options) => {
+                if (options?.range !== undefined) {
+                    throw new Error("get: The requested range is not satisfiable (10039)");
+                }
+
+                return {
+                    ...fakeObject(key),
+                    arrayBuffer: async () => new ArrayBuffer(0),
+                    body: { cancel } as unknown as ReadableStream,
+                    text: async () => "ok",
+                };
+            }),
+            head: undefined,
+        };
+
+        const storage = createStorage({ bucket: headless, bucketName: "default" });
+
+        await expect(storage.head("some/key")).resolves.toMatchObject({ key: "some/key", size: 4 });
+        expect(headless.get).toHaveBeenCalledWith("some/key");
+        // The body is discarded rather than left dangling: `head()` promises no
+        // body transfer, and this path is the one that cannot use R2's HEAD.
+        expect(cancel).toHaveBeenCalledTimes(1);
     });
 
     it("list() forwards the R2 truncated flag", async () => {

--- a/packages/storage/__tests__/upload-handler.test.ts
+++ b/packages/storage/__tests__/upload-handler.test.ts
@@ -382,6 +382,24 @@ describe("createUploadHandler (RLS-gated, non-admin)", () => {
             expect(withinCap.status).toBe(201);
         });
 
+        it("rejects a maxFileSize that is not a finite, non-negative number", async () => {
+            expect.hasAssertions();
+
+            // `??` only fills in a nullish value, so an unset upload-limit env
+            // var coerced with `Number(...)` survives as `NaN` — and
+            // `declaredSize > NaN` is always false, so
+            // every TUS/chunked-REST create passed the only cap this handler
+            // enforces for those protocols.
+            expect(() => createUploadHandler({ maxFileSize: Number.NaN, silent: true, storage: new MemoryStorage({ path: "/upload" }) })).toThrow(
+                /maxFileSize/,
+            );
+            expect(() => createUploadHandler({ maxFileSize: Number.POSITIVE_INFINITY, silent: true, storage: new MemoryStorage({ path: "/upload" }) })).toThrow(
+                /maxFileSize/,
+            );
+            // The mirror image: a negative cap rejects every upload.
+            expect(() => createUploadHandler({ maxFileSize: -1, silent: true, storage: new MemoryStorage({ path: "/upload" }) })).toThrow(/maxFileSize/);
+        });
+
         it("rejects a chunked-REST create whose declared total (X-Total-Size) is over the cap", async () => {
             expect.hasAssertions();
 

--- a/packages/storage/__tests__/workerd/create-storage.integration.test.ts
+++ b/packages/storage/__tests__/workerd/create-storage.integration.test.ts
@@ -158,6 +158,61 @@ describe("createStorage (workerd + Miniflare R2 integration)", () => {
         await expect(sut.download("streamed/too-big.txt")).resolves.toBeNull();
     });
 
+    // A view and a string are both shapes R2's `put` stores bytes from, and both
+    // used to slip past `maxSize` (`body.size` is `undefined` for either, and
+    // `undefined > maxSize` is false) — real R2 stored the full 100 bytes under
+    // a 10-byte cap.
+    it("enforces maxSize for an ArrayBufferView and a string body, storing neither", async () => {
+        expect.assertions(4);
+
+        const sut = storage();
+
+        await expect(sut.upload("capped/view.bin", new Uint8Array(100).fill(65), { maxSize: 10 })).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+        await expect(sut.download("capped/view.bin")).resolves.toBeNull();
+
+        await expect(sut.upload("capped/string.txt", "x".repeat(100), { maxSize: 10 })).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+        await expect(sut.download("capped/string.txt")).resolves.toBeNull();
+    });
+
+    // Real R2 answers `MaxKeys params must be positive integer <= 1000. (10022)`
+    // for a `NaN` limit — `Math.floor(NaN)` is `NaN` and passed both clamps. The
+    // guard has to fire locally, so the rejection names `limit`, not `MaxKeys`.
+    it("rejects a non-integer list limit locally instead of letting R2 answer 10022", async () => {
+        expect.assertions(2);
+
+        const sut = storage();
+
+        await expect(sut.list("any/", { limit: Number.NaN })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+        await expect(sut.list("any/", { limit: 0 })).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    });
+
+    // The `head`-less fallback used to ask R2 for a 0-length range, which R2
+    // refuses (`get: The requested range is not satisfiable (10039)`), so the
+    // documented degradation could not work against a real bucket. A 1-byte
+    // range fails the same way on a 0-byte object, which this covers too.
+    it("head() works through a head-less binding, including for a 0-byte object", async () => {
+        expect.assertions(3);
+
+        const headless = createStorage({
+            bucket: {
+                delete: async (key) => {
+                    await env.BUCKET.delete(key);
+                },
+                get: async (key, options) => (options ? await env.BUCKET.get(key, options) : await env.BUCKET.get(key)),
+                list: async (options) => await env.BUCKET.list(options),
+                put: async (key, body, options) => await env.BUCKET.put(key, body, options),
+            },
+            bucketName: "default",
+        });
+
+        await headless.upload("headless/ten.txt", "abcdefghij");
+        await headless.upload("headless/empty.txt", new Uint8Array(0));
+
+        await expect(headless.head("headless/ten.txt")).resolves.toMatchObject({ size: 10 });
+        await expect(headless.head("headless/empty.txt")).resolves.toMatchObject({ size: 0 });
+        await expect(headless.head("headless/missing.txt")).resolves.toBeNull();
+    });
+
     // R2 omits `httpMetadata`/`customMetadata` from list entries unless the call
     // asks for them (`r2_list_honor_include`, on for every compat date since
     // 2022-08-04). The fake bucket returns whatever it stored, so only workerd

--- a/packages/storage/src/create-storage.ts
+++ b/packages/storage/src/create-storage.ts
@@ -19,8 +19,19 @@ import type {
     UploadOptions,
 } from "./types";
 
-/** Accepted upload body shapes (bytes, blob, or a byte stream). */
-type UploadBody = ReadableStream | ArrayBuffer | Blob;
+/**
+ * Accepted upload body shapes — every shape R2's `put` takes bytes from (see
+ * `R2BucketLike.put` in `@lunora/platform`).
+ *
+ * `ArrayBufferView` and `string` are here because R2 accepts them and callers
+ * hand them over: a `Uint8Array` is the most natural thing to give a byte store,
+ * and `v.bytes()` already accepts a view because views arrive on the wire. While
+ * this type listed only `ArrayBuffer`/`Blob`/`ReadableStream`, {@link applyMaxSize}
+ * measured a body as `body instanceof ArrayBuffer ? byteLength : body.size` —
+ * both `undefined` for a view or a string, and `undefined > maxSize` is false,
+ * so an uncapped body was forwarded to R2 verbatim.
+ */
+type UploadBody = ReadableStream | ArrayBuffer | ArrayBufferView | Blob | string;
 
 /** R2's documented key-length ceiling. */
 const MAX_KEY_LENGTH = 1024;
@@ -228,6 +239,54 @@ const collectStreamWithinMaxSize = async (stream: ReadableStream, maxSize: numbe
     return await new Response(stream.pipeThrough(counter)).blob();
 };
 
+/** Shared encoder for measuring UTF-8 byte length (not UTF-16 `String.length`). */
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * UTF-8 byte length of a key. R2's ceiling is documented in **bytes**, so a key
+ * of multi-byte (CJK/emoji) characters can sit well under 1024 UTF-16 code units
+ * yet exceed 1024 bytes — `String.length` waved it through only for R2 to reject
+ * it remotely, which defeats the point of validating here. `@lunora/bindings/kv`
+ * already measures this way and its comment describes exactly this failure; the
+ * error strings on this side said "byte limit" while counting code units.
+ */
+const byteLength = (value: string): number => TEXT_ENCODER.encode(value).length;
+
+/**
+ * Byte length of a non-stream body, or `undefined` when the value is none of the
+ * shapes R2 stores bytes from — the caller then refuses it rather than uploading
+ * something it could not measure.
+ *
+ * A string is measured in UTF-8 **bytes**, not UTF-16 code units: that is what
+ * R2 stores and what `maxSize` is expressed in, and a multi-byte character would
+ * otherwise under-count (a 100-character emoji string is 400 bytes).
+ *
+ * `size` is read duck-typed rather than behind `instanceof Blob` so a Blob-like
+ * double still measures, which is how the fakes in this package's tests supply
+ * bodies.
+ */
+const measureBody = (body: unknown): number | undefined => {
+    if (body instanceof ArrayBuffer) {
+        return body.byteLength;
+    }
+
+    if (ArrayBuffer.isView(body)) {
+        return body.byteLength;
+    }
+
+    if (typeof body === "string") {
+        return byteLength(body);
+    }
+
+    if (typeof body !== "object" || body === null) {
+        return undefined;
+    }
+
+    const { size } = body as { size?: unknown };
+
+    return typeof size === "number" ? size : undefined;
+};
+
 /**
  * Apply a `maxSize` cap, returning the body to hand R2.
  *
@@ -263,7 +322,14 @@ const applyMaxSize = async (body: UploadBody, maxSize: number): Promise<UploadBo
         return await collectStreamWithinMaxSize(body, maxSize);
     }
 
-    const size = body instanceof ArrayBuffer ? body.byteLength : body.size;
+    const size = measureBody(body);
+
+    // An unmeasurable body is refused rather than waved through: the previous
+    // `body.size` read answered `undefined` for every shape it didn't know, and
+    // `undefined > maxSize` is false, so the cap silently did nothing.
+    if (size === undefined) {
+        throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: cannot measure body length, so maxSize cannot be enforced");
+    }
 
     if (size > maxSize) {
         throw new LunoraError("PAYLOAD_TOO_LARGE", `@lunora/storage: body exceeds maxSize (${String(size)} > ${String(maxSize)})`);
@@ -271,19 +337,6 @@ const applyMaxSize = async (body: UploadBody, maxSize: number): Promise<UploadBo
 
     return body;
 };
-
-/** Shared encoder for measuring UTF-8 byte length (not UTF-16 `String.length`). */
-const TEXT_ENCODER = new TextEncoder();
-
-/**
- * UTF-8 byte length of a key. R2's ceiling is documented in **bytes**, so a key
- * of multi-byte (CJK/emoji) characters can sit well under 1024 UTF-16 code units
- * yet exceed 1024 bytes — `String.length` waved it through only for R2 to reject
- * it remotely, which defeats the point of validating here. `@lunora/bindings/kv`
- * already measures this way and its comment describes exactly this failure; the
- * error strings on this side said "byte limit" while counting code units.
- */
-const byteLength = (value: string): number => TEXT_ENCODER.encode(value).length;
 
 /**
  * Reject keys that escape the bucket, contain a path-traversal segment, or
@@ -437,12 +490,25 @@ export const createStorage = (options: LunoraStorageOptions): Storage => {
         validateKey(key);
 
         // Prefer a true HEAD (no body transfer) when the binding exposes one.
-        // Fall back to a 0-length ranged GET (`{ length: 0 }`) so we still avoid
-        // streaming the body when running against a `head`-less double or runtime.
-        // Either way `size` is the FULL object size — R2 reports the object's
-        // size, not the returned window's — which is what makes this enough to
-        // resolve a `Range` against.
-        const object = options.bucket.head ? await options.bucket.head(key) : await options.bucket.get(key, { range: { length: 0 } });
+        //
+        // The fallback for a `head`-less binding used to ask for a 0-length range
+        // (`{ length: 0 }`), which R2 refuses outright — `get: The requested
+        // range is not satisfiable (10039)` — so the documented degradation threw
+        // instead of degrading. A 1-byte range is no fix either: it fails the
+        // same way on a 0-byte object. So the fallback reads the object and
+        // discards the body without consuming it; `size` is the object's full
+        // size either way, which is what makes this enough to resolve a `Range`
+        // against.
+        let object: R2ObjectLike | null;
+
+        if (options.bucket.head) {
+            object = await options.bucket.head(key);
+        } else {
+            const withBody = await options.bucket.get(key);
+
+            await withBody?.body?.cancel();
+            object = withBody;
+        }
 
         // The `toListObject` projection, not `download()`'s `withSha256` Proxy: a
         // head result has no body to keep native accessors alive for, and it IS
@@ -469,8 +535,20 @@ export const createStorage = (options: LunoraStorageOptions): Storage => {
             throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: prefix contains NUL byte");
         }
 
-        const requested = listOptions.limit ?? DEFAULT_LIST_LIMIT;
-        const limit = Math.min(Math.max(1, Math.floor(requested)), MAX_LIST_LIMIT);
+        // Reject a non-integer or non-positive limit here rather than coercing
+        // it. `Math.floor(NaN)` is `NaN` and passes both clamps, so a
+        // `limit: Number(env.PAGE_SIZE)` with the variable unset forwarded `NaN`
+        // to R2, which answers `MaxKeys params must be positive integer <= 1000.
+        // (10022)` — a remote error naming a parameter the caller never wrote.
+        // Silently clamping instead would hide the same configuration bug behind
+        // a page size nobody asked for. Mirrors `@lunora/bindings/kv`'s `list`.
+        if (listOptions.limit !== undefined && (!Number.isInteger(listOptions.limit) || listOptions.limit <= 0)) {
+            throw new LunoraError("VALIDATION_ERROR", `@lunora/storage: list limit must be a positive integer (received ${String(listOptions.limit)})`);
+        }
+
+        // The upper bound stays a clamp, as documented on `Storage.list`
+        // ("Defaults to 100, capped at 1000").
+        const limit = Math.min(listOptions.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
         const result = await options.bucket.list({
             cursor: listOptions.cursor,
             delimiter: listOptions.delimiter,

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -101,6 +101,9 @@ export interface ListOptions {
     /**
      * Defaults to 100, capped at 1000 (R2 limit). A ceiling, not a promise: R2
      * may return fewer per page to fit the entry metadata.
+     *
+     * Must be a positive integer when given — `0`, `12.5` and `NaN` throw rather
+     * than being coerced into a page size the caller never asked for.
      */
     limit?: number;
 }
@@ -232,8 +235,25 @@ export interface Storage {
      * alias for {@link Storage.upload} — it accepts the same {@link UploadOptions}
      * so the `maxSize` / `allowedContentTypes` guards aren't lost behind the alias.
      */
-    store: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{ etag: string; httpEtag: string; key: string }>;
-    upload: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{ etag: string; httpEtag: string; key: string }>;
+    store: (
+        key: string,
+        body: ReadableStream | ArrayBuffer | ArrayBufferView | Blob | string,
+        options?: UploadOptions,
+    ) => Promise<{ etag: string; httpEtag: string; key: string }>;
+
+    /**
+     * Upload `body` to `key`, returning the stored key + etag.
+     *
+     * The accepted shapes mirror what R2's `put` stores bytes from — a view
+     * (`Uint8Array`) and a `string` included. They are listed here because
+     * `maxSize` measures every one of them; a shape the cap cannot measure is
+     * refused rather than uploaded uncapped.
+     */
+    upload: (
+        key: string,
+        body: ReadableStream | ArrayBuffer | ArrayBufferView | Blob | string,
+        options?: UploadOptions,
+    ) => Promise<{ etag: string; httpEtag: string; key: string }>;
 }
 
 export {

--- a/packages/storage/src/upload-handler.ts
+++ b/packages/storage/src/upload-handler.ts
@@ -18,6 +18,7 @@
  * (create, chunk PATCH, resume HEAD, delete) and denies fail-closed — a thrown
  * callback is a deny, never a 500.
  */
+import { LunoraError } from "@lunora/errors";
 import { Multipart, Rest, Tus } from "@visulima/storage/handler/http/fetch";
 import { AwsLightStorage } from "@visulima/storage/provider/aws-light";
 
@@ -77,7 +78,9 @@ interface CreateUploadHandlerOptions {
      * `Upload-Length` (TUS), `X-Total-Size` (chunked REST) and `Content-Length`
      * — see {@link declaredUploadSize}. Defaults to
      * {@link DEFAULT_MAX_UPLOAD_BYTES} (100 MiB) — pass this to raise or lower
-     * the ceiling; there is no unbounded option.
+     * the ceiling; there is no unbounded option. Must be a finite, non-negative
+     * number: anything else (notably a `NaN` from an unset env var) throws at
+     * construction rather than disabling the cap.
      */
     maxFileSize?: number;
     /** Which protocol to speak. Default `"tus"` (the resumable, pause/resume-capable one). */
@@ -236,6 +239,17 @@ const instantiateHandler = (protocol: UploadProtocol, handlerOptions: UploadHand
 const createUploadHandler = (options: CreateUploadHandlerOptions): UploadHandler => {
     const protocol = options.protocol ?? "tus";
     const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_UPLOAD_BYTES;
+
+    // `??` only fills in a nullish value, so an unset upload-limit env var
+    // coerced with `Number(...)` survives as `NaN` — and `declaredSize > NaN` is
+    // always false, which silently removes the ONLY cap this handler enforces
+    // for the TUS and chunked-REST protocols. A negative cap is the opposite
+    // failure (every upload rejected). Both are configuration bugs, caught at
+    // construction rather than acted on per request, mirroring the same guard on
+    // `UploadOptions.maxSize` in `createStorage`.
+    if (!Number.isFinite(maxFileSize) || maxFileSize < 0) {
+        throw new LunoraError("VALIDATION_ERROR", `@lunora/storage: maxFileSize must be a finite, non-negative number (received ${String(maxFileSize)})`);
+    }
 
     const handlerOptions: UploadHandlerOptions = {
         maxFileSize,


### PR DESCRIPTION
Four guards in `@lunora/storage` that could not fire, each reproduced before the fix and each covered
by a test that fails without it.

## 1 — `maxFileSize: NaN` disabled the only cap `createUploadHandler` enforces (HIGH)

`??` only fills in a nullish value, so `maxFileSize: Number(env.SOME_LIMIT)` with the variable unset
stayed `NaN`, and `declaredSize > NaN` is always false. Every TUS / chunked-REST create passed the
pre-check that is the *only* enforcement of `maxFileSize` for those two protocols (the library's own
`maxFileSize` bounds the multipart parser only).

Reproduced (Node, vitest `mocks` project — three handlers, one oversized TUS create each):

```
[F-nan-cap] maxFileSize=100 → status 413, reachedProtocolHandler=false
[F-nan-cap] maxFileSize=NaN → status 201, reachedProtocolHandler=true
[F-nan-cap] maxFileSize=undefined → status 413, reachedProtocolHandler=false
```

Fixed by validating at construction, mirroring the guard the same package already applies to
`UploadOptions.maxSize`.

## 2 — `maxSize` was bypassed for an `ArrayBufferView` or `string` body (MEDIUM)

R2's `put` stores bytes from a view and a string as well, and both were measured as
`body instanceof ArrayBuffer ? byteLength : body.size` — `undefined` for either, and
`undefined > maxSize` is false, so the uncapped body was forwarded verbatim.

Reproduced (Node, recording bucket double):

```
[F-view] puts: 1 | body forwarded is the same view: true
[F-string] puts: 2 | body forwarded is the string: true
[F-control] ArrayBuffer refused, puts: 0 (@lunora/storage: body exceeds maxSize (100 > 10))
```

Reproduced against real R2 (workerd + Miniflare R2 emulator, `maxSize: 10`, 100-byte bodies):

```
[W-view] head size: 100
[W-string] head size: 100
```

Reach, stated honestly: TypeScript callers were blocked by the old body type (`tsc` rejects
`Uint8Array` where `ArrayBuffer` is wanted), so this was reachable from JavaScript, casts and untyped
paths. It is still worth closing rather than narrowing: `v.bytes()` accepts an `ArrayBufferView`
because views arrive on the wire, and `R2BucketLike.put` accepts both shapes, so the storage type was
the odd one out.

Fixed by measuring every shape R2 accepts (a string in **UTF-8 bytes**, not UTF-16 code units — a
multi-byte character would otherwise under-count), refusing a body it cannot measure instead of
waving it through, and widening `UploadBody` plus the public `upload`/`store` signatures so the type
agrees with the binding.

## 3 — `list({ limit })` forwarded a non-integer limit to R2 (LOW severity, HIGH mechanism)

`Math.min(Math.max(1, Math.floor(requested)), MAX_LIST_LIMIT)` — `Math.floor(NaN)` is `NaN` and
passes both clamps.

Reproduced (Node, forwarded options captured; `JSON.stringify` renders `NaN` as `null`):

```
[F-list] forwarded limits: [null,12]
```

Reproduced against real R2 (workerd + Miniflare R2):

```
[W-list] list: MaxKeys params must be positive integer <= 1000. (10022)
```

**Decision: throw, like the KV sibling, rather than clamp to the default.** Clamping would answer a
page size the caller never asked for and hide the configuration bug — the same reasoning `@lunora/bindings/kv`
records for its own `limit` check — and the remote alternative is an R2 error naming `MaxKeys`, a
parameter that appears nowhere in the caller's code. `0` now throws too (it used to be clamped up to
a one-row page) and a fractional limit throws (it used to be floored). The documented upper bound
stays a clamp: "Defaults to 100, capped at 1000".

## 4 — the `head`-less fallback asked R2 for a zero-length range (HIGH mechanism, LOW reach)

`options.bucket.head ? head(key) : get(key, { range: { length: 0 } })`. Reproduced against real R2
(workerd + Miniflare R2):

```
[W-head] zero-length range → get: The requested range is not satisfiable (10039)
[W-head] length:1 range → size 10, body drained: a
[W-head] length:1 on a 0-byte object → get: Unspecified error (0)
[W-head] plain get on a 0-byte object → size 0
```

**Decision: keep `head` optional and make the fallback work, rather than making `head` required.**
Both in-repo hosts (real R2, the Node host) do implement `head`, so requiring it was on the table —
but it is a public-surface change to `@lunora/platform` that would also break the two in-repo
`R2BucketLike` test doubles (`packages/do/__tests__/_helpers/fake-r2.ts`,
`packages/shard-engine/__tests__/_helpers/fake-r2.ts`, neither of which implements `head`), and it
lands in the same files another change is currently touching. `{ length: 1 }` is not the fix either:
the third line above shows it failing on a zero-byte object. So the fallback now reads the object and
cancels the body without consuming it, and the comment says what that costs instead of claiming a
body-free read.

## Tests

Every new test was verified by breaking the code first. With the guards reverted:

```
× upload() enforces maxSize for an ArrayBufferView and a string body
    AssertionError: promise resolved "{ etag: 'etag-new', …(2) }" instead of rejecting
× upload() measures a string body in UTF-8 bytes, not UTF-16 code units
× upload() refuses a body whose length it cannot measure rather than uploading it uncapped
× rejects a maxFileSize that is not a finite, non-negative number
    AssertionError: expected [Function] to throw error matching /maxFileSize/ but got undefined
× list() rejects a limit that is not a positive integer instead of forwarding it to R2
    AssertionError: promise resolved "{ cursor: 'next-cursor', …(3) }" instead of rejecting
× head() reads metadata through a head-less binding without asking for a byte range
    Caused by: Error: get: The requested range is not satisfiable (10039)
```

and in the `workerd` project, against the real R2 emulator:

```
× enforces maxSize for an ArrayBufferView and a string body, storing neither
    AssertionError: promise resolved "{ …(3) }" instead of rejecting
× rejects a non-integer list limit locally instead of letting R2 answer 10022
    + "message": "list: MaxKeys params must be positive integer <= 1000. (10022)",
× head() works through a head-less binding, including for a 0-byte object
    Caused by: Error: get: The requested range is not satisfiable (10039)
```

Two pre-existing tests asserted the broken `{ range: { length: 0 } }` call and were updated — they
passed only because the fake bucket accepted a range real R2 refuses.

## Gates

- `pnpm run build:packages` — pass
- `@lunora/storage` tests — 149 passed
- `LUNORA_WORKERD_TESTS=1` (workerd project included) — 162 passed
- `pnpm run test:affected` — pass (storage, platform-node, playground, 2 examples)
- `pnpm run lint:types` — pass (75 projects)
- `pnpm run api:check` — drifted as expected on the widened `upload`/`store` body type;
  `api:update` run and `api-snapshots/storage.api.md` committed (that one interface, nothing else)
- prettier, then eslint (`--max-warnings=0`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
