### PR TITLE
docs(cli): name the files these two checks read

### DIFF
--- a/apps/docs/src/content/docs/deployment.mdx
+++ b/apps/docs/src/content/docs/deployment.mdx
@@ -57,7 +57,7 @@ dispatch origin from its own env and refuses to enqueue without it, so
 
 One optional file at the project root carries the project's Lunora settings — the
 deploy `target`, the `remote`-binding dev preference, and the `app` hook a
-Vite-first project composes its worker with. It replaces `lunora.config.*`: the two
+Vite-first project composes its worker with. It replaces `lunora.json`: the two
 were always the same question, split across a format boundary that existed only
 because the CLI could not read TypeScript. It can now (`jiti`), so there is one
 file and it is real code.

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -334,7 +334,7 @@ prose is not. New codes are added over time; treat an unknown one as advisory.
 | `r2-lifecycle-unset`             | info  | An R2 bucket may lack an abort-incomplete-multipart lifecycle rule.                 |
 | `scheduler-origin-missing`       | warn  | A `SchedulerDO` is declared but `LUNORA_ORIGIN_URL` is missing from wrangler.       |
 | `schema-unreadable`              | fail  | `lunora/schema.ts` could not be parsed, so schema-derived checks were skipped.      |
-| `stale-lunora-json`              | warn  | `lunora.config.*` is present but no longer read (`lunora.config.*` replaced it).    |
+| `stale-lunora-json`              | warn  | `lunora.json` is present but no longer read (`lunora.config.*` replaced it).        |
 | `vector-metadata-index-required` | info  | A declared Vectorize metadata filter needs its metadata index created.              |
 | `vector-metadata-unfilterable`   | warn  | A metadata property has a type Vectorize cannot filter on.                          |
 | `version-counter-spread`         | info  | Same-channel `@lunora/*` pre-release counters differ (normal, worth noting).        |
@@ -794,7 +794,7 @@ lunora env unset FOO         # remove a key
 lunora env push              # upload to Cloudflare (prompts unless --yes)
 lunora env push --prod --yes # push to the production environment
 lunora env diff              # compare local .dev.vars keys against Cloudflare
-lunora env doctor            # validate .dev.vars against wrangler.jsonc bindings
+lunora env doctor            # validate .dev.vars against .dev.vars.example
 ```
 
 `diff` reads the deployed Worker's secret **names** via `wrangler secret list`


### PR DESCRIPTION
Three lines in the reference name the wrong file.

**`lunora env doctor`** is documented as validating `.dev.vars` against `wrangler.jsonc` bindings. It never opens `wrangler.jsonc` — `runEnvDoctor` diffs `.dev.vars` against `.dev.vars.example` and reports keys the example lists but the file lacks, values still at placeholders, and keys present locally but absent from the example. A reader following the reference looks for a binding check that does not exist, and misses the example file the command actually requires. `concepts/environment-variables.mdx` already describes it correctly.

**`stale-lunora-json`** names `lunora.config.*` as both the stale file and its replacement, so the row reads as a file replaced by itself. The check fires on `lunora.json`, and the finding's own message says so.

The **deployment guide** carries the same slip, introducing `lunora.config.ts` as replacing `lunora.config.*`.

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
