### PR TITLE
fix(mail): correct empty recipient list handling

### DIFF
--- a/packages/mail/__tests__/cloudflare-binding.test.ts
+++ b/packages/mail/__tests__/cloudflare-binding.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import createMailer from "../src/create-mailer";
+
+/**
+ * Drives the REAL `@visulima/email` Cloudflare provider — no module mock.
+ *
+ * The provider rejects a send whose `cc`/`bcc` is merely *present*
+ * (`cc !== undefined`), not just non-empty, and that rejection is flattened into
+ * the generic "send failed" with the binding never called. A mocked provider
+ * cannot see that, so the empty-list path has to be covered against the real one.
+ */
+describe("cloudflare transport against the real provider", () => {
+    it("invokes the send binding when `cc`/`bcc` are empty arrays", async () => {
+        expect.assertions(3);
+
+        const cloudflareSend = vi.fn<(from: string, to: string, raw: string) => Promise<void>>(async () => undefined);
+        const mailer = createMailer({ cloudflareSend, from: "noreply@x.test" });
+
+        const result = await mailer.send({ bcc: [], cc: [], subject: "Hi", text: "x", to: "user@x.test" });
+
+        expect(cloudflareSend).toHaveBeenCalledTimes(1);
+        expect(cloudflareSend.mock.calls[0]?.slice(0, 2)).toStrictEqual(["noreply@x.test", "user@x.test"]);
+        expect(result.id).toStrictEqual(expect.any(String));
+    });
+
+    it("invokes the send binding when no `cc`/`bcc` is supplied at all", async () => {
+        expect.assertions(1);
+
+        const cloudflareSend = vi.fn<(from: string, to: string, raw: string) => Promise<void>>(async () => undefined);
+        const mailer = createMailer({ cloudflareSend, from: "noreply@x.test" });
+
+        await mailer.send({ subject: "Hi", text: "x", to: "user@x.test" });
+
+        expect(cloudflareSend).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/mail/__tests__/cloudflare-transport.test.ts
+++ b/packages/mail/__tests__/cloudflare-transport.test.ts
@@ -81,7 +81,7 @@ describe("cloudflare transport (default provider)", () => {
     });
 
     it("does not trip the cc/bcc guard on empty cc/bcc arrays", async () => {
-        expect.assertions(1);
+        expect.assertions(3);
 
         sendEmail.mockResolvedValue({ data: { messageId: "cf-3" }, success: true });
         const mailer = createMailer({ cloudflareSend: async () => undefined, from: "noreply@x.test" });
@@ -91,6 +91,14 @@ describe("cloudflare transport (default provider)", () => {
         const result = await mailer.send({ bcc: [], cc: [], subject: "Hi", text: "x", to: "user@x.test" });
 
         expect(result).toStrictEqual({ id: "cf-3" });
+
+        // The real provider tests cc/bcc for PRESENCE, so an empty list must reach
+        // it as `undefined` — an `[]` here is a send the binding never sees. See
+        // `cloudflare-binding.test.ts` for the same path against the real provider.
+        const [options] = sendEmail.mock.calls[0] as [{ bcc?: unknown; cc?: unknown }];
+
+        expect(options.cc).toBeUndefined();
+        expect(options.bcc).toBeUndefined();
     });
 
     it("throws a generic error and logs the provider detail on failure", async () => {

--- a/packages/mail/__tests__/create-mailer.test.ts
+++ b/packages/mail/__tests__/create-mailer.test.ts
@@ -8,6 +8,7 @@ import type { MailTransport, QueueLike, SendPayload } from "../src/types";
 const FROM_PATTERN = /from/;
 const API_KEY_PATTERN = /apiKey/;
 const QUEUE_PATTERN = /queue/;
+const RECIPIENT_PATTERN = /at least one recipient/;
 
 const fakeTransport = (id: string = "msg-1"): { sent: SendPayload[]; transport: MailTransport } => {
     const sent: SendPayload[] = [];
@@ -94,6 +95,36 @@ describe("createMailer", () => {
             subject: "Queued",
             to: ["a@x.test", "b@x.test"],
         });
+        expect(sent).toHaveLength(0);
+    });
+
+    it("queue() rejects a message with no recipients instead of enqueueing a poison message", async () => {
+        expect.assertions(3);
+
+        const { sent, transport } = fakeTransport();
+        const queueMessages: unknown[] = [];
+        const queue: QueueLike = {
+            send: vi.fn<QueueLike["send"]>(async (payload: unknown) => {
+                queueMessages.push(payload);
+            }),
+        };
+        const mailer = createMailer({ from: "Default <noreply@x.test>", queue, transport });
+
+        // `queue()` must apply the same recipient check `send()` does, and apply it
+        // BEFORE the enqueue — an empty `to` fails on every consumer attempt and
+        // retries its way to the dead-letter queue after the caller was told it was queued.
+        await expect(mailer.queue({ subject: "Queued", text: "hi", to: [] })).rejects.toThrow(RECIPIENT_PATTERN);
+        expect(queueMessages).toHaveLength(0);
+        expect(sent).toHaveLength(0);
+    });
+
+    it("send() rejects a message with no recipients on every transport", async () => {
+        expect.assertions(2);
+
+        const { sent, transport } = fakeTransport();
+        const mailer = createMailer({ from: "Default <noreply@x.test>", transport });
+
+        await expect(mailer.send({ subject: "Hi", text: "hi", to: [] })).rejects.toThrow(RECIPIENT_PATTERN);
         expect(sent).toHaveLength(0);
     });
 

--- a/packages/mail/docs/index.mdx
+++ b/packages/mail/docs/index.mdx
@@ -94,6 +94,12 @@ Cloudflare Queue binding you passed as `queue`. React elements are NOT
 structured-cloneable, so the queue body always carries pre-rendered html/
 text, never the original JSX.
 
+Addresses, the subject and custom headers are validated before the enqueue, with
+the same checks `mailer.send(...)` applies — a message with no `to` recipient is
+rejected rather than accepted and left to fail on every consumer attempt. An empty
+`cc` / `bcc` array means "no recipients" and is treated exactly like omitting the
+field.
+
 A consumer Worker re-hydrates the payload and sends it with
 `consumeQueuedSend(mailer, body)` — it validates the untrusted message body, then
 calls `mailer.send(...)` for you and returns `{ id }`. Call `message.ack()` after

--- a/packages/mail/src/address.ts
+++ b/packages/mail/src/address.ts
@@ -87,12 +87,24 @@ const toAddress = (input: string): { email: string; name?: string } => {
     return toBareAddress(input);
 };
 
+/**
+ * Normalize an optional recipient field. An empty list collapses to `undefined`
+ * so "no recipients" is indistinguishable from "field absent": providers test
+ * `cc`/`bcc` for *presence* (`!== undefined`), so a surviving `[]` reads as a
+ * cc/bcc send — the Cloudflare provider rejects it outright and the failure
+ * arrives as an undifferentiated "send failed" with the binding never called.
+ * `cc: []` is what `cc: extras.filter(...)` produces, so this is a live path.
+ */
 const toAddressList = (input: string | string[] | undefined): { email: string; name?: string }[] | undefined => {
     if (input === undefined) {
         return undefined;
     }
 
     const list = Array.isArray(input) ? input : [input];
+
+    if (list.length === 0) {
+        return undefined;
+    }
 
     return list.map((entry) => toAddress(entry));
 };
@@ -102,9 +114,17 @@ const toAddressList = (input: string | string[] | undefined): { email: string; n
  * rejection that the transports apply, but discard the parsed result. Called
  * from `buildPayload` so custom transports and the queue path get the exact same
  * validation — without changing the string wire shape the payload carries.
+ *
+ * Also enforces the one recipient rule here rather than in each transport: a
+ * message with no `to` is undeliverable, and `queue()` would otherwise accept it,
+ * report `{ queued: true }`, and leave a poison message to retry its way to the
+ * dead-letter queue.
  */
 const assertSafeAddresses = (payload: { bcc?: string | string[]; cc?: string | string[]; from?: string; replyTo?: string; to?: string | string[] }): void => {
-    toAddressList(payload.to);
+    if (toAddressList(payload.to) === undefined) {
+        throw new LunoraError("INTERNAL", "@lunora/mail: at least one recipient is required");
+    }
+
     toAddressList(payload.cc);
     toAddressList(payload.bcc);
 

--- a/packages/mail/src/create-mailer.ts
+++ b/packages/mail/src/create-mailer.ts
@@ -94,8 +94,12 @@ const createMailer = (options: LunoraMailOptions): Mailer => {
         });
 
         return {
-            bcc: options_.bcc,
-            cc: options_.cc,
+            // Drop an empty optional recipient list rather than carrying `[]` into
+            // the payload: downstream (providers, custom transports, the capture
+            // sink) tests these for presence, so an empty list must be spelled the
+            // same way an absent field is.
+            bcc: options_.bcc?.length ? options_.bcc : undefined,
+            cc: options_.cc?.length ? options_.cc : undefined,
             from,
             headers: options_.headers,
             html,


### PR DESCRIPTION
Two defects in `@lunora/mail`, both caused by an empty recipient list travelling as `[]` rather than as "absent".

## 1. An empty `cc` failed the send, and the binding was never called

`toAddressList([])` returned `[]`, so `toProviderEmail` built a provider payload with `cc: []`. The `@visulima/email` Cloudflare provider tests cc/bcc for **presence**, not length:

```js
if (i.length !== 1 || e.cc !== void 0 || e.bcc !== void 0)
    return { error: new o(r, "Cloudflare Email supports exactly one `to` recipient and does not support cc/bcc"), success: false };
```

So the provider short-circuited, `s.send(...)` — the Worker's `send_email` binding — was never reached, and `interpretSendResult` flattened the rejection into the generic `@lunora/mail: send failed`. The transport's own cc/bcc guard uses a length check, so it correctly let the empty list through and never got to emit its actionable message.

Notably, the transport's guard is *not* the mechanism, and neither is a `join("")` or a thrown normalisation — it is the provider's presence check, one level below.

`cc: extras.filter(...)` is the natural way a caller produces an empty list, so this is a live path.

**Fix (root):** an empty optional recipient list collapses to `undefined` in `toAddressList` — the single normalizer every transport's address handling routes through — and `buildPayload` likewise drops an empty `cc`/`bcc` from the `SendPayload` it constructs, so custom transports and the capture sink see the same thing. An empty list is now indistinguishable from an absent field on every transport.

## 2. `queue()` reported `{ queued: true }` for a message with no recipients

The recipient check lived only in the two provider transports (`requireRecipients`), so the direct `send()` path was covered by accident of which transport was configured — a custom transport accepted an empty `to` too — and `queue()` was not covered at all: it enqueued the message and returned `{ queued: true }`, leaving a poison message that fails on every consumer attempt and retries its way to the dead-letter queue.

**Fix (root):** the check moved into `assertSafeAddresses`, the shared validation `buildPayload` already calls on both paths, so it runs before the enqueue and applies to every transport. The error message is unchanged (`@lunora/mail: at least one recipient is required`), and the transport-level guard stays for direct transport use.

## Tests

Written against the unfixed code first, and each confirmed to fail for the stated reason:

- `cloudflare-binding.test.ts` (new) drives the **real** provider, no module mock: `cc: []` / `bcc: []` must reach the send binding. Pre-fix it failed with `LunoraError: @lunora/mail: send failed` and the logged reason `[cloudflare-email] Cloudflare Email supports exactly one 'to' recipient and does not support cc/bcc`. The pre-existing empty-array test mocks the provider, so it passed without ever exercising the presence check that rejects — a new mocked assertion now also pins `cc`/`bcc` to `undefined` in the provider payload.
- `create-mailer.test.ts`: `queue({ to: [] })` must reject and must not enqueue (pre-fix: resolved `{ queued: true }`), and `send({ to: [] })` must reject on a custom transport (pre-fix: resolved `{ id: 'msg-1' }`).

Docs: the Queueing section of `packages/mail/docs/index.mdx` now states that validation runs before the enqueue and that an empty `cc`/`bcc` is treated as omitted. (`apps/docs/src/content/docs/packages/` is generated and was not touched.)

## Gates

| command | result |
| --- | --- |
| `pnpm run build:packages` | exit 0 — 54 projects |
| `pnpm run api:check` | exit 0 — "Public API surface matches all 54 committed snapshots." |
| `pnpm run lint:types` | exit 0 — 75 projects (`mail:lint:types` uncached, 2.7s) |
| `pnpm --filter "@lunora/mail" run test` | exit 0 — 12 files, 122 tests |
| `pnpm run test:affected` | exit 0 — 18 projects, 141 files, 1811 tests |
| `pnpm --filter "@lunora/mail" run lint:eslint` | exit 0 |

`test:workerd` was not run: this change touches no SQL, storage, or Durable Object path.

## Deliberately not fixed

`to: ""` (an empty string rather than an empty list) still normalizes to a one-entry list `[{ email: "" }]` and is rejected downstream by the provider rather than by the mailer. It is a different mechanism (address parsing, not list emptiness), outside the two reported defects, and changing it touches validation shared by every address field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
