### PR TITLE
fix: close template, CLI and reference drift

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -114,6 +114,7 @@ interface CodegenResult {
     schemaSnapshot: SchemaSnapshot;
     schemaSnapshotPath: string;
     workflows: ReadonlyArray<WorkflowIR>;
+    writtenFiles: ReadonlyArray<string>;
 }
 ```
 

--- a/examples/auth-playground/wrangler.jsonc
+++ b/examples/auth-playground/wrangler.jsonc
@@ -11,7 +11,7 @@
         // Auth identity, sessions, organizations, members live in D1 — better-auth
         // discovers the schema across every configured plugin and runs migrations
         // against this binding via `ensureMigrated` / `compileMigrationsSql`.
-        { "binding": "DB", "database_name": "lunora-auth-playground", "database_id": "REPLACE_WITH_D1_ID" },
+        { "binding": "DB", "database_name": "lunora-auth-playground", "database_id": "<replace-with-d1-create-id>" },
     ],
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
     "observability": { "enabled": true, "head_sampling_rate": 1 },

--- a/examples/chess/wrangler.jsonc
+++ b/examples/chess/wrangler.jsonc
@@ -12,6 +12,6 @@
     "d1_databases": [
         // better-auth's identity tables only — the game state itself lives in
         // the ShardDO, not in D1.
-        { "binding": "DB", "database_name": "lunora-example-chess", "database_id": "REPLACE_WITH_D1_ID" },
+        { "binding": "DB", "database_name": "lunora-example-chess", "database_id": "<replace-with-d1-create-id>" },
     ],
 }

--- a/examples/expo/wrangler.jsonc
+++ b/examples/expo/wrangler.jsonc
@@ -10,7 +10,7 @@
     "d1_databases": [
         // better-auth identity + sessions live in D1. Create the database with
         // `wrangler d1 create lunora-expo-example` and paste the id below.
-        { "binding": "DB", "database_name": "lunora-expo-example", "database_id": "REPLACE_WITH_D1_ID" },
+        { "binding": "DB", "database_name": "lunora-expo-example", "database_id": "<replace-with-d1-create-id>" },
     ],
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
     "observability": { "enabled": true, "head_sampling_rate": 1 },

--- a/examples/team-chat/wrangler.jsonc
+++ b/examples/team-chat/wrangler.jsonc
@@ -13,7 +13,7 @@
         // better-auth's identity tables (user, session, account, verification)
         // plus the `.global()` `profiles` table, which has to be readable from
         // every message shard.
-        { "binding": "DB", "database_name": "lunora-example-team-chat", "database_id": "REPLACE_WITH_D1_ID" },
+        { "binding": "DB", "database_name": "lunora-example-team-chat", "database_id": "<replace-with-d1-create-id>" },
     ],
     "r2_buckets": [{ "binding": "FILES", "bucket_name": "lunora-example-team-chat-files" }],
     "vars": {

--- a/packages/cli/__tests__/commands/add.test.ts
+++ b/packages/cli/__tests__/commands/add.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { runAddFeature } from "../../src/commands/add/handler";
 import { applyDeps, confirmDepMutation, projectUsesUmbrella, resolveDepRange, rewriteUmbrellaImports } from "../../src/commands/registry/apply";
@@ -394,19 +394,57 @@ describe("lunora add", () => {
             rmSync(customRegistry, { force: true, recursive: true });
         });
 
-        it("rewrites a manifest's workspace: dep range to a publishable one", async () => {
-            expect.assertions(2);
+        it("rewrites a manifest's workspace: dep range to the concrete published version", async () => {
+            expect.assertions(3);
 
             // The ratelimit fixture pins `@lunora/ratelimit: workspace:*`. The
             // workspace protocol is only resolvable inside the monorepo — leaking
             // it into a consumer's package.json makes `pnpm install` abort with
             // ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
-            await runAddCommand({ cwd: workdir, from: registryRoot, logger: makeLogger().logger, names: ["ratelimit"], yes: true });
+            //
+            // What replaces it is the CONCRETE version the CLI's channel tag
+            // currently points at, not the tag: a dist-tag in package.json lets a
+            // stale lockfile or pnpm metadata cache keep an older release, since
+            // the specifier still matches and is never re-resolved. `init` pins
+            // for exactly this reason and `add` used to write a floating "alpha"
+            // right beside init's pinned `lunorash`.
+            const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ "dist-tags": { [resolveDistTag()]: "9.9.9-test.1" } }));
 
-            const pkg = JSON.parse(readFileSync(join(workdir, "package.json"), "utf8")) as { dependencies: Record<string, string> };
+            try {
+                const { lines, logger } = makeLogger();
 
-            expect(pkg.dependencies["@lunora/ratelimit"]).toBe(resolveDistTag());
-            expect(JSON.stringify(pkg)).not.toContain("workspace:");
+                await runAddCommand({ cwd: workdir, from: registryRoot, logger, names: ["ratelimit"], yes: true });
+
+                const pkg = JSON.parse(readFileSync(join(workdir, "package.json"), "utf8")) as { dependencies: Record<string, string> };
+
+                expect(pkg.dependencies["@lunora/ratelimit"]).toBe("9.9.9-test.1");
+                expect(JSON.stringify(pkg)).not.toContain("workspace:");
+                // The plan preview resolves through the same map, so what it
+                // advertises is what lands.
+                expect(lines.join("\n")).toContain("@lunora/ratelimit@9.9.9-test.1");
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+
+        it("falls back to the channel dist-tag when the registry is unreachable", async () => {
+            expect.assertions(2);
+
+            // Offline, there is no version to pin. The channel tag still resolves
+            // to installable code (unlike `latest` on a pre-release channel), so
+            // it is the right fallback — never the `workspace:` protocol.
+            const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("getaddrinfo ENOTFOUND registry.npmjs.org"));
+
+            try {
+                await runAddCommand({ cwd: workdir, from: registryRoot, logger: makeLogger().logger, names: ["ratelimit"], yes: true });
+
+                const pkg = JSON.parse(readFileSync(join(workdir, "package.json"), "utf8")) as { dependencies: Record<string, string> };
+
+                expect(pkg.dependencies["@lunora/ratelimit"]).toBe(resolveDistTag());
+                expect(JSON.stringify(pkg)).not.toContain("workspace:");
+            } finally {
+                fetchSpy.mockRestore();
+            }
         });
     });
 

--- a/packages/cli/__tests__/commands/docs-reference.test.ts
+++ b/packages/cli/__tests__/commands/docs-reference.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { REGISTERED_COMMAND_NAMES } from "../../src/cli";
+import { FRAMEWORK_CHOICES } from "../../src/commands/init/handler";
+import { STACK_FEATURE_OPTIONS } from "../../src/commands/init/offer-extras";
+
+const DOCS_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "docs", "index.mdx");
+const DOCS = readFileSync(DOCS_PATH, "utf8");
+
+/**
+ * `version` and `completion` are cerebro built-ins registered alongside the
+ * Lunora commands. They are not Lunora surface and have no reference section.
+ */
+const BUILT_IN_COMMANDS = new Set(["completion", "version"]);
+
+/** The first column of every markdown table row in the section headed `heading`. */
+const tableKeysAfter = (heading: string): string[] => {
+    const start = DOCS.indexOf(heading);
+
+    if (start === -1) {
+        throw new Error(`docs/index.mdx has no "${heading}" section`);
+    }
+
+    // Stop at the next section so a table can only contribute to its own.
+    const next = DOCS.indexOf("\n### ", start + heading.length);
+    const section = next === -1 ? DOCS.slice(start) : DOCS.slice(start, next);
+
+    return [...section.matchAll(/^\| {1,2}`(?<key>[a-z\d-]+)` +\|/gmu)].map((match) => match.groups?.key ?? "");
+};
+
+/**
+ * `packages/cli/docs/index.mdx` is the CLI reference consumers read (the copy
+ * under `apps/docs/src/content/docs/packages/` is generated from it). Its tables
+ * restate lists that live in code, and restated lists drift: the `-t` table was
+ * missing three templates and the feature table listed two of fifteen, each for
+ * as long as it took someone to notice by hand — no gate covered either.
+ *
+ * So each list is asserted against its source of truth, the same way
+ * `doctor.test.ts` pins the finding codes against their table. Adding a
+ * template, a feature or a command now fails here until the reference documents
+ * it, in the same change.
+ */
+describe("cLI reference (docs/index.mdx)", () => {
+    it("documents exactly the templates `-t` accepts, in picker order", () => {
+        expect.assertions(1);
+
+        expect(tableKeysAfter("### `lunora init`")).toStrictEqual(FRAMEWORK_CHOICES.map((choice) => choice.value));
+    });
+
+    it("documents exactly the features `lunora add` and `init --add` offer", () => {
+        expect.assertions(1);
+
+        expect(tableKeysAfter("### `lunora add`")).toStrictEqual(STACK_FEATURE_OPTIONS.map((option) => option.value));
+    });
+
+    it("gives every registered command a reference section", () => {
+        expect.assertions(1);
+
+        // One heading may name several commands (`### `lunora export` /
+        // `lunora import``), so every occurrence on a heading line counts.
+        const documented = new Set(
+            [...DOCS.matchAll(/^#{3,4} .+$/gmu)].flatMap((heading) =>
+                [...heading[0].matchAll(/`lunora (?<name>[a-z\d-]+)/gu)].map((match) => match.groups?.name ?? ""),
+            ),
+        );
+
+        expect(REGISTERED_COMMAND_NAMES.filter((name) => !BUILT_IN_COMMANDS.has(name) && !documented.has(name))).toStrictEqual([]);
+    });
+});

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -142,43 +142,53 @@ automation contract.
 ### `lunora init`
 
 Scaffolds a new Lunora project by fetching a template from
-`gh:anolilab/lunora/templates/<type>#<version>`. `init` (and `add`) resolve
-that release branch to the immutable commit SHA it currently points at (logged
-as `pinned … → <sha>`), so the fetch is reproducible and tamper-evident; if the
-SHA can't be resolved (offline / rate-limited) it falls back to the branch with
-a one-line UNPINNED warning. Pass `-t` / `--template` to choose the starting
-point:
+`gh:anolilab/lunora/templates/<type>#<ref>`. The ref is a **branch**, derived
+from the running CLI's own version: a pre-release resolves to its channel
+(`alpha`, `beta`, `next`), a stable release to `main`. `--ref` overrides it with
+any branch, tag or commit. `init` (and `add`) then resolve that ref to the
+immutable commit SHA it currently points at (logged as `pinned … → <sha>`), so
+the fetch is reproducible and tamper-evident; if the SHA can't be resolved
+(offline / rate-limited) it falls back to the ref itself with a one-line
+UNPINNED warning. Pass `-t` / `--template` to choose the starting point:
 
-| Value                  | Description                                                               |
-| ---------------------- | ------------------------------------------------------------------------- |
-| `react`                | React SPA: the official create-vite base + the Lunora layer (default)     |
-| `vue`                  | Vue SPA: create-vite base + Lunora                                        |
-| `solid`                | Solid SPA: create-vite base + Lunora                                      |
-| `svelte`               | Svelte SPA: create-vite base + Lunora                                     |
-| `next`                 | Next.js (App Router): OpenNext on Cloudflare + a standalone Lunora worker |
-| `tanstack-start-react` | TanStack Start (React): SSR with live-loader routes                       |
-| `tanstack-start-solid` | TanStack Start (Solid)                                                    |
-| `react-router`         | React Router v7 (framework mode): SSR composed into the Lunora worker     |
-| `astro`                | Astro + a standalone Lunora worker                                        |
-| `analog`               | AnalogJS (Angular): single-worker, Lunora mounted in Nitro                |
-| `nuxt`                 | Nuxt (Vue): single-worker, Lunora mounted in Nitro                        |
-| `sveltekit`            | SvelteKit + a standalone Lunora worker                                    |
-| `expo`                 | React Native (Expo): an iOS/Android/web app + a Lunora worker backend     |
-| `standalone`           | Worker only, no frontend                                                  |
+| Value                  | Description                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `react`                | React SPA — official create-vite base + the Lunora layer (the default)               |
+| `vue`                  | Vue SPA — create-vite base + Lunora                                                  |
+| `solid`                | Solid SPA — create-vite base + Lunora                                                |
+| `solid-v2`             | Solid 2.0 SPA — the Solid 2 line (`@solidjs/web`, vite-plugin-solid 3)               |
+| `svelte`               | Svelte SPA — create-vite base + Lunora                                               |
+| `next`                 | Next.js (App Router) — OpenNext on Cloudflare + a standalone Lunora worker           |
+| `tanstack-start-react` | TanStack Start (React) — SSR with live-loader routes                                 |
+| `tanstack-start-solid` | TanStack Start (Solid)                                                               |
+| `vinext`               | Next.js App Router on Vite (vinext) — composed into the Lunora worker (experimental) |
+| `vinext-pages`         | Next.js Pages Router on Vite (vinext) — composed into one worker (experimental)      |
+| `react-router`         | React Router (v7, framework mode) — SSR composed into the Lunora worker              |
+| `astro`                | Astro (islands) — single-worker, Lunora composed into the adapter worker             |
+| `analog`               | AnalogJS (Angular) — single-worker, Lunora mounted in Nitro                          |
+| `nuxt`                 | Nuxt (Vue) — single-worker, Lunora mounted in Nitro                                  |
+| `sveltekit`            | SvelteKit — single-worker, Lunora composed into the adapter worker                   |
+| `expo`                 | React Native (Expo) — an iOS/Android/web app + a Lunora worker backend               |
+| `standalone`           | Worker only — no frontend                                                            |
 
-The four create-vite frameworks (`react`, `vue`, `solid`, `svelte`) scaffold
-through the **overlay** engine (the official create-vite base plus the Lunora
-layer), while the rest are bespoke Lunora templates. Run `lunora init` with no
-`-t` to pick from the same list interactively.
+The create-vite frameworks (`react`, `vue`, `solid`, `svelte`, plus
+`vanilla` via `--vite`) scaffold through the **overlay** engine (the official
+create-vite base plus the Lunora layer), while the rest are bespoke Lunora
+templates — `solid-v2` included, because create-vite's Solid base is still
+1.x. Run `lunora init` with no `-t` to pick from the same list interactively.
 
 Additional flags:
 
+- `--vite <framework>`: scaffold via the create-vite overlay for `react` | `vue` | `solid` | `svelte` | `vanilla`. Equivalent to passing the same value to `-t`.
 - `--from <dir>`: copy from a local templates root instead of fetching remotely (offline-friendly; expects `<type>/` subdirs)
 - `--source <ref>`: override the remote template source (e.g. `gh:owner/repo/sub#ref`)
+- `--ref <ref>`: fetch templates from a git branch, tag or commit (e.g. `--ref alpha`), overriding the version-derived default above
 - `--allow-unsafe-source`: permit `--source` values outside `gh:/github:/https://`
 - `--here`: add Lunora to an existing project (detect the framework, patch the config, scaffold `lunora/`, print per-framework wiring steps)
 - `-i` / `--interactive`: after scaffolding, offer to add authentication and transactional email. Defaults on when stdin is a TTY; never prompts in CI.
 - `-y` / `--yes`: scaffold only — skip every post-scaffold prompt (the auth/email offer, the dependency-install offer, and `git init`). The project is complete; run the printed install command yourself.
+- `--add <list>`: add features non-interactively after scaffolding — a comma-separated list of the values in the [`lunora add` table](#lunora-add), each applied with its shipped defaults. Bypasses the interactive picker and its sub-prompts.
+- `--dry-run`: walk every step (prompts and output included) without writing files, installing, or running git.
 - `--ci <github\|gitlab>`: also scaffold a CI deploy pipeline (`.github/workflows/deploy.yml` for GitHub Actions, `.gitlab-ci.yml` for GitLab CI), with a production `lunora deploy` on the default branch **and** a `lunora deploy --preview` on every pull / merge request. Set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as the provider's secrets / CI-CD variables.
 
 ### `lunora add`
@@ -192,12 +202,35 @@ lunora add auth --yes           # default provider (email & password), no prompt
 lunora add email                # transactional email (Cloudflare Email Workers + dev mail catcher)
 ```
 
-| Feature | Installs                                                  | Notes                                                                                                              |
-| ------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `auth`  | the `auth` registry item (or `auth-clerk` / `auth-auth0`) | Adds `@lunora/auth` + a D1 `DB` binding; verification / reset mail is captured into the studio **Mail** tab in dev |
-| `email` | the `mail` registry item                                  | Cloudflare Email Workers transport (`SEND_EMAIL` binding) + the dev mail catcher                                   |
+These are the features the interactive picker offers and `lunora init --add`
+accepts. Each is the registry item of the same name, applied with its shipped
+defaults — except `email`, which maps to the `mail` item, and `auth`, which
+picks between `auth`, `auth-clerk` and `auth-auth0`:
 
-Flags: `--provider <auth\|clerk\|auth0>`, `--yes`, `--from <dir>` (local registry root), `--source <ref>`, `--allow-unsafe-source`.
+| Feature             | Installs                                                         |
+| ------------------- | ---------------------------------------------------------------- |
+| `ai`                | LLMs via Workers AI (summarize, generate, stream)                |
+| `auth`              | Sign-up / sign-in (asks which provider)                          |
+| `auth-ui`           | Copy-in auth screens for your framework (sign in/up, reset, 2FA) |
+| `backup`            | Snapshot + restore your Durable Object data                      |
+| `browser`           | Headless browser screenshots + PDFs                              |
+| `cloudflare-access` | Zero Trust identity via Cloudflare Access                        |
+| `crons`             | Scheduled jobs via Cron Triggers (`@lunora/scheduler`)           |
+| `email`             | Cloudflare Email Workers + a dev mail catcher                    |
+| `flags`             | OpenFeature feature flags (`ctx.flags`)                          |
+| `hyperdrive`        | External Postgres/MySQL via Hyperdrive                           |
+| `payment`           | Stripe-first payments (checkout, subscription, webhooks)         |
+| `presence`          | Live presence / who's-online over hibernated WebSockets          |
+| `queue`             | Async message queues (push/pull consumers)                       |
+| `storage`           | Typed R2 buckets + signed URLs (`@lunora/storage`)               |
+| `workflow`          | Durable long-running workflows (`step.do`, sleep, branch)        |
+
+`auth` adds `@lunora/auth` plus a D1 `DB` binding, and its verification / reset
+mail is captured into the studio **Mail** tab in dev. Any other registry item
+name works here too (`auth-clerk`, …) — this table is the curated shortlist, not
+the whole registry; `lunora registry list` enumerates that.
+
+Flags: `--provider <auth\|clerk\|auth0>`, `--db <name>`, `--bucket <name>`, `--mail-to <address>`, `--yes`, `--from <dir>` (local registry root), `--source <ref>`, `--ref <ref>`, `--allow-unsafe-source`.
 
 ### `lunora view`
 
@@ -708,6 +741,31 @@ first use, idempotently and additively. What it will never do is drop or
 retype, so the `DROP TABLE` / `DROP INDEX` statements and the hand-written
 block under "NOT auto-generated" are the parts worth applying.
 
+#### `lunora migrate d1-to-hyperdrive`
+
+The third kind: a **backend** migration that copies `.global()` table data out
+of a D1-backed deployment into a Hyperdrive-backed one, for when a project
+outgrows D1. It is a guided orchestration over the admin export/import — it
+streams the source's global rows to an NDJSON dump, imports them into the
+target (whose `.global({ backend: "hyperdrive" })` tables route the writes to
+Hyperdrive), and verifies the row counts match. The blue-green flow: deploy the
+new Hyperdrive worker alongside the old D1 one, then point the two legs at them.
+
+```bash
+lunora migrate d1-to-hyperdrive \
+  --from-url https://old-worker.example.workers.dev \
+  --to-url   https://new-worker.example.workers.dev
+```
+
+The two URLs must be **distinct deployments**: given one, both legs would
+address the same database and the run would report "counts match" having done
+nothing, so the command refuses. `--from-token` / `--to-token` each fall back to
+`--token` (prefer `LUNORA_ADMIN_TOKEN`). `--tables a,b` limits the move to named
+`.global()` tables (default: all of them), and `--out <path>` keeps the
+intermediate NDJSON dump — without it the dump is staged in a private `0700`
+temp directory and discarded. Sharded tables are untouched: they live in
+per-Durable-Object SQLite, not in D1.
+
 ### `lunora run`
 
 Send a single RPC to a running Worker without spinning up the client SDK:
@@ -744,6 +802,70 @@ is printed for you to paste rather than rewritten.
 `--api-spec` selects which API description to emit alongside the generated
 modules: `openapi` (the default) writes `openapi.json`, `openrpc` writes
 `openrpc.json`, `both` writes both, and `none` writes neither.
+
+The success line names the files this run actually emitted, which is not a fixed
+set: alongside the always-written modules, the per-feature ones (containers,
+workflows, agents, queues, scheduler, seed, collections) are written only while
+their feature is in use and **deleted** when it stops being, and the spec
+artifacts follow `--api-spec`. [Codegen output](#codegen-output) below describes
+what each file is for.
+
+### `lunora advisor`
+
+Scores your app's static advisor findings — the splinter-style schema, query and
+security lints from `@lunora/advisor` — into a health map, so the trend is a
+number CI can gate on rather than a wall of warnings:
+
+```bash
+lunora advisor                              # score the app, write lunora.advisor.map.json
+lunora advisor --all                        # every procedure as a check matrix
+lunora advisor --entry messages#sendMessage # inspect one procedure
+lunora advisor --min-score 80               # exit non-zero below 80
+lunora advisor --baseline                   # fail on any regression vs the committed map
+lunora advisor --no-write                   # report only, write no artifact
+```
+
+Commit the map: `--baseline` diffs against it, so a PR that makes the schema
+worse fails even while the absolute score is still above `--min-score`. The same
+findings drive the studio's **Advisors** tab.
+
+### `lunora eval`
+
+Discovers every `*.eval.ts` under `evals/` and runs it through its default-
+exported `run()`, which calls `evaluate` / `agentHarness` from
+`@lunora/testing`. Entirely in-process — unlike `seed` and `insights` it needs
+no running worker:
+
+```bash
+lunora eval                                     # run every eval, print the aggregate table
+lunora eval --threshold 0.8                     # non-zero exit below an average of 0.8
+lunora eval --dir evals/support --format json   # a subset, machine-readable
+```
+
+`--threshold` is a global score gate in `[0, 1]`; an eval that exports its own
+`threshold` wins over it for that eval.
+
+### `lunora sdk`
+
+Generates a self-contained, typed client SDK for another language from the
+project's OpenRPC surface — transport included, so the emitted package has no
+Lunora runtime dependency:
+
+```bash
+lunora sdk generate --lang python                  # → ./sdk/python
+lunora sdk generate --lang go --out ./clients/go   # choose the output directory
+lunora sdk generate --lang dart                    # Flutter-ready; live queries arrive as a Stream
+lunora sdk generate --lang rust --from ./sdks      # copy the transport from a local checkout
+```
+
+`--lang` defaults to `python`; `lunora sdk generate --help` lists the registered
+targets, and an unrecognised one is refused with the same list. The spec
+defaults to `./lunora/_generated/openrpc.json`, so run `lunora codegen
+--api-spec openrpc` (or `both`) first — `--spec <path>` points at another
+document. The transport is
+fetched at this CLI's own release tag so it matches the generated surface;
+`--ref` overrides that and `--from <dir>` copies from a local directory of
+per-language transports instead.
 
 ### `lunora insights`
 
@@ -791,11 +913,21 @@ lunora env list              # list all keys in .dev.vars
 lunora env get DATABASE_URL  # read a single key
 lunora env set FOO bar       # write a key
 lunora env unset FOO         # remove a key
+lunora env generate          # generate strong values for the project's secrets
+lunora env generate AUTH_SECRET --set  # generate one and write it into .dev.vars
 lunora env push              # upload to Cloudflare (prompts unless --yes)
 lunora env push --prod --yes # push to the production environment
 lunora env diff              # compare local .dev.vars keys against Cloudflare
 lunora env doctor            # validate .dev.vars against .dev.vars.example
 ```
+
+`generate` mints cryptographically-strong values (32-byte hex). With no key it
+mints every secret this project can generate locally (`AUTH_SECRET`, …); name
+one to mint just that. By default it **prints** `KEY=value` lines on stdout — so
+you can pipe them into `wrangler secret put` — and `--set` writes them into
+`.dev.vars` instead. Minting replaces a value irreversibly, so `--set` refuses
+to overwrite a key that already holds a live (non-placeholder) secret unless you
+add `--yes`.
 
 `diff` reads the deployed Worker's secret **names** via `wrangler secret list`
 and reports which keys are local-only (need a `push`), remote-only, or in both.

--- a/packages/cli/src/commands/codegen/handler.ts
+++ b/packages/cli/src/commands/codegen/handler.ts
@@ -110,7 +110,10 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
         outputDirectory: result.outputDirectory,
     };
 
-    logger.success(`codegen wrote dataModel.ts, api.ts, server.ts to ${result.outputDirectory}`);
+    // What was actually emitted, from codegen itself — the set varies with the
+    // project's features and `--api-spec`, so any list restated here is wrong
+    // for someone.
+    logger.success(`codegen wrote ${result.writtenFiles.join(", ")} to ${result.outputDirectory}`);
 
     // Static schema advisories (unindexed FKs, …). Surface each with its
     // remediation so the warning is actionable; one grouped `warn` keeps it in

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -2065,6 +2065,6 @@ const execute: CommandHandler<InitOptions> = defineHandler<InitOptions>(({ argum
     });
 });
 
-export { execute, isTemplate, resolveTemplateFlag, resolveTemplateSource };
+export { execute, FRAMEWORK_CHOICES, isTemplate, resolveTemplateFlag, resolveTemplateSource };
 export type { InitCommandOptions, InitCommandResult, Template };
 export { runInitCommand };

--- a/packages/cli/src/commands/registry/apply.ts
+++ b/packages/cli/src/commands/registry/apply.ts
@@ -10,9 +10,24 @@ import { join } from "@visulima/path";
 import { applyEdits, modify, parse } from "jsonc-parser";
 
 import type { Logger } from "../../util/logger";
-import { resolveDistTag } from "../../util/source-ref";
+import { resolveDistTag, resolveTagVersions } from "../../util/source-ref";
 import { tuiConfirm } from "../../util/tui-prompts";
 import type { AddCommandOptions, RegistryBinding, RegistryEnvVariable, RegistryManifest } from "./types";
+
+/**
+ * True when a manifest range is a bare `workspace:` alias — the forms that
+ * carry no version of their own and therefore have to be resolved against the
+ * CLI's release channel. See {@link resolveDepRange}.
+ */
+const isBareWorkspaceRange = (range: string): boolean => {
+    if (!range.startsWith("workspace:")) {
+        return false;
+    }
+
+    const rest = range.slice("workspace:".length);
+
+    return rest === "" || rest === "*" || rest === "^" || rest === "~";
+};
 
 /**
  * Translate a pnpm `workspace:` protocol range into a publishable one.
@@ -22,14 +37,21 @@ import type { AddCommandOptions, RegistryBinding, RegistryEnvVariable, RegistryM
  * But `add` writes these ranges into a *consumer's* package.json, where the
  * workspace protocol is meaningless — pnpm aborts with
  * `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. So when the range carries an explicit
- * version (`workspace:^1.2.3` → `^1.2.3`) we strip the prefix; the bare alias
- * forms (`workspace:*` / `^` / `~`) have no version to recover, so they pin to
- * the CLI's release-channel dist-tag (the packages are independently versioned —
- * there is no single version to pin to from here, and on a pre-release channel
- * the `latest` tag is a placeholder, so the channel tag is what actually
- * resolves to installable code). See {@link resolveDistTag}.
+ * version (`workspace:^1.2.3` → `^1.2.3`) we strip the prefix.
+ *
+ * The bare alias forms (`workspace:*` / `^` / `~`) have no version to recover.
+ * `pinned` carries the CONCRETE version the CLI's release-channel dist-tag
+ * currently resolves to (looked up once per invocation by
+ * {@link resolvePinnedDepVersions}); a scaffolded package.json must pin that
+ * rather than the floating tag, because a tag lets a stale lockfile or pnpm
+ * metadata cache silently keep an older release — the specifier still
+ * "matches", so the lockfile is never re-resolved. This is the same reason
+ * `init` pins. When the lookup failed (offline, registry unreachable) the name
+ * is absent from `pinned` and we fall back to the channel tag, which still
+ * resolves to installable code — unlike `latest` on a pre-release channel.
+ * See {@link resolveDistTag} and {@link resolveTagVersions}.
  */
-const resolveDepRange = (range: string): string => {
+const resolveDepRange = (range: string, pinned?: ReadonlyMap<string, string>, name?: string): string => {
     if (!range.startsWith("workspace:")) {
         return range;
     }
@@ -37,10 +59,33 @@ const resolveDepRange = (range: string): string => {
     const rest = range.slice("workspace:".length);
 
     if (rest === "" || rest === "*" || rest === "^" || rest === "~") {
-        return resolveDistTag();
+        return (name === undefined ? undefined : pinned?.get(name)) ?? resolveDistTag();
     }
 
     return rest;
+};
+
+/**
+ * Resolve every bare `workspace:` dependency across a whole plan to the
+ * CONCRETE version the CLI's release-channel dist-tag points at — one batched
+ * registry lookup per invocation, so the plan preview and the package.json it
+ * writes cannot disagree. Names whose lookup fails are simply absent (the
+ * offline-safe fallback lives in {@link resolveDepRange}).
+ */
+const resolvePinnedDepVersions = async (manifests: ReadonlyArray<RegistryManifest>): Promise<ReadonlyMap<string, string>> => {
+    const names = new Set<string>();
+
+    for (const manifest of manifests) {
+        for (const section of [manifest.deps, manifest.devDependencies]) {
+            for (const [name, range] of Object.entries(section ?? {})) {
+                if (isBareWorkspaceRange(range)) {
+                    names.add(name);
+                }
+            }
+        }
+    }
+
+    return names.size === 0 ? new Map() : resolveTagVersions([...names], resolveDistTag());
 };
 
 /**
@@ -101,6 +146,10 @@ const rewriteUmbrellaImports = (source: string): string =>
  * When `useUmbrella` is set, base packages the `lunorash` umbrella re-exports
  * ({@link UMBRELLA_REEXPORTED_DEPS}) are skipped — the umbrella already provides
  * them, and adding a parallel copy risks a second instance.
+ *
+ * `pinned` is the plan's resolved dist-tag → concrete version map
+ * ({@link resolvePinnedDepVersions}); omitting it writes the floating channel
+ * tag, which is only correct when no registry is reachable.
  */
 const applyDeps = (
     deps: Readonly<Record<string, string>>,
@@ -108,6 +157,7 @@ const applyDeps = (
     logger: Logger,
     section: "dependencies" | "devDependencies" = "dependencies",
     useUmbrella = false,
+    pinned?: ReadonlyMap<string, string>,
 ): ReadonlyArray<string> => {
     const entries = Object.entries(deps);
 
@@ -143,7 +193,7 @@ const applyDeps = (
             continue;
         }
 
-        const edits = modify(text, [section, name], resolveDepRange(range), {
+        const edits = modify(text, [section, name], resolveDepRange(range, pinned, name), {
             formattingOptions: { insertSpaces: true, tabSize: 4 },
         });
 
@@ -483,16 +533,22 @@ const applyBindings = (bindings: ReadonlyArray<RegistryBinding>, projectRoot: st
  * Returns the deps + bindings added. `useUmbrella` routes base-package deps
  * through the `lunorash` umbrella (skipping the granular duplicates).
  */
-const applyItemResources = (manifest: RegistryManifest, cwd: string, logger: Logger, useUmbrella = false): { bindings: string[]; deps: string[] } => {
+const applyItemResources = (
+    manifest: RegistryManifest,
+    cwd: string,
+    logger: Logger,
+    useUmbrella = false,
+    pinned?: ReadonlyMap<string, string>,
+): { bindings: string[]; deps: string[] } => {
     const deps: string[] = [];
     const bindings: string[] = [];
 
     if (manifest.deps) {
-        deps.push(...applyDeps(manifest.deps, cwd, logger, "dependencies", useUmbrella));
+        deps.push(...applyDeps(manifest.deps, cwd, logger, "dependencies", useUmbrella, pinned));
     }
 
     if (manifest.devDependencies) {
-        deps.push(...applyDeps(manifest.devDependencies, cwd, logger, "devDependencies", useUmbrella));
+        deps.push(...applyDeps(manifest.devDependencies, cwd, logger, "devDependencies", useUmbrella, pinned));
     }
 
     if (manifest.bindings) {
@@ -585,4 +641,13 @@ const confirmDepMutation = async (items: ReadonlyArray<{ manifest: RegistryManif
 };
 
 export type { ConfirmOutcome };
-export { applyDeps, applyItemResources, confirmDepMutation, isCustomRegistrySource, projectUsesUmbrella, resolveDepRange, rewriteUmbrellaImports };
+export {
+    applyDeps,
+    applyItemResources,
+    confirmDepMutation,
+    isCustomRegistrySource,
+    projectUsesUmbrella,
+    resolveDepRange,
+    resolvePinnedDepVersions,
+    rewriteUmbrellaImports,
+};

--- a/packages/cli/src/commands/registry/commands.ts
+++ b/packages/cli/src/commands/registry/commands.ts
@@ -10,7 +10,7 @@ import { join } from "@visulima/path";
 import { detectPackageManager, installArgsFor } from "../../util/detect-package-manager";
 import { EXIT_CODE } from "../../util/exit-code";
 import type { Logger } from "../../util/logger";
-import { confirmDepMutation, resolveDepRange } from "./apply";
+import { confirmDepMutation, resolveDepRange, resolvePinnedDepVersions } from "./apply";
 import { buildRegistryIndex, collectCatalog } from "./catalog";
 import safe from "./display";
 import { readItemFile, reconcileItems } from "./reconcile";
@@ -18,8 +18,12 @@ import { readManifest, resolveItemDirectory, resolvePlan, resolveRegistryRoot, s
 import type { AddCommandOptions, AddCommandResult, RegistryManifest, RegistryPlanItem } from "./types";
 import { emptyResult } from "./types";
 
-/** Render the human-readable plan for one item. */
-const printPlan = (logger: Logger, manifest: RegistryManifest): void => {
+/**
+ * Render the human-readable plan for one item. `pinned` is the plan's resolved
+ * dependency-name → concrete-version map, so the printed range is the one that
+ * will actually be written.
+ */
+const printPlan = (logger: Logger, manifest: RegistryManifest, pinned?: ReadonlyMap<string, string>): void => {
     const label = manifest.title ?? manifest.description;
 
     logger.info(`plan: ${safe(manifest.name)}${label ? ` — ${safe(label)}` : ""}`);
@@ -33,30 +37,15 @@ const printPlan = (logger: Logger, manifest: RegistryManifest): void => {
     // resolves to the local checkout, but that protocol is meaningless in a
     // consumer's package.json — printing it raw made the plan look like it was
     // about to break `pnpm install`.
-    // `resolveDepRange` resolves the CLI's dist-tag for every bare `workspace:`
-    // specifier, so it is memoised across the whole plan rather than re-resolved
-    // per dependency line.
-    const renderedRange = new Map<string, string>();
-    const rangeFor = (range: string): string => {
-        const cached = renderedRange.get(range);
-
-        if (cached !== undefined) {
-            return cached;
-        }
-
-        const resolved = resolveDepRange(range);
-
-        renderedRange.set(range, resolved);
-
-        return resolved;
-    };
-
+    // `resolveDepRange` resolves the CLI's dist-tag to the concrete version in
+    // `pinned` for every bare `workspace:` specifier — the same resolution the
+    // write path uses, so preview and package.json cannot disagree.
     for (const [dep, range] of Object.entries(manifest.deps ?? {})) {
-        logger.info(`  dep   ${safe(dep)}@${safe(rangeFor(range))}`);
+        logger.info(`  dep   ${safe(dep)}@${safe(resolveDepRange(range, pinned, dep))}`);
     }
 
     for (const [dep, range] of Object.entries(manifest.devDependencies ?? {})) {
-        logger.info(`  dev   ${safe(dep)}@${safe(rangeFor(range))}`);
+        logger.info(`  dev   ${safe(dep)}@${safe(resolveDepRange(range, pinned, dep))}`);
     }
 
     for (const binding of manifest.bindings ?? []) {
@@ -243,8 +232,15 @@ const runAddCommand = async (options: AddCommandOptions): Promise<AddCommandResu
             : resolvedItems;
 
         // --- Plan ---
+        // One batched registry lookup for the whole plan: every bare
+        // `workspace:` range resolves to the CONCRETE version the CLI's channel
+        // dist-tag points at. Written into package.json rather than the floating
+        // tag, because a tag lets a stale lockfile keep an older release — the
+        // same reason `init` pins. Offline, the map is empty and the tag stands.
+        const pinnedVersions = await resolvePinnedDepVersions(items.map((item) => item.manifest));
+
         for (const { manifest } of items) {
-            printPlan(logger, manifest);
+            printPlan(logger, manifest, pinnedVersions);
         }
 
         // The plan IS the document: it says what this invocation resolved, and it
@@ -279,7 +275,7 @@ const runAddCommand = async (options: AddCommandOptions): Promise<AddCommandResu
         }
 
         // --- Reconcile ---
-        const { bindings, deps, skipped, written } = reconcileItems(items, cwd, logger, { overwrite: options.overwrite });
+        const { bindings, deps, skipped, written } = reconcileItems(items, cwd, logger, { overwrite: options.overwrite, pinnedVersions });
 
         reportAddResult(items, deps, written.length, skipped.length, logger, cwd);
 
@@ -334,7 +330,8 @@ const runRegistryViewCommand = async (options: AddCommandOptions): Promise<AddCo
 
             const manifest = readManifest(directory, name);
 
-            printPlan(options.logger, manifest);
+            // eslint-disable-next-line no-await-in-loop -- one lookup per viewed item; the loop is already sequential by design
+            printPlan(options.logger, manifest, await resolvePinnedDepVersions([manifest]));
 
             for (const file of manifest.files) {
                 options.logger.info(`--- ${safe(file.to)} (${safe(file.merge)}) ---`);

--- a/packages/cli/src/commands/registry/reconcile.ts
+++ b/packages/cli/src/commands/registry/reconcile.ts
@@ -461,7 +461,7 @@ const reconcileItems = (
                 continue;
             }
 
-            const applied = applyItemResources(manifest, cwd, logger, useUmbrella);
+            const applied = applyItemResources(manifest, cwd, logger, useUmbrella, reconcileOptions.pinnedVersions);
 
             depsAdded.push(...applied.deps);
             bindingsApplied.push(...applied.bindings);

--- a/packages/cli/src/commands/registry/types.ts
+++ b/packages/cli/src/commands/registry/types.ts
@@ -152,8 +152,14 @@ interface ResolvedItem {
 
 /** Outcome of reconciling a single file. */
 type ReconcileOutcome = { kind: "skipped" | "written"; path: string };
-/** Per-run reconcile modifiers. */
-type ReconcileOptions = { diff?: boolean; overwrite?: boolean };
+
+/**
+ * Per-run reconcile modifiers. `pinnedVersions` is the plan's resolved
+ * dependency-name → concrete-version map (see `resolvePinnedDepVersions`), so
+ * `workspace:*` ranges land in package.json as the exact published version the
+ * CLI's release channel currently points at rather than a floating dist-tag.
+ */
+type ReconcileOptions = { diff?: boolean; overwrite?: boolean; pinnedVersions?: ReadonlyMap<string, string> };
 
 /** An empty (no-op) command result; spread to set a non-zero `code`. */
 const emptyResult = (): AddCommandResult => {

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -1020,21 +1020,46 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     const schemaSnapshotPath = join(lunoraDirectory, SCHEMA_SNAPSHOT_FILENAME);
     const schemaSnapshotExists = existsSync(schemaSnapshotPath);
 
+    // The `_generated/` files this run emits, in write order. Which files those
+    // are depends on the project (conditional features, `apiSpec`), so it is
+    // recorded here rather than restated by each caller — the CLI used to print
+    // a hardcoded three-file list that had been wrong since the fourth file was
+    // added, and nothing could have caught it.
+    const writtenFiles: string[] = [];
+
     if (!options.dryRun) {
         if (!existsSync(outputDirectory)) {
             mkdirSync(outputDirectory, { recursive: true });
         }
 
-        writeIfChanged(join(outputDirectory, "app.ts"), appContent);
-        writeIfChanged(dataModelPath, dataModelContent);
-        writeIfChanged(join(outputDirectory, "api.ts"), apiContent);
-        writeIfChanged(serverPath, serverContent);
-        writeIfChanged(join(outputDirectory, "functions.ts"), functionsContent);
-        writeIfChanged(join(outputDirectory, "shard.ts"), shardContent);
-        writeIfChanged(join(outputDirectory, "crons.ts"), cronsContent);
-        writeIfChanged(join(outputDirectory, "vectors.ts"), vectorsContent);
-        writeIfChanged(join(outputDirectory, "drizzle.global.ts"), drizzleFiles.global);
-        writeIfChanged(join(outputDirectory, "drizzle.shard.ts"), drizzleFiles.shard);
+        /** Always-emitted file: write it and record the name. */
+        const emit = (fileName: string, content: string): void => {
+            writeIfChanged(join(outputDirectory, fileName), content);
+            writtenFiles.push(fileName);
+        };
+
+        /**
+         * Conditionally-emitted file: `writeIfPresent` DELETES it when `content`
+         * is `""`, so only a non-empty emit counts as written.
+         */
+        const emitOptional = (fileName: string, content: string): void => {
+            writeIfPresent(join(outputDirectory, fileName), content);
+
+            if (content !== "") {
+                writtenFiles.push(fileName);
+            }
+        };
+
+        emit("app.ts", appContent);
+        emit("dataModel.ts", dataModelContent);
+        emit("api.ts", apiContent);
+        emit("server.ts", serverContent);
+        emit("functions.ts", functionsContent);
+        emit("shard.ts", shardContent);
+        emit("crons.ts", cronsContent);
+        emit("vectors.ts", vectorsContent);
+        emit("drizzle.global.ts", drizzleFiles.global);
+        emit("drizzle.shard.ts", drizzleFiles.shard);
 
         // Conditionally-emitted files: each is written only when its feature is
         // in use (the `emit*` helper returns `""` otherwise), so projects that
@@ -1042,15 +1067,15 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         //   - containers.ts  → `@lunora/container`, when containers are declared
         //   - workflows.ts   → `@lunora/workflow`, when workflows are declared
         //   - seed.ts        → `@lunora/seed`, when it's a declared dependency
-        writeIfPresent(join(outputDirectory, "containers.ts"), containersContent);
-        writeIfPresent(join(outputDirectory, "workflows.ts"), workflowsContent);
+        emitOptional("containers.ts", containersContent);
+        emitOptional("workflows.ts", workflowsContent);
         //   - agents.ts      → `@lunora/agent`, when agents are declared
-        writeIfPresent(join(outputDirectory, "agents.ts"), agentsContent);
-        writeIfPresent(join(outputDirectory, "queues.ts"), queuesContent);
-        writeIfPresent(join(outputDirectory, "scheduler.ts"), schedulerContent);
-        writeIfPresent(join(outputDirectory, "seed.ts"), seedContent);
+        emitOptional("agents.ts", agentsContent);
+        emitOptional("queues.ts", queuesContent);
+        emitOptional("scheduler.ts", schedulerContent);
+        emitOptional("seed.ts", seedContent);
         //   - collections.ts → `@lunora/db`, when the project declares shapes
-        writeIfPresent(join(outputDirectory, "collections.ts"), collectionsContent);
+        emitOptional("collections.ts", collectionsContent);
 
         // The `.json` is the portable artifact for external tooling; the `.ts`
         // (same document, inlined) is what the worker imports and passes to
@@ -1059,10 +1084,10 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         // (empty content when the mode is off) so switching `apiSpec` away from a
         // format also DELETES its now-stale spec files instead of leaving a
         // portable artifact that documents endpoints/args that no longer exist.
-        writeIfPresent(join(outputDirectory, "openapi.json"), wantsOpenApi ? openApiContent : "");
-        writeIfPresent(join(outputDirectory, "openapi.ts"), wantsOpenApi ? openApiModuleContent : "");
-        writeIfPresent(join(outputDirectory, "openrpc.json"), wantsOpenRpc ? openRpcContent : "");
-        writeIfPresent(join(outputDirectory, "openrpc.ts"), wantsOpenRpc ? openRpcModuleContent : "");
+        emitOptional("openapi.json", wantsOpenApi ? openApiContent : "");
+        emitOptional("openapi.ts", wantsOpenApi ? openApiModuleContent : "");
+        emitOptional("openrpc.json", wantsOpenRpc ? openRpcContent : "");
+        emitOptional("openrpc.ts", wantsOpenRpc ? openRpcModuleContent : "");
 
         // Bless the schema baseline on first capture (so a project gets a
         // committed snapshot the moment it runs codegen) or when explicitly
@@ -1123,6 +1148,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         schemaSnapshot,
         schemaSnapshotPath,
         workflows,
+        writtenFiles,
     };
 };
 
@@ -1338,6 +1364,17 @@ export interface CodegenResult {
      * adds no binding or migration. Empty when the project declares no workflows.
      */
     workflows: ReadonlyArray<WorkflowIR>;
+
+    /**
+     * The `_generated/` file names this run emitted, in write order, relative to
+     * {@link CodegenResult.outputDirectory}. Conditional files appear only when
+     * their feature is in use, and the spec artifacts only for the requested
+     * `apiSpec` — so this is what the project actually has, not a fixed list.
+     * Empty under `dryRun` (nothing is written). Callers report from this rather
+     * than restating the set, which is how the CLI came to advertise three of
+     * twelve files.
+     */
+    writtenFiles: ReadonlyArray<string>;
 }
 
 // Exports kept at end-of-file per the package's `import/exports-last` rule.

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -3136,7 +3136,7 @@ export const schema = defineSchema({
                 {
                     compatibility_date: REQUIRED_COMPATIBILITY_DATE,
                     compatibility_flags: ["nodejs_compat"],
-                    d1_databases: [{ binding: "DB", database_id: "REPLACE_WITH_D1_ID", database_name: "lunora-example-team-chat" }],
+                    d1_databases: [{ binding: "DB", database_id: "<replace-with-d1-create-id>", database_name: "lunora-example-team-chat" }],
                     durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
                     main: "src/server/index.ts",
                     migrations: [{ new_sqlite_classes: ["ShardDO"] }],

--- a/templates/expo/README.md
+++ b/templates/expo/README.md
@@ -23,7 +23,7 @@ Install dependencies with your package manager (`npm`, `pnpm`, `yarn`, or `bun`)
 
 Create a D1 database for the better-auth identity/session tables and paste the
 printed id into `wrangler.jsonc` (`d1_databases[0].database_id`, replacing
-`REPLACE_WITH_D1_ID`):
+`<replace-with-d1-create-id>`):
 
 ```bash
 npx wrangler d1 create {{name}}

--- a/templates/expo/package.json
+++ b/templates/expo/package.json
@@ -12,8 +12,8 @@
         "ios": "expo start --ios",
         "web": "expo start --web",
         "codegen": "lunora codegen",
-        "dev:server": "wrangler dev",
-        "deploy": "wrangler deploy",
+        "dev:server": "lunora dev",
+        "deploy": "lunora deploy",
         "lint:types": "lunora codegen && tsc --noEmit"
     },
     "dependencies": {

--- a/templates/expo/wrangler.jsonc
+++ b/templates/expo/wrangler.jsonc
@@ -10,7 +10,7 @@
     "d1_databases": [
         // better-auth identity + sessions live in D1. Create the database with
         // `wrangler d1 create {{name}}` and paste the printed id below.
-        { "binding": "DB", "database_name": "{{name}}", "database_id": "REPLACE_WITH_D1_ID" },
+        { "binding": "DB", "database_name": "{{name}}", "database_id": "<replace-with-d1-create-id>" },
     ],
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
     // Blast-radius cap. Alerting is lagging by definition — by the time a

--- a/templates/solid-v2/wrangler.jsonc
+++ b/templates/solid-v2/wrangler.jsonc
@@ -8,5 +8,14 @@
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
     },
     "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
-    "observability": { "enabled": true, "head_sampling_rate": 1 },
+    // Blast-radius cap. Alerting is lagging by definition — by the time a
+    // threshold trips, the runaway handler has already run — so a CPU ceiling is
+    // one of the few controls that bounds the damage rather than reporting it.
+    // Raise it if a legitimate handler needs longer.
+    "limits": { "cpu_ms": 30000 },
+    "observability": { "enabled": true, "head_sampling_rate": 1, "logs": { "invocation_logs": true } },
+    // Deploy attribution: the runtime reads this binding and stamps
+    // `deploymentId` / `versionTag` onto every request-log row and Workers-Logs
+    // event, so a spike resolves to a deploy by group-by, not by eyeballing graphs.
+    "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }


### PR DESCRIPTION
Five independently-verified defects in the templates, the CLI and the CLI reference. Each was re-checked by execution before being touched; one item in the brief turned out to be wrong and is left alone (below).

## What changed

**`templates/expo` bypassed the CLI, and its D1 placeholder was unguarded.**
`dev:server` / `deploy` ran `wrangler` directly while every sibling routes through the CLI, so `<pm> run deploy` shipped whatever was in `_generated/` with no codegen, drift, advisory or placeholder gate. Separately the template used a second placeholder spelling, `REPLACE_WITH_D1_ID`, that neither the deploy handler nor `reconcile-bindings` matches — both compare against `<replace-with-d1-create-id>`. Proven on a real scaffold:

```
# old spelling — gate skipped entirely
info  running codegen
ok    codegen complete
info  dry run: validating + bundling without publishing   ← sailed past

# unified spelling
info  running codegen
ok    codegen complete
error deploy blocked: the "DB" D1 binding has a placeholder database_id
```

The spelling is unified everywhere it appeared: the expo template and README, four examples, and the `wrangler-validator` fixture that mirrors `examples/team-chat`.

**`templates/solid-v2` was missing config all twelve siblings ship.** `limits.cpu_ms`, `version_metadata` and `observability.logs.invocation_logs`, all three at values that are byte-identical across the other twelve. Adopted verbatim, comments included.

**`lunora add` wrote a floating dist-tag where `init` pins.** A scaffolded manifest ended up with `"@lunora/flags": "alpha"` beside `"lunorash": "1.0.0-alpha.255"`. A dist-tag lets a stale lockfile keep an older release — the specifier still matches, so it is never re-resolved, which is precisely why `init` pins. Now resolved once per invocation through the same `resolveTagVersions`, threaded through the plan preview and the write path so both report what lands. Offline, the lookup fails and the channel tag stands, unchanged; both paths are tested.

**`lunora codegen` under-reported what it wrote**, via a hardcoded three-file string that had been wrong since the fourth emitter landed. Now derived from the run — the set is not fixed (per-feature modules come and go, spec artifacts follow `--api-spec`). Adds `CodegenResult.writtenFiles`.

**The CLI reference had drifted in five ways at once** — three missing templates, four undocumented flags, a `#<version>` claim the code contradicts, two of fifteen features listed, and five registered commands with no mention. Fixed, and pinned: the two tables are now asserted against `FRAMEWORK_CHOICES` and `STACK_FEATURE_OPTIONS`, and every registered command against `REGISTERED_COMMAND_NAMES`, following the doctor-codes precedent. All three assertions fail against the reference as it stood.

## Evidence

| Gate | Result |
| --- | --- |
| `build:packages` / `build:packages:prod` | 54 projects, green |
| `lint:types` | 75 projects / 121 tasks, green (run with `--no-cache`) |
| `api:check` | 54 snapshots match (one line accepted for `writtenFiles`) |
| `dist:check` | green |
| `lint:package-json` | 89 files sorted |
| `lint:prettier` / `lint:eslint` | green |
| `lint:registry:sync` / `lint:generated` | green |
| `@lunora/cli` test | 1596 passed |
| `@lunora/codegen` test | 1817 passed |
| `@lunora/config` test | 747 passed |
| `test:affected` | 65 projects / 117 tasks, green (re-run after the rebase) |
| `test:templates solid-v2` | PASS, including the credential-free deploy dry run |

`lunora codegen` on a real scaffold now names exactly the twelve files `ls lunora/_generated` shows, and the `add` plan and the written manifest agree on `@lunora/flags@1.0.0-alpha.50`.

The new docs test was verified reachable, not just green: deleting one table row re-ran that task alone (32 of 33 still cached) and failed it.

## Deliberately not changed

**The `expo` smoke-test skip stays.** The brief called it arbitrary; it is not. `scripts/template-build-smoke.sh` already documents the real reason in detail — expo is a React Native/Metro app whose install pulls a largely-native toolchain not represented by the matrix's `allowBuilds`, it has no `pnpm run build` step, and the comment goes on to state plainly that nothing else covers it and to name the two ways of closing it. Unskipping needs the native toolchain in CI, which is a separate call. The comment is accurate as written.

**`templates/analog` and `templates/nuxt` have the same bare-`wrangler deploy` shape** as expo did. They are left alone: `set_deploy_dryrun` in the smoke script hardcodes a mirror of each template's deploy script and documents these two as deliberately not using `lunora deploy` ("Nitro owns the adapter, so there is no `lunora deploy` in the path to mirror"). Changing them means changing that gate in the same breath, and I have no evidence `lunora deploy` is correct for a Nitro-composed worker. Worth a look, but not on this branch.

> [!NOTE]
> Rebased onto `alpha` after #746 landed. Two files overlapped: `init/handler.ts` (they added `writePnpmBuildAllowlist`, I changed only the export line — both kept) and the `init` flag list in `docs/index.mdx`, where their rewritten `-y` / `--yes` bullet is kept alongside my new `--add` and `--dry-run` ones. Every other file in this branch is byte-identical across the rebase.
>
> `packages/errors/__tests__/catalog-registration.test.ts` is currently red on `alpha` for two unregistered error codes from an already-merged PR. It is not in this branch's affected set (nothing here touches `errors`, `runtime` or `shard-engine`) and is fixed by #749. This branch will be rebased once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz
