### PR TITLE
fix: five data-correctness defects on the write and migration paths

### DIFF
--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -4849,6 +4849,12 @@ const stableStringify: (value: unknown) => string;
 const stableWireKey: (value: unknown) => string;
 ```
 
+### `stripReservedPatchFields` (const)
+
+```ts
+const stripReservedPatchFields: (patch: Record<string, unknown>) => Record<string, unknown>;
+```
+
 ### `subscriptionFrames` (const)
 
 ```ts

--- a/packages/codegen/__tests__/schema-drift.test.ts
+++ b/packages/codegen/__tests__/schema-drift.test.ts
@@ -179,6 +179,30 @@ describe("schema-drift", () => {
             expect(newTable.changes.some((c) => c.type === "addedTable" && c.severity === "safe")).toBe(true);
         });
 
+        it("treats an added non-unique index as safe but an added UNIQUE index as breaking", () => {
+            // A non-unique index is pure DDL over rows that already satisfy it.
+            // A UNIQUE one is a constraint the stored rows may already violate,
+            // and `CREATE UNIQUE INDEX` throws inside the shard's cold-start
+            // migration when they do — so it needs a de-dup backfill first, the
+            // same classification an added `.unique()` COLUMN already gets.
+            expect.assertions(2);
+
+            const plain = diffSchemaSnapshots(
+                baseline,
+                buildSchemaSnapshot(schema([table("users", { age: numberField, name: stringField }, { indexes: [{ fields: ["name"], name: "byName" }] })]), []),
+            );
+            const unique = diffSchemaSnapshots(
+                baseline,
+                buildSchemaSnapshot(
+                    schema([table("users", { age: numberField, name: stringField }, { indexes: [{ fields: ["name"], name: "byName", unique: true }] })]),
+                    [],
+                ),
+            );
+
+            expect(plain.changes.some((c) => c.type === "addedIndex" && c.severity === "safe" && c.remediation === "none")).toBe(true);
+            expect(unique.changes.some((c) => c.type === "addedIndex" && c.severity === "breaking" && c.remediation === "backfill")).toBe(true);
+        });
+
         it("flags a dropped table, removed index, removed relation, and changed shard mode as breaking", () => {
             expect.assertions(4);
 

--- a/packages/shard-engine/__tests__/ctx-db-migrations.unique-index.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db-migrations.unique-index.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Declaring a `.unique()` index over a table that already holds duplicates is a
+ * migration that cannot succeed. It has to fail as a diagnostic naming the
+ * remedy, not as a raw `UNIQUE constraint failed` from the middle of a shard's
+ * cold-start migration — `ensureMigrated()` leaves `migrated` false after the
+ * throw, so every later dispatch re-runs and re-throws, the shard never opens,
+ * and the de-dup data migration that would fix it cannot run either (it goes
+ * through `ensureMigrated()` first).
+ */
+const withoutIndex: SchemaLike = {
+    tables: { notes: { indexes: [], shape: { slug: { kind: "string" } } } },
+};
+
+const withUniqueIndex: SchemaLike = {
+    tables: { notes: { indexes: [{ fields: ["slug"], name: "by_slug", unique: true }], shape: { slug: { kind: "string" } } } },
+};
+
+const withUniqueColumn: SchemaLike = {
+    tables: { notes: { indexes: [], shape: { slug: { _meta: { column: { unique: true } }, kind: "string" } } } },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+/** Provision the index-free shape and write two rows sharing a slug. */
+const seedDuplicates = async (): Promise<void> => {
+    runShardMigrations(harness.sql, withoutIndex);
+
+    const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema: withoutIndex, sql: harness.sql });
+
+    await writer.insert("notes", { slug: "dup" });
+    await writer.insert("notes", { slug: "dup" });
+};
+
+describe("runShardMigrations — adding a UNIQUE index over existing rows", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("refuses a declared unique index whose column list already has duplicates", async () => {
+        expect.assertions(1);
+
+        await seedDuplicates();
+
+        expect(() => {
+            runShardMigrations(harness.sql, withUniqueIndex);
+        }).toThrow(/duplicate/iu);
+    });
+
+    it("refuses a `.unique()` column whose values already have duplicates", async () => {
+        expect.assertions(1);
+
+        await seedDuplicates();
+
+        expect(() => {
+            runShardMigrations(harness.sql, withUniqueColumn);
+        }).toThrow(/duplicate/iu);
+    });
+
+    it("still creates the index when the column list is duplicate-free", async () => {
+        expect.assertions(1);
+
+        runShardMigrations(harness.sql, withoutIndex);
+
+        const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema: withoutIndex, sql: harness.sql });
+
+        await writer.insert("notes", { slug: "a" });
+        await writer.insert("notes", { slug: "b" });
+
+        runShardMigrations(harness.sql, withUniqueIndex);
+
+        expect(harness.raw(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'notes_by_slug'`)).toHaveLength(1);
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.creation-time.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.creation-time.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { BroadcastDelta, DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * `_creationTime` is documented as "when the row was inserted", and every
+ * default read order plus every keyset cursor is built on it. So it has to
+ * survive a rewrite: a `replace` that re-stamps it moves the row to the end of
+ * every `_creationTime`-ordered index, and a paginating client then sees the row
+ * twice or never. A `patch` that accepts a forged one writes it into the stored
+ * document only, so CDC rows, broadcasts and replicas disagree with what `get`
+ * reads back off the column.
+ */
+const schema: SchemaLike = {
+    tables: {
+        notes: {
+            indexes: [],
+            shape: { body: { kind: "string" } },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+let deltas: Parameters<BroadcastDelta>[0][];
+
+/** A writer whose clock advances a second per read, so a re-stamp is unmistakable. */
+const setup = (): DatabaseWriterLike => {
+    runShardMigrations(harness.sql, schema, { cdc: true });
+
+    let now = 1_700_000_000_000;
+
+    return createShardContextDatabase({
+        broadcast: (delta) => deltas.push(delta),
+        cdc: true,
+        clock: () => {
+            now += 1000;
+
+            return now;
+        },
+        schema,
+        sql: harness.sql,
+    });
+};
+
+describe("ctx-db `_creationTime` across the write verbs", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+        deltas = [];
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("replace() preserves the row's original _creationTime", async () => {
+        expect.assertions(2);
+
+        const writer = setup();
+        const id = await writer.insert("notes", { body: "first" });
+        const inserted = await writer.get(id, "notes");
+
+        await writer.replace(id, { body: "second" }, "notes");
+
+        const replaced = await writer.get(id, "notes");
+
+        expect(replaced?.["body"]).toBe("second");
+        expect(replaced?.["_creationTime"]).toBe(inserted?.["_creationTime"]);
+    });
+
+    it("replace() still honors an explicit _creationTime under allowExplicitId", async () => {
+        expect.assertions(1);
+
+        const writer = setup();
+        const id = await writer.insert("notes", { body: "first" });
+
+        await writer.replace(id, { _creationTime: 42, body: "second" }, "notes", { allowExplicitId: true });
+
+        const replaced = await writer.get(id, "notes");
+
+        expect(replaced?.["_creationTime"]).toBe(42);
+    });
+
+    it("patch() ignores a forged _creationTime in the patch object", async () => {
+        expect.assertions(3);
+
+        const writer = setup();
+        const id = await writer.insert("notes", { body: "first" });
+        const inserted = await writer.get(id, "notes");
+
+        deltas = [];
+
+        await writer.patch(id, { _creationTime: 1, body: "second" }, "notes");
+
+        const patched = await writer.get(id, "notes");
+        const logged = harness.raw(`SELECT doc FROM "__cdc_log" WHERE op = 'update' ORDER BY seq DESC LIMIT 1`)[0];
+        const loggedDocument = typeof logged?.["doc"] === "string" ? (JSON.parse(logged["doc"]) as Record<string, unknown>) : {};
+
+        // The stored column is what `get` reads back...
+        expect(patched?.["_creationTime"]).toBe(inserted?.["_creationTime"]);
+        // ...so the broadcast and the CDC row a replica applies must agree with it.
+        expect(deltas[0]?.row?.["_creationTime"]).toBe(inserted?.["_creationTime"]);
+        expect(loggedDocument["_creationTime"]).toBe(inserted?.["_creationTime"]);
+    });
+});

--- a/packages/shard-engine/__tests__/data-migration.test.ts
+++ b/packages/shard-engine/__tests__/data-migration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { SqlExec } from "../src/ctx-db";
+import type { SqlExec, WriteHook } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase } from "../src/ctx-db";
 import { runShardMigrations } from "../src/ctx-db-migrations";
 import type { DataMigrationLike } from "../src/data-migration";
@@ -31,11 +31,12 @@ const usersSchema: SchemaLike = {
 
 let harness: ReturnType<typeof createSqliteExec>;
 
-const setupWriter = (): DatabaseWriterLike => {
+const setupWriter = (overrides: { onWrite?: WriteHook } = {}): DatabaseWriterLike => {
     runShardMigrations(harness.sql, usersSchema);
 
     return createShardContextDatabase({
         clock: () => 1_700_000_000_000,
+        onWrite: overrides.onWrite,
         schema: usersSchema,
         sql: harness.sql,
     });
@@ -713,10 +714,86 @@ describe("runDataMigration", () => {
 
             expect(snapshot.map((document) => document["version"])).toEqual([1, 1, 1, 1, 1]);
         });
+
+        it("does not re-apply a row whose write committed before a post-write hook threw", async () => {
+            // `replace` commits the guarded UPDATE and only THEN awaits its
+            // after-update triggers and `onWrite`. A throw from there is not a
+            // failed write — the row is already rewritten — so the runner has to
+            // advance past it. Leaving the cursor behind makes the resume bump a
+            // `version + 1` transform twice on a row that was already migrated.
+            expect.assertions(3);
+
+            let explode = true;
+
+            const writer = setupWriter({
+                onWrite: ({ id, op }) => {
+                    if (explode && op === "update" && id === "u3") {
+                        explode = false;
+
+                        throw new Error("post-write hook exploded");
+                    }
+                },
+            });
+
+            await seed(writer);
+
+            await expect(runDataMigration({ batchSize: 10, migration: bumpVersion, sql: harness.sql, writer })).rejects.toThrow("post-write hook exploded");
+
+            // u3's UPDATE committed before the hook ran, so it is already at 1.
+            const halfway = await allUsers(writer);
+
+            expect(halfway.map((document) => document["version"])).toEqual([1, 1, 1, 0, 0]);
+
+            await runDataMigration({ batchSize: 10, migration: bumpVersion, sql: harness.sql, writer });
+
+            const resumed = await allUsers(writer);
+
+            expect(resumed.map((document) => document["version"])).toEqual([1, 1, 1, 1, 1]);
+        });
+    });
+
+    describe("runDataMigration — soft-deleted rows", () => {
+        it("visits a soft-deleted row, so restoring it cannot resurrect a pre-migration document", async () => {
+            // `findMany` hides tombstones by default, so the runner walked past
+            // them and recorded `completed`. A later `restore(id)` then handed the
+            // application a document written against the old shape.
+            expect.assertions(2);
+
+            const softSchema: SchemaLike = {
+                tables: {
+                    users: {
+                        indexes: [],
+                        shape: { deletedAt: { kind: "number" }, name: { kind: "string" }, score: { kind: "number" }, version: { kind: "number" } },
+                        softDeleteMode: { field: "deletedAt" },
+                    },
+                },
+            };
+
+            runShardMigrations(harness.sql, softSchema);
+
+            const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema: softSchema, sql: harness.sql });
+
+            await writer.insert("users", { _id: "u1", name: "one", score: 10, version: 0 }, { allowExplicitId: true });
+            await writer.insert("users", { _id: "u2", name: "two", score: 20, version: 0 }, { allowExplicitId: true });
+            await writer.delete("u2", "users");
+
+            const result = await runDataMigration({ migration: bumpVersion, sql: harness.sql, writer });
+
+            expect(result).toMatchObject({ changed: 2, processed: 2, status: "completed" });
+
+            await writer.restore?.("u2", "users");
+
+            const restored = await writer.get("u2", "users");
+
+            expect(restored?.["version"]).toBe(1);
+        });
     });
 
     describe("runDataMigration — resume across a cursor-format bump", () => {
-        it("resumes from a cursor minted under the previous cursor prefix", async () => {
+        // Every prefix a build before the current one stamped. The runner's key
+        // list is the fixed `MIGRATION_ORDER_KEYS`, so the payload is
+        // `[_creationTime, _id]` under all of them and only the stamp differs.
+        it.each(["~2", "~3"])("resumes from a cursor minted under the %s prefix", async (priorPrefix) => {
             expect.assertions(3);
 
             const writer = setupWriter();
@@ -736,7 +813,7 @@ describe("runDataMigration", () => {
              * payload itself is untouched: this runner's key list is fixed, so it
              * is `[_creationTime, _id]` on both sides of the bump.
              */
-            harness.raw(`UPDATE "${DATA_MIGRATION_STATE_TABLE}" SET cursor = '~2' || substr(cursor, 3) WHERE id = ?`, "bump-version");
+            harness.raw(`UPDATE "${DATA_MIGRATION_STATE_TABLE}" SET cursor = ? || substr(cursor, 3) WHERE id = ?`, priorPrefix, "bump-version");
 
             const second = await runDataMigration({ batchSize: 10, migration: bumpVersion, sql: harness.sql, writer });
 

--- a/packages/shard-engine/src/ctx-db-migrations.ts
+++ b/packages/shard-engine/src/ctx-db-migrations.ts
@@ -71,6 +71,39 @@ import { recordSchemaVersion } from "./schema-history";
 const INDEX_SORT_KEYS = dsql`_creationTime, id`;
 
 /**
+ * Refuse to build a UNIQUE index over rows that already violate it.
+ *
+ * `CREATE UNIQUE INDEX` raises a bare `UNIQUE constraint failed: index '<name>'`
+ * on duplicates, and it raises it from inside the cold-start migration —
+ * `ensureMigrated()` leaves `migrated` false, so every later dispatch re-runs
+ * the pass and re-throws. The shard never opens, and the de-dup
+ * `defineMigration` that would clear it cannot run either, because
+ * `runShardDataMigration` calls `ensureMigrated()` first. Probing first turns a
+ * wedged shard into a diagnostic that names the table and the remedy.
+ *
+ * Restricted to rows where EVERY indexed column is non-NULL, because the two
+ * sides disagree about NULL: `GROUP BY` treats NULLs as equal, a SQLite UNIQUE
+ * index treats them as distinct. `json_extract` yields NULL for an unset
+ * optional field, so without the filter two rows that simply never set an
+ * optional `.unique()` column read as a duplicate and a `CREATE UNIQUE INDEX`
+ * that would have SUCCEEDED is refused.
+ */
+const assertNoDuplicatesUnder = (sql: SqlExec, indexName: string, tableName: string, expressions: SQL, refs: ReadonlyArray<SQL>, situation: string): void => {
+    const nonNull = dsql.join(
+        refs.map((reference) => dsql`${reference} IS NOT NULL`),
+        dsql` AND `,
+    );
+    const duplicates = runDrizzle(sql, dsql`SELECT 1 FROM ${dsql.identifier(tableName)} WHERE ${nonNull} GROUP BY ${expressions} HAVING COUNT(*) > 1 LIMIT 1`);
+
+    if (duplicates.toArray().length > 0) {
+        throw new LunoraError(
+            "INTERNAL",
+            `unique index "${indexName}" on "${tableName}" ${situation}: existing rows are duplicates under it. De-duplicate the table with a data migration first; the previous index is left in place.`,
+        );
+    }
+};
+
+/**
  * Drop `indexName` when the index SQLite already holds was built from a
  * different column list than the one we are about to create.
  *
@@ -134,31 +167,35 @@ const dropIndexIfShapeChanged = (sql: SqlExec, indexName: string, tableName: str
     // already carry the same catalog-parsing logic, and a guard on one
     // destructive DDL path but not the other is worse than the duplication.
     if (unique) {
-        // Restricted to rows where EVERY indexed column is non-NULL, because the
-        // two sides disagree about NULL: `GROUP BY` treats NULLs as equal, a
-        // SQLite UNIQUE index treats them as distinct. `json_extract` yields NULL
-        // for an unset optional field, so without the filter two rows that simply
-        // never set an optional `.unique()` column read as a duplicate, this
-        // throws, and a `CREATE UNIQUE INDEX` that would have SUCCEEDED is
-        // refused — inside the shard migration, so the shard never opens again.
-        const nonNull = dsql.join(
-            refs.map((reference) => dsql`${reference} IS NOT NULL`),
-            dsql` AND `,
-        );
-        const duplicates = runDrizzle(
-            sql,
-            dsql`SELECT 1 FROM ${dsql.identifier(tableName)} WHERE ${nonNull} GROUP BY ${expressions} HAVING COUNT(*) > 1 LIMIT 1`,
-        );
-
-        if (duplicates.toArray().length > 0) {
-            throw new LunoraError(
-                "INTERNAL",
-                `unique index "${indexName}" on "${tableName}" cannot be re-created with its new column list: existing rows are duplicates under it. De-duplicate the table with a data migration first; the previous index is left in place.`,
-            );
-        }
+        assertNoDuplicatesUnder(sql, indexName, tableName, expressions, refs, "cannot be re-created with its new column list");
     }
 
     runDrizzle(sql, dsql`DROP INDEX IF EXISTS ${dsql.identifier(indexName)}`);
+};
+
+/**
+ * Whether SQLite already holds an index under this name on this table.
+ *
+ * The duplicate probe below is a `GROUP BY` over the whole table, so it only
+ * runs when the `CREATE ... IF NOT EXISTS` that follows would really build
+ * something — an index already in place has been enforcing the constraint all
+ * along, and re-scanning for it on every cold start would be pure cost.
+ */
+const indexIsHeld = (sql: SqlExec, indexName: string, tableName: string): boolean =>
+    runDrizzle(sql, dsql`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ${indexName} AND tbl_name = ${tableName} LIMIT 1`).toArray().length > 0;
+
+/**
+ * Create one index, probing for duplicates first when it is UNIQUE and not yet
+ * provisioned — see {@link assertNoDuplicatesUnder}. Both producers of a UNIQUE
+ * index (a declared `unique: true` index, a `.unique()` column) go through here,
+ * so neither can reach `CREATE UNIQUE INDEX` unguarded.
+ */
+const createIndexGuarded = (sql: SqlExec, indexName: string, tableName: string, expressions: SQL, unique: boolean, refs: ReadonlyArray<SQL>): void => {
+    if (unique && !indexIsHeld(sql, indexName, tableName)) {
+        assertNoDuplicatesUnder(sql, indexName, tableName, expressions, refs, "cannot be created");
+    }
+
+    runDrizzle(sql, createIndexSql(indexName, tableName, expressions, unique));
 };
 
 /**
@@ -178,7 +215,7 @@ const migrateSecondaryIndexes = (sql: SqlExec, tableName: string, definition: Ta
         const expressions = unique ? fields : dsql`${fields}, ${INDEX_SORT_KEYS}`;
 
         dropIndexIfShapeChanged(sql, indexName, tableName, expressions, unique, refs);
-        runDrizzle(sql, createIndexSql(indexName, tableName, expressions, unique));
+        createIndexGuarded(sql, indexName, tableName, expressions, unique, refs);
     }
 
     // `.unique()` columns synthesize a UNIQUE expression index so SQLite
@@ -188,9 +225,9 @@ const migrateSecondaryIndexes = (sql: SqlExec, tableName: string, definition: Ta
             continue;
         }
 
-        const indexName = `${tableName}_unique_${field}`;
+        const reference = jsonPathSql(field);
 
-        runDrizzle(sql, createIndexSql(indexName, tableName, jsonPathSql(field), true));
+        createIndexGuarded(sql, `${tableName}_unique_${field}`, tableName, reference, true, [reference]);
     }
 };
 

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -2063,6 +2063,33 @@ const assertNoExplicitUndefined = (op: "patch" | "replace", document: Record<str
     }
 };
 
+/**
+ * The system fields a `patch` object may not set. `_id` and `_creationTime` are
+ * the row's identity and its insertion time; `_commitSeq` is minted per write.
+ */
+const PATCH_RESERVED_FIELDS: ReadonlyArray<string> = ["_commitSeq", "_creationTime", "_id"];
+
+/**
+ * Drop the system fields from a patch object.
+ *
+ * A patch is a partial document, and the merge that builds the written row put
+ * whatever it carried straight into the stored blob. A forged `_creationTime`
+ * therefore reached `__doc__` ONLY — `get` re-reads that field off the real
+ * column and disagreed, while the CDC row, the broadcast delta and every replica
+ * applying them carried the forgery. Stripping here, at the one place a patch is
+ * merged, keeps the row's own copy of a system field authoritative.
+ *
+ * Returns the argument untouched when it carries none of them, which is every
+ * ordinary patch — the copy is only paid for by a caller that actually sent one.
+ */
+const stripReservedPatchFields = (patch: Record<string, unknown>): Record<string, unknown> => {
+    if (!PATCH_RESERVED_FIELDS.some((field) => field in patch)) {
+        return patch;
+    }
+
+    return Object.fromEntries(Object.entries(patch).filter(([field]) => !PATCH_RESERVED_FIELDS.includes(field)));
+};
+
 /** workerd and node:sqlite both phrase a UNIQUE-index breach as "UNIQUE constraint failed". */
 const UNIQUE_VIOLATION_RE = /unique constraint failed/i;
 const isUniqueViolation = (error: unknown): boolean => error instanceof Error && UNIQUE_VIOLATION_RE.test(error.message);
@@ -4234,7 +4261,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // would silently strip them, deleting the field instead of updating it.
             assertNoExplicitUndefined("patch", patch);
 
-            const merged = { ...existing, ...patch, ...commitSeqFields(tableName), _id: id };
+            const merged = { ...existing, ...stripReservedPatchFields(patch), ...commitSeqFields(tableName), _id: id };
 
             applyOnUpdate(tableDefinition, patch, merged, auth);
 
@@ -4663,12 +4690,22 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // would silently strip them, deleting the field instead of writing it.
             assertNoExplicitUndefined("replace", document);
 
+            // `_creationTime` is when the row was INSERTED, so a rewrite carries
+            // the stored one forward — the same thing `patch` does. Minting a
+            // fresh `clock()` here moved every replaced row to the end of every
+            // `_creationTime`-ordered index and past every live keyset cursor, so
+            // a paginating client saw it twice or never.
+            //
             // A client-supplied `_creationTime` is honored only under the
             // trusted-replay `allowExplicitId` opt-in (CDC replay, data-migration
-            // rewrite — both replay a row's original creation time). The default
-            // mutation path mints from `clock()` so a forged document
-            // `_creationTime` can't overwrite the persisted timestamp.
-            const creationTime = replaceOptions?.allowExplicitId && typeof document["_creationTime"] === "number" ? document["_creationTime"] : clock();
+            // rewrite — both replay a row's original creation time); a forged one
+            // on the default mutation path cannot overwrite the persisted
+            // timestamp.
+            const replayed = replaceOptions?.allowExplicitId && typeof document["_creationTime"] === "number" ? document["_creationTime"] : undefined;
+            const stored = typeof previous["_creationTime"] === "number" ? previous["_creationTime"] : undefined;
+            // `clock()` is the last resort, for a row with no readable stored
+            // timestamp; the `??` chain keeps it unevaluated on the normal paths.
+            const creationTime = replayed ?? stored ?? clock();
             const replaced: Record<string, unknown> = { ...document, ...commitSeqFields(tableName), _creationTime: creationTime, _id: id };
 
             applyOnUpdate(tableDefinition, document, replaced, auth);
@@ -4817,7 +4854,7 @@ export { IDEMPOTENCY_TABLE, readIdempotent, trimIdempotent, writeIdempotent } fr
 export { runShardMigrations } from "./ctx-db-migrations";
 export { SEARCH_STATE_TABLE } from "./ctx-db-search-state";
 export type { ShapeRow } from "./ctx-db-shapes";
-export { assertNoExplicitUndefined };
+export { assertNoExplicitUndefined, stripReservedPatchFields };
 export { selectShapeMembers, selectShapeRows } from "./ctx-db-shapes";
 export {
     type BroadcastDelta,

--- a/packages/shard-engine/src/data-migration.ts
+++ b/packages/shard-engine/src/data-migration.ts
@@ -440,18 +440,26 @@ const readMigrationStatus = (sql: SqlExec, id?: string): MigrationStatusRow[] =>
 const MIGRATION_ORDER_KEYS: OrderKey[] = [{ direction: "asc", field: "_creationTime", nullable: false }];
 
 /**
- * The cursor prefix this runner's persisted resume points were minted under
- * before {@link CURSOR_PREFIX} was bumped to `"~3"`.
+ * Every cursor prefix this runner's persisted resume points were minted under
+ * before {@link CURSOR_PREFIX} reached its current value.
+ *
+ * All of them, not just the immediately preceding one: a migration that paused
+ * two bumps ago is exactly as stuck as one that paused under the last. Each
+ * bump must ADD its predecessor here after re-verifying the payload claim below,
+ * which is why this is a set of prefixes rather than a "anything older" test.
  */
-const PRIOR_CURSOR_PREFIX = "~2";
+const PRIOR_CURSOR_PREFIXES = /^~[23]/u;
 
 /**
- * Re-stamp a persisted resume cursor that was minted under {@link PRIOR_CURSOR_PREFIX}.
+ * Re-stamp a persisted resume cursor that was minted under one of
+ * {@link PRIOR_CURSOR_PREFIXES}.
  *
- * The bump exists because a `.withIndex(q => q.eq(f, v)).paginate()` cursor
- * changed payload — `[value, id]` became `[creationTime, id]`, the same length,
- * so nothing downstream could catch it — and `decodeCursor` therefore refuses
- * any older prefix outright. Correct there; fatal here. This runner PERSISTS its
+ * Each bump exists because some OTHER read's cursor changed payload at the same
+ * length, so nothing downstream could catch it — `~2` -> `~3` when a
+ * `.withIndex(q => q.eq(f, v)).paginate()` cursor went from `[value, id]` to
+ * `[creationTime, id]`, `~3` -> `~4` when `normalizeOrderKeys` learned to drop
+ * keys and so made some lists SHORTER. `decodeCursor` therefore refuses any
+ * older prefix outright. Correct there; fatal here. This runner PERSISTS its
  * cursor, so a resume fed the stored value straight back into `findMany`, threw
  * `invalid cursor`, and re-persisted `failed` with the same doomed cursor: every
  * later run of that migration wedged on it, with no reset short of running the
@@ -460,18 +468,72 @@ const PRIOR_CURSOR_PREFIX = "~2";
  *
  * Safe HERE and only here, for one reason: this path's key list is
  * {@link MIGRATION_ORDER_KEYS}, a fixed constant that bypasses
- * `normalizeOrderKeys` entirely, so its payload is `[_creationTime, _id]` on
- * BOTH sides of the bump — byte-for-byte valid, stale prefix and all. Nothing
- * general may be inferred from that: making `decodeCursor` itself lenient would
- * restore exactly the silently-wrong page the bump was minted to stop.
+ * `normalizeOrderKeys` entirely, and it has held that same value across both
+ * bumps — so its payload is `[_creationTime, _id]` under `~2`, `~3` and `~4`
+ * alike, byte-for-byte valid, stale prefix and all. Nothing general may be
+ * inferred from that: making `decodeCursor` itself lenient would restore exactly
+ * the silently-wrong page the bumps were minted to stop.
  *
- * A FUTURE prefix bump must re-verify this before adding its own predecessor
- * here — if the encoded payload for `[_creationTime, _id]` ever changes, the
- * cursor is not merely mis-prefixed and re-stamping it would seek to the wrong
- * row.
+ * A FUTURE prefix bump must re-verify this before adding its own predecessor to
+ * {@link PRIOR_CURSOR_PREFIXES} — if the encoded payload for
+ * `[_creationTime, _id]` ever changes, the cursor is not merely mis-prefixed and
+ * re-stamping it would seek to the wrong row.
  */
-const restampResumeCursor = (cursor: null | string): null | string =>
-    typeof cursor === "string" && cursor.startsWith(PRIOR_CURSOR_PREFIX) ? CURSOR_PREFIX + cursor.slice(PRIOR_CURSOR_PREFIX.length) : cursor;
+const restampResumeCursor = (cursor: null | string): null | string => {
+    if (typeof cursor !== "string") {
+        return cursor;
+    }
+
+    const prior = PRIOR_CURSOR_PREFIXES.exec(cursor);
+
+    return prior === null ? cursor : CURSOR_PREFIX + cursor.slice(prior[0].length);
+};
+
+/**
+ * Rewrite one row, reporting it settled the moment its write LANDS rather than
+ * when this call returns.
+ *
+ * Those are not the same moment: `replace` commits its guarded UPDATE and only
+ * THEN awaits its after-update triggers and `onWrite`, so a throw out of it is
+ * not proof the write failed. The runner has to know which it was — leaving the
+ * cursor behind a row that IS rewritten makes the resume re-apply a
+ * non-idempotent transform to it, and moving the cursor past one that is NOT
+ * leaves it unmigrated for good.
+ *
+ * Only the stored row can say, so it is read back: a row that still matches what
+ * `replace` compare-and-swapped on was never written (a before-update trigger
+ * threw, or the CAS lost), while one that moved was. The single case the two
+ * collapse into is a transform whose output is byte-identical to its input,
+ * where re-applying it on resume is by definition harmless.
+ */
+const rewriteRow = async (options: {
+    document: Record<string, unknown>;
+    id: string;
+    onSettled: (outcome: "changed" | "unchanged") => void;
+    /** The row image `replace` was handed, as read immediately before the write. */
+    previous: Record<string, unknown>;
+    table: string;
+    writer: DatabaseWriterLike;
+}): Promise<void> => {
+    const { document, id, onSettled, previous, table, writer } = options;
+
+    try {
+        // Trusted rewrite: replay the row's original `_creationTime` via the
+        // `allowExplicitId` opt-in, so the rewrite is explicit about the
+        // timestamp it means rather than leaning on `replace`'s default.
+        await writer.replace(id, document, undefined, { allowExplicitId: true });
+    } catch (error) {
+        const after = await writer.get(id, table);
+
+        if (after !== null && stableWireKey(after) !== stableWireKey(previous)) {
+            onSettled("changed");
+        }
+
+        throw error;
+    }
+
+    onSettled("changed");
+};
 
 /**
  * How many times one row's transform is re-applied against a fresher read before
@@ -501,17 +563,25 @@ const MAX_ROW_ATTEMPTS = 3;
  * failed, which would let one hot row abort a whole shard's run) — and a row
  * that keeps moving eventually raises, because a transform that can never see a
  * stable row is not something to paper over.
- * @returns whether the row was rewritten (`changed`) or left alone
+ *
+ * `onSettled` reports the row as fully handled, and fires from INSIDE rather
+ * than on return, because those two are not the same moment: `replace` commits
+ * its guarded UPDATE and only then awaits its after-update triggers and
+ * `onWrite`, so a throw from there still leaves the row rewritten. Counting from
+ * the caller left the cursor behind such a row and the resume re-applied a
+ * non-idempotent transform to it. A row this gives up on (see
+ * {@link MAX_ROW_ATTEMPTS}) is deliberately never settled — it is not handled.
  */
 const applyTransformToRow = async (options: {
     context: DataMigrationContext;
     document: DataMigrationDocument;
     dryRun: boolean;
+    onSettled: (outcome: "changed" | "unchanged") => void;
     table: string;
     transform: DataMigrationTransform;
     writer: DatabaseWriterLike;
-}): Promise<"changed" | "unchanged"> => {
-    const { context, document, dryRun, table, transform, writer } = options;
+}): Promise<void> => {
+    const { context, document, dryRun, onSettled, table, transform, writer } = options;
     const id = String(document["_id"]);
     let source = document;
 
@@ -520,11 +590,15 @@ const applyTransformToRow = async (options: {
         const next = await transform(source, context);
 
         if (next === undefined) {
-            return "unchanged";
+            onSettled("unchanged");
+
+            return;
         }
 
         if (dryRun) {
-            return "changed";
+            onSettled("changed");
+
+            return;
         }
 
         // Pinned to the migration's own table: a bare `get` probes every table in
@@ -535,16 +609,23 @@ const applyTransformToRow = async (options: {
         if (latest === null) {
             // Deleted under us. Rewriting it would resurrect a row the
             // application removed, so leave it: counted processed, not changed.
-            return "unchanged";
+            onSettled("unchanged");
+
+            return;
         }
 
         if (stableWireKey(latest) === stableWireKey(source)) {
-            // Trusted rewrite: preserve the row's original `_creationTime` via
-            // the `allowExplicitId` opt-in (default replace mints a fresh clock()).
             // eslint-disable-next-line no-await-in-loop -- writes share one SQLite handle; parallelizing would interleave statements on a single connection.
-            await writer.replace(id, { ...next, _creationTime: source["_creationTime"], _id: source["_id"] }, undefined, { allowExplicitId: true });
+            await rewriteRow({
+                document: { ...next, _creationTime: source["_creationTime"], _id: source["_id"] },
+                id,
+                onSettled,
+                previous: latest,
+                table,
+                writer,
+            });
 
-            return "changed";
+            return;
         }
 
         source = latest;
@@ -660,25 +741,43 @@ const runDataMigration = async (options: RunDataMigrationOptions): Promise<Migra
 
     try {
         while (!isDone && batches < maxBatches) {
+            // `includeDeleted` because a soft-deleted row is still a row: the
+            // tombstone keeps its document, `restore(id)` hands it back to the
+            // application, and a migration that skipped it resurrects a
+            // pre-migration document into a schema that has moved on. Without
+            // this the run also records `completed` while `countLegacyRows` —
+            // which counts tombstones, being raw SQL — never reaches zero.
+            //
             // eslint-disable-next-line no-await-in-loop -- batches must run sequentially: each page's cursor depends on the prior page, and all rewrites share one SQLite handle.
-            const batch = await writer.findMany(migration.table, { cursor, limit: batchSize });
+            const batch = await writer.findMany(migration.table, { cursor, includeDeleted: true, limit: batchSize });
 
             for (const document of batch.page) {
+                // Counted and cursor-advanced only once the row is fully handled,
+                // and from INSIDE the call rather than after it. Both used to move
+                // BEFORE the transform / at the end of the batch, so a mid-batch
+                // throw persisted the page-START cursor with the failed row
+                // already counted; moving them here but after the `await` then
+                // left the cursor behind a row whose write had COMMITTED and only
+                // whose after-update trigger threw. Either way the resume
+                // re-walked rows it had already rewritten, bumping a
+                // `version + 1` transform twice.
                 // eslint-disable-next-line no-await-in-loop -- rows share one SQLite handle; a transform's cross-table read must complete before the next row's rewrite
-                const outcome = await applyTransformToRow({ context: migrationContext, document, dryRun, table: migration.table, transform, writer });
+                await applyTransformToRow({
+                    context: migrationContext,
+                    document,
+                    dryRun,
+                    onSettled: (outcome) => {
+                        if (outcome === "changed") {
+                            changed += 1;
+                        }
 
-                if (outcome === "changed") {
-                    changed += 1;
-                }
-
-                // Counted and cursor-advanced only once the row is fully handled.
-                // Both used to move BEFORE the transform / at the end of the batch,
-                // so a mid-batch throw persisted the page-start cursor with the
-                // failed row already counted: the resume re-walked rows it had
-                // already rewritten (bumping a `version + 1` transform twice) and
-                // re-counted them.
-                processed += 1;
-                cursor = encodeCursor(document, MIGRATION_ORDER_KEYS);
+                        processed += 1;
+                        cursor = encodeCursor(document, MIGRATION_ORDER_KEYS);
+                    },
+                    table: migration.table,
+                    transform,
+                    writer,
+                });
 
                 // Mid-batch heartbeat: keep the claim fresh so a batch that runs
                 // longer than the stale-claim window can't be reclaimed out from

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -63,6 +63,7 @@ export {
     readCdcChangeKeys,
     readCdcChanges,
     runShardMigrations,
+    stripReservedPatchFields,
     trimCdcChanges,
 } from "./ctx-db";
 export { backfillSearchIndexesForTable } from "./ctx-db-backfill";

--- a/packages/sql-store/__tests__/ctx-db.test.ts
+++ b/packages/sql-store/__tests__/ctx-db.test.ts
@@ -1208,7 +1208,12 @@ describe("createSqlCtxDb — _creationTime is server-authoritative", () => {
         expect(insert?.params[1]).toBe(1);
     });
 
-    it("replace() mints clock() and ignores a forged document _creationTime", async () => {
+    it("replace() preserves the stored _creationTime and ignores a forged one", async () => {
+        // `_creationTime` is when the row was INSERTED, and every default order
+        // and keyset cursor is built on it — so a rewrite must not re-stamp it,
+        // or the row jumps to the end of every ordered read and a paginating
+        // client sees it twice or never. `patch` preserves it; the two write
+        // verbs cannot disagree about a system field.
         expect.assertions(3);
 
         // resolveTableName + the OCC snapshot both read; return this row for every SELECT.
@@ -1221,9 +1226,24 @@ describe("createSqlCtxDb — _creationTime is server-authoritative", () => {
         const update = calls.find((call) => /update .*notes.* set/iu.test(call.sql));
 
         expect(update).toBeDefined();
-        // The SET clause binds `_creationTime = ?` first, so the minted clock() is the leading param — never the forged 5.
-        expect(update?.params[0]).toBe(CLOCK);
+        // The SET clause binds `_creationTime = ?` first, so the stored 42 is the leading param — never the forged 5, never a fresh clock().
+        expect(update?.params[0]).toBe(42);
         expect(update?.params).not.toContain(5);
+    });
+
+    it("replace() WITH allowExplicitId honors the document _creationTime (import/CDC replay)", async () => {
+        expect.assertions(2);
+
+        const snapshotRow = { _creationTime: 42, archived: 0, body: "x", id: "row1", priority: 1, slug: "s" };
+        const { calls, exec } = recordingExecWithParams([snapshotRow]);
+        const writer = createSqlCtxDb({ clock: () => CLOCK, dialect: makeSqliteDialect(), exec, schema });
+
+        await writer.replace("row1", { _creationTime: 5, archived: false, body: "y", priority: 7, slug: "s" }, undefined, { allowExplicitId: true });
+
+        const update = calls.find((call) => /update .*notes.* set/iu.test(call.sql));
+
+        expect(update).toBeDefined();
+        expect(update?.params[0]).toBe(5);
     });
 });
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -101,6 +101,7 @@ import {
     selectIndexForGroupBy,
     softDeleteScope,
     sortColumnName,
+    stripReservedPatchFields,
     throwingScheduler,
     tiebreakDirectionFor,
     uniqueIndexFields,
@@ -3340,7 +3341,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 throw new LunoraError("INTERNAL", `document not found: ${id}`);
             }
 
-            const merged: Record<string, unknown> = { ...existing, ...patch, _id: id };
+            const merged: Record<string, unknown> = { ...existing, ...stripReservedPatchFields(patch), _id: id };
 
             applyOnUpdate(definition, patch, merged, auth);
 
@@ -3864,12 +3865,22 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             const needsPrevious =
                 hasTrigger(schema, tableName, "update") || (definition.aggregateIndexes ?? []).length > 0 || (definition.rankIndexes ?? []).length > 0;
             const previous = needsPrevious ? (decodeRow(definition, snapshot) ?? undefined) : undefined;
+            // `_creationTime` is when the row was INSERTED, so a rewrite carries
+            // the stored one forward — the same thing `patch` does. Minting a
+            // fresh `clock()` here moved every replaced row to the end of every
+            // `_creationTime`-ordered index and past every live keyset cursor, so
+            // a paginating client saw it twice or never.
+            //
             // A client-supplied `_creationTime` is honored only under the
             // trusted-replay `allowExplicitId` opt-in (CDC replay, data-migration
-            // rewrite — both replay a row's original creation time). The default
-            // mutation path mints from `clock()` so a forged document
-            // `_creationTime` can't overwrite the persisted timestamp.
-            const creationTime = replaceOptions?.allowExplicitId && typeof document["_creationTime"] === "number" ? document["_creationTime"] : clock();
+            // rewrite — both replay a row's original creation time); a forged one
+            // on the default mutation path cannot overwrite the persisted
+            // timestamp.
+            const replayed = replaceOptions?.allowExplicitId && typeof document["_creationTime"] === "number" ? document["_creationTime"] : undefined;
+            const stored = typeof snapshot["_creationTime"] === "number" ? snapshot["_creationTime"] : undefined;
+            // `clock()` is the last resort, for a row with no readable stored
+            // timestamp; the `??` chain keeps it unevaluated on the normal paths.
+            const creationTime = replayed ?? stored ?? clock();
             const replaced: Record<string, unknown> = { ...document, _creationTime: creationTime, _id: id };
 
             applyOnUpdate(definition, document, replaced, auth);

--- a/shared/schema-snapshot.ts
+++ b/shared/schema-snapshot.ts
@@ -680,14 +680,32 @@ const diffIndexes = (tableName: string, baseline: TableSnapshot, current: TableS
         const old = baseline.indexes[name];
 
         if (old === undefined) {
-            changes.push({
-                remediation: "none",
-                scope: "table",
-                severity: "safe",
-                summary: `added index ${name} on ${tableName}`,
-                table: tableName,
-                type: "addedIndex",
-            });
+            // A UNIQUE index is a CONSTRAINT, not just DDL: the rows already on
+            // disk may violate it, and nothing in the schema can say whether they
+            // do. `CREATE UNIQUE INDEX` then throws inside the shard's cold-start
+            // migration, `ensureMigrated()` leaves the shard unmigrated, and every
+            // later dispatch re-runs and re-throws — the shard never opens, and
+            // the de-dup data migration that would fix it cannot run either.
+            // Same classification an added `.unique()` COLUMN already carries.
+            changes.push(
+                index.unique
+                    ? {
+                          remediation: "backfill",
+                          scope: "table",
+                          severity: "breaking",
+                          summary: `added unique index ${name} on ${tableName} — existing duplicates would violate it; add a data migration to de-duplicate first`,
+                          table: tableName,
+                          type: "addedIndex",
+                      }
+                    : {
+                          remediation: "none",
+                          scope: "table",
+                          severity: "safe",
+                          summary: `added index ${name} on ${tableName}`,
+                          table: tableName,
+                          type: "addedIndex",
+                      },
+            );
 
             continue;
         }


### PR DESCRIPTION
Five reproduced data-correctness defects on the write and data-migration paths. Each one
got a failing test written against the unfixed code first, run to confirm it failed, and
re-run after the fix.

## `_creationTime` no longer moves

`replace()` bound `clock()` unless `allowExplicitId` supplied a timestamp, so every
replaced row got a fresh insertion time — jumping to the end of every
`_creationTime`-ordered index and past every live keyset cursor, where a paginating client
sees it twice or never. `patch()` preserves it, so the two write verbs disagreed about a
field the docs define as "when the row was inserted". Fixed on both the shard plane and
the global (sql-store) plane; `allowExplicitId` still replays an explicit timestamp for
CDC replay and the data-migration rewrite.

**Contract change:** `packages/sql-store/__tests__/ctx-db.test.ts` carried
`replace() mints clock() and ignores a forged document _creationTime`, which pinned the
old behaviour. It is rewritten to pin preservation, plus a new case for the
`allowExplicitId` replay. That flip is deliberate.

Folded in: `patch` now strips `_id`/`_creationTime`/`_commitSeq` from the patch object
before merging. A forged `_creationTime` reached the stored blob only, so `get` re-read
the real column and disagreed while the CDC row, the broadcast delta and every replica
applying them carried the forgery.

## A unique index over duplicates no longer bricks the shard

`diffIndexes` gave an added index `severity: "safe", remediation: "none"` whether or not
it was UNIQUE, so the deploy gate waved it through. `runShardMigrations` then ran
`CREATE UNIQUE INDEX`, which throws on existing duplicates — from inside the cold-start
pass, where `ensureMigrated()` leaves `migrated` false. Every later dispatch re-ran and
re-threw, so the shard never opened, and the de-dup `defineMigration` that would clear it
could not run either (`runShardDataMigration` calls `ensureMigrated()` first).

Both halves are fixed, because the gate and the runtime each have to hold on their own:
an added unique index is now breaking/backfill (matching what an added `.unique()` column
already was), and both producers of a unique index route through one create helper that
runs the existing `GROUP BY … HAVING COUNT(*) > 1` probe first. The probe only runs when
the index is not already held, so a cold start costs nothing extra.

## A paused data migration is resumable again

Three separate ways the runner broke its own "each row is visited exactly once … survives
a failure" promise:

- **A `~3` resume cursor was refused forever.** `restampResumeCursor` only re-stamped
  `~2` while `CURSOR_PREFIX` had reached `~4`, so a migration paused on a `~3` build threw
  `invalid cursor` and the catch re-persisted `failed` with the same doomed cursor. Now
  every prior prefix is re-stamped. The safety claim was re-verified against both bumps
  rather than assumed: the runner mints from the fixed `MIGRATION_ORDER_KEYS`, which held
  the same value at each bump, so the payload is `[_creationTime, _id]` under `~2`, `~3`
  and `~4` alike.
- **A throw after the write committed re-applied a non-idempotent transform.** `replace`
  commits its guarded UPDATE and only then awaits its after-update triggers and `onWrite`,
  so a throw out of it is not proof the write failed — but the cursor advanced only on a
  clean return. The row is now counted and the cursor advanced from inside the call, the
  moment the write is known to have landed; the error path reads the row back to tell a
  committed write from one that never happened, so a genuinely failed row is still
  re-visited.
- **Soft-deleted rows were never visited.** The page read passed no `includeDeleted`, so
  tombstones were filtered out, the run recorded `completed`, and `restore(id)` handed the
  application a pre-migration document. `countLegacyRows` counts tombstones (raw SQL) and
  so never reached zero for the same reason.

## Deliberately not fixed

`packages/sql-store/src/ctx-db-migrations.ts` carries the same unguarded
`CREATE UNIQUE INDEX` on its D1 provisioning path. It is a different failure mode (a
global table's migration, not a shard that stops opening), it was not part of what was
reproduced here, and it needs its own test — so it is left for a follow-up rather than
widened into this change.

## Gates

`build:packages` · `api:check` (one intentional export added to the shard-engine snapshot)
· `lint:types --no-cache` · `vis run test --no-cache` (117 tasks) · `test:workerd` (all 11
suites) · `lint:eslint` on the three touched packages · `prettier --check .` ·
`dist:check` (after a prod build) · `lint:generated` · `lint:package-json` ·
`lint:batch-cap` · `lint:project-json`. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
