### PR TITLE
fix(cdc): detect a changelog that rolled back

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -608,6 +608,10 @@ const ERROR_CATALOG: {
         readonly status: 409;
         readonly title: "CDC log trimmed";
     };
+    readonly CDC_TIMELINE_FORKED: {
+        readonly status: 409;
+        readonly title: "CDC timeline forked";
+    };
     readonly CDC_PAYLOAD_COMPACTED: {
         readonly status: 409;
         readonly title: "CDC payloads compacted";

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -3607,10 +3607,22 @@ const buildShapeDiff: (sql: SqlExec, resolved: ResolvedShape, sinceSeq: number, 
 const bumpCdcEpoch: (sql: SqlExec) => string;
 ```
 
+### `cdcArchiveRewound` (const)
+
+```ts
+const cdcArchiveRewound: (bucket: R2BucketLike, scope: CdcArchiveScope, archivedThrough: number) => Promise<boolean>;
+```
+
 ### `cdcCanVouchFor` (const)
 
 ```ts
 const cdcCanVouchFor: (sql: SqlExec, deps: ReadonlySet<string>) => boolean;
+```
+
+### `cdcForkedError` (const)
+
+```ts
+const cdcForkedError: (cursor: number, sinceSeq: number, epoch: string) => LunoraError;
 ```
 
 ### `cdcSeqLeavingRows` (const)

--- a/apps/docs/src/content/docs/errors.mdx
+++ b/apps/docs/src/content/docs/errors.mdx
@@ -82,7 +82,7 @@ to branch on, see [Error handling](/docs/concepts/error-handling).
 
 ## Error codes
 
-All 144 codes Lunora publishes, generated from the catalog the runtime, CLI, overlay, Studio and client SDK all read.
+All 145 codes Lunora publishes, generated from the catalog the runtime, CLI, overlay, Studio and client SDK all read.
 Every heading is an anchor, so `/docs/errors#conflict` links straight to one.
 
 ### `ADMIN_FORBIDDEN`
@@ -168,6 +168,10 @@ Narrow the snapshot with `backupTables`, or take this backup off-platform with `
 ### `CDC_PAYLOAD_COMPACTED`
 
 `409` — CDC payloads compacted
+
+### `CDC_TIMELINE_FORKED`
+
+`409` — CDC timeline forked
 
 ### `CLIENT_CLOSED`
 

--- a/packages/do/__tests__/shard-do.delta-read-path.test.ts
+++ b/packages/do/__tests__/shard-do.delta-read-path.test.ts
@@ -1,3 +1,4 @@
+import type { LunoraError } from "@lunora/errors";
 import type { CdcChange, DatabaseWriterLike, ShapeProbeCounters, SocketAttachment } from "@lunora/shard-engine";
 import {
     CDC_LOG_TABLE_SEQ_INDEX,
@@ -96,6 +97,11 @@ class ProbeCountingShard extends ShardDO {
         await this.getWriter().insert("roomMembers", { _id: id, roomId, userId: "u1" }, { allowExplicitId: true });
     }
 
+    /** This shard's CDC epoch — what a fork seal re-mints, so a test can tell one timeline from the next. */
+    public cdcEpoch(): string | undefined {
+        return this.currentCdcEpoch();
+    }
+
     /** The changelog page a streaming-export / read-replica consumer pulls, exposed so a test can assert what it refuses. */
     public syncCdc(sinceSeq: number): { changes: CdcChange[]; cursor: number } {
         return this.runShardCdcSync({ sinceSeq });
@@ -154,6 +160,48 @@ const makeState = (sockets: FakeWebSocket[], name?: string): ShardDOState => {
         storage: { sql: harness.sql as unknown as ShardDOState["storage"]["sql"] },
     };
 };
+
+/**
+ * A native point-in-time restore, as far as anything outside Cloudflare can
+ * reproduce one: SQLite's CONTENT reverts to an earlier moment — the changelog
+ * rows, the `sqlite_sequence` high-watermark `readCdcCursor` reads, the archive
+ * watermark — and nothing held outside this shard's SQLite does.
+ *
+ * The native API is out of reach rather than merely inconvenient. workerd
+ * implements `getCurrentBookmark` / `getBookmarkForTime`, but
+ * `onNextSessionRestoreBookmark` answers "This Durable Object's storage back-end
+ * does not implement point-in-time recovery", so neither `node:sqlite` nor the
+ * workerd suite can perform a restore. The revert is the whole of what these
+ * paths turn on, so the revert is what is modelled — deliberately including the
+ * `__cdc_meta` epoch, which a restore reverts with everything else and which is
+ * therefore never, by itself, evidence that the timeline forked.
+ */
+const restoreSqliteTo = (seq: number): void => {
+    // The rows the undone changelog entries describe go back with them — these
+    // suites only ever insert, so undoing an insert is a delete by id.
+    for (const row of harness.sql.exec(`SELECT "table", id FROM __cdc_log WHERE seq > ?`, seq).toArray() as { id: string; table: string }[]) {
+        harness.sql.exec(`DELETE FROM ${JSON.stringify(row.table)} WHERE id = ?`, row.id);
+    }
+
+    harness.sql.exec(`DELETE FROM __cdc_log WHERE seq > ?`, seq);
+    harness.sql.exec(`UPDATE sqlite_sequence SET seq = ? WHERE name = '__cdc_log'`, seq);
+
+    // Only the archiving path creates the watermark table, so a shard that has
+    // never archived has none to revert.
+    if (harness.sql.exec(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '__cdc_archive'`).toArray().length > 0) {
+        harness.sql.exec(`UPDATE __cdc_archive SET seq = ? WHERE id = 1 AND seq > ?`, seq, seq);
+    }
+};
+
+/** The id of the first change in the segment stored at `key` — what a re-keyed put would have replaced. */
+const firstChangeId = async (bucket: ReturnType<typeof createFakeR2Bucket>, key: string): Promise<string | undefined> => {
+    const body = await bucket.get(key);
+
+    return body === null ? undefined : (JSON.parse(await body.text()) as { changes: { id: string }[] }).changes[0]?.id;
+};
+
+/** The epoch segment of an archive key (`cdc/<shard>/<epoch>/<seq>.json`). */
+const epochOfKey = (key: string): string => key.split("/")[2] ?? "";
 
 const write = (functionPath: string, args: Record<string, unknown>): Request =>
     new Request("https://shard.internal/rpc", {
@@ -565,7 +613,7 @@ describe("delta-sync read path", () => {
          * off the write path — a test that did not await it would assert against
          * a log the sweep had not finished touching.
          */
-        const sweepWithArchive = async (environment: Record<string, unknown>, rows: number): Promise<ProbeCountingShard> => {
+        const sweepWithArchive = async (environment: Record<string, unknown>, rows: number, idPrefix = "m"): Promise<ProbeCountingShard> => {
             const pending: Promise<unknown>[] = [];
             const sockets: FakeWebSocket[] = [];
             const state: ShardDOState = {
@@ -578,11 +626,20 @@ describe("delta-sync read path", () => {
 
             for (let index = 0; index < rows; index += 1) {
                 // eslint-disable-next-line no-await-in-loop -- sequential writes build the changelog range the sweep acts on
-                await shard.seed(`m${String(index)}`, "c1");
+                await shard.seed(`${idPrefix}${String(index)}`, "c1");
             }
 
-            await shard.fetch(write("messages:send", { _id: "trigger", channelId: "c1" }));
-            await Promise.all(pending);
+            await shard.fetch(write("messages:send", { _id: `${idPrefix}-trigger`, channelId: "c1" }));
+
+            // Drained rather than `Promise.all(pending)` once: the flush is
+            // itself deferred through `waitUntil`, and the archive task it starts
+            // is pushed while that first promise is already being awaited — a
+            // single snapshot of the array therefore returns before the sweep has
+            // finished touching the log it is about to be asserted against.
+            while (pending.length > 0) {
+                // eslint-disable-next-line no-await-in-loop -- draining a queue that grows while it is awaited is the point
+                await Promise.all(pending.splice(0));
+            }
 
             return shard;
         };
@@ -684,6 +741,115 @@ describe("delta-sync read path", () => {
             environment["LUNORA_CDC_ARCHIVE"] = createFakeR2Bucket();
 
             await expect(shard.syncCdcArchived(0)).rejects.toThrow(/trimmed/u);
+        });
+
+        it("starts a fresh prefix when the archive holds segments the shard has no record of writing", async () => {
+            expect.assertions(5);
+
+            const bucket = createFakeR2Bucket();
+            const environment: Record<string, unknown> = { LUNORA_CDC_ARCHIVE: bucket, LUNORA_CDC_LOG_RETENTION: "5" };
+            const before = await sweepWithArchive(environment, 20);
+            const firstEpoch = before.cdcEpoch();
+
+            expect(bucket.keys().map((key) => epochOfKey(key))).toStrictEqual([firstEpoch]);
+
+            // A restore to before the shard's first write: the rows go back with
+            // the log, and the archive WATERMARK goes with them — while R2, which
+            // no restore can reach, keeps every segment already written.
+            restoreSqliteTo(0);
+            harness.sql.exec(`DELETE FROM messages`);
+
+            // So the rewound shard re-issues the same `seq` range for different
+            // changes, and a segment key IS its range's last seq: left alone this
+            // sweep puts the second timeline over the first one's object.
+            const after = await sweepWithArchive(environment, 20, "n");
+
+            expect(after.cdcEpoch()).not.toBe(firstEpoch);
+            // The first timeline's segment is still the first timeline's — a put
+            // under the reused key replaces rows already deleted from SQLite with
+            // changes that never happened, and nothing anywhere reports it.
+            await expect(firstChangeId(bucket, bucket.keys()[0] ?? "")).resolves.toBe("m0");
+
+            // The fresh epoch is a fresh prefix, so the next sweep archives beside
+            // the old timeline rather than over it.
+            const later = await sweepWithArchive(environment, 20, "o");
+
+            expect(new Set(bucket.keys().map((key) => epochOfKey(key)))).toStrictEqual(new Set([firstEpoch, later.cdcEpoch()]));
+
+            // …and a read-back on the new timeline serves the new timeline only.
+            // On one shared prefix the two are stitched into a single ascending
+            // run, so a consumer paging from below the floor is handed rolled-back
+            // changes as though they were the ones it missed.
+            const page = await later.syncCdcArchived(0);
+
+            expect(page.changes.filter((change) => change.id.startsWith("m"))).toStrictEqual([]);
+        });
+    });
+
+    /**
+     * A point-in-time restore reverts every durable thing INSIDE this shard's
+     * SQLite — the changelog rows, the `sqlite_sequence` high-watermark
+     * `readCdcCursor` reads, the `__cdc_meta` epoch, the archive watermark — and
+     * nothing a consumer holds outside it. So a consumer arrives carrying a
+     * cursor the shard has issued but can no longer account for, and every read
+     * path has to treat that as proof rather than as a cursor.
+     */
+    describe("rewound timeline", () => {
+        const buildShard = (): ProbeCountingShard => new ProbeCountingShard(makeState([]), {});
+
+        it("refuses a consumer whose cursor is above the rewound log", async () => {
+            expect.assertions(4);
+
+            const shard = buildShard();
+
+            for (const id of ["m1", "m2", "m3", "m4", "m5"]) {
+                // eslint-disable-next-line no-await-in-loop -- sequential writes build the changelog range the consumer checkpoints against
+                await shard.seed(id, "c1");
+            }
+
+            // The consumer drains the log and checkpoints at 5.
+            expect(shard.syncCdc(0).cursor).toBe(5);
+
+            restoreSqliteTo(2);
+            await shard.seed("post-restore", "c1");
+
+            const epochBefore = shard.cdcEpoch();
+
+            // Echoing `sinceSeq` back here reports "caught up" to a consumer that
+            // is about to skip the entire post-restore range: seq 3 onwards are
+            // now different changes, and the consumer's own cursor is what keeps
+            // it from ever asking for them.
+            const refusal = (() => {
+                try {
+                    shard.syncCdc(5);
+                } catch (error) {
+                    return error as LunoraError;
+                }
+
+                return undefined;
+            })();
+
+            expect(refusal?.message).toMatch(/rolled back/u);
+            // The surviving cursor and the timeline to resynchronise against —
+            // without them the consumer knows only that it must not continue.
+            expect(refusal?.data).toStrictEqual({ cursor: 3, epoch: expect.any(String) });
+
+            // The refusal seals the fork for everyone else: a subscriber holding
+            // the pre-restore epoch re-snapshots instead of resuming onto it.
+            expect(shard.cdcEpoch()).not.toBe(epochBefore);
+        });
+
+        it("still answers a consumer that is merely up to date", async () => {
+            expect.assertions(1);
+
+            const shard = buildShard();
+
+            await shard.seed("m1", "c1");
+
+            // A quiet consumer sitting exactly at the high-watermark has nothing
+            // to be told: an empty page is the correct answer and must not be
+            // turned into an error by the guard above.
+            expect(shard.syncCdc(1)).toStrictEqual({ changes: [], cursor: 1 });
         });
     });
 });

--- a/packages/do/src/cdc-retention.ts
+++ b/packages/do/src/cdc-retention.ts
@@ -21,6 +21,7 @@ import type { R2BucketLike } from "@lunora/platform";
 import type { CdcChange, SqlExec } from "@lunora/shard-engine";
 import {
     archiveCdcSegment,
+    cdcArchiveRewound,
     cdcSeqLeavingRows,
     compactCdcDocs,
     envOptionalPositiveInt,
@@ -95,8 +96,17 @@ interface CdcRetentionHost {
     epoch: () => string | undefined;
     /** Report a swallowed failure; retention is maintenance and must never surface on a write path. */
     recordError: (scope: string, error: unknown) => void;
+
     /** Lowest cursor any durable in-shard consumer has reached — the seq a sweep may not cross. */
     retentionFloor: (sql: SqlExec) => number;
+
+    /**
+     * Re-mint the CDC epoch because this shard's changelog has provably forked —
+     * `ShardDO.sealForkedTimeline`. The sweep calls it when the ARCHIVE turns out
+     * to know about segments the shard has no record of writing, which is what a
+     * rewound watermark looks like from the one place a restore cannot reach.
+     */
+    sealTimeline: () => void;
     /** This DO's shard key, or `__root__` for the single-DO default. */
     shardKey: () => string;
     sql: () => SqlExec;
@@ -314,8 +324,26 @@ class CdcRetentionRunner {
                     // epoch the read path refuses, so they would cost storage
                     // forever and answer nothing.
                     const epoch = this.host.epoch() as string;
+                    const scope = { epoch, shard: this.host.shardKey() };
 
-                    await archiveCdcSegment(bucket, { epoch, shard: this.host.shardKey() }, batch);
+                    // A segment above the watermark means the shard and the
+                    // archive disagree about what has been written, and the
+                    // reachable cause is a point-in-time restore: it reverts the
+                    // watermark and the epoch together, so without this the
+                    // rewound timeline archives over the old one's objects under
+                    // the same prefix. Seal the fork and let the NEXT sweep write
+                    // under the fresh prefix — the watermark did not advance, so
+                    // nothing in this batch is lost by skipping a cycle, and the
+                    // retention below it must not run either: trimming rows whose
+                    // only copy lives under a prefix this shard has just stopped
+                    // reading would destroy them outright.
+                    if (await cdcArchiveRewound(bucket, scope, archivedAlready)) {
+                        this.host.sealTimeline();
+
+                        return;
+                    }
+
+                    await archiveCdcSegment(bucket, scope, batch);
 
                     // Only now. The watermark is the claim "this is durable
                     // elsewhere", and advancing it over an upload that did not

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -143,6 +143,7 @@ import {
     bumpCdcEpoch,
     CDC_LOG_TABLE,
     cdcCanVouchFor,
+    cdcForkedError,
     cdcTouchesTables,
     cdcTrimmedError,
     clearCapturedMail,
@@ -1820,6 +1821,9 @@ abstract class ShardDO {
             this.recordShapeError(scope, error);
         },
         retentionFloor: (sql) => this.retentionFloor(sql),
+        sealTimeline: () => {
+            this.sealForkedTimeline();
+        },
         shardKey: () => this.currentShardKey(),
         sql: () => this.sql as SqlExec,
         waitUntil: (promise) => this.shardHost.waitUntil?.(promise),
@@ -3558,8 +3562,35 @@ abstract class ShardDO {
             return { changes: [], cursor: args.sinceSeq };
         }
 
-        // Retention-gap guard, and it comes first because it is the more
-        // destructive of the two levels. `trimCdcChanges` DELETES rows, so a
+        // Rollback guard, ahead of both retention levels because it is the only
+        // one that says the cursor itself is meaningless rather than merely out
+        // of range.
+        //
+        // A consumer cannot legitimately hold a `seq` above the high-watermark:
+        // it is monotonic and outlives a trim (`readCdcCursor` reads
+        // `sqlite_sequence`). A cursor above it is therefore proof that the log
+        // rolled back under the consumer — a native point-in-time restore, which
+        // reverts this shard's whole SQLite database and with it every durable
+        // record of the pre-restore timeline, the `__cdc_meta` epoch included.
+        //
+        // Returning the empty page this read would otherwise produce tells that
+        // consumer it is caught up, and the shard's post-restore writes then
+        // climb back through seqs the consumer has already passed — skipped one
+        // by one, permanently, with nothing anywhere reporting it. So refuse,
+        // and seal the fork for everyone else at the same time: the subscription
+        // path already treats exactly this proof this way (see
+        // {@link ShardDO.sealForkedTimeline} and {@link ShardDO.evaluateResume}),
+        // and this path — the one warehouse connectors and `cdcSync` use — did
+        // not. The freshly minted epoch also re-prefixes the changelog archive,
+        // so the rewound timeline stops writing segments over the old one's.
+        const cursor = readCdcCursor(sql);
+
+        if (args.sinceSeq > cursor) {
+            throw cdcForkedError(cursor, args.sinceSeq, this.sealForkedTimeline());
+        }
+
+        // Retention-gap guard, and it comes first of the two retention levels
+        // because it is the more destructive of them. `trimCdcChanges` DELETES rows, so a
         // consumer resuming below the retained floor would be handed the surviving
         // tail with an advanced cursor and no indication that anything was
         // skipped — a warehouse table permanently missing the trimmed range, and
@@ -3656,14 +3687,19 @@ abstract class ShardDO {
      * no longer account for. Only a rollback produces that — in practice a native
      * PITR restore, which is armed in {@link handlePitrAdminOp}.
      *
-     * **Why the signal has to come from a client.** A restore reverts the whole
-     * SQLite database, `__cdc_meta` included, so the proactive bump `pitrRestore`
-     * performs is rolled back along with everything else — the epoch cannot
-     * detect the one event it exists for. Nothing durable inside a SQLite-backed
-     * Durable Object escapes that: the KV half of `state.storage` is the same
-     * database, and an alarm is a row in it. The only record of the pre-restore
-     * timeline that the restore cannot reach is the cursor each CLIENT cached, so
-     * that is what this reads. Turning one client's refusal into a shard-wide
+     * **Why the signal has to come from outside SQLite.** A restore reverts the
+     * whole SQLite database, `__cdc_meta` included, so the proactive bump
+     * `pitrRestore` performs is rolled back along with everything else — the
+     * epoch cannot detect the one event it exists for. Nothing durable inside a
+     * SQLite-backed Durable Object escapes that: the KV half of `state.storage`
+     * is the same database, and an alarm is a row in it. So every record of the
+     * pre-restore timeline that survives is somewhere the restore could not
+     * reach, and this shard has exactly two: the cursor a CONSUMER cached (a
+     * subscriber's `sinceSeq` here, a connector's in
+     * {@link ShardDO.runShardCdcSync}, a follower's in `replica.ts`), and the
+     * changelog ARCHIVE's own segments, which R2 keeps while the watermark
+     * naming them rolls back (`cdcArchiveRewound`, consulted by the retention
+     * sweep). Either one calls this, and turning one witness into a shard-wide
      * epoch bump is what extends the protection to clients that reconnect later,
      * after post-restore writes have climbed the AUTOINCREMENT back past their
      * own `sinceSeq` and the `sinceSeq > cursor` guard no longer fires for them.
@@ -3674,9 +3710,10 @@ abstract class ShardDO {
      * subscriber set reconnects with pre-restore cursors while the restored
      * cursor is still low. The first of them seals the fork for the rest.
      *
-     * **What it cannot detect.** A rollback on a shard whose clients ALL stay
-     * offline until the cursor has climbed back past their cursors — nobody is
-     * left to present the proof. A shard with no subscribers at all is the
+     * **What it cannot detect.** A rollback on a shard whose consumers ALL stay
+     * offline until the cursor has climbed back past their cursors, and which
+     * archives nothing — nobody is left to present the proof. A shard with no
+     * subscribers, no connector, no follower and no archive bucket is the
      * degenerate case of that, and is also the case where nothing is stale.
      *
      * **On trusting `sinceSeq`.** It is client-supplied, so a caller that already
@@ -3774,9 +3811,9 @@ abstract class ShardDO {
         // Rollback guard: a legitimate `sinceSeq` can never exceed the current
         // high-watermark (the cursor is monotonic and survives trims). A client
         // claiming to have seen MORE than the shard holds, on THIS epoch, is
-        // proof the log rolled back under it — and is the only such proof that
-        // exists (see {@link sealForkedTimeline}). Refuse this client, and seal
-        // the fork for every other one.
+        // proof the log rolled back under it — one of the few such proofs that
+        // survive a restore at all (see {@link sealForkedTimeline}). Refuse this
+        // client, and seal the fork for every other one.
         if (sinceSeq > cursor) {
             return { cursor, epoch: this.sealForkedTimeline(), resumable: false };
         }
@@ -9188,10 +9225,11 @@ abstract class ShardDO {
         // cover is the one between arming and the restart.
         //
         // The other half is reactive and lives in
-        // {@link ShardDO.sealForkedTimeline}: the first client to present a
-        // cursor ahead of the rewound log, on the reverted epoch, proves the fork
-        // from outside SQLite and re-mints the epoch for everyone. Read that
-        // comment for what the pair can and cannot detect.
+        // {@link ShardDO.sealForkedTimeline}: the first witness from OUTSIDE
+        // SQLite — a subscriber's cursor, a `cdcSync` consumer's, a replica
+        // follower's, or the changelog archive's own segments — proves the fork
+        // and re-mints the epoch for everyone. Read that comment for what the
+        // pair can and cannot detect.
         //
         // Best-effort: `cdcEnabled()` is false on a stub `sql` handle or a
         // pre-CDC shard, so the bump simply no-ops there.

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -503,13 +503,16 @@ export const ERROR_CATALOG = {
      * `NESTED_TRANSACTION` and `SQL_UNAVAILABLE` are "should never happen" state
      * invariants (mirrors `RUN_DEPTH_EXCEEDED`'s posture above): today's message
      * is static and safe, but flagged internal so a future edit that adds
-     * diagnostic detail can't accidentally start leaking it. The two `CDC_*`
-     * codes are the opposite — ordinary, expected, operator-configured outcomes
-     * — and both are `409` because the cursor the caller holds is real but no
-     * longer serveable, so the recovery is a snapshot rather than a retry.
+     * diagnostic detail can't accidentally start leaking it. The three `CDC_*`
+     * codes are the opposite — ordinary, expected outcomes of a configured
+     * retention window or an operator-ordered restore — and all three are `409`
+     * because the cursor the caller holds is real but no longer serveable, so
+     * the recovery is a snapshot rather than a retry.
      */
     /** A resume below the deleted changelog prefix: the entries are gone outright, for every consumer. */
     CDC_LOG_TRIMMED: { status: 409, title: "CDC log trimmed" },
+    /** A resume from ABOVE the changelog's high-watermark: the shard's log rewound (a point-in-time restore), so the cursor indexes a timeline that no longer exists. Carries the surviving cursor and the freshly minted epoch to resynchronise against. */
+    CDC_TIMELINE_FORKED: { status: 409, title: "CDC timeline forked" },
     /** A resume below the compacted prefix: the keys survive but their post-images do not, so only a payload consumer (streaming export, replay-PITR, a read replica) is refused. */
     CDC_PAYLOAD_COMPACTED: { status: 409, title: "CDC payloads compacted" },
     EXPIRED: { status: 404, title: "Session expired" },

--- a/packages/shard-engine/__tests__/replica.test.ts
+++ b/packages/shard-engine/__tests__/replica.test.ts
@@ -341,6 +341,39 @@ describe("read replicas", () => {
         expect(replica?.isDivergent()).toBe(true);
     });
 
+    it("bootstraps when the owner's log rewound beneath it on the SAME epoch", async () => {
+        expect.assertions(4);
+
+        const replica = createReplicaLink(host);
+
+        owner.changes = [change(1, "a"), change(2, "b"), change(3, "c")];
+
+        await replica?.ensureFresh(3);
+
+        // A NATIVE point-in-time restore is the case the epoch cannot report: it
+        // reverts the owner's whole SQLite database, the `__cdc_meta` row that
+        // holds the epoch included, so the timeline forks and the epoch comes
+        // back identical. The follower's own applied position is then the only
+        // surviving record of the pre-restore timeline — and a high-watermark
+        // BELOW it is proof the owner can no longer account for rows the
+        // follower has already replayed.
+        owner.changes = [change(1, "z")];
+        // The owner's changelog read refuses such a cursor outright; the pull
+        // must answer with its rewound high-watermark before reaching it, since a
+        // thrown response reads here as "owner unreachable" and would be retried
+        // forever instead of bootstrapping.
+        owner.readThrows = true;
+
+        const pullsBefore = owner.pulls;
+
+        await expect(replica?.ensureFresh(4)).resolves.toBe("unavailable");
+        expect(replica?.isDivergent()).toBe(true);
+        // Nothing from the second timeline was replayed over the snapshot the
+        // first one produced, which is the corruption this refusal prevents.
+        expect(applied).toStrictEqual([]);
+        expect(owner.pulls).toBe(pullsBefore);
+    });
+
     it("reports unavailable when the log was compacted past its position", async () => {
         expect.assertions(2);
 

--- a/packages/shard-engine/src/ctx-db-cdc-archive.ts
+++ b/packages/shard-engine/src/ctx-db-cdc-archive.ts
@@ -81,12 +81,19 @@ interface CdcSegment {
 interface CdcArchiveScope {
     /**
      * The shard's CDC epoch. Part of the key PREFIX rather than a metadata field,
-     * because an epoch change means the timeline forked (a PITR restore rolled
-     * the log back) and every segment written before it describes changes that no
-     * longer happened. Keying by epoch makes those segments unreachable by
-     * construction instead of relying on a reader to remember to check a field —
-     * a forked shard finds an empty archive and falls back to the re-seed it
-     * would have demanded anyway.
+     * because an epoch change means the timeline forked and every segment written
+     * before it describes changes that no longer happened. Keying by epoch makes
+     * those segments unreachable by construction instead of relying on a reader
+     * to remember to check a field — a forked shard finds an empty archive and
+     * falls back to the re-seed it would have demanded anyway.
+     *
+     * That only separates two timelines if the epoch actually changes when one
+     * forks, and a native PITR restore is precisely the fork it cannot see by
+     * itself: `__cdc_meta` is a SQLite row, so the restore reverts the epoch
+     * along with the log it was supposed to discriminate. The change has to come
+     * from a witness the restore could not reach — a consumer's cursor, or this
+     * archive's own contents ({@link cdcArchiveRewound}) — and the sweep re-mints
+     * the epoch on either before it writes another segment.
      */
     epoch: string;
     /** The DO's shard key, or `__root__` for the single-DO default. */
@@ -134,10 +141,12 @@ const migrateCdcArchive = (sql: SqlExec): void => {
  * a cost that grows with everything ever written, paid on a write path, to
  * answer a question the shard already knows.
  *
- * A restore that rolls the changelog back also rolls this back with it, which is
- * correct: the epoch changes at the same moment (see {@link CdcArchiveScope}),
- * so the new timeline writes under a fresh prefix and cannot collide with what
- * the old one left behind.
+ * A restore rolls this back along with the changelog, and — this is the part
+ * that was assumed rather than true — it rolls the EPOCH back as well, since
+ * that is a SQLite row too. So the rewound shard does not automatically write
+ * under a fresh prefix; it re-issues the old prefix's keys for different
+ * changes. The rewind of this very watermark is what makes that detectable:
+ * see {@link cdcArchiveRewound}, which the sweep consults before it writes.
  */
 const readCdcArchivedThrough = (sql: SqlExec): number => {
     migrateCdcArchive(sql);
@@ -193,6 +202,46 @@ const archiveCdcSegment = async (bucket: R2BucketLike, scope: CdcArchiveScope, c
     await bucket.put(segmentKey(scope, to), JSON.stringify({ changes, from, to } satisfies CdcSegment), {
         httpMetadata: { contentType: "application/json" },
     });
+};
+
+/**
+ * Does the archive hold a segment this shard has no record of writing?
+ *
+ * The watermark ({@link readCdcArchivedThrough}) lives in SQLite and the
+ * segments live in object storage, and that split is what makes this question
+ * answerable at all: a point-in-time restore reverts the watermark — and the
+ * epoch, and the changelog — while R2 keeps every segment already written. A
+ * segment above the watermark is therefore the archive's own record of a
+ * timeline the shard has forgotten, and the one witness to a rollback that the
+ * rollback cannot reach.
+ *
+ * It matters because a segment's key IS its range's last `seq`. A rewound shard
+ * re-issues that range for different changes, so the next sweep either puts the
+ * second timeline's rows over the first's (the object holding rows already
+ * deleted from SQLite is simply replaced) or lands beside them, where the
+ * read-back stitches the two into one ascending run and serves a consumer
+ * rolled-back changes as if they were the ones it missed. Neither is reported
+ * anywhere. Answering `true` lets the caller re-mint the epoch first, which puts
+ * the new timeline under its own prefix and leaves the old one intact and
+ * unreachable — the behaviour {@link CdcArchiveScope} describes and, until the
+ * epoch could be shown to survive a restore, did not get.
+ *
+ * One `list` of one key, and in the steady state it matches nothing: the
+ * watermark only ever trails what has been written.
+ *
+ * **The benign false positive**, stated because it is the cost of keeping this
+ * to a single listing: a sweep that uploads a segment and dies before
+ * {@link writeCdcArchivedThrough} lands leaves exactly this shape without any
+ * rollback. It is read as a fork, so the epoch is re-minted and consumers
+ * re-seed once. Nothing is lost — the watermark never advanced, so the trim that
+ * would have destroyed those rows never ran, and the next sweep re-archives them
+ * under the fresh prefix. The inverse error is not survivable in the same way.
+ */
+const cdcArchiveRewound = async (bucket: R2BucketLike, scope: CdcArchiveScope, archivedThrough: number): Promise<boolean> => {
+    const prefix = scopePrefix(scope);
+    const listing = await bucket.list({ limit: 1, prefix, startAfter: `${prefix}${padSeq(archivedThrough)}.json` });
+
+    return listing.objects.length > 0;
 };
 
 /** Parse a stored segment, returning `undefined` for anything that is not one (a truncated write, a foreign object under the prefix). */
@@ -382,5 +431,5 @@ const readArchivedCdcChanges = async (
     return { changes: served, cursor: served.at(-1)?.seq ?? sinceSeq };
 };
 
-export { archiveCdcSegment, readArchivedCdcChanges, readCdcArchivedThrough, writeCdcArchivedThrough };
+export { archiveCdcSegment, cdcArchiveRewound, readArchivedCdcChanges, readCdcArchivedThrough, writeCdcArchivedThrough };
 export type { CdcArchiveScope };

--- a/packages/shard-engine/src/ctx-db-cdc.ts
+++ b/packages/shard-engine/src/ctx-db-cdc.ts
@@ -539,6 +539,33 @@ const cdcTrimmedError = (floor: number, sinceSeq: number, scope: "global" | "sha
     );
 
 /**
+ * The refusal a read path returns to a consumer whose cursor sits ABOVE the
+ * changelog's high-watermark.
+ *
+ * That is not a cursor, it is proof: `seq` is monotonic and survives a trim
+ * (`readCdcCursor` reads `sqlite_sequence`), so no consumer can legitimately
+ * hold one this shard has not issued. The one thing that produces it is a
+ * rollback of the log itself — in practice a native point-in-time restore, which
+ * reverts the whole SQLite database and every durable record of the old timeline
+ * inside it, `__cdc_meta`'s epoch included. The consumer's own cursor is then the
+ * only surviving witness, which is why it is treated as one.
+ *
+ * The alternative — echoing `sinceSeq` back with an empty page — tells that
+ * consumer it is caught up, and it then never asks for the post-restore range:
+ * the shard's writes climb back through seqs the consumer has already passed and
+ * are skipped one by one, silently and permanently. So this refuses, and carries
+ * what a resynchronisation needs: the surviving `cursor`, and the `epoch` the
+ * seal re-minted, which is what tells the consumer it is a different timeline
+ * rather than the same one shortened.
+ */
+const cdcForkedError = (cursor: number, sinceSeq: number, epoch: string): LunoraError =>
+    new LunoraError(
+        "CDC_TIMELINE_FORKED",
+        `cdc cursor ${String(sinceSeq)} is above this shard's high-watermark ${String(cursor)}; the changelog rolled back (a point-in-time restore) and the changes you hold are on a timeline that no longer exists — resume from a snapshot at epoch ${epoch}`,
+        { data: { cursor, epoch }, status: 409 },
+    );
+
+/**
  * Oldest `seq` still retained in the changelog, or `undefined` when the log is
  * empty. A reconnecting subscriber whose `sinceSeq` is below `floor - 1` has
  * missed changes that `trimCdcChanges` already compacted away, so it must take a
@@ -703,6 +730,7 @@ export {
     CDC_LOG_TABLE_SEQ_INDEX,
     CDC_META_TABLE,
     cdcCanVouchFor,
+    cdcForkedError,
     cdcSeqLeavingRows,
     cdcTouchesTables,
     cdcTrimmedError,

--- a/packages/shard-engine/src/ctx-db-commit-seq.ts
+++ b/packages/shard-engine/src/ctx-db-commit-seq.ts
@@ -31,7 +31,7 @@
  * sequence it has seen the whole of. See the "Checkpoint on a sequence boundary"
  * section of the commit-ordering doc.
  *
- * Two properties callers should NOT read into it:
+ * Four properties callers should NOT read into it:
  *
  * - **It is not gapless.** A mutation that allocates and then throws rolls its
  * writes back, but the counter row rolls back with them — so no gap from an
@@ -43,6 +43,23 @@
  * independently and their sequences say nothing about each other. `.global()`
  * tables live in D1 with no shard-local transaction to allocate inside, so
  * `.commitOrdered()` is rejected on them at schema-build time.
+ * - **It does not survive a point-in-time restore.** The counter is a row in the
+ * same SQLite database as everything it orders, so a restore rewinds it along
+ * with the rows: the allocator re-issues sequences an external consumer has
+ * already checkpointed past, and hands them to different writes. Measured on the
+ * faithful model of a restore (counter AND rows reverted together, since nothing
+ * local can restore only one): a consumer checkpointed at 5 is served nothing
+ * until post-restore writes climb back over 5, and the writes numbered 3, 4, 5
+ * in between are skipped permanently. Nothing inside the shard can detect this —
+ * every durable record of the old timeline reverts at the same instant — so a
+ * feed that must survive one has to pair its cursor with something minted
+ * OUTSIDE SQLite. The CDC epoch is that discriminator (`__cdc_meta`, re-minted
+ * by `ShardDO.sealForkedTimeline` the first time any consumer or the changelog
+ * archive proves the fork), and `_commitSeq` has no channel of its own to carry
+ * it: a consumer pages this field with its own `WHERE _commitSeq > cursor`
+ * query. A changefeed whose consumer cannot tolerate a silent rewind should read
+ * `__cdc_log` through `cdcSync`, which refuses a rewound cursor outright
+ * (`CDC_TIMELINE_FORKED`).
  * - **A hard delete is invisible to it.** `_commitSeq` lives on the row, so a
  * physically removed row takes its sequence with it: a consumer paging
  * `_commitSeq > cursor` sees the row stop appearing but is never told it went

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -4828,6 +4828,7 @@ export {
     bumpCdcEpoch,
     CDC_LOG_TABLE,
     cdcCanVouchFor,
+    cdcForkedError,
     cdcSeqLeavingRows,
     cdcTouchesTables,
     cdcTrimmedError,

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -51,6 +51,7 @@ export {
     backfillSearchIndexes,
     CDC_LOG_TABLE,
     cdcCanVouchFor,
+    cdcForkedError,
     cdcSeqLeavingRows,
     cdcTouchesTables,
     cdcTrimmedError,
@@ -79,7 +80,7 @@ export {
     readCdcEpoch,
 } from "./ctx-db-cdc";
 export type { CdcArchiveScope } from "./ctx-db-cdc-archive";
-export { archiveCdcSegment, readArchivedCdcChanges, readCdcArchivedThrough, writeCdcArchivedThrough } from "./ctx-db-cdc-archive";
+export { archiveCdcSegment, cdcArchiveRewound, readArchivedCdcChanges, readCdcArchivedThrough, writeCdcArchivedThrough } from "./ctx-db-cdc-archive";
 export { advanceClientWatermark, CLIENT_WATERMARK_TABLE, migrateClientWatermark, readClientWatermark } from "./ctx-db-client-watermark";
 export { allocateCommitSeq, COMMIT_SEQ_FIELD, COMMIT_SEQ_TABLE, migrateCommitSeq, readCommitSeq } from "./ctx-db-commit-seq";
 export type { CompanionSync, CompanionSyncDeps } from "./ctx-db-companions";

--- a/packages/shard-engine/src/replica.ts
+++ b/packages/shard-engine/src/replica.ts
@@ -371,6 +371,24 @@ const servePull = (host: ReplicaOwnerHost, epoch: string, sinceSeq: number): Res
         return replicaResponse({ changes: [], cursor: host.ownerCursor() ?? sinceSeq, epoch, floor });
     }
 
+    const ownerCursor = host.ownerCursor() ?? 0;
+
+    // A follower ASKING from above the owner's high-watermark has applied changes
+    // the owner can no longer account for: the owner's log rolled back under it,
+    // which a native point-in-time restore does WITHOUT minting a new epoch —
+    // the restore reverts `__cdc_meta` along with everything else, so the epoch
+    // comes back identical and cannot report the one fork it exists to report.
+    //
+    // Answered here rather than left to `readChanges`, which refuses such a
+    // cursor outright, for exactly the reason the floor is answered here: a
+    // thrown response reaches the follower as a bare non-2xx it reads as "owner
+    // unreachable", so it would retry the identical doomed round trip forever
+    // instead of bootstrapping. The rewound cursor routes it through
+    // `hasDiverged` into `bootstrap`, which is the recovery that exists.
+    if (sinceSeq > ownerCursor) {
+        return replicaResponse({ changes: [], cursor: ownerCursor, epoch, ...(floor === undefined ? {} : { floor }) });
+    }
+
     const { changes, cursor } = host.readChanges(sinceSeq, PULL_PAGE_SIZE);
 
     return replicaResponse({ changes, cursor, epoch, ...(floor === undefined ? {} : { floor }) });
@@ -608,7 +626,19 @@ class ShardReplica {
         const floor = page.floor ?? (compactedEmpty ? page.cursor : 0);
         const compactedPastUs = floor > 0 && floor > state.appliedSeq + 1;
 
-        if (page.epoch === state.epoch && !compactedPastUs) {
+        // The owner's high-watermark BELOW our applied position is a rollback on
+        // the owner, and it is the case the epoch cannot report: a point-in-time
+        // restore reverts the owner's whole SQLite database, the `__cdc_meta` row
+        // holding that epoch included, so the epoch comes back identical while
+        // the log underneath it is a different timeline. Our own applied position
+        // is then the only surviving record of the timeline we replayed, and
+        // following on means replaying a second timeline's changes over a first
+        // one's rows. Detectable only while the owner is still behind us — once
+        // it has written back past our cursor neither side can tell, the same
+        // blind spot `ShardDO.sealForkedTimeline` documents for its subscribers.
+        const rewoundBeneathUs = page.cursor < state.appliedSeq;
+
+        if (page.epoch === state.epoch && !compactedPastUs && !rewoundBeneathUs) {
             return false;
         }
 


### PR DESCRIPTION
A point-in-time restore reverts the whole of a shard's SQLite. Every durable record of the
pre-restore timeline goes with it — the changelog rows, the `sqlite_sequence` high-watermark that
`readCdcCursor` reads, the archive watermark, and `__cdc_meta`'s epoch, which exists to discriminate
exactly this fork and cannot, because it is a row in the database being reverted.

What survives is outside that database: a cursor a consumer cached, and the segments already written
to R2. Three read paths treated the first as a cursor rather than as the proof it is, and the sweep
ignored the second.

## What was wrong

**`cdcSync` echoed a rewound cursor back.** `runShardCdcSync` ended with
`cursor: changes.at(-1)?.seq ?? sinceSeq`, so a consumer above the rewound high-watermark got an
empty page and its own cursor — "you are caught up". It then never asked again, and every
post-restore write was skipped as the log climbed back through seqs it had already passed.

**The retention sweep archived the second timeline under the first one's prefix.** Segment keys are
derived from the range's last `seq`, which a rewound shard re-issues. Measured in
`shard-do.delta-read-path.test.ts` against the unfixed code: the second timeline's segment replaced
the first's object at the same key (`expected 'n0' to be 'm0'`), taking with it rows already deleted
from SQLite. Where the cutoffs do not line up exactly it lands beside it instead, and the read-back
stitches both timelines into one ascending run.

**A read replica froze.** `servePull` answered a follower pulling from above the owner's
high-watermark with the same epoch and an empty page; `hasDiverged` compares epochs, so the follower
concluded it was current and never bootstrapped.

## The mechanism

One rule, at every site: **a cursor — or an archived segment — above what the shard believes it has
issued is proof the log rewound**, and the witness lives outside the SQLite the restore reverts.

- `runShardCdcSync` refuses with a typed `CDC_TIMELINE_FORKED` (409) carrying the surviving `cursor`
  and the fresh `epoch`, and seals the fork through `sealForkedTimeline` — the same guard, and the
  same seal, the subscription path in `evaluateResume` already applied to the same proof.
- The sweep consults `cdcArchiveRewound` (one `list` of one key, matching nothing in the steady
  state) before it writes. A segment above the watermark seals the timeline and skips the cycle; the
  next sweep archives under the fresh prefix, beside the old one rather than over it.
- `servePull` answers the rewound cursor rather than letting `readChanges` throw — a thrown response
  reads there as "owner unreachable" and is retried forever — and `hasDiverged` treats a
  high-watermark below its applied position as divergence, which routes the follower to `bootstrap`.

The seal is what closes the archive defect as well as the sync one: re-minting the epoch re-prefixes
the archive. An ordinary "no new changes" (`sinceSeq === cursor`) still returns an empty page.

## `_commitSeq`

Verified and not fixable inside the shard: the counter is a row in the same database, so it rewinds
with the rows it orders and re-issues sequences an external consumer has already checkpointed past.
The earlier framing (`UPDATE __commit_seq` alone) produces a state a restore does not — two live rows
sharing one sequence; the faithful model (counter and rows reverted together) still re-issues 3 to a
consumer checkpointed at 5, which never sees it. There is no framework-issued cursor for this field
to pair an epoch with, so the exposure is documented on the module with the CDC epoch named as the
discriminator a feed has to carry.

## Verification

- New tests fail first against the unfixed code, and each was re-broken afterwards to confirm it
  fails for its own reason (rewind guard disabled / made to over-fire, seal no-opped, archive witness
  forced false, both replica clauses removed, the error code unregistered).
- Native PITR cannot be exercised locally: workerd implements `getCurrentBookmark` /
  `getBookmarkForTime`, but `onNextSessionRestoreBookmark` answers "This Durable Object's storage
  back-end does not implement point-in-time recovery". The tests model the one thing a restore does
  that matters here — SQLite's content reverts, and nothing outside it does.
- `build:packages`, `api:check`, `lint:types --no-cache`, `@lunora/shard-engine` (1499), `@lunora/do`
  (743), `test:affected` (1301 across 143 files), `test:workerd` (all 11 suites) all green.
  `vis run test --query "project=errors" --no-cache` green for the new catalog entry, with
  `apps/docs` error reference and both API snapshots regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fk2r14izBDQteWpxDZ2jz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CDC timeline fork detection after point-in-time restores or changelog rewinds.
  * Consumers now receive a clear resynchronization error with the surviving cursor and epoch instead of silently skipping changes.
  * Replica synchronization now detects divergent timelines and requests a rewind when needed.

* **Bug Fixes**
  * Protected archived CDC data from destructive retention when a timeline rewind is detected.
  * Prevented replicas and changefeed consumers from continuing with stale or invalid checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->