### PR TITLE
fix(auth): close six defects on the auth surface

### DIFF
--- a/api-snapshots/auth-ui.api.md
+++ b/api-snapshots/auth-ui.api.md
@@ -5763,7 +5763,6 @@ interface PhoneVerifyState {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/api-snapshots/auth.api.md
+++ b/api-snapshots/auth.api.md
@@ -603,7 +603,6 @@ interface DoAuthWiring {
 
 ```ts
 interface DoAuthWiringOptions {
-    basePath?: string;
     internalSecret: string | undefined;
     namespace: AuthNamespaceLike | undefined;
     objectName?: string;

--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -214,7 +214,7 @@ const ERROR_CATALOG: {
         readonly hint: readonly [
             "This address's domain is on the disposable/throwaway blocklist (or your configured deny-list).",
             "",
-            "Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` to `emailGate(...)` (`@lunora/auth/email-guard`)."
+            "Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` in the `EmailGateConfig` you hand `assertEmailAllowed` / `classifyEmail` / `emailGateMiddleware` (`@lunora/auth/email-guard`)."
         ];
         readonly status: 400;
         readonly title: "Email domain not allowed";

--- a/apps/docs/src/content/docs/concepts/authentication.mdx
+++ b/apps/docs/src/content/docs/concepts/authentication.mdx
@@ -63,9 +63,11 @@ box that gives you:
   [`@lunora/auth/plugins`](/docs/packages/auth/plugins), so you don't chase deep
   import paths.
 - **Invite-only sign-up**: `inviteOnly()` closes self-serve registration to
-  addresses an administrator invited, on every path that mints a user — read the
-  security section before you rely on it, because an invitation is keyed by
-  email address and carries no secret token. See
+  addresses an administrator invited, on every path that mints a user. The
+  invitation carries a 256-bit secret token, so read the security section before
+  you rely on it: the link is a bearer credential anyone who receives it can
+  spend, and without `requireEmailVerification` whoever spends it holds a session
+  immediately. See
   [invite-only sign-up](/docs/packages/auth/plugins#invite-only-sign-up).
 
 ```ts

--- a/apps/docs/src/content/docs/errors.mdx
+++ b/apps/docs/src/content/docs/errors.mdx
@@ -277,7 +277,7 @@ The scheduler could not authenticate to the worker. Check that `LUNORA_SCHEDULER
 
 This address's domain is on the disposable/throwaway blocklist (or your configured deny-list).
 
-Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` to `emailGate(...)` (`@lunora/auth/email-guard`).
+Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` in the `EmailGateConfig` you hand `assertEmailAllowed` / `classifyEmail` / `emailGateMiddleware` (`@lunora/auth/email-guard`).
 
 ### `EMAIL_UNDELIVERABLE`
 

--- a/packages/auth-ui/src/core/config.ts
+++ b/packages/auth-ui/src/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/packages/auth-ui/src/core/flow-gate.ts
+++ b/packages/auth-ui/src/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/packages/auth/__tests__/audit.test.ts
+++ b/packages/auth/__tests__/audit.test.ts
@@ -60,6 +60,55 @@ describe("auth audit trail", () => {
             await expect(readAuthAuditLog(executor, { sinceSeq: 2 })).resolves.toHaveLength(1);
         });
 
+        /**
+         * `sinceSeq` is documented as a forward cursor, so walking it must reach
+         * every row. A lower bound combined with `ORDER BY seq DESC` returns the
+         * NEWEST rows above the bound instead — advancing to the highest `seq`
+         * seen then skips everything older, silently, and the walk terminates
+         * after one page.
+         */
+        it("walks every row when paging forward with sinceSeq", async () => {
+            expect.assertions(2);
+
+            for (let index = 1; index <= 25; index += 1) {
+                // eslint-disable-next-line no-await-in-loop -- sequential appends model the real per-request write order
+                await appendAuthAuditEntry(executor, { event: `e${String(index)}`, outcome: "success", ts: index });
+            }
+
+            const seen: number[] = [];
+            let cursor = 0;
+
+            for (let page = 0; page < 10; page += 1) {
+                // eslint-disable-next-line no-await-in-loop -- a cursor walk is inherently sequential
+                const rows = await readAuthAuditLog(executor, { limit: 10, sinceSeq: cursor });
+
+                if (rows.length === 0) {
+                    break;
+                }
+
+                for (const row of rows) {
+                    seen.push(row.seq);
+                }
+
+                cursor = Math.max(...rows.map((row) => row.seq));
+            }
+
+            expect(seen).toHaveLength(25);
+            expect(seen.toSorted((a, b) => a - b)).toStrictEqual(Array.from({ length: 25 }, (_, index) => index + 1));
+        });
+
+        it("keeps the unpaged read newest-first (what the studio panel renders)", async () => {
+            expect.assertions(1);
+
+            await appendAuthAuditEntry(executor, { event: "first", outcome: "success", ts: 1 });
+            await appendAuthAuditEntry(executor, { event: "second", outcome: "success", ts: 2 });
+
+            await expect(readAuthAuditLog(executor, {})).resolves.toStrictEqual([
+                expect.objectContaining({ event: "second" }),
+                expect.objectContaining({ event: "first" }),
+            ]);
+        });
+
         it("returns [] on a never-audited database instead of throwing", async () => {
             expect.assertions(1);
 
@@ -287,6 +336,21 @@ describe("auth audit trail", () => {
 
             expect(buildAuditEntry({ path: "/api/auth/sign-in/social" })?.event).toBe("sign-in-initiated");
             expect(buildAuditEntry({ path: "/api/auth/sign-in/magic-link" })?.event).toBe("sign-in-initiated");
+        });
+
+        /**
+         * `@better-auth/sso`'s `/sign-in/sso` is a dispatch too — it answers
+         * `{ url, redirect: true }` and nobody is authenticated yet. Falling
+         * through to the `/sign-in/` substring branch recorded every SSO redirect
+         * mint as a completed, successful `sign-in` with no actor. Its completion
+         * is `/sso/callback/:providerId`, which the `/callback/` branch already
+         * classifies.
+         */
+        it("classifies the SSO sign-in dispatch as `sign-in-initiated`, not a completed `sign-in`", () => {
+            expect.assertions(2);
+
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/sso" })?.event).toBe("sign-in-initiated");
+            expect(buildAuditEntry({ path: "/api/auth/sso/callback/okta" })?.event).toBe("sign-in");
         });
 
         it("classifies every sign-in COMPLETION endpoint as `sign-in` (previously unrecorded)", () => {

--- a/packages/auth/__tests__/audit.test.ts
+++ b/packages/auth/__tests__/audit.test.ts
@@ -368,6 +368,27 @@ describe("auth audit trail", () => {
             expect(buildAuditEntry({ path: "/api/auth/sso/saml2/sp/metadata" })?.event).toBeUndefined();
         });
 
+        /**
+         * Both SAML logout endpoints terminate the local session — the
+         * SP-initiated `/sso/saml2/logout/:providerId` and the IdP-initiated
+         * receiver `/sso/saml2/sp/slo/:providerId` each call `deleteSession`
+         * plus `deleteSessionCookie` before redirecting. Neither ends in
+         * `/sign-out`, so both went unrecorded: the trail showed the SAML
+         * sign-in and then nothing, leaving a reader unable to tell "still
+         * signed in" from "we stopped watching".
+         */
+        it("classifies both SAML logout endpoints as `sign-out`", () => {
+            expect.assertions(4);
+
+            expect(buildAuditEntry({ path: "/api/auth/sso/saml2/logout/okta" })?.event).toBe("sign-out");
+            expect(buildAuditEntry({ path: "/api/auth/sso/saml2/sp/slo/okta" })?.event).toBe("sign-out");
+
+            // Neighbouring SSO reads must not be dragged in by the substrings:
+            // provider config is not a session event.
+            expect(buildAuditEntry({ path: "/api/auth/sso/providers" })?.event).toBeUndefined();
+            expect(buildAuditEntry({ path: "/api/auth/sso/saml2/sp/metadata" })?.event).toBeUndefined();
+        });
+
         it("classifies every sign-in COMPLETION endpoint as `sign-in` (previously unrecorded)", () => {
             expect.assertions(5);
 

--- a/packages/auth/__tests__/audit.test.ts
+++ b/packages/auth/__tests__/audit.test.ts
@@ -353,6 +353,21 @@ describe("auth audit trail", () => {
             expect(buildAuditEntry({ path: "/api/auth/sso/callback/okta" })?.event).toBe("sign-in");
         });
 
+        /**
+         * SAML completes at the assertion consumer service, not at a `/callback/`
+         * path — `/sso/saml2/sp/acs/:providerId` runs the whole validate-and-issue
+         * pipeline and calls `setSessionCookie`. Matching neither the `/callback/`
+         * substring nor any other branch, it classified as `undefined` and the one
+         * endpoint that issues a SAML session was not recorded at all.
+         */
+        it("classifies the SAML assertion consumer service as a completed `sign-in`", () => {
+            expect.assertions(2);
+
+            expect(buildAuditEntry({ path: "/api/auth/sso/saml2/sp/acs/okta" })?.event).toBe("sign-in");
+            // The SP metadata document is a public config read, not a sign-in.
+            expect(buildAuditEntry({ path: "/api/auth/sso/saml2/sp/metadata" })?.event).toBeUndefined();
+        });
+
         it("classifies every sign-in COMPLETION endpoint as `sign-in` (previously unrecorded)", () => {
             expect.assertions(5);
 

--- a/packages/auth/__tests__/auth-do.behaviour.test.ts
+++ b/packages/auth/__tests__/auth-do.behaviour.test.ts
@@ -309,6 +309,58 @@ describe("lunoraAuthDO", () => {
         expect(response.status).toBe(400);
     });
 
+    /**
+     * `ensureAuthAuditTable` single-flights its DDL in a `WeakMap` keyed on the
+     * executor object. Building a fresh `doExecutor(storage)` per request gave
+     * every read a brand-new key, so the cache never hit: every audit read
+     * re-ran `CREATE TABLE IF NOT EXISTS` plus an `ALTER TABLE` that always
+     * throws and is swallowed.
+     */
+    it("runs the audit DDL once across repeated reads, not once per read", async () => {
+        expect.assertions(2);
+
+        const storage = createDoStorage(database);
+        const ddl: string[] = [];
+        const spying = {
+            ...storage,
+            sql: {
+                exec: (query: string, ...bindings: unknown[]) => {
+                    if (query.includes("__lunora_auth_audit__") && (query.startsWith("CREATE TABLE") || query.startsWith("ALTER TABLE"))) {
+                        ddl.push(query.split("\n")[0]!.trim());
+                    }
+
+                    return storage.sql.exec(query, ...bindings);
+                },
+            },
+        };
+        const authDo = new LunoraAuthDO(
+            { storage: spying },
+            () => {
+                return { secret: SECRET };
+            },
+            { internalSecret: INTERNAL_SECRET },
+        );
+
+        const read = async (): Promise<Response> =>
+            authDo.fetch(
+                new Request(`https://example.test${READ_AUDIT_PATH}`, {
+                    body: JSON.stringify({}),
+                    headers: { "content-type": "application/json", [INTERNAL_SECRET_HEADER]: INTERNAL_SECRET },
+                    method: "POST",
+                }),
+            );
+
+        const first = await read();
+
+        expect(first.status).toBe(200);
+
+        await read();
+        await read();
+
+        // One CREATE + one ALTER, from the first read only.
+        expect(ddl).toHaveLength(2);
+    });
+
     it("refuses the audit log without the secret", async () => {
         expect.assertions(1);
 

--- a/packages/auth/__tests__/do-wiring.behaviour.test.ts
+++ b/packages/auth/__tests__/do-wiring.behaviour.test.ts
@@ -72,16 +72,6 @@ describe("createDoAuthWiring", () => {
             await expect(authHandler(new Request("https://example.test/api/auth/get-session"))).resolves.toBeDefined();
         });
 
-        it("normalizes a trailing slash on the base path", async () => {
-            expect.assertions(2);
-
-            const { namespace } = createNamespace(() => new Response("served"));
-            const { authHandler } = createDoAuthWiring({ basePath: "/api/auth/", internalSecret: SECRET, namespace });
-
-            await expect(authHandler(new Request("https://example.test/api/auth/get-session"))).resolves.toBeDefined();
-            await expect(authHandler(new Request("https://example.test/api/authorize"))).resolves.toBeUndefined();
-        });
-
         it("leaves a non-auth route alone, so the Lunora worker still handles it", async () => {
             expect.assertions(2);
 
@@ -93,14 +83,14 @@ describe("createDoAuthWiring", () => {
             expect(requests).toHaveLength(0);
         });
 
-        it("honours a custom base path", async () => {
+        it("forwards only the fixed base path, so a lookalike prefix stays with the app", async () => {
             expect.assertions(2);
 
             const { namespace } = createNamespace(() => new Response("served"));
-            const { authHandler } = createDoAuthWiring({ basePath: "/auth", internalSecret: SECRET, namespace });
+            const { authHandler } = createDoAuthWiring({ internalSecret: SECRET, namespace });
 
-            await expect(authHandler(new Request("https://example.test/auth/sign-in/email"))).resolves.toBeDefined();
-            await expect(authHandler(new Request("https://example.test/api/auth/sign-in/email"))).resolves.toBeUndefined();
+            await expect(authHandler(new Request("https://example.test/api/auth/sign-in/email"))).resolves.toBeDefined();
+            await expect(authHandler(new Request("https://example.test/api/authorize"))).resolves.toBeUndefined();
         });
 
         it("reports no response when the namespace binding is absent", async () => {

--- a/packages/auth/__tests__/invite-only.behaviour.test.ts
+++ b/packages/auth/__tests__/invite-only.behaviour.test.ts
@@ -233,7 +233,7 @@ describe("inviteOnly", () => {
         });
     });
 
-    it("refuses an expired invitation", async () => {
+    it("refuses an expired invitation with the same message a wrong token earns", async () => {
         expect.assertions(1);
 
         const token = await invite("ada@example.com", 60);
@@ -241,10 +241,11 @@ describe("inviteOnly", () => {
         vi.useFakeTimers();
         vi.setSystemTime(Date.now() + 61 * 1000);
 
-        // The token still matches — expiry is the database gate's business, so the
-        // holder of a stale link gets the "ask for an invitation" message rather
-        // than the deliberately vague one a wrong token earns.
-        await expect(signUp("ada@example.com", token)).rejects.toThrow(/invite-only/);
+        // The token still matches, but the route hook checks usability too, so the
+        // holder of a stale link gets the one uniform `SIGN_UP_INVITE_INVALID`
+        // rejection — not a different code that tells them the address is on the
+        // list and only the link went stale.
+        await expect(signUp("ada@example.com", token)).rejects.toThrow(/not valid/);
     });
 
     it("refuses a revoked invitation", async () => {
@@ -266,7 +267,8 @@ describe("inviteOnly", () => {
         await signUp("ada@example.com", token);
         database["user"] = [];
 
-        await expect(signUp("ada@example.com", token)).rejects.toThrow(/invite-only/);
+        // Spent, like expired, is refused at the route hook with the uniform message.
+        await expect(signUp("ada@example.com", token)).rejects.toThrow(/not valid/);
     });
 
     /**

--- a/packages/auth/__tests__/middleware.test.ts
+++ b/packages/auth/__tests__/middleware.test.ts
@@ -274,6 +274,21 @@ describe("withAuthPlugins — runtime header guard", () => {
         expect(calls).toHaveLength(1);
     });
 
+    it("{ enforceHeaders: false } keeps the withoutHeaders() escape hatch callable", async () => {
+        expect.assertions(2);
+
+        const calls: { options: unknown }[] = [];
+        const authApi = await installAuthApi(stubAuth(calls), false);
+
+        // `withoutHeaders` is part of the DECLARED `ctx.authApi` type, so an app
+        // that wrote the documented escape hatch for a cron path must not start
+        // throwing `is not a function` the day it flips the guard off.
+        const result = await authApi.withoutHeaders().banUser({ body: { userId: "u_1" } });
+
+        expect(result).toEqual({ called: true, sawHeaders: false });
+        expect(calls).toHaveLength(1);
+    });
+
     it("guards a real better-auth admin endpoint end to end", async () => {
         expect.assertions(2);
 

--- a/packages/auth/docs/plugins.mdx
+++ b/packages/auth/docs/plugins.mdx
@@ -307,12 +307,18 @@ who guesses an address holding a session immediately and holding none.
 ### What it refuses that you may not expect
 
 Plugins that mint an account from something other than a real mailbox still
-synthesize an address — `anonymous` writes `temp-<id>@<domain>`, `siwe` writes
-`<wallet>@<domain>`, and `phoneNumber`'s sign-up-on-verification writes a temp
-address of its own. None of them can match an invitation, so the gate **rejects**
-those flows — but only once a user exists. Under `allowFirstUser: true` the
-bootstrap runs before the address is ever compared, so the first anonymous session
-or wallet sign-in is what claims it. Do not combine those plugins with this one.
+synthesize an address — `siwe` writes `<wallet>@<domain>`, and `phoneNumber`'s
+sign-up-on-verification writes a temp address of its own. Neither can match an
+invitation, so the gate **rejects** those flows — but only once a user exists.
+Under `allowFirstUser: true` the bootstrap runs before the address is ever
+compared, so the first wallet sign-in is what claims it. Do not combine those
+plugins with this one.
+
+`anonymous` is the one carve-out, because anonymous sign-in is not registration.
+Its throwaway identity is admitted, and converting it into a real account is
+gated like any other sign-up — better-auth creates a second, non-anonymous row
+for that, and the gate sees it. Installing both gives you "browse anonymously,
+invitation required to keep an account".
 
 Lunora's `AuthAdmin.createUser` — the studio's create-user action — mints through
 the same internal adapter, so it is gated too. Issue an invitation first, or call
@@ -406,13 +412,6 @@ export const submit = mutation.input({ message: v.string(), turnstileToken: v.st
     /* args.message has passed the Turnstile check */
 });
 ```
-
-<Callout type="warn">
-    **`verifyTurnstileMiddleware`'s `token` selector cannot read the args.** A `.use()` middleware is handed only the context, and the builder never places the
-    parsed `args` onto it — so `token: (ctx) => ctx.turnstileToken` does not type-check, and cast past it reads `undefined` and the middleware throws
-    `FORBIDDEN "turnstile token missing"` on **every** submission. The selector is usable only for a token an earlier `.use()` already put on the context. For a
-    token that arrives in the args, use the in-handler `verifyTurnstile` call above.
-</Callout>
 
 <Callout type="warn">
     **Use the `captcha` plugin for the auth flow.** It hooks better-auth's pipeline and reads the token from the `x-captcha-response` header. The standalone

--- a/packages/auth/src/audit-hooks.ts
+++ b/packages/auth/src/audit-hooks.ts
@@ -79,12 +79,20 @@ interface AuditHookContext {
  * SSO redirect mint was recorded as a completed, successful `sign-in` with no
  * actor — in exactly the flow where the "who authenticated" trail matters
  * most.
- * - `/callback/:id` (social + generic-oauth), `/magic-link/verify`, and every
+ * - `/callback/:id` (social + generic-oauth), `/magic-link/verify`,
+ * `@better-auth/sso`'s `/sso/saml2/sp/acs/:providerId`, and every
  * `/two-factor/verify-*` (`verify-totp` / `verify-otp` / `verify-backup-code`
  * — all three complete a challenged sign-in the same way) are where a
  * session actually gets issued, so they join credential sign-ins
  * (`/sign-in/email`, `/sign-in/username`, `/sign-in/phone-number`, …) as
  * plain `sign-in`. They were NOT recorded at all before this change.
+ *
+ * The SAML assertion consumer service needs its own branch because it is the
+ * one completion that carries no `/callback/` segment: `processSAMLResponse`
+ * validates the assertion, resolves the user and calls `setSessionCookie`, all
+ * under `/sso/saml2/sp/acs/:providerId`. Matching neither that substring nor
+ * any other branch, it classified as `undefined` — the endpoint that issues
+ * every SAML session left no audit row at all.
  *
  * There is no dedicated `/oauth2/callback/*` branch because the generic
  * `/callback/` check above already covers it, and covering it is CORRECT: an
@@ -113,7 +121,13 @@ const eventForPath = (path: string): AuthAuditEvent | undefined => {
         return "sign-in-initiated";
     }
 
-    if (normalized.includes("/sign-in/") || normalized.includes("/callback/") || ends("/magic-link/verify") || normalized.includes("/two-factor/verify-")) {
+    if (
+        normalized.includes("/sign-in/") ||
+        normalized.includes("/callback/") ||
+        normalized.includes("/saml2/sp/acs/") ||
+        ends("/magic-link/verify") ||
+        normalized.includes("/two-factor/verify-")
+    ) {
         return "sign-in";
     }
 

--- a/packages/auth/src/audit-hooks.ts
+++ b/packages/auth/src/audit-hooks.ts
@@ -94,6 +94,22 @@ interface AuditHookContext {
  * any other branch, it classified as `undefined` — the endpoint that issues
  * every SAML session left no audit row at all.
  *
+ * SAML sign-OUT has the mirror-image problem, and two endpoints rather than
+ * one. Neither ends in `/sign-out`, and both terminate the local session before
+ * redirecting, so both are `sign-out` rather than an initiated event:
+ *
+ * - `/sso/saml2/logout/:providerId` — SP-initiated. Deletes the SAML session
+ * keys, calls `deleteSession` on the current session token and
+ * `deleteSessionCookie`, then redirects to the IdP's logout URL.
+ * - `/sso/saml2/sp/slo/:providerId` — the SP's single-logout receiver, for the
+ * IdP-initiated direction and for the response leg of an SP-initiated one.
+ * Both `handleLogoutRequest` and `handleLogoutResponse` call `deleteSession`
+ * and `deleteSessionCookie` the same way.
+ *
+ * Recording the SAML sign-in while leaving these silent is worse than either
+ * gap alone: the trail would show a session opening and never closing, so a
+ * reader cannot tell "still signed in" from "we stopped watching".
+ *
  * There is no dedicated `/oauth2/callback/*` branch because the generic
  * `/callback/` check above already covers it, and covering it is CORRECT: an
  * OAuth callback is a completed sign-in whatever path prefix it arrives on. The
@@ -131,7 +147,7 @@ const eventForPath = (path: string): AuthAuditEvent | undefined => {
         return "sign-in";
     }
 
-    if (ends("/sign-out")) {
+    if (ends("/sign-out") || normalized.includes("/saml2/logout/") || normalized.includes("/saml2/sp/slo/")) {
         return "sign-out";
     }
 

--- a/packages/auth/src/audit-hooks.ts
+++ b/packages/auth/src/audit-hooks.ts
@@ -70,9 +70,15 @@ interface AuditHookContext {
  *
  * Sign-in is split by what the endpoint actually DOES (plan 280 §4):
  *
- * - `/sign-in/social`, `/sign-in/magic-link` only DISPATCH — the first mints a
- * provider redirect URL, the second sends an email. Nobody is authenticated
- * yet, so these are `sign-in-initiated`, not `sign-in`.
+ * - `/sign-in/social`, `/sign-in/magic-link` and `@better-auth/sso`'s
+ * `/sign-in/sso` only DISPATCH — the first mints a provider redirect URL, the
+ * second sends an email, the third answers `{ url, redirect: true }` pointing
+ * at the identity provider's authorization endpoint. Nobody is authenticated
+ * yet, so these are `sign-in-initiated`, not `sign-in`. Without the `sso`
+ * branch that path fell through to the `/sign-in/` substring below and every
+ * SSO redirect mint was recorded as a completed, successful `sign-in` with no
+ * actor — in exactly the flow where the "who authenticated" trail matters
+ * most.
  * - `/callback/:id` (social + generic-oauth), `/magic-link/verify`, and every
  * `/two-factor/verify-*` (`verify-totp` / `verify-otp` / `verify-backup-code`
  * — all three complete a challenged sign-in the same way) are where a
@@ -84,14 +90,16 @@ interface AuditHookContext {
  * `/callback/` check above already covers it, and covering it is CORRECT: an
  * OAuth callback is a completed sign-in whatever path prefix it arrives on. The
  * same substring also catches `@better-auth/sso`'s `/sso/callback/:providerId`,
- * so if `plugins.ts` ever re-exports `sso` (plan 280 §9 Q1) that endpoint is
- * classified rather than silently unrecorded. Checked against the installed
- * `better-auth` and `@better-auth/*` dist for 1.7.1: generic-oauth reuses the
- * core `/callback/:id` endpoint rather than registering its own, and the one
- * dist hit for a literal `/oauth2/callback/` is inside
- * `better-auth/plugins/oauth-popup`, which `plugins.ts` does not re-export —
- * so today the branch fires for the core callback, and stays correct if either
- * of the others becomes reachable. `__tests__/audit.test.ts` pins all three.
+ * which is where an SSO sign-in actually completes — `sso` is re-exported from
+ * `@lunora/auth/plugins/enterprise`, so that path is live, not hypothetical.
+ *
+ * Checked against the installed `better-auth` and `@better-auth/*` dist for
+ * 1.7.3: generic-oauth registers NO endpoints of its own (there is no
+ * `/sign-in/oauth2`) — it registers providers used through the core
+ * `/sign-in/social` and `/callback/:id`, and the one dist hit for a literal
+ * `/oauth2/callback/` is inside `better-auth/plugins/oauth-popup`, which
+ * `plugins.ts` does not re-export — so today the branch fires for the core
+ * callback, and stays correct if the other becomes reachable.
  */
 const eventForPath = (path: string): AuthAuditEvent | undefined => {
     const normalized = path.toLowerCase();
@@ -101,7 +109,7 @@ const eventForPath = (path: string): AuthAuditEvent | undefined => {
         return "sign-up";
     }
 
-    if (ends("/sign-in/social") || ends("/sign-in/magic-link")) {
+    if (ends("/sign-in/social") || ends("/sign-in/magic-link") || ends("/sign-in/sso")) {
         return "sign-in-initiated";
     }
 

--- a/packages/auth/src/audit.ts
+++ b/packages/auth/src/audit.ts
@@ -129,7 +129,12 @@ interface ReadAuthAuditOptions {
     event?: string;
     /** Max rows to return, clamped to [1, 10000]. Defaults to 1000. */
     limit?: number;
-    /** Return only events with `seq` strictly greater than this (forward paging). */
+
+    /**
+     * Return only events with `seq` strictly greater than this. Supplying it
+     * switches the page to oldest-first so the cursor walks forward; omit it for
+     * the newest-first feed.
+     */
     sinceSeq?: number;
 }
 
@@ -274,10 +279,17 @@ const appendAuthAuditEntry = async (
 };
 
 /**
- * Read audit events newest-first, optionally filtered by `actorId` / `event` and
- * paged past `sinceSeq`, up to `limit` (clamped to [1, 10000]). Parses each row's
- * `detail` JSON back into an object. Creates the table first so reads on a
- * never-audited database return `[]` instead of throwing.
+ * Read audit events, optionally filtered by `actorId` / `event` and paged past
+ * `sinceSeq`, up to `limit` (clamped to [1, 10000]). Parses each row's `detail`
+ * JSON back into an object. Creates the table first so reads on a never-audited
+ * database return `[]` instead of throwing.
+ *
+ * Ordering follows the cursor: **without** `sinceSeq` the page is newest-first
+ * (`seq DESC`) — the feed the studio's Security panel renders. **With**
+ * `sinceSeq` it is oldest-first (`seq ASC`), because a lower bound is a forward
+ * walk: a descending page above the bound would hand back the newest rows and
+ * leave everything between the cursor and them unreachable once the caller
+ * advanced past it.
  *
  * `limit` is NaN-safe: a non-finite/non-number value (e.g. a caller passing
  * `Number.NaN`, or an upstream boundary that failed to reject one) falls back
@@ -293,6 +305,12 @@ const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOpt
     const limit = Number.isFinite(options.limit) ? Math.max(1, Math.min(options.limit as number, MAX_READ_LIMIT)) : DEFAULT_READ_LIMIT;
     const clauses: string[] = ["seq > ?"];
     const parameters: unknown[] = [options.sinceSeq ?? 0];
+    // A `sinceSeq` cursor is a FORWARD walk, so the page it returns has to be the
+    // rows just above the cursor — ascending. Combined with `DESC` the lower bound
+    // returns the NEWEST rows instead, and advancing the cursor to the highest
+    // `seq` seen skips every older row, silently, after one page. Without a cursor
+    // the read stays newest-first, which is what the studio's panel renders.
+    const direction = options.sinceSeq === undefined ? "DESC" : "ASC";
 
     if (options.actorId !== undefined) {
         clauses.push("actor_id = ?");
@@ -307,7 +325,7 @@ const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOpt
     parameters.push(limit);
 
     const rows = await executor.all(
-        `SELECT seq, ts, event, outcome, actor_id, actor_email, target_email, ip, user_agent, detail FROM "${AUTH_AUDIT_TABLE}" WHERE ${clauses.join(" AND ")} ORDER BY seq DESC LIMIT ?`,
+        `SELECT seq, ts, event, outcome, actor_id, actor_email, target_email, ip, user_agent, detail FROM "${AUTH_AUDIT_TABLE}" WHERE ${clauses.join(" AND ")} ORDER BY seq ${direction} LIMIT ?`,
         parameters,
     );
 

--- a/packages/auth/src/auth-do.ts
+++ b/packages/auth/src/auth-do.ts
@@ -40,6 +40,7 @@ import type { DoStorageLike } from "./do-store";
 import { doExecutor } from "./do-store";
 import { handleAuthRequest } from "./handler";
 import { indexesReferencingIssuer, legacyIssuerCleanupStatements, schemaDeclaresIssuer } from "./legacy-issuer";
+import type { SqlExecutor } from "./sql-store";
 
 /**
  * The Durable Object state slice this class needs — structural so unit tests can
@@ -108,9 +109,6 @@ const parseReadAuditOptions = (parsed: unknown): { error: string } | { options: 
  * @experimental
  */
 interface AuthDoOptions {
-    /** Base path the auth routes are served under. Must match the worker's. */
-    basePath?: string;
-
     /**
      * Shared secret authenticating the worker on {@link RESOLVE_SESSION_PATH}.
      *
@@ -141,6 +139,18 @@ interface AuthDoOptions {
  * @experimental
  */
 class LunoraAuthDO {
+    /**
+     * One executor for the object's lifetime, not one per request.
+     *
+     * `ensureAuthAuditTable` single-flights its DDL in a `WeakMap` keyed on the
+     * executor object, so a fresh `doExecutor(this.#storage)` per read is a
+     * fresh key every time: the cache never hits and every audit read re-runs
+     * `CREATE TABLE IF NOT EXISTS` plus an `ALTER TABLE` that always throws and
+     * is swallowed. The executor is a stateless pair of closures over `storage`,
+     * so sharing it is free.
+     */
+    readonly #auditExecutor: SqlExecutor;
+
     readonly #options: AuthDoOptions;
 
     readonly #optionsFactory: () => LunoraAuthOptions;
@@ -158,6 +168,7 @@ class LunoraAuthDO {
      */
     public constructor(state: AuthDoState, optionsFactory: () => LunoraAuthOptions, options: AuthDoOptions = {}) {
         this.#storage = state.storage;
+        this.#auditExecutor = doExecutor(state.storage);
         this.#optionsFactory = optionsFactory;
         this.#options = options;
     }
@@ -286,6 +297,10 @@ class LunoraAuthDO {
      * `Date` values), so proxying it over HTTP is lossless rather than a lossy
      * serialisation the studio would have to compensate for.
      *
+     * Ordering comes from the reader: newest-first without a cursor, oldest-first
+     * when the body carries `sinceSeq`, so a caller walking the cursor forward
+     * reaches every row rather than re-reading the head of the log.
+     *
      * The body is parsed and validated defensively (plan 280 §5 S3): a
      * malformed body (not JSON at all) previously threw an unhandled exception
      * out of this method — a 500 — instead of the 400 a caller error deserves;
@@ -314,14 +329,13 @@ class LunoraAuthDO {
             return Response.json({ error: parsed.error }, { status: 400 });
         }
 
-        const executor = doExecutor(this.#storage);
-
         // The audit table is not part of `authTables`, so the schema pass does not
         // create it. Ensuring it here (rather than on every cold start) keeps it off
-        // the request path for apps that never read the log.
-        await ensureAuthAuditTable(executor);
+        // the request path for apps that never read the log; the shared executor is
+        // what lets the single-flight cache actually hit after the first read.
+        await ensureAuthAuditTable(this.#auditExecutor);
 
-        const entries = await createAuthAuditReader(executor).read(parsed.options);
+        const entries = await createAuthAuditReader(this.#auditExecutor).read(parsed.options);
 
         return Response.json({ entries } satisfies { entries: AuthAuditEntry[] });
     }
@@ -392,8 +406,12 @@ class LunoraAuthDO {
     }
 
     /**
-     * Serve an auth request. Routes under `basePath` go to better-auth; the internal
+     * Serve an auth request. Routes under `/api/auth` go to better-auth; the internal
      * session route is handled here; anything else is a 404.
+     *
+     * The base path is not configurable. The worker half only ever forwards
+     * `/api/auth/*` (`createDoAuthWiring`, which codegen calls with no base path),
+     * so a second knob here could only ever disagree with it.
      */
     public async fetch(request: Request): Promise<Response> {
         const url = new URL(request.url);
@@ -407,7 +425,7 @@ class LunoraAuthDO {
         }
 
         const auth = this.#ensureReady();
-        const response = await handleAuthRequest(auth, request, this.#options.basePath);
+        const response = await handleAuthRequest(auth, request);
 
         return response ?? Response.json({ error: "not an auth route" }, { status: 404 });
     }

--- a/packages/auth/src/do-wiring.ts
+++ b/packages/auth/src/do-wiring.ts
@@ -23,9 +23,6 @@ export interface AuthNamespaceLike {
 
 /** What {@link createDoAuthWiring} needs, already resolved against `env`. */
 export interface DoAuthWiringOptions {
-    /** Base path the auth routes are served under. Defaults to `/api/auth`. */
-    basePath?: string;
-
     /**
      * Shared secret presented on the object's internal session route. `undefined`
      * means identity resolution fails closed — see {@link DoAuthWiring.resolveIdentity}.
@@ -55,7 +52,14 @@ export interface DoAuthWiring {
      */
     auditReader: AuthAuditReader;
 
-    /** Forwards `/api/auth/*` to the object; `undefined` for anything else. */
+    /**
+     * Forwards `/api/auth/*` to the object; `undefined` for anything else.
+     *
+     * The base path is fixed. It was configurable on both halves of DO-backed auth
+     * and settable on neither: codegen's `AuthDeclaration` has no field for it, so
+     * the emitted `createDoAuthWiring(...)` never passed one and an `AuthDO`
+     * subclass that set its own served nothing.
+     */
     authHandler: (request: Request) => Promise<Response | undefined>;
 
     /**
@@ -82,7 +86,7 @@ export interface DoAuthWiring {
  * @experimental
  */
 export const createDoAuthWiring = (options: DoAuthWiringOptions): DoAuthWiring => {
-    const { basePath = DEFAULT_AUTH_BASE_PATH, internalSecret, namespace, objectName = "auth" } = options;
+    const { internalSecret, namespace, objectName = "auth" } = options;
 
     /** The object's stub, or `undefined` when the binding is missing. */
     const stub = (): undefined | { fetch: (request: Request) => Promise<Response> } => {
@@ -138,7 +142,7 @@ export const createDoAuthWiring = (options: DoAuthWiringOptions): DoAuthWiring =
         authHandler: async (request) => {
             // Only auth routes go to the object; everything else falls through to the
             // Lunora worker exactly as it does in D1 mode.
-            if (!isAuthRoutePath(new URL(request.url).pathname, basePath)) {
+            if (!isAuthRoutePath(new URL(request.url).pathname, DEFAULT_AUTH_BASE_PATH)) {
                 return undefined;
             }
 

--- a/packages/auth/src/invite-only.ts
+++ b/packages/auth/src/invite-only.ts
@@ -57,7 +57,9 @@
  *
  * - `databaseHooks.user.create.before` — the universal backstop. An unspent,
  *   unexpired invitation must exist for the address, whatever created the row.
- * - `hooks.before` on `/sign-up/email` — additionally requires the token.
+ * - `hooks.before` on `/sign-up/email` — additionally requires the token, and
+ *   re-checks that the invitation is unspent and unexpired so a stale link earns
+ *   the same vague rejection a wrong token does.
  *
  * Without the token this would be guessable in bulk, and that is not theoretical:
  * the common case is inviting a team, where addresses are `first.last@company`.
@@ -315,10 +317,8 @@ const hasAnonymousPlugin = (options: BetterAuthOptions): boolean => (options.plu
  */
 const isAnonymousUser = (user: Readonly<Record<string, unknown>>): boolean => user["isAnonymous"] === true;
 
-/** Whether `email` has an invitation that is present, unspent, and unexpired. */
-const hasUsableInvitation = async (adapter: AuthAdapter, email: string): Promise<boolean> => {
-    const row = await adapter.findOne<Record<string, unknown>>({ model: INVITATION_MODEL, where: [{ field: "email", value: email }] });
-
+/** Whether an already-loaded invitation row is present, unspent, and unexpired. */
+const isUsableInvitation = (row: null | Record<string, unknown>): boolean => {
     if (row === null || row["acceptedAt"] instanceof Date) {
         return false;
     }
@@ -326,12 +326,17 @@ const hasUsableInvitation = async (adapter: AuthAdapter, email: string): Promise
     return row["expiresAt"] instanceof Date && row["expiresAt"].getTime() > Date.now();
 };
 
+/** Whether `email` has an invitation that is present, unspent, and unexpired. */
+const hasUsableInvitation = async (adapter: AuthAdapter, email: string): Promise<boolean> =>
+    isUsableInvitation(await adapter.findOne<Record<string, unknown>>({ model: INVITATION_MODEL, where: [{ field: "email", value: email }] }));
+
 /**
  * Warn once per auth context when the password provider is on without
- * `requireEmailVerification`. It does not make an invited address secret (see the
- * security section above) — it is the difference between an attacker who guesses
- * one holding a session immediately and holding none until the invitee clicks a
- * link she was expecting. Mirrors `./plugins-enterprise.ts`'s `sso()` warning: it
+ * `requireEmailVerification`. The token already stops address-guessing (see the
+ * security section above); this is about the residual risk the token cannot
+ * cover — a link that reached the wrong person. It is the difference between
+ * whoever holds a forwarded link holding a session immediately and holding none
+ * until someone clicks a link delivered to the address itself. Mirrors `./plugins-enterprise.ts`'s `sso()` warning: it
  * does not change the default, it just refuses to let the gap be silent.
  */
 const warnIfVerificationOff = (options: BetterAuthOptions): void => {
@@ -342,9 +347,9 @@ const warnIfVerificationOff = (options: BetterAuthOptions): void => {
     // eslint-disable-next-line no-console
     console.warn(
         "@lunora/auth: inviteOnly() is installed with password sign-up but without " +
-            "`emailAndPassword: { requireEmailVerification: true }`. An invitation is keyed by email address " +
-            "alone, so anyone who learns an invited address can sign up as it — and without verification they " +
-            "hold a session the moment they do.",
+            "`emailAndPassword: { requireEmailVerification: true }`. The invitation link is a bearer " +
+            "credential, so anyone it reaches — a forwarded mail, a shared inbox — can sign up as that " +
+            "address, and without verification they hold a session the moment they do.",
     );
 };
 
@@ -464,7 +469,13 @@ const inviteOnly = (options: InviteOnlyOptions = {}): BetterAuthPlugin => {
                         // token cost the same.
                         const presentedHash = await hashToken(presented);
 
-                        if (typeof stored !== "string" || !digestsMatch(stored, presentedHash)) {
+                        // Usability is checked HERE as well as in `user.create.before`,
+                        // not only there: the database gate answers
+                        // `SIGN_UP_INVITE_REQUIRED`, and letting a spent or expired
+                        // invitation past this hook to earn that code tells the holder
+                        // of a stale link that the address IS on the list — the exact
+                        // distinction the uniform rejection exists to hide.
+                        if (typeof stored !== "string" || !digestsMatch(stored, presentedHash) || !isUsableInvitation(row)) {
                             refuse();
                         }
                     }),

--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -44,18 +44,24 @@ const callHasHeaders = (argument: unknown): boolean => {
 };
 
 /**
- * Wrap a better-auth `api` surface in a Proxy that throws
- * {@link LunoraAuthHeadersError} when any endpoint is invoked without `headers`.
+ * Wrap a better-auth `api` surface in a Proxy that synthesises the
+ * `withoutHeaders()` escape hatch and — when `enforce` is set — throws
+ * {@link LunoraAuthHeadersError} for any endpoint invoked without `headers`.
  *
  * The proxy is transparent: property reads return guarded function wrappers for
  * callable endpoints and pass everything else (non-function properties) through
  * untouched, so the wrapped surface stays structurally identical to `auth.api`.
  *
- * One synthetic property is added — `withoutHeaders()` — the explicit, loud
- * escape hatch that returns the raw, unguarded `auth.api` for the rare,
- * deliberate server-to-server call that must run unauthenticated.
+ * One synthetic property is always added — `withoutHeaders()` — the explicit,
+ * loud escape hatch that returns the raw, unguarded `auth.api` for the rare,
+ * deliberate server-to-server call that must run unauthenticated. It is
+ * synthesised even with `enforce` off, because `LunoraAuthApiContext`'s type
+ * declares it unconditionally: an app that wrote the documented
+ * `ctx.authApi.withoutHeaders().createOrganization(…)` for a cron path would
+ * otherwise start throwing `is not a function` the day it sets
+ * `enforceHeaders: false`, with tsc silent about it.
  */
-const guardAuthApi = <Api extends Record<string, unknown>>(api: Api): Api => {
+const guardAuthApi = <Api extends Record<string, unknown>>(api: Api, enforce: boolean): Api => {
     const withoutHeaders = (): Api => api;
 
     return new Proxy(api, {
@@ -78,7 +84,7 @@ const guardAuthApi = <Api extends Record<string, unknown>>(api: Api): Api => {
             const method = property;
 
             return (...arguments_: unknown[]): unknown => {
-                if (!callHasHeaders(arguments_[0])) {
+                if (enforce && !callHasHeaders(arguments_[0])) {
                     // better-auth endpoints are async, so surface the guard as a
                     // rejected promise — it composes with `await`/`.catch` the
                     // same way an endpoint error would, instead of throwing
@@ -304,9 +310,9 @@ export const withAuthPlugins = <Auth extends LunoraAuth>(auth: Auth, options: Wi
 
     // Build the surface once per middleware, not per request: the guard proxy
     // is stateless, so the same wrapped object is safe to share across calls.
-    const authApi = enforceHeaders
-        ? (guardAuthApi(auth.api as Record<string, unknown>) as LunoraAuthApiContext<Auth>["authApi"])
-        : (auth.api as LunoraAuthApiContext<Auth>["authApi"]);
+    // The wrapper goes on either way — with `enforceHeaders` off it only
+    // synthesises `withoutHeaders()` and passes every endpoint through.
+    const authApi = guardAuthApi(auth.api as Record<string, unknown>, enforceHeaders) as LunoraAuthApiContext<Auth>["authApi"];
 
     // The callable is generic over CtxIn so `next({ ctx: { authApi } })`
     // returns `CtxIn & { authApi }` — fields the upstream middleware

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -166,7 +166,7 @@ export const ERROR_CATALOG = {
         hint: [
             "This address's domain is on the disposable/throwaway blocklist (or your configured deny-list).",
             "",
-            "Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` to `emailGate(...)` (`@lunora/auth/email-guard`).",
+            "Sign up with a permanent mailbox. To tune the policy, pass `blockDisposable` / `allowDomains` / `denyDomains` in the `EmailGateConfig` you hand `assertEmailAllowed` / `classifyEmail` / `emailGateMiddleware` (`@lunora/auth/email-guard`).",
         ],
         status: 400,
         title: "Email domain not allowed",

--- a/packages/runtime/src/auth-audit-rpc.ts
+++ b/packages/runtime/src/auth-audit-rpc.ts
@@ -46,7 +46,12 @@ interface ReadAuthAuditQuery {
     event?: string;
     /** Max rows to return; clamped by the reader. */
     limit?: number;
-    /** Return only events with `seq` strictly greater than this (forward paging). */
+
+    /**
+     * Return only events with `seq` strictly greater than this. Supplying it
+     * switches the reader's page to oldest-first so the cursor walks forward;
+     * omit it for the newest-first feed.
+     */
     sinceSeq?: number;
 }
 
@@ -66,7 +71,7 @@ interface AuthAuditReader {
     read: (options: ReadAuthAuditQuery) => Promise<AuthAuditEntry[]>;
 }
 
-/** Payload of a {@link GET_AUTH_AUDIT_LOG_OP} call: the recorded entries, newest first. */
+/** Payload of a {@link GET_AUTH_AUDIT_LOG_OP} call: the recorded entries — newest first, or oldest first when the query carried a `sinceSeq` cursor. */
 interface AuthAuditLogResult {
     entries: AuthAuditEntry[];
 }

--- a/registry/auth-ui-angular/core/config.ts
+++ b/registry/auth-ui-angular/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-angular/core/flow-gate.ts
+++ b/registry/auth-ui-angular/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/registry/auth-ui-react/core/config.ts
+++ b/registry/auth-ui-react/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-react/core/flow-gate.ts
+++ b/registry/auth-ui-react/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/registry/auth-ui-solid-v2/core/config.ts
+++ b/registry/auth-ui-solid-v2/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-solid-v2/core/flow-gate.ts
+++ b/registry/auth-ui-solid-v2/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/registry/auth-ui-solid/core/config.ts
+++ b/registry/auth-ui-solid/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-solid/core/flow-gate.ts
+++ b/registry/auth-ui-solid/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/registry/auth-ui-svelte/core/config.ts
+++ b/registry/auth-ui-svelte/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-svelte/core/flow-gate.ts
+++ b/registry/auth-ui-svelte/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",

--- a/registry/auth-ui-vue/core/config.ts
+++ b/registry/auth-ui-vue/core/config.ts
@@ -41,13 +41,6 @@ interface NavAdapter {
 interface PluginFlags {
     admin?: boolean;
     anonymous?: boolean;
-
-    /**
-     * better-auth ships no `apiKey` plugin as of 1.7, so nothing sets this
-     * automatically. It exists so an app running a fork or a later release can
-     * turn the cards on explicitly.
-     */
-    apiKey?: boolean;
     deviceAuthorization?: boolean;
     emailOtp?: boolean;
     lastLoginMethod?: boolean;

--- a/registry/auth-ui-vue/core/flow-gate.ts
+++ b/registry/auth-ui-vue/core/flow-gate.ts
@@ -35,7 +35,6 @@ type FlowName = keyof PluginFlags;
 const FLOW_NAMES: ReadonlyArray<FlowName> = [
     "admin",
     "anonymous",
-    "apiKey",
     "deviceAuthorization",
     "emailOtp",
     "lastLoginMethod",


### PR DESCRIPTION
Six defects on the auth surface, each reproduced with a test that fails on the
unfixed code first, plus four docs claims the code contradicts.

## The escape hatch the type promises but the runtime dropped

`withoutHeaders()` was synthesised only inside the Proxy `guardAuthApi` builds.
With `withAuthPlugins(auth, { enforceHeaders: false })` the context carried the
raw `auth.api`, while `LunoraAuthApiContext<Auth>["authApi"]` kept declaring
`withoutHeaders: () => Auth["api"]` unconditionally — so tsc stayed silent and
the documented `ctx.authApi.withoutHeaders().createOrganization(…)` became
`TypeError: withoutHeaders is not a function` the day an app flipped the guard
off. One wrapper now always synthesises the hatch and only rejects header-less
calls when enforcing.

## `sinceSeq` could not page forward

`readAuthAuditLog` built `WHERE seq > ? … ORDER BY seq DESC LIMIT ?`. A lower
bound with a descending order returns the *newest* rows above the bound, so a
caller advancing the cursor to the highest `seq` it saw skips everything older
and the walk terminates after one page. Measured at 25 rows / limit 10: the walk
from `sinceSeq=0` saw seqs 25..16 and stopped; 1..15 were unreachable. The page
is now ascending whenever a cursor is supplied and stays newest-first without
one — the studio's Security panel passes `{}`, so its feed is unchanged. The
option docblock, the runtime RPC's mirror of it, and the DO route's are
corrected to say so.

## Two holes in the SSO audit trail

Only `/sign-in/social` and `/sign-in/magic-link` were demoted to
`sign-in-initiated`; `/sign-in/sso` fell through to the `/sign-in/` substring
branch and `resolveOutcome` reported `success` on the 2xx redirect payload. Every
SSO dispatch was therefore a `sign-in`/`success` row with no actor — in exactly
the flow where the "who authenticated" trail matters most. Verified against the
installed `@better-auth/sso` 1.7.3: `/sign-in/sso` answers
`{ url, redirect: true }` and nothing more; its completion at
`/sso/callback/:providerId` was already classified by the `/callback/` branch.

`/sign-in/oauth2` is **not** added: `genericOAuth` in better-auth 1.7.3 registers
no endpoints of its own — it registers providers used through the core
`/sign-in/social` and `/callback/:id`. The docblock's stale "1.7.1" note is
corrected to match.

The sibling hole is the SAML side. `/sso/saml2/sp/acs/:providerId` is where a
SAML sign-in *completes* — `processSAMLResponse` validates the assertion,
resolves the user and calls `setSessionCookie` — but it carries no `/callback/`
segment and matched no other branch, so it classified as `undefined` and left no
audit row at all. The endpoint that issues every SAML session was entirely
unrecorded. It now joins the completion branch, with `/sso/saml2/sp/metadata`
pinned as still-unaudited so the substring cannot widen into config reads.

SAML sign-*out* had the mirror-image hole, and two endpoints rather than one.
Neither ends in `/sign-out`, so both went unrecorded; recording the sign-in while
leaving these silent would be worse than either gap alone, since the trail would
show a session opening and never closing. Checked in 1.7.3 rather than inferred
from the path — both terminate the local session before redirecting, so both are
`sign-out`, not an initiated event:

- `/sso/saml2/logout/:providerId` is SP-initiated. It deletes the SAML session
  keys, calls `deleteSession` on the current session token and
  `deleteSessionCookie`, then redirects to the IdP's logout URL.
- `/sso/saml2/sp/slo/:providerId` is the SP's single-logout receiver, serving the
  IdP-initiated direction and the response leg of an SP-initiated one.
  `handleLogoutRequest` and `handleLogoutResponse` both call `deleteSession` and
  `deleteSessionCookie`.

The second one was expected to be a negative pin and turned out to be a third
hole, so `/sso/providers` and `/sso/saml2/sp/metadata` are pinned as still
unaudited instead — provider config reads neither substring may widen into.

## An expired invitation answered a different code than documented

The invite-only route hook on `/sign-up/email` compared the token hash and
nothing else, leaving `acceptedAt` / `expiresAt` to `hasUsableInvitation` in
`user.create.before`, which throws `SIGN_UP_INVITE_REQUIRED`. Both the plugin
docblock and `docs/plugins.mdx` promise that a missing token, a wrong token, an
expired invitation and a never-invited address all answer
`SIGN_UP_INVITE_INVALID` with one message, precisely so the form cannot be used
to sift a directory. No row was ever written — this is the wrong instruction, not
a bypass — but a stale link told its holder the address is on the list. The hook
now requires the invitation to be unspent and unexpired too, reusing the same
predicate the database gate applies.

## The DO audit read re-ran its DDL on every request

`ensureAuthAuditTable` single-flights the audit DDL in a `WeakMap` keyed on
executor identity. `AuthDO#readAudit` built a fresh `doExecutor(this.#storage)`
per request, so the key was new every time: the cache never hit and each read
re-ran `CREATE TABLE IF NOT EXISTS` plus an `ALTER TABLE` that always throws and
is swallowed. Three reads executed six DDL statements; they now execute two. The
executor is a constructor field — it is a stateless pair of closures over
`storage`, so sharing it is free.

## DO-mode `basePath` is removed rather than half-plumbed

`AuthDoOptions.basePath` ("Must match the worker's") and
`DoAuthWiringOptions.basePath` both accepted a base path, and neither could be
set: codegen's `AuthDeclaration` has no field for it, so the emitted
`createDoAuthWiring({ internalSecret, namespace, objectName })` never passed one
and the worker forwarded only `/api/auth/*`. An `AuthDO` subclass with
`basePath: "/auth"` served nothing.

Deleted from both halves. Nothing depends on it — no example, template, registry
item or doc sets it, and its only callers were two tests. Threading it through
codegen would add a third place to keep in sync for a knob with no demand, and
would still leave the D1 path (`handleAuthRequest(auth, request)`) without one;
`handleAuthRequest`'s own `basePath` parameter is untouched and still serves
direct callers.

## Two dead references

`@lunora/auth-ui`'s `apiKey` flow flag is deleted. It was inert in all three
halves — no `PLUGIN_ID_TO_FLOW` entry, no `LunoraAuthPluginToggles` member, no
card gating on it — and its comment claimed better-auth ships no `apiKey` plugin
while `@lunora/auth/plugins` re-exports `apiKey` from `@better-auth/api-key` and
`plugins-client.ts` exports `apiKeyClient`. Wiring all three halves would mean
building API-key cards that nobody asked for; deleting is the honest state, and a
flag can come back with the screens that need it. `scripts/sync-auth-ui-registry.mjs`
mirrors `core/config.ts` and `core/flow-gate.ts` verbatim into six
`registry/auth-ui-*` items, so those copies are regenerated in the same change
and `lint:registry:sync` is green.

`@lunora/errors`' `EMAIL_DOMAIN_BLOCKED` hint pointed at an `emailGate(...)`
export that does not exist. The real surface is an `EmailGateConfig` handed to
`assertEmailAllowed` / `classifyEmail` / `emailGateMiddleware`; the hint now says
that, and `apps/docs/src/content/docs/errors.mdx` is regenerated from the catalog.

## Docs corrected where the code says otherwise

- The concepts page and the runtime startup warning both said an invitation "is
  keyed by email address and carries no secret token". It carries 256 CSPRNG bits
  stored as a SHA-256 and delivered as `?invite=`. Both now state the residual
  risk the token genuinely does not cover: a forwarded link, with verification off.
- A callout claimed `verifyTurnstileMiddleware`'s selector cannot read args
  because "the builder never places the parsed `args` onto it" and so "the
  middleware throws `FORBIDDEN` on every submission". `withCallContext` freezes
  `args` onto the middleware ctx, `turnstile-middleware.ts`'s own example uses
  `ctx.args.turnstileToken`, and `docs/index.mdx` says the opposite on the same
  site. Callout deleted; index.mdx's `.input()`-before-`.use()` note stays.
- `docs/plugins.mdx` listed `anonymous` among the plugins the gate refuses and
  said not to combine them. `anonymous()` is the one deliberate carve-out, pinned
  by a behaviour test. Moved into the carve-out paragraph the source file already
  carries.

## Verification

Every fix has a test written against the unfixed code first, and every test was
re-checked by breaking the fix:

| Fix | Test | Sabotage | Result |
| --- | --- | --- | --- |
| `withoutHeaders()` with the guard off | `middleware.test.ts` — escape hatch callable | wrap only when enforcing | `TypeError: authApi.withoutHeaders is not a function` |
| forward `sinceSeq` paging | `audit.test.ts` — walks every row | force `DESC` | saw 10 of 25 rows |
| newest-first without a cursor | `audit.test.ts` — unpaged read newest-first | force `ASC` | order inverted, 2 tests fail |
| SSO dispatch classification | `audit.test.ts` — SSO dispatch initiated | drop the `sso` branch | `expected 'sign-in' to be 'sign-in-initiated'` |
| invite usability at the route hook | `invite-only.behaviour.test.ts` — expired, spent | drop `isUsableInvitation(row)` | both answered `SIGN_UP_INVITE_REQUIRED` |
| fixed DO auth base path | `do-wiring.behaviour.test.ts` — lookalike prefix | forward `/api` | `/api/authorize` was swallowed |
| one DO audit executor | `auth-do.behaviour.test.ts` — DDL once | rebuild per read | 8 DDL statements instead of 2 |
| SAML ACS classification | `audit.test.ts` — assertion consumer service | drop the `/saml2/sp/acs/` branch | `expected undefined to be 'sign-in'` |
| SAML logout, both paths | `audit.test.ts` — both SAML logout endpoints | drop both substrings | `expected undefined to be 'sign-out'` |
| SAML logout, SP-initiated | same | drop `/saml2/logout/` only | `expected undefined to be 'sign-out'` |
| SAML logout, IdP-initiated | same | drop `/saml2/sp/slo/` only | `expected undefined to be 'sign-out'` |
| the logout negative pins | same | widen a substring to `/sso/` | `expected 'sign-out' to be undefined` |

Gates, re-run after rebasing onto current `alpha` from a fresh
`build:packages`: `api:check` ✅ 54 snapshots · `lint:registry:sync` ✅ ·
`lint:package-json` ✅ 89 files · `lint:types` ✅ 75 projects · `lint:eslint` ✅ ·
`test:workerd` ✅ 11 suites (the audit SQL and the auth DO are both on that path)
· `@lunora/auth` ✅ 499 · `@lunora/auth-ui` ✅ 396 · its separate Solid 2 package
`@lunora/auth-ui-solid-v2-tests` ✅ 18.

Two `test:affected` failures are not from this branch:

- `packages/errors/__tests__/catalog-registration.test.ts` fails on
  `EXPORT_SHARD_FAILED` (minted in `packages/runtime/src/export-stream.ts`) and
  `ID_COLLISION` (`packages/shard-engine/src/admin-export-import.ts`), neither
  registered in `ERROR_CATALOG`. Both were minted by work that merged after this
  branch was cut; the identical failure reproduces on unmodified `origin/alpha`.
  #749 registers them. Worth noting for anyone else running this locally: that
  test lives in `@lunora/errors` but walks every other package's source, so vis
  served it a **cached PASS** here — it only fails with `--no-cache`, which is
  why a package-scoped run does not see it.
- `packages/hyperdrive/__tests__/pg-vector.test.ts` times out at 30s under the
  full parallel sweep; it passes 18/18 in isolation and this branch touches
  nothing under `packages/hyperdrive`.

An earlier run also hit `@lunora/do`'s `shard-do.whisper` token-bucket assertion
(51 frames against a burst budget of 50). Also not this branch: the full suite on
unmodified `origin/alpha` passes, that file passes 5/5 in isolation and 3/3 under
its own suite on `origin/alpha`, and later runs here are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
