### PR TITLE
fix(errors): register the two export/import codes

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -324,6 +324,15 @@ const ERROR_CATALOG: {
         readonly status: 404;
         readonly title: "Cron job not found";
     };
+    readonly EXPORT_SHARD_FAILED: {
+        readonly hint: readonly [
+            "One or more shards failed to export, so the snapshot would have been short. Nothing is written when this fires — a partial export must never be mistaken for a complete one.",
+            "",
+            "The message names each failed shard key and its error. Re-run the export once those shards are reachable; a shard that fails repeatedly is usually over the per-request memory budget, which `backupTables` narrows."
+        ];
+        readonly status: 502;
+        readonly title: "Export failed on one or more shards";
+    };
     readonly EXPORT_TAP_NOT_CONFIGURED: {
         readonly status: 400;
         readonly title: "Export tap not configured";
@@ -335,6 +344,15 @@ const ERROR_CATALOG: {
     readonly GLOBALS_NOT_CONFIGURED: {
         readonly status: 400;
         readonly title: "Global-table introspector not configured";
+    };
+    readonly ID_COLLISION: {
+        readonly hint: readonly [
+            "The imported row carries an `_id` that is already held by a DIFFERENT table in this shard. Ids are per-table, so inserting it would leave two tables claiming one id and make a later lookup resolve to whichever one it reached first.",
+            "",
+            "This is reported per row rather than aborting the import: the remaining rows still apply. Re-mint the id on the source side, or import that table into a shard that does not already hold it."
+        ];
+        readonly status: 409;
+        readonly title: "Document id already belongs to another table";
     };
     readonly KV_NOT_CONFIGURED: {
         readonly status: 400;

--- a/apps/docs/src/content/docs/errors.mdx
+++ b/apps/docs/src/content/docs/errors.mdx
@@ -82,7 +82,7 @@ to branch on, see [Error handling](/docs/concepts/error-handling).
 
 ## Error codes
 
-All 142 codes Lunora publishes, generated from the catalog the runtime, CLI, overlay, Studio and client SDK all read.
+All 144 codes Lunora publishes, generated from the catalog the runtime, CLI, overlay, Studio and client SDK all read.
 Every heading is an anchor, so `/docs/errors#conflict` links straight to one.
 
 ### `ADMIN_FORBIDDEN`
@@ -291,6 +291,14 @@ Check for a typo in the domain. MX verification is opt-in (`mx: true`) and needs
 
 `404` — Session expired
 
+### `EXPORT_SHARD_FAILED`
+
+`502` — Export failed on one or more shards
+
+One or more shards failed to export, so the snapshot would have been short. Nothing is written when this fires — a partial export must never be mistaken for a complete one.
+
+The message names each failed shard key and its error. Re-run the export once those shards are reachable; a shard that fails repeatedly is usually over the per-request memory budget, which `backupTables` narrows.
+
 ### `EXPORT_TAP_NOT_CONFIGURED`
 
 `400` — Export tap not configured
@@ -358,6 +366,14 @@ Check for a typo in the domain. MX verification is opt-in (`mx: true`) and needs
 ### `HTTP_STREAM_TRANSPORT`
 
 `502` — HTTP stream transport error
+
+### `ID_COLLISION`
+
+`409` — Document id already belongs to another table
+
+The imported row carries an `_id` that is already held by a DIFFERENT table in this shard. Ids are per-table, so inserting it would leave two tables claiming one id and make a later lookup resolve to whichever one it reached first.
+
+This is reported per row rather than aborting the import: the remaining rows still apply. Re-mint the id on the source side, or import that table into a shard that does not already hold it.
 
 ### `INVALID_INPUT`
 

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -300,9 +300,27 @@ export const ERROR_CATALOG = {
     },
     CRON_JOBS_NOT_CONFIGURED: { status: 400, title: "Cron jobs not configured" },
     CRON_JOB_NOT_FOUND: { status: 404, title: "Cron job not found" },
+    EXPORT_SHARD_FAILED: {
+        hint: [
+            "One or more shards failed to export, so the snapshot would have been short. Nothing is written when this fires — a partial export must never be mistaken for a complete one.",
+            "",
+            "The message names each failed shard key and its error. Re-run the export once those shards are reachable; a shard that fails repeatedly is usually over the per-request memory budget, which `backupTables` narrows.",
+        ],
+        status: 502,
+        title: "Export failed on one or more shards",
+    },
     EXPORT_TAP_NOT_CONFIGURED: { status: 400, title: "Export tap not configured" },
     FUNCTIONS_NOT_CONFIGURED: { status: 400, title: "Functions registry not configured" },
     GLOBALS_NOT_CONFIGURED: { status: 400, title: "Global-table introspector not configured" },
+    ID_COLLISION: {
+        hint: [
+            "The imported row carries an `_id` that is already held by a DIFFERENT table in this shard. Ids are per-table, so inserting it would leave two tables claiming one id and make a later lookup resolve to whichever one it reached first.",
+            "",
+            "This is reported per row rather than aborting the import: the remaining rows still apply. Re-mint the id on the source side, or import that table into a shard that does not already hold it.",
+        ],
+        status: 409,
+        title: "Document id already belongs to another table",
+    },
     KV_NOT_CONFIGURED: { status: 400, title: "KV introspector not configured" },
     MIGRATION_ID_REQUIRED: { status: 400, title: "Migration id required" },
     PITR_UNAVAILABLE: { status: 409, title: "Point-in-time recovery unavailable" },


### PR DESCRIPTION
`alpha` is red. `EXPORT_SHARD_FAILED` and `ID_COLLISION` are minted by the export stream and the import row reader but were never added to `ERROR_CATALOG`, so both reach the wire with no status, no title and no hint — and `packages/errors/__tests__/catalog-registration.test.ts`, which walks the whole repo for minted codes, fails.

Reproduced on `origin/alpha` before the fix:

```
FAIL  __tests__/catalog-registration.test.ts > every minted error code across the whole repo is a catalog key
AssertionError: Found error code(s) minted outside ERROR_CATALOG.
+   "EXPORT_SHARD_FAILED (first seen in packages/runtime/src/export-stream.ts)",
+   "ID_COLLISION (first seen in packages/shard-engine/src/admin-export-import.ts)",
```

## Why this got through

The test lives in `@lunora/errors` and reads every *other* package's source. `vis affected` cannot reach it from a change that touches only the packages doing the minting — the gate is real, but unreachable from the diff that breaks it, and a whole-repo `test` run can serve a cached PASS for `@lunora/errors` because none of its own inputs changed.

## Choices

**`EXPORT_SHARD_FAILED` → 502.** The export request itself is well-formed; the failure is downstream, in the shards it fanned out to. Deliberately **not** `internal`: the per-shard detail is the entire diagnostic, the route is admin-gated, and the message is assembled from our own error envelopes rather than raw driver output. Marking it internal would replace the one thing an operator needs with a generic string.

**`ID_COLLISION` → 409.** Reported per row rather than aborting the import, so the hint says that, and says the collision is with a *different table* — ids are per-table, so inserting anyway would leave two tables claiming one id and make a later lookup resolve to whichever it reached first.

## Verification

- `pnpm --filter "@lunora/errors" run test` — 689 passed (was 1 failed / 680 passed on `alpha`).
- `pnpm run api:check` — the catalog keys form the `LunoraErrorCode` union, so the two additions move `errors.api.md`; regenerated with `api:update` after a fresh build, and that snapshot diff is the intended surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer error reporting when export shards fail, including guidance for retrying or narrowing the snapshot.
  * Added error reporting for imported rows whose IDs conflict with another table, with per-row import handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->