### PR TITLE
fix: four data-loss defects on the export/import/backup path

### DIFF
--- a/packages/runtime/__tests__/admin-export-import.test.ts
+++ b/packages/runtime/__tests__/admin-export-import.test.ts
@@ -173,6 +173,54 @@ describe("createWorker — admin export endpoint", () => {
         expect(JSON.parse(lines[0]!)).toEqual({ doc: { _id: "u1", email: "a@b.com" }, table: "users" });
     });
 
+    it("errors the stream when a shard's export failed instead of serving a short snapshot", async () => {
+        expect.assertions(2);
+
+        const orchestrateExport = vi.fn<() => Promise<unknown>>(async () => {
+            return {
+                failed: 1,
+                ok: 1,
+                shards: [
+                    { rows: [{ doc: { _id: "u1" }, table: "users" }], shardKey: "c1" },
+                    { error: { message: 'shard "c2" failed: boom', timedOut: false }, shardKey: "c2" },
+                ],
+            };
+        });
+
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            queryCoordinator: {
+                fanOut: vi.fn<() => never>(),
+                orchestrateApplyCdc: vi.fn<() => never>(),
+                orchestrateCdcSync: vi.fn<() => never>(),
+                orchestrateExport: orchestrateExport as never,
+                orchestrateImport: vi.fn<() => never>(),
+                orchestrateMigration: vi.fn<() => never>(),
+                orchestrateRank: vi.fn<() => never>(),
+                orchestrateRankPage: vi.fn<() => never>(),
+                orchestrateShardTraffic: vi.fn<() => never>(),
+                registry: {} as never,
+            },
+            shardDO: noopNamespace,
+        });
+
+        const response = await worker.fetch(
+            new Request("https://app.example/_lunora/admin/export", {
+                body: JSON.stringify({ tables: ["users"] }),
+                headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+                method: "POST",
+            }),
+            {},
+            fakeContext,
+        );
+
+        // The status line is committed before the fan-out runs, so the only
+        // honest signal left is an aborted body — which a consumer cannot mistake
+        // for a complete dump the way it can mistake a short one.
+        expect(response.status).toBe(200);
+        await expect(response.text()).rejects.toThrow(/c2/u);
+    });
+
     it("streams D1 globals when exportGlobals is configured", async () => {
         expect.assertions(2);
 

--- a/packages/runtime/__tests__/query-coordinator.export-import.test.ts
+++ b/packages/runtime/__tests__/query-coordinator.export-import.test.ts
@@ -102,6 +102,26 @@ describe("orchestrateExport", () => {
 
         expect(visited).toEqual(new Set(["c1", "c2", "c3"]));
     });
+
+    it("still reaches the default shard for a root table once another table has registered keys", async () => {
+        expect.assertions(1);
+
+        // `users` is a plain root-DO table: the registry has no entry for it and
+        // never will, so its keys resolve to the default shard. `messages` is
+        // `.shardBy()`-ed and registered. Unioning first and falling back only on
+        // an empty union dropped the default shard the moment ANY table had a
+        // key, so every root-table row was missing from a whole-deployment export.
+        const registry = createStaticShardRegistry({ messages: ["c1"], users: [] });
+        const coordinator = createQueryCoordinator({ registry });
+
+        const spy = createShardSpy(() => json({ result: { rows: [] } }));
+
+        await coordinator.orchestrateExport(spy.namespace, { defaultShardKey: "__root__", tables: ["users", "messages"] });
+
+        const visited = new Set(spy.calls.map((c) => c.shardKey));
+
+        expect(visited).toEqual(new Set(["__root__", "c1"]));
+    });
 });
 
 describe("orchestrateImport", () => {

--- a/packages/runtime/__tests__/scheduled-backup.test.ts
+++ b/packages/runtime/__tests__/scheduled-backup.test.ts
@@ -234,6 +234,49 @@ describe("createWorker — scheduled backup", () => {
         expect(store.put).not.toHaveBeenCalled();
     });
 
+    it("refuses to write a snapshot when a shard's export failed", async () => {
+        expect.assertions(3);
+
+        const store = memoryBackupStore();
+        const coordinator = {
+            fanOut: vi.fn<() => never>(),
+            orchestrateApplyCdc: vi.fn<() => never>(),
+            orchestrateCdcSync: vi.fn<() => never>(),
+            orchestrateExport: vi.fn<() => Promise<unknown>>(async () => {
+                return {
+                    failed: 1,
+                    ok: 1,
+                    shards: [
+                        { rows: [{ doc: { _id: "u1" }, table: "users" }], shardKey: "c1" },
+                        { error: { message: 'shard "c2" failed: boom', timedOut: false }, shardKey: "c2" },
+                    ],
+                };
+            }),
+            orchestrateImport: vi.fn<() => never>(),
+            orchestrateMigration: vi.fn<() => never>(),
+            orchestrateRank: vi.fn<() => never>(),
+            orchestrateRankPage: vi.fn<() => never>(),
+            orchestrateShardTraffic: vi.fn<() => never>(),
+            registry: {} as never,
+        } as unknown as QueryCoordinator;
+
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            backupCron: BACKUP_CRON,
+            backupStore: store,
+            queryCoordinator: coordinator,
+            shardDO: noopNamespace,
+        });
+
+        // A backup whose fan-out lost a shard is a partial snapshot. Writing it
+        // — and a manifest vouching for it — is how a restore silently comes back
+        // missing every row that shard held.
+        await expect(fire(worker, { cron: BACKUP_CRON, scheduledTime: SCHEDULED_TIME })).rejects.toThrow(/c2/u);
+
+        expect(store.objects.size).toBe(0);
+        expect(store.put).not.toHaveBeenCalled();
+    });
+
     /** `POST …/backup/prune` with a body — the only thing that deletes a backup. */
     const pruneWith = async (
         worker: ReturnType<typeof createWorker>,

--- a/packages/runtime/src/export-stream.ts
+++ b/packages/runtime/src/export-stream.ts
@@ -10,6 +10,7 @@
  * `create-worker` — no runtime values cross the edge.
  */
 import type { WorkerOptions } from "./create-worker";
+import { LunoraError } from "./errors";
 import type { QueryCoordinator } from "./query-coordinator";
 import type { ShardNamespaceLike } from "./resolve-shard";
 
@@ -41,9 +42,19 @@ const partitionExportTables = (options: WorkerOptions, tables: ReadonlyArray<str
 };
 
 /**
- * Fan the shard-local export out via the coordinator and write each
- * successful shard's rows. A failed shard is skipped (its error was already
- * surfaced through the fan-out roll-up).
+ * Fan the shard-local export out via the coordinator and write each shard's
+ * rows.
+ *
+ * A shard that failed aborts the whole export. The rows it holds are simply
+ * absent from the roll-up, and there is no way to say so in-band: the NDJSON
+ * body is a row per line with no envelope, and the admin route has already
+ * committed `200` and its headers before the fan-out runs, so a shorter file is
+ * indistinguishable from a smaller deployment. Skipping the shard therefore
+ * handed the caller an incomplete snapshot labelled complete — one the scheduled
+ * backup then wrote a manifest for. Throwing is the one signal a consumer cannot
+ * mistake for success: the backup writes nothing, and the streamed response ends
+ * as an errored body rather than a clean short one (the CLI discards its staged
+ * partial file on exactly that).
  */
 const exportShardLocalRows = async (
     coordinator: QueryCoordinator,
@@ -79,11 +90,20 @@ const exportShardLocalRows = async (
         tables: shardLocalTables,
     });
 
-    for (const shard of result.shards) {
-        if (shard.error) {
-            continue;
-        }
+    // Checked before a single row is written, so a failed fan-out leaves the
+    // stream untouched rather than truncated mid-table.
+    const failed = result.shards.filter((shard) => shard.error);
 
+    if (failed.length > 0) {
+        const detail = failed.map((shard) => `${shard.shardKey}: ${shard.error?.message ?? "unknown error"}`).join("; ");
+
+        throw new LunoraError(`export failed on ${String(failed.length)} of ${String(result.shards.length)} shard(s) — ${detail}`, {
+            code: "EXPORT_SHARD_FAILED",
+            status: 502,
+        });
+    }
+
+    for (const shard of result.shards) {
         for (const row of shard.rows ?? []) {
             writeRow(row);
         }

--- a/packages/runtime/src/query-coordinator.ts
+++ b/packages/runtime/src/query-coordinator.ts
@@ -1248,13 +1248,6 @@ const runBoundedJobs = async <T, R>(jobs: ReadonlyArray<T>, concurrency: number,
     return results;
 };
 
-/** Union of the live shard keys across every requested table, so a multi-table fan-out reaches each shard once. */
-const unionShardKeys = async (registry: ShardRegistry, tables: ReadonlyArray<string>): Promise<string[]> => {
-    const perTableKeys = await Promise.all(tables.map(async (table) => registry.listShardKeys(table)));
-
-    return [...new Set(perTableKeys.flat())];
-};
-
 /**
  * Resolve the shards a fan-out should reach, falling back to the default shard
  * when discovery finds nothing.
@@ -1275,6 +1268,26 @@ const unionShardKeys = async (registry: ShardRegistry, tables: ReadonlyArray<str
  */
 const withDefaultShard = (discovered: ReadonlyArray<string>, defaultShardKey: DefaultShardKey): ReadonlyArray<string> =>
     discovered.length > 0 || defaultShardKey === null ? discovered : [defaultShardKey];
+
+/**
+ * Union of the live shard keys across every requested table, so a multi-table
+ * fan-out reaches each shard once.
+ *
+ * {@link withDefaultShard} is applied PER TABLE, before the union: an empty key
+ * list is that table's "the registry cannot answer", and a root-DO table's list
+ * is always empty. Unioning first and falling back only on an empty union
+ * answered the question once for the whole request, so a single registered
+ * `.shardBy(...)` key was enough to drop the default shard — and with it every
+ * root-table row — from a whole-deployment export.
+ *
+ * The caller still wraps the result: with no tables at all there is nothing to
+ * ask per table, and the fallback is the whole answer.
+ */
+const unionShardKeys = async (registry: ShardRegistry, tables: ReadonlyArray<string>, defaultShardKey: DefaultShardKey): Promise<string[]> => {
+    const perTableKeys = await Promise.all(tables.map(async (table) => withDefaultShard(await registry.listShardKeys(table), defaultShardKey)));
+
+    return [...new Set(perTableKeys.flat())];
+};
 
 const runBoundedFanOut = async (
     namespace: ShardNamespaceInput,
@@ -1562,7 +1575,7 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
             // Union the shard keys across all requested shard-local tables so
             // an export of `["users","messages"]` reaches every shard that
             // holds either table. Skip globals — they live in D1, not a DO.
-            const discovered = await unionShardKeys(options.registry, request.tables);
+            const discovered = await unionShardKeys(options.registry, request.tables, request.defaultShardKey);
 
             const shardKeys = withDefaultShard(discovered, request.defaultShardKey);
 
@@ -1584,7 +1597,7 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
             // live shard keys. Unlike export, each shard resumes from its own
             // cursor, so (like import) we can't reuse `runBoundedFanOut`'s
             // same-args-to-all model; we drive a per-shard-args worker loop.
-            const shardKeys = withDefaultShard(await unionShardKeys(options.registry, request.tables), request.defaultShardKey);
+            const shardKeys = withDefaultShard(await unionShardKeys(options.registry, request.tables, request.defaultShardKey), request.defaultShardKey);
             const cursors = request.cursors ?? {};
 
             const results = await runBoundedJobs(shardKeys, maxConcurrency, async (shardKey) => {

--- a/packages/runtime/src/scheduled-backup.ts
+++ b/packages/runtime/src/scheduled-backup.ts
@@ -387,8 +387,11 @@ const runScheduledBackup = async (
         chunks.push(chunk);
     };
 
-    // An error from the export (including the size guard) propagates out of
-    // here, so no partial object and no manifest is ever written.
+    // An error from the export propagates out of here, so no partial object and
+    // no manifest is ever written. That covers the size guard above AND a shard
+    // the fan-out could not reach — which `streamExportRows` raises rather than
+    // skipping, precisely so a snapshot missing a shard's rows never gets a
+    // manifest vouching for it.
     await streamExportRows(options, coordinator, forwardedHeaders, tables, writeRow, shardDO);
 
     const prefix = normalizeBackupPrefix(options.backupPrefix ?? BACKUP_KEY_PREFIX);

--- a/packages/shard-engine/__tests__/admin-export-import.id-scope.test.ts
+++ b/packages/shard-engine/__tests__/admin-export-import.id-scope.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { importShardRows } from "../src/admin-export-import";
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Append-mode import skips a row whose `_id` is already taken. "Already taken"
+ * has to mean "in the row's own table": the probe reached every table, so an id
+ * that happened to exist anywhere in the shard silently consumed the inbound row
+ * and reported it as a conflict the caller could not distinguish from a real one.
+ */
+const schema: SchemaLike = {
+    tables: {
+        notes: { indexes: [], shape: { title: { kind: "string" } } },
+        tasks: { indexes: [], shape: { label: { kind: "string" } } },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+const writerFor = (source: ReturnType<typeof createSqliteExec>): DatabaseWriterLike => {
+    runShardMigrations(source.sql, schema);
+
+    return createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: source.sql });
+};
+
+describe("shard admin import — `_id` conflict probe", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("inserts a row whose `_id` is free in its own table", async () => {
+        expect.assertions(3);
+
+        const writer = writerFor(harness);
+
+        await writer.insert("notes", { _id: "shared-1", title: "taken over here" }, { allowExplicitId: true });
+
+        const result = await importShardRows(writer, schema, { rows: [{ doc: { _id: "fresh-1", label: "todo" }, table: "tasks" }] });
+
+        expect(result.errors).toStrictEqual([]);
+        expect(result.conflicts).toBe(0);
+        expect(result.inserted).toStrictEqual({ tasks: 1 });
+    });
+
+    it("counts a same-table `_id` collision as a conflict", async () => {
+        expect.assertions(3);
+
+        const writer = writerFor(harness);
+
+        await writer.insert("notes", { _id: "n1", title: "original" }, { allowExplicitId: true });
+
+        const result = await importShardRows(writer, schema, { rows: [{ doc: { _id: "n1", title: "incoming" }, table: "notes" }] });
+
+        expect(result.errors).toStrictEqual([]);
+        expect(result.conflicts).toBe(1);
+        expect(result.inserted).toStrictEqual({});
+    });
+
+    it("reports a cross-table `_id` collision per row instead of skipping it silently", async () => {
+        expect.assertions(3);
+
+        const writer = writerFor(harness);
+
+        await writer.insert("notes", { _id: "shared-1", title: "taken over here" }, { allowExplicitId: true });
+
+        const result = await importShardRows(writer, schema, { rows: [{ doc: { _id: "shared-1", label: "todo" }, table: "tasks" }] });
+
+        expect(result.conflicts).toBe(0);
+        expect(result.inserted).toStrictEqual({});
+        expect(result.errors).toStrictEqual([expect.objectContaining({ code: "ID_COLLISION", line: 1, table: "tasks" })]);
+    });
+});

--- a/packages/shard-engine/__tests__/admin-export-import.soft-delete.test.ts
+++ b/packages/shard-engine/__tests__/admin-export-import.soft-delete.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportShardRows, importShardRows } from "../src/admin-export-import";
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * A `.softDelete()` row is a tombstone, not an absent row: `restore()` brings it
+ * back, and a changefeed consumer reads it as the event that the row went away.
+ * The export walks tables with the same list read a user query uses, whose
+ * default scope hides tombstones — so a snapshot dropped every one of them and a
+ * restored deployment had nothing left to `restore()`.
+ */
+const schema: SchemaLike = {
+    tables: {
+        notes: {
+            indexes: [],
+            shape: { deletedAt: { kind: "optional" }, title: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+let source: ReturnType<typeof createSqliteExec>;
+let target: ReturnType<typeof createSqliteExec>;
+
+const writerFor = (harness: ReturnType<typeof createSqliteExec>): DatabaseWriterLike => {
+    runShardMigrations(harness.sql, schema);
+
+    return createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+};
+
+describe("shard admin export/import — soft-deleted rows", () => {
+    beforeEach(() => {
+        source = createSqliteExec();
+        target = createSqliteExec();
+    });
+
+    afterEach(() => {
+        source.close();
+        target.close();
+    });
+
+    it("exports tombstones and round-trips them as restorable rows", async () => {
+        expect.assertions(5);
+
+        const writer = writerFor(source);
+
+        await writer.insert("notes", { _id: "n1", title: "live" }, { allowExplicitId: true });
+        await writer.insert("notes", { _id: "n2", title: "gone" }, { allowExplicitId: true });
+        await writer.delete("n2", "notes");
+
+        const rows: { doc: Record<string, unknown>; table: string }[] = [];
+
+        for await (const row of exportShardRows(writer, schema, {})) {
+            rows.push(row);
+        }
+
+        expect(rows.map((row) => String(row.doc["_id"])).toSorted((a, b) => (a < b ? -1 : Number(a > b)))).toStrictEqual(["n1", "n2"]);
+        expect(rows.find((row) => row.doc["_id"] === "n2")?.doc["deletedAt"]).toBe(1_700_000_000_000);
+
+        const restored = writerFor(target);
+        const result = await importShardRows(restored, schema, { rows });
+
+        expect(result.errors).toStrictEqual([]);
+        expect(result.inserted).toStrictEqual({ notes: 2 });
+
+        // The tombstone survived as a tombstone — so `restore()` still has
+        // something to bring back on the restored deployment.
+        await restored.restore?.("n2", "notes");
+
+        const reloaded = await restored.get("n2", "notes");
+
+        expect(reloaded?.["deletedAt"]).toBeNull();
+    });
+});

--- a/packages/shard-engine/src/admin-export-import.ts
+++ b/packages/shard-engine/src/admin-export-import.ts
@@ -57,7 +57,7 @@ interface ImportShardArgs {
 }
 
 interface ImportShardResult {
-    /** Skipped rows whose `_id` conflicted with an existing document. */
+    /** Skipped rows whose `_id` conflicted with an existing document in the same table. */
     conflicts: number;
     errors: ImportError[];
     /** Number of rows successfully inserted, per table. */
@@ -85,6 +85,13 @@ const selectExportTables = (schema: SchemaLike, requested?: ReadonlyArray<string
  * Read every row in `table` and yield it as an {@link ExportRow}. Walks in
  * keyset batches of `batchSize` (default 200) so a 1M-row table doesn't
  * inflate the JS heap with a single materialized array.
+ *
+ * `includeDeleted` because a snapshot is not a user-facing list read: a
+ * `.softDelete()` tombstone is a row the deployment still holds, `restore()`
+ * still reaches and the changefeed still reports. Without it the default
+ * soft-delete scope filtered every tombstone out, so a backup — and the replica
+ * bootstrap that rides the same path — came back with nothing left to restore.
+ * The D1 half of the snapshot has always exported them.
  */
 const exportShardTable = async function* (
     writer: DatabaseWriterLike,
@@ -97,7 +104,7 @@ const exportShardTable = async function* (
 
     while (!done) {
         // eslint-disable-next-line no-await-in-loop -- keyset pagination: each page's cursor depends on the previous page
-        const page = await writer.findMany(table, { cursor, limit: batchSize });
+        const page = await writer.findMany(table, { cursor, includeDeleted: true, limit: batchSize });
 
         for (const record of page.page) {
             yield { doc: record, table };
@@ -205,9 +212,10 @@ const validateImportRow = (schema: SchemaLike, table: string, record: Record<str
 /**
  * Re-insert every row in `args.rows` through the writer, validating each one
  * against the table's declared shape. Rows that fail validation are recorded
- * in the result's `errors` array; rows whose `_id` already exists in the table
- * are counted in `conflicts` and skipped (the v1 mode is `append` — no
- * upsert). All `inserted` counts are bucketed per table.
+ * in the result's `errors` array; rows whose `_id` already exists in the SAME
+ * table are counted in `conflicts` and skipped (the v1 mode is `append` — no
+ * upsert), and one already held by a different table is an `ID_COLLISION` error.
+ * All `inserted` counts are bucketed per table.
  *
  * The writer is responsible for invoking this from within the appropriate
  * transaction; this helper takes no SQL handle of its own.
@@ -215,16 +223,33 @@ const validateImportRow = (schema: SchemaLike, table: string, record: Record<str
 /** Outcome of importing one row: a recorded error, a skipped conflict, or a successful insert into `table`. */
 type RowOutcome = { error: ImportError; kind: "error" } | { kind: "conflict" } | { kind: "inserted"; table: string };
 
-/** Probe whether a row with `explicitId` already exists (append mode skips collisions). */
-const idAlreadyExists = async (writer: DatabaseWriterLike, explicitId: string): Promise<boolean> => {
+/**
+ * The name of the table that already holds `explicitId`, or `undefined` when the
+ * id is free. `table` itself means an append-mode conflict; any other name is a
+ * cross-table collision.
+ *
+ * Scoping matters. The probe used to be a bare `writer.get(explicitId)`, which
+ * resolves an id across every table — so a row whose id merely coincided with
+ * one in an unrelated table was counted as a conflict and dropped, and the
+ * caller saw a `conflicts` tally it could not tell apart from a real collision.
+ * A genuine cross-table collision is not a conflict either: ids are unique
+ * per-shard, not per-table, so inserting one would leave two tables claiming the
+ * same id and every by-id read resolving to whichever the probe hit first. It is
+ * reported per row instead.
+ */
+const locateExistingId = async (writer: DatabaseWriterLike, table: string, explicitId: string): Promise<string | undefined> => {
     try {
-        const existing = await writer.get(explicitId);
+        if (writer.lookupById) {
+            const located = await writer.lookupById(explicitId);
 
-        return existing !== null;
+            return located === null ? undefined : located.tableName;
+        }
+
+        return (await writer.get(explicitId, table)) === null ? undefined : table;
     } catch {
-        // `get` probes every table; an unknown-table failure here is surfaced
-        // when the insert runs against the real schema.
-        return false;
+        // An unknown-table failure here is surfaced when the insert runs against
+        // the real schema.
+        return undefined;
     }
 };
 
@@ -266,11 +291,21 @@ const importOneRow = async (writer: DatabaseWriterLike, schema: SchemaLike, row:
         return { error: { code: "VALIDATION_ERROR", line, message: failure, table }, kind: "error" };
     }
 
-    // v1 mode is `append`: when `_id` collides, skip the row and count it.
+    // v1 mode is `append`: when `_id` collides in its own table, skip the row and
+    // count it. The same id under a DIFFERENT table is not a conflict to skip —
+    // it is unrepresentable (ids resolve per shard, not per table), so say so.
     const explicitId = typeof doc["_id"] === "string" ? doc["_id"] : undefined;
 
-    if (explicitId !== undefined && (await idAlreadyExists(writer, explicitId))) {
-        return { kind: "conflict" };
+    if (explicitId !== undefined) {
+        const owner = await locateExistingId(writer, table, explicitId);
+
+        if (owner === table) {
+            return { kind: "conflict" };
+        }
+
+        if (owner !== undefined) {
+            return { error: { code: "ID_COLLISION", line, message: `_id "${explicitId}" already belongs to table "${owner}"`, table }, kind: "error" };
+        }
     }
 
     try {


### PR DESCRIPTION
Four data-loss defects on the export / import / backup path. Each fix landed with
a test written against the unfixed code first, and each test was re-verified by
breaking its fix and watching it fail again.

## 1. The DO plane dropped every soft-deleted row from a snapshot

`exportShardRows` walked each table with a plain `findMany`, whose default
soft-delete scope hides tombstones. Backups, `lunora export` and the replica
bootstrap (which calls the same helper through `runShardExport`) therefore lost
every `.softDelete()` row, and a restored deployment had nothing left to
`restore()`. The D1 half of the same snapshot has always exported tombstones, so
the two planes disagreed about what a snapshot contains.

Now reads with `includeDeleted: true`. The round-trip is covered end to end: a
tombstone exports, imports, and `restore()` still brings it back on the target.

## 2. A whole-deployment export stopped contacting `__root__`

`orchestrateExport` unioned every requested table's registered shard keys and
applied the default-shard fallback only when that union came back empty. A plain
root-DO table has no registry entry and never will, so an empty key list is that
table's "the registry cannot answer" — but the union answered it once for the
whole request. One registered `.shardBy(...)` key was enough to drop the default
shard, and with it every root-table row.

The fallback now applies per table, before the union. `orchestrateCdcSync` shares
the helper and had the same discovery bug; it is fixed by the same change.

## 3. A failed shard was skipped, and the route still answered 200

`exportShardLocalRows` did `if (shard.error) { continue; }`. The admin route then
returned 200 with a short NDJSON body, and the scheduled backup wrote a snapshot
plus a manifest vouching for it — while the comment above that write claimed an
export error "propagates out of here, so no partial object and no manifest is
ever written". It did not.

The fan-out failure is now raised before a single row is written, and that
comment says what the code does.

**Why a throw rather than a failure record in the stream.** The admin route
constructs its `Response` — status line and headers — before the fan-out runs
inside the stream's `pull`, so no non-200 is reachable once streaming starts. The
remaining option was an out-of-band line in the body, but the NDJSON contract is
one `{table,doc}` row per line with no envelope: every consumer (the CLI's
importer, the batcher, any Fivetran-style reader) would skip an unknown line and
still treat a short dump as complete. An errored body is the one signal a naive
consumer cannot ignore — `lunora export` already discards its staged partial file
on exactly that — and the backup writer, which needs a throw, gets one.

## 4. Import's `_id` collision probe was not table-scoped

`idAlreadyExists` called `writer.get(explicitId)` with no table, and `get`
resolves an id across every table. A row whose id merely coincided with one in an
unrelated table was counted in `conflicts` and silently never inserted, and the
caller could not tell that apart from a genuine same-table collision.

The probe is scoped to the row's own table. A genuine cross-table collision is
not a skippable conflict either — ids resolve per shard, not per table, so both
tables would claim the same id and every by-id read would resolve to whichever
branch the probe hit first — so it is reported per row as an `ID_COLLISION` error
instead.

## Breaking changes

Pre-release branch, so both land without shims:

- An export whose shard fan-out lost a shard fails instead of returning the
  reachable shards' rows.
- A cross-table `_id` collision on import is an entry in `errors` rather than a
  silent increment of `conflicts`.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm run build:packages` / `build:packages:prod` | 54 projects, pass |
| `pnpm run api:check` | 54 snapshots match |
| `pnpm run lint:types` (`--no-cache`) + `lint:types:registry` | 121 tasks, pass |
| `pnpm run dist:check` | 1402 files, pass |
| `pnpm run test` | 117 tasks, pass |
| `@lunora/runtime` / `@lunora/shard-engine` vitest | 1091 + 1489 pass |
| `pnpm run test:workerd` | all 11 suites pass |

Sabotage matrix — each fix reverted in isolation, paired test re-run:

| Fix reverted | Test that failed |
| --- | --- |
| `includeDeleted: true` | `exports tombstones and round-trips them as restorable rows` |
| per-table default-shard fallback | `still reaches the default shard for a root table once another table has registered keys` |
| the failed-shard throw | `errors the stream when a shard's export failed…` and `refuses to write a snapshot when a shard's export failed` |
| table-scoped id probe | `reports a cross-table _id collision per row instead of skipping it silently` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
