### PR TITLE
fix: unbreak the first five minutes of a new project

### DIFF
--- a/api-snapshots/hyperdrive.api.md
+++ b/api-snapshots/hyperdrive.api.md
@@ -38,7 +38,7 @@ interface HyperdriveLike {
 
 ```ts
 interface Mysql2Like {
-    execute: (text: string, params?: ReadonlyArray<unknown>) => Promise<[
+    execute(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<[
         unknown,
         unknown
     ]>;
@@ -49,7 +49,7 @@ interface Mysql2Like {
 
 ```ts
 interface NodePgLike {
-    query: (text: string, params?: ReadonlyArray<unknown>) => Promise<{
+    query(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<{
         rows: unknown[];
     }>;
 }
@@ -59,7 +59,7 @@ interface NodePgLike {
 
 ```ts
 interface PostgresJsLike {
-    unsafe: (text: string, params?: ReadonlyArray<unknown>) => Promise<unknown>;
+    unsafe(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<unknown>;
 }
 ```
 

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -168,6 +168,62 @@ describe("lunora init", () => {
             expect(workspace).toContain("'ssh2': false");
         });
 
+        it("writes the allowBuilds allowlist for --yes, which never reaches the install offer", async () => {
+            expect.assertions(3);
+
+            // The allowlist used to be written INSIDE the install offer, after
+            // `confirm()` returned true — so `--yes`, a non-TTY (CI, an agent) and
+            // "No" at the prompt each produced a project whose very next step,
+            // `pnpm install`, exits 1 with `ERR_PNPM_IGNORED_BUILDS: esbuild,
+            // workerd, …`. It belongs to the scaffold, not to the offer.
+            //
+            // A bare lock file above the target pins `detectPackageManager` to
+            // pnpm without making the parent a workspace root (`isWorkspaceRoot`
+            // reads `pnpm-workspace.yaml` / a `workspaces` field, not a lock file),
+            // so the monorepo skip below stays out of the way.
+            writeFileSync(join(workdir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+            const result = await runInitCommand({
+                cwd: workdir,
+                from: templatesRoot,
+                logger: silentLogger(),
+                name: "yes-app",
+                templateType: "tanstack-start-react",
+                yes: true,
+            });
+
+            expect(result.code).toBe(0);
+
+            const workspace = readFileSync(join(workdir, "yes-app", "pnpm-workspace.yaml"), "utf8");
+
+            expect(workspace).toContain("'workerd': true");
+            expect(workspace).toContain("'cpu-features': false");
+        });
+
+        it("writes no pnpm-workspace.yaml into a scaffold inside a monorepo", async () => {
+            expect.assertions(2);
+
+            // The workspace ROOT owns `allowBuilds` there — the new package is not
+            // a member yet, so its install has to run from the root (which is what
+            // the next-steps hint says). A second `pnpm-workspace.yaml` here would
+            // make the scaffold a workspace root of its own and break `workspace:`
+            // resolution for it.
+            writeFileSync(join(workdir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+            writeFileSync(join(workdir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+
+            const result = await runInitCommand({
+                cwd: workdir,
+                from: templatesRoot,
+                logger: silentLogger(),
+                name: "nested-app",
+                templateType: "tanstack-start-react",
+                yes: true,
+            });
+
+            expect(result.code).toBe(0);
+            expect(existsSync(join(workdir, "nested-app", "pnpm-workspace.yaml"))).toBe(false);
+        });
+
         it("does not install when the user declines the offer", async () => {
             expect.assertions(2);
 

--- a/packages/cli/__tests__/commands/registry-items.test.ts
+++ b/packages/cli/__tests__/commands/registry-items.test.ts
@@ -13,6 +13,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { applyEdits, modify, parse as parseJsonc } from "jsonc-parser";
+import { ScriptTarget, transpileModule } from "typescript";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { parseManifest, runAddCommand, runBuildIndexCommand } from "../../src/commands/registry/index";
@@ -149,6 +150,84 @@ const itemImports = (): { scanned: string[]; undeclared: string[] } => {
     }
 
     return { scanned, undeclared };
+};
+
+/**
+ * The dependencies an item pulls in through the code CODEGEN emits, not through
+ * the code the item itself imports.
+ *
+ * `itemImports()` above cannot see these: `lunora/crons.ts` imports `cronJobs`
+ * from `@lunora/server` and nothing else, yet the declaration it makes is what
+ * puts `import { createScheduler } from "@lunora/scheduler"` into
+ * `_generated/app.ts`. An item that declares a cron without declaring
+ * `@lunora/scheduler` therefore scaffolds cleanly and then fails the project's
+ * very next `lunora codegen` with "this schema's generated code imports packages
+ * the project does not declare" — exit 1, no dev server.
+ *
+ * So the signals here mirror the signal-driven arms of
+ * `packages/codegen/src/assert-required-packages.ts`: the declaration codegen
+ * reads, and the package the emitted output will import because of it. Keep the
+ * two in step when a new signal is added there.
+ *
+ * The storage row currently matches nothing in the registry — no shipped item
+ * declares a `v.storage()` column or reads `ctx.storage` outside a comment. It
+ * is the other half of the same contract, not evidence of coverage; the guard
+ * below pins only what the scan really finds.
+ */
+const EMITTED_DEPENDENCY_SIGNALS: ReadonlyArray<{ package: string; pattern: RegExp }> = [
+    { package: "@lunora/scheduler", pattern: /\bcronJobs\s*\(|\bcrons\.(?:cron|daily|interval|monthly|weekly)\s*\(/u },
+    { package: "@lunora/storage", pattern: /\bctx\.storage\b|\bv\.storage\s*\(/u },
+];
+
+/**
+ * Comments removed, so prose counts for nothing.
+ *
+ * Codegen discovers these declarations by AST, so a sentence mentioning
+ * `ctx.storage` is not a `ctx.storage` read — and `backup.ts`, `crons/jobs.ts`
+ * and `mail.ts` all mention `ctx.scheduler` in a doc comment. A comment-blind
+ * scan would demand a dependency the generated code never imports.
+ */
+const withoutComments = (source: string): string =>
+    transpileModule(source, { compilerOptions: { removeComments: true, target: ScriptTarget.ESNext } }).outputText;
+
+/**
+ * Every (item, package) pair the emitted output will need, and whether the
+ * manifest declares it.
+ *
+ * The scan surface is what `lunora add <item>` puts in front of the user: the
+ * `.ts` files it writes, AND the manifest's `docs` string, which the command
+ * prints as the item's next step. `backup` ships no cron of its own — its `docs`
+ * tells the reader to add two `crons.daily(...)` lines — so a files-only scan
+ * would read it as clean and leave the same defect standing in the item that
+ * documents the cron rather than writing it.
+ */
+const emittedDependencies = (): { needed: string[]; undeclared: string[] } => {
+    const needed: string[] = [];
+    const undeclared: string[] = [];
+
+    for (const { manifest, name } of manifests) {
+        const declared = new Set(Object.keys(manifest.deps ?? {}));
+        const surfaces: ReadonlyArray<[string, string]> = [
+            ["docs", manifest.docs ?? ""],
+            ...manifest.files
+                .filter((file) => /\.tsx?$/u.test(file.from))
+                .map((file): [string, string] => [file.from, withoutComments(readFileSync(join(registryRoot, name, file.from), "utf8"))]),
+        ];
+
+        for (const signal of EMITTED_DEPENDENCY_SIGNALS) {
+            for (const [where] of surfaces.filter(([, text]) => signal.pattern.test(text))) {
+                const entry = `${name} → ${signal.package} (${where})`;
+
+                needed.push(entry);
+
+                if (!declared.has(signal.package)) {
+                    undeclared.push(entry);
+                }
+            }
+        }
+    }
+
+    return { needed, undeclared };
 };
 
 /** Every `createMailerFromEnv(` call site in the registry, split by whether it guards `cloudflareSend`. */
@@ -327,6 +406,24 @@ describe("shipped registry items", () => {
         // `.svelte` file — turns it green rather than red. Require positive
         // evidence that the SFC ports were read.
         expect(scanned.filter((entry) => /\((?:vue|svelte)\/[^)]+\.(?:vue|svelte)\)$/u.test(entry))).not.toHaveLength(0);
+    });
+
+    it("every package an item's GENERATED code needs is declared in its `deps`", () => {
+        expect.assertions(2);
+
+        // The dependency no import scan can see. `crons` declared `@lunora/server`
+        // and stopped there, so `lunora add crons` succeeded ("2 written") and the
+        // project's next `lunora codegen` exited 1 on `@lunora/scheduler` — a
+        // package the item never imports and `_generated/app.ts` does. `backup`,
+        // whose docs instruct the same cron registration, carried the same gap.
+        const { needed, undeclared } = emittedDependencies();
+
+        expect(undeclared).toStrictEqual([]);
+        // Guard the guard: this passes by finding nothing undeclared, so a pattern
+        // that stops matching, or a scan surface that stops being read, turns it
+        // green instead of red. Demand the two signals that are really there — one
+        // from a scaffolded file, one from a manifest's `docs`.
+        expect(needed).toStrictEqual(expect.arrayContaining(["crons → @lunora/scheduler (crons.ts)", "backup → @lunora/scheduler (docs)"]));
     });
 
     it("no item hands `createMailerFromEnv` an unguarded `cloudflareSend`", () => {

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -178,7 +178,7 @@ Additional flags:
 - `--allow-unsafe-source`: permit `--source` values outside `gh:/github:/https://`
 - `--here`: add Lunora to an existing project (detect the framework, patch the config, scaffold `lunora/`, print per-framework wiring steps)
 - `-i` / `--interactive`: after scaffolding, offer to add authentication and transactional email. Defaults on when stdin is a TTY; never prompts in CI.
-- `-y` / `--yes`: skip the auth/email offer and scaffold only.
+- `-y` / `--yes`: scaffold only — skip every post-scaffold prompt (the auth/email offer, the dependency-install offer, and `git init`). The project is complete; run the printed install command yourself.
 - `--ci <github\|gitlab>`: also scaffold a CI deploy pipeline (`.github/workflows/deploy.yml` for GitHub Actions, `.gitlab-ci.yml` for GitLab CI), with a production `lunora deploy` on the default branch **and** a `lunora deploy --preview` on every pull / merge request. Set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as the provider's secrets / CI-CD variables.
 
 ### `lunora add`

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -439,6 +439,28 @@ const pnpmWorkspaceYaml = (): string =>
         "",
     ].join("\n");
 
+/**
+ * Write the build-script allowlist into a scaffold, unless it already has one.
+ *
+ * Idempotent, because there are two moments that know pnpm is in play and
+ * neither subsumes the other: the scaffold step knows the manager DETECTED for
+ * the new project (what the next-steps hint tells the user to run), and the
+ * install offer knows the manager the user actually PICKED, which can differ —
+ * `npx lunora init` detects npm while the offer still defaults to pnpm.
+ *
+ * Without it `pnpm install` exits 1 with `ERR_PNPM_IGNORED_BUILDS` on a tree
+ * that contains esbuild/workerd — i.e. every scaffold — which is precisely the
+ * command the printed next steps and the getting-started docs hand the user.
+ * @param target the scaffolded project directory.
+ */
+const writePnpmBuildAllowlist = (target: string): void => {
+    const workspacePath = join(target, PNPM_WORKSPACE_FILENAME);
+
+    if (!existsSync(workspacePath)) {
+        writeFileSync(workspacePath, pnpmWorkspaceYaml(), "utf8");
+    }
+};
+
 const collectFiles = (directory: string): ReadonlyArray<string> => {
     const out: string[] = [];
 
@@ -776,17 +798,12 @@ const maybeOfferInstall = async (options: InitCommandOptions, target: string): P
         return undefined;
     }
 
-    // Only when pnpm is the chosen manager: write the build-script allowlist to
-    // pnpm-workspace.yaml just before the install (pnpm v10.16+ no longer reads
-    // the package.json `pnpm` field), so `pnpm install` runs the toolchain's
-    // native builds (esbuild/sharp/workerd) without a follow-up
-    // `pnpm approve-builds`. npm/yarn scaffolds don't get a stray pnpm file.
+    // The scaffold step already wrote this for a project whose DETECTED manager
+    // is pnpm; repeat it here for the case detection cannot reach — the user
+    // picking pnpm at the prompt after `npx lunora init` detected npm. No-op
+    // when the file is already there. npm/yarn scaffolds get no stray pnpm file.
     if (manager === "pnpm") {
-        const workspacePath = join(target, PNPM_WORKSPACE_FILENAME);
-
-        if (!existsSync(workspacePath)) {
-            writeFileSync(workspacePath, pnpmWorkspaceYaml(), "utf8");
-        }
+        writePnpmBuildAllowlist(target);
     }
 
     const spawner = options.spawner ?? defaultSpawner;
@@ -1613,6 +1630,48 @@ const scaffoldTemplatePath = async (
     return scaffoldFromRemote({ logger: options.logger, markComplete, name, ref: options.ref, source: options.source, target, templateType });
 };
 
+/**
+ * Part of the scaffold itself, not of the install offer: a project whose
+ * detected package manager is pnpm gets the build-script allowlist on disk the
+ * moment its files are written.
+ *
+ * It used to be written inside `maybeOfferInstall`, after `confirm()` returned
+ * true — so `--yes`, a non-TTY (CI, an agent), and "No" at the prompt all
+ * scaffolded a project whose `pnpm install` exits 1 with
+ * `ERR_PNPM_IGNORED_BUILDS`. That is the command the next steps printed three
+ * lines further down, and the one the getting-started docs give.
+ *
+ * Skipped inside a monorepo, deliberately. The new package is not a workspace
+ * member yet, so its install has to run from the workspace ROOT — whose own
+ * `pnpm-workspace.yaml` already governs `allowBuilds`. Writing a second one here
+ * would make the scaffold a workspace root in its own right: `workspace:` deps
+ * would stop resolving, and `isWorkspaceRoot` would from then on read the new
+ * package as a monorepo root, silently suppressing the install offer for
+ * anything scaffolded beneath it.
+ * @param target the scaffolded project directory.
+ * @param cwd the directory `init` was invoked from — the monorepo probe's start.
+ */
+const writeScaffoldPackageManagerConfig = (target: string, cwd: string): void => {
+    if (isInsideMonorepo(cwd)) {
+        return;
+    }
+
+    let manager: PackageManager;
+
+    try {
+        manager = detectPackageManager(target);
+    } catch {
+        // Nothing resolved: no lock file or `packageManager` field above the
+        // scaffold, no launching manager, none on PATH. `printNextSteps` surfaces
+        // that separately; there is no manager to write config for.
+        return;
+    }
+
+    if (manager === "pnpm") {
+        writePnpmBuildAllowlist(target);
+    }
+};
+
 const scaffoldNewProject = async (options: InitCommandOptions, cwd: string, tracker: ScaffoldTracker): Promise<InitCommandResult> => {
     // Moonrise header, then create-astro-style linear questions: each prompt shows
     // its badge + question and collapses to a dimmed transcript line on submit.
@@ -1716,9 +1775,16 @@ const scaffoldNewProject = async (options: InitCommandOptions, cwd: string, trac
     // emptied back out) — see `resetPartialScaffold`.
     tracker.record(target, targetPreExisted);
 
-    return choice.kind === "overlay"
-        ? scaffoldOverlayPath(options, choice.framework, name, target, tracker.complete)
-        : scaffoldTemplatePath(options, choice.templateType, name, target, tracker.complete);
+    const result =
+        choice.kind === "overlay"
+            ? await scaffoldOverlayPath(options, choice.framework, name, target, tracker.complete)
+            : await scaffoldTemplatePath(options, choice.templateType, name, target, tracker.complete);
+
+    if (result.code === 0) {
+        writeScaffoldPackageManagerConfig(target, cwd);
+    }
+
+    return result;
 };
 
 /** Tracks the project directory a `lunora init` run creates, so a Ctrl-C abort can reset it. */

--- a/packages/hyperdrive/__tests__/create-hyperdrive.test.ts
+++ b/packages/hyperdrive/__tests__/create-hyperdrive.test.ts
@@ -184,9 +184,7 @@ describe.skipIf(!process.env.CI)("real Hyperdrive binding (CI-only)", () => {
                 const driver = postgres(connectionString, { max: 1 });
 
                 try {
-                    // postgres.js's `unsafe` takes a narrower params type than the structural
-                    // projection; the runtime shape is exactly PostgresJsLike.
-                    const sql = fromPostgresJs(driver as unknown as PostgresJsLike);
+                    const sql = fromPostgresJs(driver);
 
                     await expect(sql.query("SELECT 1 + 1 AS sum")).resolves.toEqual([{ sum: 2 }]);
                     await expect(sql.query("SELECT title FROM todos WHERE id = $1", ["t1"])).resolves.toEqual([{ title: "ship hyperdrive" }]);
@@ -298,8 +296,11 @@ describe.skipIf(!process.env.CI)("real Hyperdrive binding (CI-only)", () => {
                     await connection.query("CREATE TABLE hyperdrive_roundtrip (id VARCHAR(16) PRIMARY KEY, title TEXT NOT NULL)");
                     await connection.query("INSERT INTO hyperdrive_roundtrip (id, title) VALUES ('m1', 'ship hyperdrive')");
 
-                    // mysql2's overloaded `execute` doesn't structurally match the
-                    // projection, but the runtime shape is exactly Mysql2Like.
+                    // Still cast, and deliberately: mysql2 types `execute`'s second
+                    // argument as a single `ExecuteValues` — a union of scalars,
+                    // arrays and records — which relates to the projection's
+                    // `ReadonlyArray<unknown>` in NEITHER direction, so the method
+                    // syntax that fixed postgres.js cannot reach it. See Mysql2Like.
                     const sql = fromMysql2(connection as unknown as Mysql2Like);
 
                     await expect(sql.query("SELECT 1 + 1 AS sum")).resolves.toEqual([{ sum: 2 }]);

--- a/packages/hyperdrive/src/types.ts
+++ b/packages/hyperdrive/src/types.ts
@@ -92,25 +92,51 @@ export interface SqlClient {
 /**
  * Structural projection of a `pg` (node-postgres) `Client`/`Pool`. Only the
  * `query` method `fromNodePg` calls is required, kept structural for testing.
+ *
+ * Method syntax, not an arrow property — see {@link PostgresJsLike}.
  */
+/* eslint-disable @typescript-eslint/method-signature-style, @typescript-eslint/no-invalid-void-type -- bivariant params (the drivers declare mutable arrays), and `this: void` is the `allowAsThisParameter` case the repo config does not enable */
 export interface NodePgLike {
-    query: (text: string, params?: ReadonlyArray<unknown>) => Promise<{ rows: unknown[] }>;
+    query(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<{ rows: unknown[] }>;
 }
 
 /**
  * Structural projection of a `postgres` (postgres.js) tagged-template client.
  * The adapter uses the `.unsafe(text, params)` escape hatch so callers keep
  * full control of the parameter list.
+ *
+ * **`unsafe` is declared with METHOD syntax, and that is load-bearing.** Under
+ * `strictFunctionTypes` an arrow PROPERTY is checked contravariantly in its
+ * parameters, so a driver whose `unsafe` takes a MUTABLE array — which real
+ * postgres.js does (`parameters?: ParameterOrJSON<never>[]`) — is not assignable
+ * to one declared `params?: ReadonlyArray<unknown>`. As an arrow property this
+ * projection could therefore never accept the package it projects: every
+ * consumer got
+ * `TS2345: Argument of type 'Sql<{}>' is not assignable to parameter of type
+ * 'PostgresJsLike'`, and this repo's own test reached for
+ * `as unknown as PostgresJsLike` to get past it. Method syntax is checked
+ * bivariantly, which is what a structural projection of someone else's type
+ * needs — `readonly unknown[]` and postgres.js's mutable array relate in one
+ * direction, which is all bivariance asks for.
  */
 export interface PostgresJsLike {
-    unsafe: (text: string, params?: ReadonlyArray<unknown>) => Promise<unknown>;
+    unsafe(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<unknown>;
 }
 
 /**
  * Structural projection of a `mysql2/promise` connection/pool. `mysql2`'s
  * `execute` resolves to a `[rows, fields]` tuple; the adapter takes the first
  * element as the rows.
+ *
+ * Method syntax, not an arrow property — see {@link PostgresJsLike} — but here
+ * that is necessary and NOT sufficient, so the live-driver test still casts.
+ * mysql2 types its second argument as a single `ExecuteValues`, a union of
+ * scalars, `ExecuteValues[]` and `{ [key: string]: ExecuteValues }`. Neither
+ * direction relates to `ReadonlyArray<unknown>`, so no variance rule can bridge
+ * it: closing this needs a deliberate widening of the parameter type here (and
+ * of what {@link SqlClient} promises), not a declaration-style change.
  */
 export interface Mysql2Like {
-    execute: (text: string, params?: ReadonlyArray<unknown>) => Promise<[unknown, unknown]>;
+    execute(this: void, text: string, params?: ReadonlyArray<unknown>): Promise<[unknown, unknown]>;
 }
+/* eslint-enable @typescript-eslint/method-signature-style, @typescript-eslint/no-invalid-void-type */

--- a/registry/TYPECHECK.md
+++ b/registry/TYPECHECK.md
@@ -6,6 +6,14 @@
 
 Almost every item is checked. Function templates import the per-app builders (`mutation`/`query`/`action`/`internal*`) from `#lunora/_generated/server.js` — the module codegen emits in a real project — which `./lunora-generated-server.d.ts` stubs: `#lunora/…` is a NON-relative specifier, so an ambient `declare module` matches it. `crons/crons.ts` is the one exception: it reads `internal.<module>.<fn>` off `#lunora/_generated/api.js`, a namespace generated from the app's OWN functions — a stub for it could only be `any`-shaped, which is a gate that checks nothing. Its sibling `crons/jobs.ts` imports only the builders and IS checked. The stub keeps the base, table-name-generic `@lunora/server` contexts rather than an app's narrowed data model, so it proves imports, `ctx.*` surface, and package call signatures — not that a `ctx.db.query("…")` names a declared table. `./cloudflare-workers.d.ts`, `./cloudflare-email.d.ts`, and `./postgres.d.ts` stub the runtime/driver modules the items reach for that are not installed here.
 
+## What this gate cannot see, and what covers it instead
+
+Two classes of defect are invisible to `tsc` here, both by construction.
+
+**Dependencies only the GENERATED code introduces.** `crons/crons.ts` imports `cronJobs` from `@lunora/server` and nothing else, yet the registration it makes is what puts `import { createScheduler } from "@lunora/scheduler"` into `_generated/app.ts`. No typechecker reading the item can know that — even un-excluding `crons/crons.ts` would not have caught it; the item's own imports are complete. `lunora add crons` therefore succeeded and the project's next `lunora codegen` exited 1. The cross-check is the `every package an item's GENERATED code needs is declared in its deps` test in `packages/cli/__tests__/commands/registry-items.test.ts`, which reads the same emit signals `packages/codegen/src/assert-required-packages.ts` reads — from the item's files (comments stripped, since codegen discovers by AST) and from its manifest `docs`, because `backup` documents the cron registration rather than shipping it.
+
+**A shim more permissive than the real module.** `./cloudflare-workers.d.ts` typed `env` as `Record<string, unknown>` while the real `cloudflare:workers` types it as `Cloudflare.Env` — an interface `@cloudflare/workers-types` declares EMPTY until the project runs `wrangler types`. Five items indexed it, this gate passed, and every one failed `tsc --noEmit` in a real consumer. Each shim here must mirror the module it stands in for exactly, or it certifies the opposite of what it claims.
+
 ## `auth-emails`
 
 Same reason as the auth-ui-* items below: `auth-emails` is TSX rendered by @react-email/render, so it needs a JSX config this backend-oriented program does not have. It is type-checked at its source, `packages/auth-ui/src/emails/index.tsx`.

--- a/registry/backup/backup.ts
+++ b/registry/backup/backup.ts
@@ -35,13 +35,20 @@
  *     log rather than a snapshot.
  */
 import { internalAction, v } from "#lunora/_generated/server.js";
+import type { CloudflareBindings } from "#lunora/_generated/server.js";
 import { createStorage } from "@lunora/storage";
 import type { R2BucketLike } from "@lunora/storage";
 // `env` from `cloudflare:workers` exposes the worker's configured bindings (here
 // the BACKUP_BUCKET R2 bucket) — the standard Workers way to reach a binding
-// outside the top-level `fetch`/`scheduled` handler. Ambient types come from
-// your project's `@cloudflare/workers-types` + generated `Env`.
-import { env } from "cloudflare:workers";
+// outside the top-level `fetch`/`scheduled` handler.
+import { env as workerEnv } from "cloudflare:workers";
+
+// `cloudflare:workers` types `env` as `Cloudflare.Env`, which
+// `@cloudflare/workers-types` declares EMPTY until the project runs
+// `wrangler types` — so reading `env.BACKUP_BUCKET` off it is a `tsc` error in a
+// fresh scaffold. Go through the generated `CloudflareBindings` (an open index
+// signature of `unknown`) and narrow the binding where it is used.
+const env = workerEnv as CloudflareBindings;
 
 // TODO: list every table you want backed up. Lunora can't enumerate tables from
 // an action context, so this list is the source of truth for what `snapshot`
@@ -294,8 +301,8 @@ export const snapshot = internalAction
             throw new Error("backup/snapshot: no tables configured — edit the TABLES list in lunora/backup/index.ts (or pass { tables }) before scheduling.");
         }
 
-        // `env` values are typed `unknown` (see the registry's cloudflare-workers
-        // shim); narrow the R2 binding explicitly, then guard it.
+        // `CloudflareBindings` values are typed `unknown`; narrow the R2 binding
+        // explicitly, then guard it.
         const bucket = env.BACKUP_BUCKET as R2BucketLike | undefined;
 
         if (!bucket) {
@@ -392,9 +399,9 @@ export const prune = internalAction
             throw new Error("backup/prune: pass keepDays and/or keepLast — refusing to prune with no retention window configured.");
         }
 
-        // Same binding narrowing the `snapshot` action uses: `env` values are
-        // typed `unknown` (registry cloudflare-workers shim), so cast the R2
-        // binding explicitly, then guard it.
+        // Same binding narrowing the `snapshot` action uses: `CloudflareBindings`
+        // values are typed `unknown`, so cast the R2 binding explicitly, then
+        // guard it.
         const bucket = env.BACKUP_BUCKET as R2BucketLike | undefined;
 
         if (!bucket) {

--- a/registry/backup/registry.json
+++ b/registry/backup/registry.json
@@ -6,6 +6,7 @@
     "docs": "Register the snapshot+prune cron pair in lunora/crons.ts: `crons.daily(\"backup snapshot\", { hourUTC: 3, minuteUTC: 0 }, internal.backup.snapshot, {})` and `crons.daily(\"backup prune\", { hourUTC: 4, minuteUTC: 0 }, internal.backup.prune, { keepDays: 30, keepLast: 5 })`, then `lunora codegen`. Edit the TABLES list in lunora/backup/index.ts to cover every table you want backed up (codegen cannot enumerate tables for you). prune retention: keepDays and/or keepLast — a snapshot is deleted only if it's both older than keepDays and not among the keepLast newest. Add the BACKUP_BUCKET r2_buckets binding (added to wrangler.jsonc on install). Restore with `lunora backup restore <id|file>` — it imports a snapshot boundary; there is no `--to` and no changelog replay, so reach for `lunora backup pitr --at <ISO>` when you need an arbitrary moment. `snapshot` reads through a shard-local `ctx.db` and logs a warning saying so on every run: on a `.shardBy()` deployment it captures the default shard only, so use `lunora backup create --bucket` or the platform's `backupCron` for whole-deployment snapshots there.",
     "requires": [],
     "deps": {
+        "@lunora/scheduler": "workspace:*",
         "@lunora/server": "workspace:*",
         "@lunora/storage": "workspace:*"
     },

--- a/registry/cloudflare-workers.d.ts
+++ b/registry/cloudflare-workers.d.ts
@@ -1,17 +1,33 @@
 /**
  * Ambient stub for the `cloudflare:workers` module so registry items that read
  * Cloudflare bindings (e.g. `storage`, `backup`) type-check standalone under
- * `registry/tsconfig.json` (which ships only `types: ["node"]`). In a real
- * Lunora project, `@cloudflare/workers-types`' `cloudflare:workers` module — and
- * the project's generated `Env` — provide the precise binding types and
- * supersede this shim.
+ * `registry/tsconfig.json` (which ships only `types: ["node"]`).
+ *
+ * It mirrors `@cloudflare/workers-types` EXACTLY, and that is the point. The
+ * stub used to type `env` as `Record<string, unknown>`, which indexes freely —
+ * so five items indexed it, this gate went green, and every one of them failed
+ * `tsc --noEmit` in a real consumer with `TS7053` / `TS2339`. The real module
+ * types `env` as `Cloudflare.Env`, an interface declaration-merged from the
+ * project's own `worker-configuration.d.ts` and therefore **empty** until the
+ * project runs `wrangler types` — a fresh `lunora init` scaffold has not.
+ *
+ * So items must narrow `env` through the generated `CloudflareBindings`
+ * (`./lunora-generated-server.d.ts`) rather than index it directly, and the
+ * empty interface here is what holds them to it.
  */
+declare namespace Cloudflare {
+    // Empty, as `@cloudflare/workers-types` declares it. A project extends it by
+    // redeclaring `Cloudflare.Env` (what `wrangler types` generates); TypeScript
+    // merges the declarations.
+    interface Env {}
+}
+
 declare module "cloudflare:workers" {
     /**
-     * The Worker's configured bindings (R2 buckets, vars, secrets, …), typed as
-     * `unknown`-valued so items must narrow each binding explicitly (a guarded
-     * string for vars/secrets, an `as R2BucketLike` for buckets) rather than
-     * leaning on `any`. The consumer's generated `Env` supplies precise types.
+     * The Worker's configured bindings (R2 buckets, vars, secrets, …). Empty
+     * until the consumer runs `wrangler types` — narrow it through
+     * `CloudflareBindings` from `#lunora/_generated/server.js` and then narrow
+     * each binding at its use site.
      */
-    export const env: Record<string, unknown>;
+    export const env: Cloudflare.Env;
 }

--- a/registry/crons/registry.json
+++ b/registry/crons/registry.json
@@ -6,6 +6,7 @@
     "docs": "Edit lunora/crons.ts to register your jobs against internal.* function refs, then run `lunora codegen` — codegen lifts the schedules into wrangler's triggers.crons and a dispatcher map the Worker's scheduled() handler consumes. The shipped lunora/crons/jobs.ts is an example internal mutation; point the sample job at your own internal function and delete it.",
     "requires": [],
     "deps": {
+        "@lunora/scheduler": "workspace:*",
         "@lunora/server": "workspace:*"
     },
     "files": [

--- a/registry/hyperdrive/hyperdrive.ts
+++ b/registry/hyperdrive/hyperdrive.ts
@@ -40,19 +40,31 @@
  *
  * Action-only (non-deterministic external I/O).
  */
-import { env } from "cloudflare:workers";
+import { env as workerEnv } from "cloudflare:workers";
 import postgres from "postgres";
 
 import type { HyperdriveLike, SqlClient } from "@lunora/hyperdrive";
 import { createHyperdrive, fromPostgresJs } from "@lunora/hyperdrive";
 import { internalAction, v } from "#lunora/_generated/server.js";
+import type { CloudflareBindings } from "#lunora/_generated/server.js";
+
+/**
+ * The Worker's bindings, narrowed so they can be looked up by name.
+ *
+ * `cloudflare:workers` types `env` as `Cloudflare.Env`, which
+ * `@cloudflare/workers-types` declares EMPTY until the project runs
+ * `wrangler types` — so reading `env["HYPERDRIVE"]` off it is a `tsc` error in a
+ * fresh scaffold. The generated `CloudflareBindings` keeps the lookup open and
+ * the value `unknown`, so the binding is still narrowed below.
+ */
+const env = workerEnv as CloudflareBindings;
 
 /**
  * Build the driver-agnostic `SqlClient` for this request. Swap `fromPostgresJs`
  * for `fromNodePg` / `fromMysql2` (and the matching driver import) to change
  * drivers — the `SqlClient` surface is identical.
  *
- * `cloudflare:workers`' `env` values are typed `unknown`, so the binding is
+ * `CloudflareBindings` values are typed `unknown`, so the binding is
  * narrowed here and fails with a clear message when it is missing rather than
  * throwing somewhere inside the driver.
  */

--- a/registry/lunora-generated-server.d.ts
+++ b/registry/lunora-generated-server.d.ts
@@ -50,4 +50,22 @@ declare module "#lunora/_generated/server.js" {
 
     /** The validator builder. The generated one additionally narrows `v.id(table)` to the app's tables. */
     export const v: typeof import("@lunora/server").v;
+
+    /**
+     * The project's Cloudflare bindings, mirroring what `emit.ts` writes into
+     * every real `_generated/server.ts`: an open index signature, because the
+     * bindings a project configures in wrangler (R2/KV/D1/vars/secrets/…) are not
+     * statically visible to codegen.
+     *
+     * This is the type every item narrows `cloudflare:workers`' `env` through.
+     * That module's own `env` is `Cloudflare.Env`, which `@cloudflare/workers-types`
+     * declares EMPTY and a project fills in only by running `wrangler types` — so
+     * indexing it directly is a `tsc` error in any scaffold that has not.
+     */
+    export interface CloudflareBindings {
+        readonly [binding: string]: unknown;
+    }
+
+    /** Alias for {@link CloudflareBindings} — the typed shape of `env`. */
+    export type Env = CloudflareBindings;
 }

--- a/registry/mail/mail.ts
+++ b/registry/mail/mail.ts
@@ -49,7 +49,20 @@
 import { createMailerFromEnv } from "@lunora/mail";
 import type { Mailer, SendOptions } from "@lunora/mail";
 import { internalAction, v } from "#lunora/_generated/server.js";
-import { env } from "cloudflare:workers";
+import type { CloudflareBindings } from "#lunora/_generated/server.js";
+import { env as workerEnv } from "cloudflare:workers";
+
+/**
+ * The Worker's bindings, narrowed so they can be looked up by name.
+ *
+ * `cloudflare:workers` types `env` as `Cloudflare.Env`, which
+ * `@cloudflare/workers-types` declares EMPTY until the project runs
+ * `wrangler types` — so indexing it, or handing it to `createMailerFromEnv`
+ * (whose `MailEnv` is a `Record<string, unknown>`), is a `tsc` error in a fresh
+ * scaffold. The generated `CloudflareBindings` is the open index signature both
+ * want.
+ */
+const env = workerEnv as CloudflareBindings;
 
 /**
  * The Cloudflare Email Workers send callback: serialize the RFC 822 message

--- a/registry/payment/payment.ts
+++ b/registry/payment/payment.ts
@@ -52,13 +52,25 @@
  *      `.dev.vars` (locally) and push the secrets to production with
  *      `wrangler secret put`.
  */
-import { env } from "cloudflare:workers";
+import { env as workerEnv } from "cloudflare:workers";
 
 import { LunoraError } from "@lunora/errors";
 import type { SubscriptionState } from "@lunora/payment";
 import { action, internalAction, query, v } from "#lunora/_generated/server.js";
+import type { CloudflareBindings } from "#lunora/_generated/server.js";
 
 import { SUBSCRIPTIONS_TABLE } from "./schema.js";
+
+/**
+ * The Worker's bindings, narrowed so they can be looked up by name.
+ *
+ * `cloudflare:workers` types `env` as `Cloudflare.Env`, which
+ * `@cloudflare/workers-types` declares EMPTY until the project runs
+ * `wrangler types` — so indexing it is a `tsc` error in a fresh scaffold. The
+ * generated `CloudflareBindings` is the open index signature this needs; the
+ * value stays `unknown`, so `appOrigin` still has to narrow it.
+ */
+const env = workerEnv as CloudflareBindings;
 
 /**
  * Public origin of this deployment, used to build the checkout return URLs and
@@ -68,11 +80,13 @@ import { SUBSCRIPTIONS_TABLE } from "./schema.js";
  * time.
  *
  * `APP_BASE_URL` is declared BOTH as a wrangler `vars` entry (by this item's
- * manifest) and in `.dev.vars`. The first is what puts it on the generated env
- * TYPE — `CloudflareBindings` is built from wrangler's config, so a var that
- * lives only in `.dev.vars` reaches the running Worker and not the
- * type-checker, and reading it here is a `TS7053`. The second supplies the value
- * locally, and wins over `vars` under `wrangler dev`.
+ * manifest) and in `.dev.vars`. That is a RUNTIME split, not a typing one:
+ * `.dev.vars` is read locally and never deployed, so a var declared only there
+ * is absent from the deployed Worker; the `vars` entry is what carries it to
+ * production, and `.dev.vars` wins over it under `wrangler dev`. Neither affects
+ * the type — `env` above is `cloudflare:workers`' `Cloudflare.Env`, which only
+ * `wrangler types` populates, so the narrowing there is what makes this read
+ * compile, and it yields `unknown`.
  *
  * The manifest ships the `vars` entry EMPTY. `vars` is deployed configuration,
  * so a committed `http://localhost:…` placeholder is read only in production —

--- a/registry/postgres.d.ts
+++ b/registry/postgres.d.ts
@@ -1,17 +1,35 @@
 /**
  * Ambient stub for the `postgres` (postgres.js) driver so the `hyperdrive`
  * registry item type-checks standalone under `registry/tsconfig.json` — the
- * driver is an optional peer of `@lunora/hyperdrive` and is not installed in
- * this repo. The consumer installs the real `postgres` package (this item's
- * `registry.json` adds it) and its own types supersede this shim.
+ * driver is an optional peer of `@lunora/hyperdrive` and is not installed here.
+ * The consumer installs the real `postgres` package (this item's `registry.json`
+ * adds it) and its own types supersede this shim.
  *
- * Only the surface the item uses is declared: the factory, and the `.unsafe`
- * escape hatch `fromPostgresJs` calls (`PostgresJsLike` in `@lunora/hyperdrive`).
+ * It copies the REAL `unsafe` signature, and that is the point. This stub used
+ * to declare `unsafe` as literally `PostgresJsLike` — the type it is handed to —
+ * so the assignment it was meant to prove was true by construction. Real
+ * postgres.js declares
+ *
+ *     unsafe<T extends any[] = …>(query: string, parameters?: ParameterOrJSON<…>[],
+ *                                 queryOptions?: UnsafeQueryOptions): PendingQuery<T>
+ *
+ * — a MUTABLE parameter array, a third optional argument, and a thenable rather
+ * than a bare `Promise`. Under an arrow-property `PostgresJsLike` none of that
+ * assigns, so every consumer of the `hyperdrive` item got
+ * `TS2345: Argument of type 'Sql<{}>' is not assignable to parameter of type
+ * 'PostgresJsLike'` while this gate stayed silent. Keep the three differences
+ * above: they are what makes the check mean anything.
  */
 declare module "postgres" {
-    /** The postgres.js client, narrowed to the `PostgresJsLike` shape the adapter consumes. */
+    /** Stands in for postgres.js's `ParameterOrJSON<T>` union — the element type is not what this stub is testing. */
+    type Parameter = unknown;
+
+    /** postgres.js resolves to a thenable query object, not a bare `Promise`. */
+    type PendingQuery<T> = Promise<T> & { readonly execute: () => PendingQuery<T> };
+
+    /** The postgres.js client, carrying the `unsafe` escape hatch `fromPostgresJs` consumes. */
     export interface Sql {
-        unsafe: (text: string, params?: ReadonlyArray<unknown>) => Promise<unknown>;
+        unsafe<T = unknown>(query: string, parameters?: Parameter[], queryOptions?: Record<string, unknown>): PendingQuery<T>;
     }
 
     const postgres: (connectionString: string, options?: Record<string, unknown>) => Sql;

--- a/registry/storage/storage.ts
+++ b/registry/storage/storage.ts
@@ -39,13 +39,26 @@
  *                                     (no path: the key is verified from the
  *                                     whole URL pathname).
  */
-import { env } from "cloudflare:workers";
+import { env as workerEnv } from "cloudflare:workers";
 
 import { LunoraError } from "@lunora/errors";
 import { RateLimiter, rateLimit, createMemoryStore } from "@lunora/ratelimit";
 import { createStorage, scopeKey } from "@lunora/storage";
 import type { Storage } from "@lunora/storage";
 import { action, mutation, v } from "#lunora/_generated/server.js";
+import type { CloudflareBindings } from "#lunora/_generated/server.js";
+
+/**
+ * The Worker's bindings, narrowed so they can be looked up by name.
+ *
+ * `cloudflare:workers` types `env` as `Cloudflare.Env`, which
+ * `@cloudflare/workers-types` declares EMPTY — a project fills it in only by
+ * running `wrangler types`. Indexing it before then is a hard `tsc` error
+ * (`TS7053` / `TS2339`), which is why this goes through the generated
+ * `CloudflareBindings` instead: an open index signature of `unknown`, so every
+ * binding still has to be narrowed (and guarded) at its use site below.
+ */
+const env = workerEnv as CloudflareBindings;
 
 /** The R2 bucket binding type `createStorage` expects. */
 type StorageBucket = Parameters<typeof createStorage>[0]["bucket"];
@@ -74,7 +87,7 @@ const limiter = new RateLimiter({
 
 /**
  * Read a required string env var/secret or throw a clear, actionable error.
- * (`cloudflare:workers`' `env` values are typed `unknown`, so we narrow here —
+ * (`CloudflareBindings` values are typed `unknown`, so we narrow here —
  * a missing `STORAGE_SIGNING_SECRET` fails loudly instead of producing an opaque
  * HMAC error deep in `@lunora/storage`.)
  *


### PR DESCRIPTION
Five defects that break a brand-new project inside its first five minutes. Each one was reproduced with a CLI built from this branch, scaffolding into a temp directory against locally packed tarballs, then re-run end to end after the fix.

## D1 — `lunora add crons` left a project whose `lunora codegen` exits 1

`registry/crons` declared only `@lunora/server`. But a `cronJobs()` registration is what makes codegen write `import { createScheduler } from "@lunora/scheduler"` into `_generated/app.ts`, and `lunorash` does not re-export that package — so `add` reported success and the next command failed.

Before:

```
$ lunora add crons --yes
  ok  add complete: 2 written, 0 skipped
$ lunora codegen
 error  LunoraError: @lunora/codegen: this schema's generated code imports packages the project does not declare:
           - @lunora/scheduler — a declared cron (or `ctx.scheduler` use) makes `_generated/app.ts` import `createScheduler`
codegen exit=1
```

After:

```
$ lunora add crons --yes
  info    dep   @lunora/scheduler@alpha
    ok  added 1 dependency(ies) to package.json: @lunora/scheduler
$ lunora codegen
    ok  codegen wrote dataModel.ts, api.ts, server.ts to …/lunora/_generated
codegen exit=0
```

`registry/backup` carried the same gap — its `docs` instruct the reader to register the snapshot+prune cron pair — and is fixed with it.

### The gate

No import scan can catch this class: the item's own imports are complete, and the dependency exists only in emitted code. Un-excluding `crons/crons.ts` from `registry/tsconfig.json` would not have caught it either, for the same reason (that exclusion stays, and its own justification in `TYPECHECK.md` still holds — the `internal.*` namespace can only be stubbed as `any`).

So the cross-check reads the same emit signals `packages/codegen/src/assert-required-packages.ts` reads, per item, and asserts the manifest declares what they pull in. Scan surface is what `lunora add <item>` puts in front of the user: the `.ts` files it writes **and** the manifest's `docs`, because `backup` documents the cron rather than shipping it. Sources are comment-stripped first — codegen discovers by AST, and `backup.ts`, `crons/jobs.ts` and `mail.ts` each mention `ctx.scheduler` in prose that a comment-blind scan would read as a declaration.

Against the pre-fix manifests it reports exactly, and only, the two real gaps:

```
- []
+ [
+   "backup → @lunora/scheduler (docs)",
+   "crons → @lunora/scheduler (crons.ts)",
+ ]
```

It also asserts it positively found each of those signals, so a pattern that stops matching turns it red rather than green.

## D2 — five registry items failed `tsc --noEmit` in a consumer

`storage`, `backup`, `mail`, `hyperdrive` and `payment` index `cloudflare:workers`' `env`. In a real project that `env` is `Cloudflare.Env`, which `@cloudflare/workers-types` declares as an **empty** interface until `wrangler types` is run — and nothing in the CLI, the templates or the `add` output has ever mentioned running it.

A scaffold with all five items produced 10 diagnostics and `lunora verify` exit 1:

```
lunora/storage/index.ts(87,19): error TS7053: … can't be used to index type 'Env'.
lunora/storage/index.ts(123,24): error TS2339: Property 'UPLOADS' does not exist on type 'Env'.
lunora/backup/index.ts(299,28): error TS2339: Property 'BACKUP_BUCKET' does not exist on type 'Env'.
lunora/mail/index.ts(81,50): error TS2345: Argument of type 'Env' is not assignable to parameter of type 'MailEnv'.
lunora/payment/index.ts(70,19): error TS7053: … can't be used to index type 'Env'.
…
 error  verify: errors:
 error    - type errors: tsc --noEmit exited 2
verify exit=1
```

All five items now narrow through the generated `CloudflareBindings` — the open index signature codegen already emits for exactly this — and keep their per-binding narrowing and guards at each use site.

`payment`'s `appOrigin` docblock also claimed the wrangler `vars` entry was what put `APP_BASE_URL` on the env *type*. It is not: `env` there comes from `cloudflare:workers`, so its type is `Cloudflare.Env`, which only `wrangler types` populates. The `vars`/`.dev.vars` split is real and still documented, but as the **runtime** split it is — `.dev.vars` is local-only, `vars` is deployed config, and the manifest ships it empty on purpose.

**Should the docs tell the reader to run `wrangler types`?** No. The same scaffold was typechecked twice — with the empty `Cloudflare.Env` and with a populated one standing in for what `wrangler types` writes — and both exit 0. The narrowing makes the step unnecessary for the code we scaffold, so adding it would be an extra command in the first-five-minutes path that buys the reader nothing. Anyone who wants precise binding types for their *own* code has wrangler's documented step; that is not Lunora-specific.

### Closing the hole

`registry/cloudflare-workers.d.ts` typed `env` as `Record<string, unknown>`, which indexes freely — so all ten diagnostics passed `tsc -p registry/tsconfig.json` cleanly. It now mirrors the real module: an empty `Cloudflare.Env`. Verified: restoring the old shim on top of this branch's item fixes makes the gate silent again.

## D3 — `pnpm install` exited 1 in every scaffold that did not accept the install prompt

The `allowBuilds` map was written *inside* `maybeOfferInstall`, after `confirm()` returned true. `--yes`, any non-TTY (CI, an agent) and answering "No" therefore all produced a project whose next step fails:

```
$ lunora init my-app -t standalone --yes
$ cd my-app && pnpm install
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: cpu-features@0.0.10, esbuild@0.28.1,
  protobufjs@7.6.6, ssh2@1.17.0, vue-demi@0.14.10, workerd@1.20260911.1
pnpm install exit=1
```

That is the command the CLI's own next steps print three lines above, and the one `getting-started.mdx` gives. After:

```
$ lunora init my-app -t standalone --yes
$ cd my-app && cat pnpm-workspace.yaml
allowBuilds:
    '@parcel/watcher': true
    'esbuild': true
    …
    'ssh2': false
$ pnpm install
Done in 7.3s using pnpm v11.25.0
pnpm install exit=0
```

It is written in the scaffold step now, keyed on the manager detected for the new project. The offer keeps its own call for the one case detection cannot reach — the user picking pnpm at the prompt after `npx lunora init` detected npm — and the helper no-ops when the file already exists.

**The monorepo case** stays skipped, now deliberately rather than incidentally. The new package is not a workspace member yet, so its install has to run from the workspace root (which is what the next-steps hint already says), and that root's own `pnpm-workspace.yaml` governs `allowBuilds`. A second one in the scaffold would make it a workspace root in its own right: `workspace:` deps would stop resolving, and `isWorkspaceRoot` would read the new package as a monorepo root from then on, silently suppressing the install offer for anything scaffolded beneath it. Both behaviours have a test.

## D4 — the `hyperdrive` item could never typecheck, whatever the env fix

With D2 fixed, one diagnostic survived in any scaffold that added `hyperdrive`:

```
lunora/hyperdrive/index.ts(80,27): error TS2345: Argument of type 'Sql<{}>' is not
  assignable to parameter of type 'PostgresJsLike'.
    … 'readonly unknown[]' is 'readonly' and cannot be assigned to the mutable type
      'ParameterOrJSON<never>[]'.
```

`PostgresJsLike.unsafe` was an arrow **property**, which `strictFunctionTypes` checks contravariantly in its parameters. Real postgres.js declares a mutable `parameters` array, so it was not assignable to `params?: ReadonlyArray<unknown>` — the projection could never accept the package it projects. Method syntax is checked bivariantly, which is what a structural projection of someone else's type needs; `this: void` keeps the members usable as bare references (`vi.fn<PostgresJsLike["unsafe"]>()`), following the same idiom and the same scoped lint exemption as `VectorizeIndexLike` in `@lunora/platform`.

The live-driver test's `as unknown as PostgresJsLike` is gone, so it compiles against the real signature rather than around it. Reverting the declaration style makes that line fail — which is how the removal was verified:

```
__tests__/create-hyperdrive.test.ts(187,48): error TS2345: Argument of type 'Sql<{}>'
  is not assignable to parameter of type 'PostgresJsLike'.
```

**Why the registry gate never saw it:** `registry/postgres.d.ts` stubbed `Sql.unsafe` as literally `PostgresJsLike` — the type it is handed to — so the assignment the gate exists to prove was true by construction. It now copies the real signature (mutable parameter array, third optional argument, thenable return). Against the old arrow-property declaration it reproduces the consumer's exact error inside the repo:

```
registry/hyperdrive/hyperdrive.ts(80,27): error TS2345: Argument of type 'Sql' is not
  assignable to parameter of type 'PostgresJsLike'.
```

`NodePgLike` gets the same declaration style. It happened to work already — real `pg` takes a readonly-compatible array — but it is the same shape one dependency bump away from the same failure.

## D5 — `Mysql2Like` has the same defect and this does **not** fix it

`fromMysql2` is equally unusable with the real driver, and the live-driver test casts around it the same way. Method syntax is necessary but not sufficient there, so the cast stays, now with the reason recorded in the code:

```
error TS2345: Argument of type 'Connection' is not assignable to parameter of type 'Mysql2Like'.
  … Type 'readonly unknown[]' is not assignable to type 'ExecuteValues | undefined'.
```

mysql2 types `execute`'s second argument as a single `ExecuteValues` — a union of scalars, `ExecuteValues[]` and `{ [key: string]: ExecuteValues }`. That relates to `ReadonlyArray<unknown>` in **neither** direction, so no variance rule can bridge it. Closing it means deliberately widening the parameter type here and what `SqlClient` promises, which is a design call rather than a declaration-style one. Filed here rather than smuggled in.

The `hyperdrive` registry item ships `fromPostgresJs` and only mentions `fromMysql2` as a swap, so no scaffold hits this today.

## Verification

End to end, one scaffold with `crons` + `storage` + `mail` + `hyperdrive` + `backup` + `payment`:

```
$ lunora init my-app -t standalone --yes   → 9 files, pnpm-workspace.yaml written
$ pnpm install                             → exit 0
$ lunora add crons --yes                   → @lunora/scheduler added
$ lunora codegen                           → exit 0
$ lunora add storage mail hyperdrive backup payment --yes
$ lunora codegen                           → exit 0
$ tsc --noEmit                             → exit 0
$ lunora verify
    ok  verify: project is valid
verify exit=0
```

| gate | result |
| --- | --- |
| `pnpm run build:packages` | ✅ 54 projects |
| `pnpm run lint:types` | ✅ 75 projects + registry (re-run `--no-cache` for `cli`/`hyperdrive`) |
| `pnpm run api:check` | ✅ matches all 54 snapshots (`hyperdrive.api.md` updated after a fresh build) |
| `pnpm run lint:package-json` | ✅ all 89 sorted |
| `pnpm --filter "@lunora/cli" run test` | ✅ 108 files, 1586 tests |
| `pnpm --filter "@lunora/hyperdrive" run test` | ✅ 105 passed, 4 skipped (live-driver) |
| `pnpm run test:affected` | ✅ 65 projects |
| `lint:eslint` (`cli`, `hyperdrive`) | ✅ |

Every new test and every removed cast was proved by breaking the code it covers: reverting the two manifests makes the D1 gate report both gaps; deleting the scaffold-step call makes the `--yes` test fail; deleting the monorepo guard makes the monorepo test fail; reverting `PostgresJsLike` to an arrow property makes both the de-casted test and the registry gate fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pnpm-based projects created through non-interactive, `--yes`, or declined-install flows so build scripts are allowed during installation.
  * Automatically creates the required pnpm configuration when scaffolding a new project, including cases where package-manager detection is completed during installation.
  * Preserved existing monorepo behavior by avoiding unnecessary configuration changes within monorepos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->